### PR TITLE
Better offsets handling for gameplay props.

### DIFF
--- a/source/funkin/play/character/BaseCharacter.hx
+++ b/source/funkin/play/character/BaseCharacter.hx
@@ -1,6 +1,7 @@
 package funkin.play.character;
 
 import flixel.math.FlxPoint;
+import flixel.FlxCamera;
 import funkin.modding.events.ScriptEvent;
 import funkin.play.character.CharacterData.CharacterDataParser;
 import funkin.play.character.CharacterData.CharacterRenderType;
@@ -118,19 +119,17 @@ class BaseCharacter extends Bopper
    */
   public var cameraFocusPoint(default, null):FlxPoint = new FlxPoint(0, 0);
 
+  /**
+   * Defines the animation offset.
+   */
+  public var animOffset:FlxPoint = FlxPoint.get();
+
   override function set_animOffsets(value:Array<Float>):Array<Float>
   {
     if (animOffsets == null) value = [0, 0];
     if ((animOffsets[0] == value[0]) && (animOffsets[1] == value[1])) return value;
 
-    // Make sure animOffets are halved when scale is 0.5.
-    var xDiff = (animOffsets[0] * this.scale.x / (this.isPixel ? 6 : 1)) - value[0];
-    var yDiff = (animOffsets[1] * this.scale.y / (this.isPixel ? 6 : 1)) - value[1];
-
-    // Call the super function so that camera focus point is not affected.
-    super.set_x(this.x + xDiff);
-    super.set_y(this.y + yDiff);
-
+    animOffset.set(value[0], value[1]);
     return animOffsets = value;
   }
 
@@ -570,9 +569,23 @@ class BaseCharacter extends Bopper
     }
   }
 
+  // override getScreenPosition (used by FlxSprite's draw method) to account for animation offsets.
+  override function getScreenPosition(?result:FlxPoint, ?camera:FlxCamera):FlxPoint
+  {
+    var output:FlxPoint = super.getScreenPosition(result, camera);
+    output -= animOffset;
+    return output;
+  }
+
   public override function onDestroy(event:ScriptEvent):Void
   {
     this.characterType = OTHER;
+  }
+
+  override function destroy():Void
+  {
+    animOffset = flixel.util.FlxDestroyUtil.put(animOffset);
+    super.destroy();
   }
 
   /**

--- a/source/funkin/play/character/BaseCharacter.hx
+++ b/source/funkin/play/character/BaseCharacter.hx
@@ -1,7 +1,6 @@
 package funkin.play.character;
 
 import flixel.math.FlxPoint;
-import flixel.FlxCamera;
 import funkin.modding.events.ScriptEvent;
 import funkin.play.character.CharacterData.CharacterDataParser;
 import funkin.play.character.CharacterData.CharacterRenderType;
@@ -118,20 +117,6 @@ class BaseCharacter extends Bopper
    * Set the position of this rather than reassigning it, so that anything referencing it will not be affected.
    */
   public var cameraFocusPoint(default, null):FlxPoint = new FlxPoint(0, 0);
-
-  /**
-   * Defines the animation offset.
-   */
-  public var animOffset:FlxPoint = FlxPoint.get();
-
-  override function set_animOffsets(value:Array<Float>):Array<Float>
-  {
-    if (animOffsets == null) value = [0, 0];
-    if ((animOffsets[0] == value[0]) && (animOffsets[1] == value[1])) return value;
-
-    animOffset.set(value[0], value[1]);
-    return animOffsets = value;
-  }
 
   /**
    * If the x position changes, other than via changing the animation offset,
@@ -569,23 +554,9 @@ class BaseCharacter extends Bopper
     }
   }
 
-  // override getScreenPosition (used by FlxSprite's draw method) to account for animation offsets.
-  override function getScreenPosition(?result:FlxPoint, ?camera:FlxCamera):FlxPoint
-  {
-    var output:FlxPoint = super.getScreenPosition(result, camera);
-    output -= animOffset;
-    return output;
-  }
-
   public override function onDestroy(event:ScriptEvent):Void
   {
     this.characterType = OTHER;
-  }
-
-  override function destroy():Void
-  {
-    animOffset = flixel.util.FlxDestroyUtil.put(animOffset);
-    super.destroy();
   }
 
   /**

--- a/source/funkin/play/stage/Bopper.hx
+++ b/source/funkin/play/stage/Bopper.hx
@@ -1,6 +1,7 @@
 package funkin.play.stage;
 
 import flixel.FlxSprite;
+import flixel.FlxCamera;
 import flixel.math.FlxPoint;
 import flixel.util.FlxTimer;
 import funkin.modding.IScriptedClass.IPlayStateScriptedClass;
@@ -68,6 +69,11 @@ class Bopper extends StageProp implements IPlayStateScriptedClass
   }
 
   /**
+   * Internally used to define the animation offsets to apply.
+   */
+  var _currentAnimOffset:FlxPoint = FlxPoint.get();
+
+  /**
    * The offset of the character relative to the position specified by the stage.
    */
   public var globalOffsets(default, set):Array<Float> = [0, 0];
