### PR TITLE
New judge application logic

### DIFF
--- a/source/funkin/modding/events/ScriptEvent.hx
+++ b/source/funkin/modding/events/ScriptEvent.hx
@@ -140,16 +140,29 @@ class HitNoteScriptEvent extends NoteScriptEvent
    */
   public var score:Int;
 
-  public function new(note:NoteSprite, healthChange:Float, score:Int, judgement:String, comboCount:Int = 0):Void
+  /**
+   * Whether the judgement caused a combo break.
+   */
+  public var isComboBreak:Bool = false;
+
+  /**
+   * The time difference when the player hit the note
+   */
+  public var hitDiff:Float = 0;
+
+  public function new(note:NoteSprite, healthChange:Float, score:Int, judgement:String, isComboBreak:Bool, comboCount:Int = 0, hitDiff:Float = 0):Void
   {
     super(NOTE_HIT, note, healthChange, comboCount, true);
     this.score = score;
     this.judgement = judgement;
+    this.isComboBreak = isComboBreak;
+    this.hitDiff = hitDiff;
   }
 
   public override function toString():String
   {
-    return 'HitNoteScriptEvent(note=' + note + ', comboCount=' + comboCount + ', judgement=' + judgement + ', score=' + score + ')';
+    return 'HitNoteScriptEvent(note=' + note + ', comboCount=' + comboCount + ', judgement=' + judgement + ', score=' + score + ', isComboBreak='
+      + isComboBreak + ', hitDiff=' + hitDiff + ')';
   }
 }
 

--- a/source/funkin/modding/events/ScriptEvent.hx
+++ b/source/funkin/modding/events/ScriptEvent.hx
@@ -141,7 +141,7 @@ class HitNoteScriptEvent extends NoteScriptEvent
   public var score:Int;
 
   /**
-   * Whether the judgement caused a combo break.
+   * If the hit causes a combo break.
    */
   public var isComboBreak:Bool = false;
 
@@ -150,19 +150,26 @@ class HitNoteScriptEvent extends NoteScriptEvent
    */
   public var hitDiff:Float = 0;
 
-  public function new(note:NoteSprite, healthChange:Float, score:Int, judgement:String, isComboBreak:Bool, comboCount:Int = 0, hitDiff:Float = 0):Void
+  /**
+   * If the hit causes a notesplash
+   */
+  public var doesNotesplash:Bool = false;
+
+  public function new(note:NoteSprite, healthChange:Float, score:Int, judgement:String, isComboBreak:Bool, comboCount:Int = 0, hitDiff:Float = 0,
+      doesNotesplash:Bool = false):Void
   {
     super(NOTE_HIT, note, healthChange, comboCount, true);
     this.score = score;
     this.judgement = judgement;
     this.isComboBreak = isComboBreak;
+    this.doesNotesplash = doesNotesplash;
     this.hitDiff = hitDiff;
   }
 
   public override function toString():String
   {
     return 'HitNoteScriptEvent(note=' + note + ', comboCount=' + comboCount + ', judgement=' + judgement + ', score=' + score + ', isComboBreak='
-      + isComboBreak + ', hitDiff=' + hitDiff + ')';
+      + isComboBreak + ', hitDiff=' + hitDiff + ', doesNotesplash=' + doesNotesplash + ')';
   }
 }
 

--- a/source/funkin/play/PlayState.hx
+++ b/source/funkin/play/PlayState.hx
@@ -2552,7 +2552,7 @@ class PlayState extends MusicBeatSubState
       if (isChartingMode)
       {
         if (FlxG.sound.music != null) FlxG.sound.music.pause(); // Don't reset song position!
-        PlayState.instance.close(); // This only works because PlayState is a substate!
+        this.close(); // This only works because PlayState is a substate!
       }
       else
       {

--- a/source/funkin/play/PlayState.hx
+++ b/source/funkin/play/PlayState.hx
@@ -2555,20 +2555,12 @@ class PlayState extends MusicBeatSubState
     // Redirect to the chart editor playing the current song.
     if (controls.DEBUG_CHART)
     {
-      if (isChartingMode)
-      {
-        if (FlxG.sound.music != null) FlxG.sound.music.pause(); // Don't reset song position!
-        this.close(); // This only works because PlayState is a substate!
-      }
-      else
-      {
-        disableKeys = true;
-        persistentUpdate = false;
-        FlxG.switchState(() -> new ChartEditorState(
-          {
-            targetSongId: currentSong.id,
-          }));
-      }
+      disableKeys = true;
+      persistentUpdate = false;
+      FlxG.switchState(() -> new ChartEditorState(
+        {
+          targetSongId: currentSong.id,
+        }));
     }
     #end
 

--- a/source/funkin/play/PlayState.hx
+++ b/source/funkin/play/PlayState.hx
@@ -2549,12 +2549,20 @@ class PlayState extends MusicBeatSubState
     // Redirect to the chart editor playing the current song.
     if (controls.DEBUG_CHART)
     {
-      disableKeys = true;
-      persistentUpdate = false;
-      FlxG.switchState(() -> new ChartEditorState(
-        {
-          targetSongId: currentSong.id,
-        }));
+      if (isChartingMode)
+      {
+        if (FlxG.sound.music != null) FlxG.sound.music.pause(); // Don't reset song position!
+        PlayState.instance.close(); // This only works because PlayState is a substate!
+      }
+      else
+      {
+        disableKeys = true;
+        persistentUpdate = false;
+        FlxG.switchState(() -> new ChartEditorState(
+          {
+            targetSongId: currentSong.id,
+          }));
+      }
     }
     #end
 

--- a/source/funkin/play/PlayState.hx
+++ b/source/funkin/play/PlayState.hx
@@ -2400,7 +2400,8 @@ class PlayState extends MusicBeatSubState
     }
 
     // Send the note hit event.
