### PR TITLE
FIX WINDOW TWEEN

### DIFF
--- a/source/funkin/ui/title/TitleState.hx
+++ b/source/funkin/ui/title/TitleState.hx
@@ -283,6 +283,7 @@ class TitleState extends MusicBeatState
 
     if (FlxG.keys.justPressed.Y)
     {
+      FlxTween.cancelTweensOf(FlxG.stage.window, ['x', 'y']);
       FlxTween.tween(FlxG.stage.window, {x: FlxG.stage.window.x + 300}, 1.4, {ease: FlxEase.quadInOut, type: PINGPONG, startDelay: 0.35});
       FlxTween.tween(FlxG.stage.window, {y: FlxG.stage.window.y + 100}, 0.7, {ease: FlxEase.quadInOut, type: PINGPONG});
     }


### PR DESCRIPTION
the tween glitches out when pressing Y multiple times. just cancel the tween if it already exists