### PR TITLE
Update Controls.hx

### DIFF
--- a/source/Controls.hx
+++ b/source/Controls.hx
@@ -566,7 +566,7 @@ class Controls extends FlxActionSet
 			Control.NOTE_LEFT => [DPAD_LEFT, X, LEFT_STICK_DIGITAL_LEFT, RIGHT_STICK_DIGITAL_LEFT],
 			Control.NOTE_RIGHT => [DPAD_RIGHT, B, LEFT_STICK_DIGITAL_RIGHT, RIGHT_STICK_DIGITAL_RIGHT],
 			Control.PAUSE => [START],
-			Control.RESET => [Y]
+			Control.RESET => [6]
 			#if CAN_CHEAT
 			,Control.CHEAT => [X]
 			#end


### PR DESCRIPTION
Changed Control.RESET from [Y] to [6]. 

Why? Because that means instead of pressing Y to reset the song, you instead press the select button, which prevents accidental resets if you are playing on a non-standard xbox controller. 

I brought up [this issue](https://github.com/FunkinCrew/Funkin/issues/1968) back in 2022 and it never got solved so I just decided I'd make the pull request myself.