-    var event:HitNoteScriptEvent = new HitNoteScriptEvent(note, healthChange, score, daRating, isComboBreak, Highscore.tallies.combo + 1, noteDiff);
+    var event:HitNoteScriptEvent = new HitNoteScriptEvent(note, healthChange, score, daRating, isComboBreak, Highscore.tallies.combo + 1, noteDiff,
+      daRating == 'sick');
     dispatchEvent(event);
 
     // Calling event.cancelEvent() skips all the other logic! Neat!
@@ -2409,7 +2410,7 @@ class PlayState extends MusicBeatSubState
     Highscore.tallies.totalNotesHit++;
     // Display the hit on the strums
     playerStrumline.hitNote(note, !isComboBreak);
-    if (daRating == 'sick') playerStrumline.playNoteSplash(note.noteData.getDirection());
+    if (event.doesNotesplash) playerStrumline.playNoteSplash(note.noteData.getDirection());
     if (note.isHoldNote && note.holdNoteSprite != null) playerStrumline.playNoteHoldCover(note.holdNoteSprite);
     vocals.playerVolume = 1;
 

--- a/source/funkin/ui/debug/charting/ChartEditorState.hx
+++ b/source/funkin/ui/debug/charting/ChartEditorState.hx
@@ -6304,7 +6304,7 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
       var tempNote:NoteSprite = new NoteSprite(NoteStyleRegistry.instance.fetchDefault());
       tempNote.noteData = noteData;
       tempNote.scrollFactor.set(0, 0);
-      var event:NoteScriptEvent = new HitNoteScriptEvent(tempNote, 0.0, 0, 'perfect', 0);
+      var event:NoteScriptEvent = new HitNoteScriptEvent(tempNote, 0.0, 0, 'perfect', false, 0);
       dispatchEvent(event);
 
       // Calling event.cancelEvent() skips all the other logic! Neat!


### PR DESCRIPTION
Does a couple of things:
- Adds hitDiff to HitNoteScriptEvent
- Adds isComboBreak to HitNoteScriptEvent
- Adds doesNotesplash to HitNoteScriptEvent
- Moved code related to applying the judgement stats (score, health, etc) to a new applyScore function
- popupScore now only has 2 arguments, judgement and combo.


So, why these changes?
popupScore was a bit of a misleading title, as it doesn't just display the judges, but it also applied logic related to them, so I have split the functionality between popupScore and applyScore. This, in my opinion, makes a lot more sense and allows for scripts to display judgements seperately from score application, i.e in the case of mine/hurt notes where maybe they'd want to display a custom judgement to show that you hit a mine. Perhaps HitNoteScriptEvent.showScore can be a thing, which'd toggle whether popupScore is called or not (though in scripts you could just event.cancel and call applyScore yourself without calling popupScore to hide the judgement display)

The changes to HitNoteScriptEvent to add doesNotesplash , hitDiff and isComboBreak is to give more freedom to modders when doing things on note hit, such as special note kinds with lower hitboxes, like mines, or even custom judgements.

Mines, when implemented in FNF mods, generally combo break and have a smaller hitbox, so an example Mine script's onNoteHit could look a bit like this:
```haxe
override function onNoteHit(event){
  if(event.note.kind == 'mine'){
    var noteDiff = event.hitDiff;
    if(Math.abs(noteDiff) > 60){ // Lowers the hitbox from the full 166ms to 60ms.
      event.cancel();
      return;
    }
    event.isComboBreak = true;
    event.healthChange = -0.2;
    event.judgement = 'mine';
    event.score = -150;
    event.doesNotesplash = false;
  }
}
```

This would not be as easily possible without these changes to HitNoteScriptEvent and how score is applied.
