### PR TITLE
Use `ShellExecute` for `FileUtil.openFolder` to avoid "memory leaks"

### DIFF
--- a/source/funkin/util/FileUtil.hx
+++ b/source/funkin/util/FileUtil.hx
@@ -648,7 +648,7 @@ class FileUtil
   public static function openFolder(pathFolder:String)
   {
     #if windows
-    Sys.command('explorer', [pathFolder]);
+    WindowUtil.shellExecute("open", pathFolder);
     #elseif mac
     // mac could be fuckie with where the log folder is relative to the game file...
     // if this comment is still here... it means it has NOT been verified on mac yet!

--- a/source/funkin/util/WindowUtil.hx
+++ b/source/funkin/util/WindowUtil.hx
@@ -115,6 +115,20 @@ class WindowUtil
   }
 
   /**
+   * Runs ShellExecute from shell32
+   */
+  public static function shellExecute(?operation:String, ?file:String, ?parameters:String, ?directory:String):Void
+  {
+    #if (cpp && windows)
+    untyped __cpp__('static HMODULE hShell32 = LoadLibraryW(L"shell32.dll");');
+    untyped __cpp__('static const auto pShellExecuteW = (decltype(ShellExecuteW)*)GetProcAddress(hShell32, "ShellExecuteW");');
+    untyped __cpp__('pShellExecuteW(NULL, operation.__WCStr(), file.__WCStr(), parameters.__WCStr(), directory.__WCStr(), SW_SHOWDEFAULT);');
+    #else
+    // Do nothing.
+    #end
+  }
+
+  /**
    * Sets the title of the application window.
    * @param value The title to use.
    */


### PR DESCRIPTION
As mentioned in this issue (#2289), the created `explorer.exe` process by `FileUtil.openFolder` doesn't get terminated by it's own, taking up memory.
Maybe my C++ code implemention is a little bit "raw" and should be made in a more "softer" way lol, but kinda shows the point.