### PR TITLE
fix offsets being fucked on scaled characters

### DIFF
--- a/source/funkin/play/character/BaseCharacter.hx
+++ b/source/funkin/play/character/BaseCharacter.hx
@@ -124,8 +124,10 @@ class BaseCharacter extends Bopper
     if ((animOffsets[0] == value[0]) && (animOffsets[1] == value[1])) return value;
 
     // Make sure animOffets are halved when scale is 0.5.
-    var xDiff = (animOffsets[0] * this.scale.x / (this.isPixel ? 6 : 1)) - value[0];
-    var yDiff = (animOffsets[1] * this.scale.y / (this.isPixel ? 6 : 1)) - value[1];
+    var scaleX = this.scale.x / (this.isPixel ? 6 : 1);
+    var scaleY = this.scale.y / (this.isPixel ? 6 : 1);
+    var xDiff = (animOffsets[0] * scaleX) - (value[0] * scaleX);
+    var yDiff = (animOffsets[1] * scaleY) - (value[1] * scaleY);
 
     // Call the super function so that camera focus point is not affected.
     super.set_x(this.x + xDiff);


### PR DESCRIPTION
when a character is scaled they will slowly fly away

personally I think it'd be better to have a seperate animOffset point that gets added in the draw call but whatev
(this current approach of doing offsets could ESPECIALLY fuck with characters with scrollFactor not set to 1, 1!)