### PR TITLE
README changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,6 @@ Other installations you'd need are the additional libraries, a fully updated lis
 haxelib install hscript
 haxelib install newgrounds
 haxelib install polymod
-
 ```
 
 You'll also need to install a couple things that involve Gits. To do this, you need to do a few things first.

--- a/README.md
+++ b/README.md
@@ -82,7 +82,11 @@ To run it from your desktop (Windows, Mac, Linux) it can be a bit more involved.
 
 Once that is done you can open up a command line in the project's directory and run `lime test windows -debug`. Once that command finishes (it takes forever even on a higher end PC), you can run FNF from the .exe file under export\release\windows\bin
 
-As for Mac, `lime test mac -debug` should work, if not the internet surely has a guide on how to compile Haxe stuff for Mac.
+As for Mac, you need to install Xcode, you can either install it from the App Store or from the [Apple Developer Website](https://developer.apple.com/download/)
+
+If you get an error saying that you need a newer macOS version, [you need to install an older version of Xcode](https://developer.apple.com/download/more/) ([Wikipedia comparison table can be found here](https://en.wikipedia.org/wiki/Xcode#Version_comparison_table))
+
+Once Xcode is installed, you are free to enter the project directory and run `lime test mac -debug` to build the mac version.
 
 ### Additional guides
 

--- a/README.md
+++ b/README.md
@@ -3,10 +3,13 @@
 This is the repository for Friday Night Funkin, a game originally made for Ludum Dare 47 "Stuck In a Loop".
 
 Play the Ludum Dare prototype here: https://ninja-muffin24.itch.io/friday-night-funkin
+
 Play the Newgrounds one here: https://www.newgrounds.com/portal/view/770371
+
 Support the project on the itch.io page: https://ninja-muffin24.itch.io/funkin
 
-IF YOU MAKE A MOD AND DISTRIBUTE A MODIFIED / RECOMPILED VERSION, YOU MUST OPEN SOURCE YOUR MOD AS WELL
+
+## IF YOU MAKE A MOD AND DISTRIBUTE A MODIFIED / RECOMPILED VERSION, YOU MUST OPEN SOURCE YOUR MOD AS WELL
 
 ## Credits / shoutouts
 
@@ -29,18 +32,14 @@ IF YOU WANT TO COMPILE THE GAME YOURSELF, CONTINUE READING!!!
 ### Installing the Required Programs
 
 First, you need to install Haxe and HaxeFlixel. I'm too lazy to write and keep updated with that setup (which is pretty simple). 
-1. [Install Haxe 4.1.5](https://haxe.org/download/version/4.1.5/) (Download 4.1.5 instead of 4.2.0 because 4.2.0 is broken and is not working with gits properly...)
-2. [Install HaxeFlixel](https://haxeflixel.com/documentation/install-haxeflixel/) after downloading Haxe
+1. [Install Haxe 4.1.5](https://haxe.org/download/version/4.1.5/) (Any version after 4.1.0 works with the exception of 4.2.0, I recommend installing 4.1.5 to be safe.)
+2. [Install HaxeFlixel](https://haxeflixel.com/documentation/install-haxeflixel/) after downloading Haxe (This is a required step and compilation will fail if it isn't installed!)
 
-Other installations you'd need are the additional libraries, a fully updated list will be in `Project.xml` in the project root. Currently, these are all of the things you need to install:
+Other installations you'd need are the additional libraries, a fully updated list will be in `Project.xml` in the project root. Just copy and paste this into your terminal to install them:
 ```
-flixel
-flixel-addons
-flixel-ui
-hscript
-newgrounds
+haxelib install hscript
+haxelib install newgrounds
 ```
-So for each of those type `haxelib install [library]` so shit like `haxelib install newgrounds`
 
 You'll also need to install a couple things that involve Gits. To do this, you need to do a few things first.
 1. Download [git-scm](https://git-scm.com/downloads). Works for Windows, Mac, and Linux, just select your build.
@@ -49,9 +48,6 @@ You'll also need to install a couple things that involve Gits. To do this, you n
 4. Run `haxelib git discord_rpc https://github.com/Aidan63/linc_discord-rpc` to install Discord RPC.
 
 You should have everything ready for compiling the game! Follow the guide below to continue!
-
-At the moment, you can optionally fix the transition bug in songs with zoomed-out cameras.
-- Run `haxelib git flixel-addons https://github.com/HaxeFlixel/flixel-addons` in the terminal/command-prompt.
 
 ### Ignored files
 
