### PR TITLE
Fix a crash when querying FlxG.state in the crash handler

### DIFF
--- a/source/funkin/util/logging/CrashHandler.hx
+++ b/source/funkin/util/logging/CrashHandler.hx
@@ -141,7 +141,9 @@ class CrashHandler
 
     fullContents += '\n';
 
-    fullContents += 'Flixel Current State: ${Type.getClassName(Type.getClass(FlxG.state))}\n';
+    var currentState = FlxG.state != null ? Type.getClassName(Type.getClass(FlxG.state)) : 'No state loaded';
+
+    fullContents += 'Flixel Current State: ${currentState}\n';
 
     fullContents += '\n';
 


### PR DESCRIPTION
Another null object reference fix