### PR TITLE
Field Read and Write Overloading for Prefereneces

### DIFF
--- a/source/funkin/Preferences.hx
+++ b/source/funkin/Preferences.hx
@@ -1,12 +1,70 @@
 package funkin;
 
+import haxe.ds.StringMap;
 import funkin.save.Save;
+
+/**
+ * An abstract class which behaves as a StringMap, caching all getters of options,
+ * while also providing a more versitile way of modders adding their own preference setters and getters,
+ * without requiring arbritrary Save instance calls or even null checking those instance calls.
+ *
+ * The reason for caching all the preferences into a StringMap, rather than just calling straight to Save data,
+ * is the use of the Reflect API. This caching aims to keep it's use of Reflection to a minimum.
+ */
+abstract PreferenceMap(StringMap<Any>)
+{
+  public function new()
+  {
+    this = new StringMap<Any>();
+  }
+
+  /**
+   * An operator overloading function, which returns either a cached instance of the current preference,
+   * or a Save instance call.
+   * @param key Alias for `key` in `StringMap#get(key)`.
+   * @return Any
+   */
+  @:op(a.b)
+  inline function fieldReadOverload(key:String):Any
+  {
+    // Previously, I did null condition the Save instance, but the getter for instance already does the null checking.
+    if (!this.exists(key)) this.set(key, Reflect.field(Save.instance.options, key));
+    return this.get(key);
+  }
+
+  /**
+   * An operator overloading function, which sets not only the Save data for the preference
+   * but also sets itself into this, as to not conflict with the getter.
+   * @param key Alias for `key` in `StringMap#set(key, value)`.
+   * @param value Alias for `value` in `StringMap#set(key, value)`.
+   * @return Any
+   */
+  @:op(a.b)
+  inline function fieldWriteOverload(key:String, value:Any):Any
+  {
+    Reflect.setField(Save.instance.options, key, value);
+    Save.instance.flush();
+    this.set(key, value);
+    return value;
+  }
+}
 
 /**
  * A core class which provides a store of user-configurable, globally relevant values.
  */
 class Preferences
 {
+  static final PREFERENCE_MAP:PreferenceMap = new PreferenceMap();
+
+  /**
+   * Gets a abstracted StringMap, which acts as a wrapper for getting and setting Save option data.
+   * @return PreferenceMap
+   */
+  public static function get():PreferenceMap
+  {
+    return PREFERENCE_MAP;
+  }
+
   /**
    * Whether some particularly fowl language is displayed.
    * @default `true`
@@ -15,14 +73,12 @@ class Preferences
 
   static function get_naughtyness():Bool
   {
-    return Save?.instance?.options?.naughtyness;
+    return get().naughtyness;
   }
 
   static function set_naughtyness(value:Bool):Bool
   {
-    var save:Save = Save.instance;
-    save.options.naughtyness = value;
-    save.flush();
+    get().naughtyness = value;
     return value;
   }
 
@@ -34,14 +90,12 @@ class Preferences
 
   static function get_downscroll():Bool
   {
-    return Save?.instance?.options?.downscroll;
+    return get().downscroll;
   }
 
   static function set_downscroll(value:Bool):Bool
   {
-    var save:Save = Save.instance;
-    save.options.downscroll = value;
-    save.flush();
+    get().downscroll = value;
     return value;
   }
 
@@ -53,14 +107,12 @@ class Preferences
 
   static function get_flashingLights():Bool
   {
-    return Save?.instance?.options?.flashingLights ?? true;
+    return get().flashingLights ?? true;
   }
 
   static function set_flashingLights(value:Bool):Bool
   {
-    var save:Save = Save.instance;
-    save.options.flashingLights = value;
-    save.flush();
+    get().flashingLights = value;
     return value;
   }
 
@@ -72,14 +124,12 @@ class Preferences
 
   static function get_zoomCamera():Bool
   {
-    return Save?.instance?.options?.zoomCamera;
+    return get().zoomCamera;
   }
 
   static function set_zoomCamera(value:Bool):Bool
   {
-    var save:Save = Save.instance;
-    save.options.zoomCamera = value;
-    save.flush();
+    get().zoomCamera = value;
     return value;
   }
 
@@ -91,19 +141,16 @@ class Preferences
 
   static function get_debugDisplay():Bool
   {
-    return Save?.instance?.options?.debugDisplay;
+    return get().debugDisplay;
   }
 
   static function set_debugDisplay(value:Bool):Bool
   {
-    if (value != Save.instance.options.debugDisplay)
+    if (value != get().debugDisplay)
     {
       toggleDebugDisplay(value);
     }
-
-    var save = Save.instance;
-    save.options.debugDisplay = value;
-    save.flush();
+    get().debugDisplay = value;
     return value;
   }
 
@@ -115,16 +162,13 @@ class Preferences
 
   static function get_autoPause():Bool
   {
-    return Save?.instance?.options?.autoPause ?? true;
+    return get().autoPause ?? true;
   }
 
   static function set_autoPause(value:Bool):Bool
   {
-    if (value != Save.instance.options.autoPause) FlxG.autoPause = value;
-
-    var save:Save = Save.instance;
-    save.options.autoPause = value;
-    save.flush();
+    if (value != get().autoPause) FlxG.autoPause = value;
+    get().autoPause = value;
     return value;
   }
 

--- a/source/funkin/Preferences.hx
+++ b/source/funkin/Preferences.hx
@@ -78,8 +78,7 @@ class Preferences
 
   static function set_naughtyness(value:Bool):Bool
   {
-    get().naughtyness = value;
-    return value;
+    return get().naughtyness = value;
   }
 
   /**
@@ -95,8 +94,7 @@ class Preferences
 
   static function set_downscroll(value:Bool):Bool
   {
-    get().downscroll = value;
-    return value;
+    return get().downscroll = value;
   }
 
   /**
@@ -112,8 +110,7 @@ class Preferences
 
   static function set_flashingLights(value:Bool):Bool
   {
-    get().flashingLights = value;
-    return value;
+    return get().flashingLights = value;
   }
 
   /**
@@ -129,8 +126,7 @@ class Preferences
 
   static function set_zoomCamera(value:Bool):Bool
   {
-    get().zoomCamera = value;
-    return value;
+    return get().zoomCamera = value;
   }
 
   /**
@@ -150,8 +146,7 @@ class Preferences
     {
       toggleDebugDisplay(value);
     }
-    get().debugDisplay = value;
-    return value;
+    return get().debugDisplay = value;
   }
 
   /**
@@ -168,8 +163,7 @@ class Preferences
   static function set_autoPause(value:Bool):Bool
   {
     if (value != get().autoPause) FlxG.autoPause = value;
-    get().autoPause = value;
-    return value;
+    return get().autoPause = value;
   }
 
   /**


### PR DESCRIPTION
This adds an abstracted `PreferenceMap`, which behaves as a StringMap but with some field read and write overloading.

So now instead of needing to call:
```haxe
Save.instance.options.downscroll = true;
```
You can accomplish the same thing with:
```haxe
Preferences.get().downscroll = true;
```

There are other use cases for this but I'm tired and cannot bring myself to list them all right now