### PR TITLE
Add pixelPerfect to WiggleEffect [READ DESC!!!]

### DIFF
--- a/source/funkin/graphics/shaders/WiggleEffectRuntime.hx
+++ b/source/funkin/graphics/shaders/WiggleEffectRuntime.hx
@@ -65,7 +65,15 @@ class WiggleEffectRuntime extends FlxRuntimeShader
     return time = v;
   }
 
-  public function new(speed:Float, freq:Float, amplitude:Float, ?effect:WiggleEffectType = DREAMY):Void
+  var pixelPerfect(default, set):Bool = false;
+
+  function set_pixelPerfect(v:Bool):Bool
+  {
+    this.setBool('uPixelPerfect', v);
+    return pixelPerfect = v;
+  }
+
+  public function new(speed:Float, freq:Float, amplitude:Float, ?effect:WiggleEffectType = DREAMY, ?pixelPerfect:Bool = false):Void
   {
     super(Assets.getText(Paths.frag('wiggle')));
 
@@ -74,6 +82,7 @@ class WiggleEffectRuntime extends FlxRuntimeShader
     this.waveFrequency = freq;
     this.waveAmplitude = amplitude;
     this.effectType = effect;
+    this.pixelPerfect = pixelPerfect;
   }
 
   public function update(elapsed:Float)


### PR DESCRIPTION
### IMPORTANT!!
**This is a source part of WggleEffect fix!**
**Asset part of this fix: https://github.com/FunkinCrew/funkin.assets/pull/2**

### So what this does?
- Makes pixel perfect element of the shader optional.
- If pixel perfect flag is set - applies it to all shader modes.

### Examples
https://github.com/FunkinCrew/Funkin/assets/87835336/c4bee04a-ee6d-4a9f-b2fe-48935fbee1b2

https://github.com/FunkinCrew/Funkin/assets/87835336/f194e7ab-34c1-4618-a524-a594910aad12

### BEFORE
![small_wiggle_shader_fix_showcase_BEFORE](https://github.com/FunkinCrew/Funkin/assets/87835336/b1254b5b-fa09-4f26-a0e8-d97923c346a7)
### AFTER
![small_wiggle_shader_fix_showcase_AFTER](https://github.com/FunkinCrew/Funkin/assets/87835336/27b2dc9f-e6b3-4b29-a724-c6bbf2da60e5)
