### PR TITLE
fix focuscamera CLASSIC breaking zooms and snapping

### DIFF
--- a/source/funkin/play/PlayState.hx
+++ b/source/funkin/play/PlayState.hx
@@ -3128,7 +3128,7 @@ class PlayState extends MusicBeatSubState
   /**
    * Resets the camera's zoom level and focus point.
    */
-  public function resetCamera(?resetZoom:Bool = true, ?cancelTweens:Bool = true):Void
+  public function resetCamera(?resetZoom:Bool = true, ?cancelTweens:Bool = true, ?snap:Bool = true):Void
   {
     // Cancel camera tweens if any are active.
     if (cancelTweens)
@@ -3145,7 +3145,7 @@ class PlayState extends MusicBeatSubState
     }
 
     // Snap the camera to the follow point immediately.
-    FlxG.camera.focusOn(cameraFollowPoint.getPosition());
+    if (snap) FlxG.camera.focusOn(cameraFollowPoint.getPosition());
   }
 
   /**

--- a/source/funkin/play/event/FocusCameraSongEvent.hx
+++ b/source/funkin/play/event/FocusCameraSongEvent.hx
@@ -127,7 +127,7 @@ class FocusCameraSongEvent extends SongEvent
     switch (ease)
     {
       case 'CLASSIC': // Old-school. No ease. Just set follow point.
-        PlayState.instance.resetCamera(false, true);
+        PlayState.instance.cancelCameraFollowTween();
         PlayState.instance.cameraFollowPoint.setPosition(targetX, targetY);
       case 'INSTANT': // Instant ease. Duration is automatically 0.
         PlayState.instance.tweenCameraToPosition(targetX, targetY, 0);

--- a/source/funkin/play/event/FocusCameraSongEvent.hx
+++ b/source/funkin/play/event/FocusCameraSongEvent.hx
@@ -127,6 +127,7 @@ class FocusCameraSongEvent extends SongEvent
     switch (ease)
     {
       case 'CLASSIC': // Old-school. No ease. Just set follow point.
+        PlayState.instance.resetCamera(false, false, false);
         PlayState.instance.cancelCameraFollowTween();
         PlayState.instance.cameraFollowPoint.setPosition(targetX, targetY);
       case 'INSTANT': // Instant ease. Duration is automatically 0.


### PR DESCRIPTION
When using Classic on FocusCamera, you have to place any zooms AFTER it, because it breaks them. It also snaps the camera, creating for jerky movement when having to use many Classic camera movements
This fixes that behaviour