@@ -70,13 +66,16 @@ class APIStuff
 }
 
 ```
+Alternatively, you can also delete line 61 in `TitleState.hx`
 
 and you should be good to go there.
 
 ### Compiling game
 NOTE: If you see any messages relating to deprecated packages, ignore them. They're just warnings that don't affect compiling
 
-Once you have all those installed, it's pretty easy to compile the game. You just need to run `lime test html5 -debug` in the root of the project to build and run the HTML5 version. (command prompt navigation guide can be found here: [https://ninjamuffin99.newgrounds.com/news/post/1090480](https://ninjamuffin99.newgrounds.com/news/post/1090480))
+The -debug flag is completely optional.
+
+Once you have all those installed, it's pretty easy to compile the game. You just need to run `lime test html5 -debug` in the root of the project to build and run the HTML5 version ([command prompt navigation guide can be found here](https://ninjamuffin99.newgrounds.com/news/post/1090480)).
 To run it from your desktop (Windows, Mac, Linux) it can be a bit more involved. For Linux, you only need to open a terminal in the project directory and run `lime test linux -debug` and then run the executable file in export/release/linux/bin. For Windows, you need to install Visual Studio Community 2019. While installing VSC, don't click on any of the options to install workloads. Instead, go to the individual components tab and choose the following:
 * MSVC v142 - VS 2019 C++ x64/x86 build tools
 * Windows SDK (10.0.17763.0)

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This is the repository for Friday Night Funkin, a game originally made for Ludum
 
 [Play on Newgrounds](https://www.newgrounds.com/portal/view/770371) 
 
-[Support the project](https://ninja-muffin24.itch.io/funkin)
+[Support the project on the itch.io page](https://ninja-muffin24.itch.io/funkin)
 
 ## IF YOU MAKE A MOD AND DISTRIBUTE A MODIFIED / RECOMPILED VERSION, YOU MUST OPEN SOURCE YOUR MOD AS WELL
 

--- a/README.md
+++ b/README.md
@@ -2,9 +2,11 @@
 
 This is the repository for Friday Night Funkin, a game originally made for Ludum Dare 47 "Stuck In a Loop".
 
-[Play the Ludum Dare prototype] (https://ninja-muffin24.itch.io/friday-night-funkin)
+[Play the Ludum Dare prototype](https://ninja-muffin24.itch.io/friday-night-funkin)
 
-[Play on Newgrounds] (https://www.newgrounds.com/portal/view/770371) or [Support the project] (https://ninja-muffin24.itch.io/funkin)
+[Play on Newgrounds](https://www.newgrounds.com/portal/view/770371) 
+
+[Support the project](https://ninja-muffin24.itch.io/funkin)
 
 ## IF YOU MAKE A MOD AND DISTRIBUTE A MODIFIED / RECOMPILED VERSION, YOU MUST OPEN SOURCE YOUR MOD AS WELL
 

--- a/README.md
+++ b/README.md
@@ -2,12 +2,9 @@
 
 This is the repository for Friday Night Funkin, a game originally made for Ludum Dare 47 "Stuck In a Loop".
 
-Play the Ludum Dare prototype here: https://ninja-muffin24.itch.io/friday-night-funkin
+[Play the Ludum Dare prototype] (https://ninja-muffin24.itch.io/friday-night-funkin)
 
-Play the Newgrounds one here: https://www.newgrounds.com/portal/view/770371
-
-Support the project on the itch.io page: https://ninja-muffin24.itch.io/funkin
-
+[Play on Newgrounds] (https://www.newgrounds.com/portal/view/770371) or [Support the project] (https://ninja-muffin24.itch.io/funkin)
 
 ## IF YOU MAKE A MOD AND DISTRIBUTE A MODIFIED / RECOMPILED VERSION, YOU MUST OPEN SOURCE YOUR MOD AS WELL
 

--- a/README.md
+++ b/README.md
@@ -31,20 +31,21 @@ IF YOU WANT TO COMPILE THE GAME YOURSELF, CONTINUE READING!!!
 ### Installing the Required Programs
 
 First, you need to install Haxe and HaxeFlixel. I'm too lazy to write and keep updated with that setup (which is pretty simple). 
-1. [Install Haxe 4.1.5](https://haxe.org/download/version/4.1.5/) (Any version after 4.1.0 works with the exception of 4.2.0, I recommend installing 4.1.5 to be safe.)
+1. [Install Haxe](https://haxe.org/download/)
 2. [Install HaxeFlixel](https://haxeflixel.com/documentation/install-haxeflixel/) after downloading Haxe (This is a required step and compilation will fail if it isn't installed!)
 
 Other installations you'd need are the additional libraries, a fully updated list will be in `Project.xml` in the project root. Just copy and paste this into your terminal to install them:
 ```
 haxelib install hscript
 haxelib install newgrounds
