### PR TITLE
Fixed stutter once a wipe transition to the Main Menu completes.

### DIFF
--- a/source/funkin/ui/mainmenu/MainMenuState.hx
+++ b/source/funkin/ui/mainmenu/MainMenuState.hx
@@ -139,10 +139,6 @@ class MainMenuState extends MusicBeatState
 
     resetCamStuff();
 
-    subStateClosed.add(_ -> {
-      resetCamStuff();
-    });
-
     subStateOpened.add(sub -> {
       if (Type.getClass(sub) == FreeplayState)
       {


### PR DESCRIPTION
There is this bit of code in the MainMenuState that I assume was supposed to run immediately after changing to the state but instead is run after the transition completes to the state.
This causes the camera to be reset when the transition completes, creating a stutter effect.

I've tested this from multiple scenarios where the state is changed to MainMenuState and nothing seems to break.

_i am not sure why this bit of code exists in the first place actually since the camera reset call made just before it seems to work just fine but idk_

Footage of this problem happening in game (i apologize for the overlapping music i am too tired to rerecord this clip):

https://github.com/FunkinCrew/Funkin/assets/50346006/8ca36750-0ec5-468e-bdce-78bcecf5273e
