### PR TITLE
Fix the `funkin-assets` license link

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -5,7 +5,7 @@ The Friday Night Funkin' source code is licensed under the Apache 2.0 license: (
 Friday Night Funkin' Copyright 2020-2024 The Funkin' Crew Inc.
 All Rights Reserved. "Friday Night Funkin'" and the "Friday Night Funkin'" logo are trademarks of The Funkin' Crew Inc.
 
-You can view the `funkin-assets` license here: (https://github.com/FunkinCrew/funkin-assets/blob/main/LICENSE.md)
+You can view the `funkin-assets` license here: (https://github.com/FunkinCrew/funkin.assets/blob/main/LICENSE.md)
 
 ## Apache 2.0 License
 


### PR DESCRIPTION
Self-explanatory, the previous link was incorrect.

|    Before     |     After     |
| ------------- | ------------- |
![image](https://github.com/FunkinCrew/Funkin/assets/37378746/a8ccae88-2d91-4a97-920a-7e10ee6b2709) | ![image](https://github.com/FunkinCrew/Funkin/assets/37378746/5ddc05d8-16b9-46ad-9e8c-98ca50cece79)