@@ -95,12 +101,7 @@ class Bopper extends StageProp implements IPlayStateScriptedClass
     if (animOffsets == null) animOffsets = [0, 0];
     if ((animOffsets[0] == value[0]) && (animOffsets[1] == value[1])) return value;
 
-    var xDiff = animOffsets[0] - value[0];
-    var yDiff = animOffsets[1] - value[1];
-
-    this.x += xDiff;
-    this.y += yDiff;
-
+    _currentAnimOffset.set(value[0], value[1]);
     return animOffsets = value;
   }
 
@@ -347,6 +348,20 @@ class Bopper extends StageProp implements IPlayStateScriptedClass
   {
     if (this.animation == null || this.animation.curAnim == null) return "";
     return this.animation.curAnim.name;
+  }
+
+  // override getScreenPosition (used by FlxSprite's draw method) to account for animation offsets.
+  override function getScreenPosition(?result:FlxPoint, ?camera:FlxCamera):FlxPoint
+  {
+    var output:FlxPoint = super.getScreenPosition(result, camera);
+    output -= _currentAnimOffset;
+    return output;
+  }
+
+  override function destroy():Void
+  {
+    _currentAnimOffset = flixel.util.FlxDestroyUtil.put(_currentAnimOffset);
+    super.destroy();
   }
 
   public function onPause(event:PauseScriptEvent) {}

--- a/source/funkin/play/stage/Bopper.hx
+++ b/source/funkin/play/stage/Bopper.hx
@@ -69,11 +69,6 @@ class Bopper extends StageProp implements IPlayStateScriptedClass
   }
 
   /**
-   * Internally used to define the animation offsets to apply.
-   */
-  var _currentAnimOffset:FlxPoint = FlxPoint.get();
-
-  /**
    * The offset of the character relative to the position specified by the stage.
    */
   public var globalOffsets(default, set):Array<Float> = [0, 0];
@@ -101,7 +96,6 @@ class Bopper extends StageProp implements IPlayStateScriptedClass
     if (animOffsets == null) animOffsets = [0, 0];
     if ((animOffsets[0] == value[0]) && (animOffsets[1] == value[1])) return value;
 
-    _currentAnimOffset.set(value[0], value[1]);
     return animOffsets = value;
   }
 
@@ -354,14 +348,9 @@ class Bopper extends StageProp implements IPlayStateScriptedClass
   override function getScreenPosition(?result:FlxPoint, ?camera:FlxCamera):FlxPoint
   {
     var output:FlxPoint = super.getScreenPosition(result, camera);
-    output -= _currentAnimOffset;
+    output.x -= animOffsets[0];
+    output.y -= animOffsets[1];
     return output;
-  }
-
-  override function destroy():Void
-  {
-    _currentAnimOffset = flixel.util.FlxDestroyUtil.put(_currentAnimOffset);
-    super.destroy();
   }
 
   public function onPause(event:PauseScriptEvent) {}


### PR DESCRIPTION
Currently, Funkin directly changes the `x` and `y` properties for offsets. This is a bit tedious because it can break stuff, such as tweens.

This pull request changes the way animation offsets are handled without changing `x`, `y` or `offset`.
Ideally this could be implemented on other classes too.