### PR TITLE
Fixed an issue where hold note would be invisible for a single frame.

### DIFF
--- a/source/funkin/play/notes/Strumline.hx
+++ b/source/funkin/play/notes/Strumline.hx
@@ -576,6 +576,8 @@ class Strumline extends FlxSpriteGroup
       note.holdNoteSprite.hitNote = true;
       note.holdNoteSprite.missedNote = false;
       note.holdNoteSprite.alpha = 1.0;
+
+      note.holdNoteSprite.sustainLength = (note.holdNoteSprite.strumTime + note.holdNoteSprite.fullSustainLength) - conductorInUse.songPosition;
     }
   }
 


### PR DESCRIPTION
When hitting a note there is a frame where updateNotes() isn't called.
In most cases this doesn't cause issues but with sustains their length isn't being updated in time causing a visual bug.

https://github.com/FunkinCrew/Funkin/assets/50346006/337d9810-2f1c-449e-8466-99072b65be9e