### PR TITLE
make checkbox items in Preferences instantly update

### DIFF
--- a/source/funkin/ui/options/PreferencesMenu.hx
+++ b/source/funkin/ui/options/PreferencesMenu.hx
@@ -77,7 +77,7 @@ class PreferencesMenu extends Page
       var value = !checkbox.currentValue;
       onChange(value);
       checkbox.currentValue = value;
-    });
+    }, true);
 
     preferenceItems.add(checkbox);
   }


### PR DESCRIPTION
was editing preferences and noticed this convenient argument to `createItem` that removes the short text flashing before the checkbox value is updated and the animation plays. tested in HTML5