+haxelib install polymod
+
 ```
 
 You'll also need to install a couple things that involve Gits. To do this, you need to do a few things first.
-1. Download [git-scm](https://git-scm.com/downloads). Works for Windows, Mac, and Linux, just select your build.
-2. Follow instructions to install the application properly.
-3. Run `haxelib git polymod https://github.com/larsiusprime/polymod.git` to install Polymod.
-4. Run `haxelib git discord_rpc https://github.com/Aidan63/linc_discord-rpc` to install Discord RPC.
+1. Download [git-scm](https://git-scm.com/downloads). Works for Windows, and Mac, just select your build. (Linux users can install the git package via their respective package manager.)
+2. Follow instructions to install the application properly..
+3. Run `haxelib git discord_rpc https://github.com/Aidan63/linc_discord-rpc` to install Discord RPC.
 
 You should have everything ready for compiling the game! Follow the guide below to continue!
 
@@ -80,7 +81,7 @@ To run it from your desktop (Windows, Mac, Linux) it can be a bit more involved.
 * Windows SDK (10.0.17763.0)
 
 Once that is done you can open up a command line in the project's directory and run `lime test windows -debug`. Once that command finishes (it takes forever even on a higher end PC), you can run FNF from the .exe file under export\release\windows\bin
-As for Mac, 'lime test mac -debug' should work, if not the internet surely has a guide on how to compile Haxe stuff for Mac.
+As for Mac, `lime test mac -debug` should work, if not the internet surely has a guide on how to compile Haxe stuff for Mac.
 
 ### Additional guides
 

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Once that is done you can open up a command line in the project's directory and 
 
 As for Mac, you need to install Xcode, you can either install it from the App Store or from the [Apple Developer Website](https://developer.apple.com/download/)
 
-If you get an error saying that you need a newer macOS version, [you need to install an older version of Xcode](https://developer.apple.com/download/more/) (Wikipedia comparison table can be found [here](https://en.wikipedia.org/wiki/Xcode#Version_comparison_table))
+If you get an error saying that you need a newer macOS version, [you need to install an older version of Xcode](https://developer.apple.com/download/more/) (Wikipedia comparison table can be found [here](https://en.wikipedia.org/wiki/Xcode#Version_comparison_table), check the "min macOS" columm.)
 
 Once Xcode is installed, you are free to enter the project directory and run `lime test mac -debug` to build the mac version.
 

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ and you should be good to go there.
 NOTE: If you see any messages relating to deprecated packages, ignore them. They're just warnings that don't affect compiling
 
 The -debug flag is completely optional.
+Applying it will make a folder called `export/debug/[TARGET]/bin` instead of `export/release/[TARGET]/bin`
 
 Once you have all those installed, it's pretty easy to compile the game. You just need to run `lime test html5 -debug` in the root of the project to build and run the HTML5 version ([command prompt navigation guide can be found here](https://ninjamuffin99.newgrounds.com/news/post/1090480)).
 To run it from your desktop (Windows, Mac, Linux) it can be a bit more involved. For Linux, you only need to open a terminal in the project directory and run `lime test linux -debug` and then run the executable file in export/release/linux/bin. For Windows, you need to install Visual Studio Community 2019. While installing VSC, don't click on any of the options to install workloads. Instead, go to the individual components tab and choose the following:
@@ -80,6 +81,7 @@ To run it from your desktop (Windows, Mac, Linux) it can be a bit more involved.
 * Windows SDK (10.0.17763.0)
 
 Once that is done you can open up a command line in the project's directory and run `lime test windows -debug`. Once that command finishes (it takes forever even on a higher end PC), you can run FNF from the .exe file under export\release\windows\bin
+
 As for Mac, `lime test mac -debug` should work, if not the internet surely has a guide on how to compile Haxe stuff for Mac.
 
 ### Additional guides

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Once that is done you can open up a command line in the project's directory and 
 
 As for Mac, you need to install Xcode, you can either install it from the App Store or from the [Apple Developer Website](https://developer.apple.com/download/)
 
-If you get an error saying that you need a newer macOS version, [you need to install an older version of Xcode](https://developer.apple.com/download/more/) ([Wikipedia comparison table can be found here](https://en.wikipedia.org/wiki/Xcode#Version_comparison_table))
+If you get an error saying that you need a newer macOS version, [you need to install an older version of Xcode](https://developer.apple.com/download/more/) (Wikipedia comparison table can be found [here](https://en.wikipedia.org/wiki/Xcode#Version_comparison_table))
 
 Once Xcode is installed, you are free to enter the project directory and run `lime test mac -debug` to build the mac version.
 


### PR DESCRIPTION
1. Fix formatting error in lines 4-10
2. Made line 12 bigger to emphasize it
3. Removed flixel-addons git (the transition bug was fixed lmao)
Removed flixel-addons, flixel-tools, and flixel since they are already installable via the haxeflixel link + added `haxelib install`
5. Compiling works on the latest haxe version, so 4.1.5 is no longer required
6. Added alternative method in APIStuff section
7. Added disclaimer in compiling section stating that the debug flag is optional

There's more changes but you get the idea.


also changed the haxelib git polymod to haxelib install since polymod was recently added to haxelib