### PR TITLE
Character selection fix for chart editor

### DIFF
--- a/source/funkin/ui/debug/charting/dialogs/ChartEditorCharacterIconSelectorMenu.hx
+++ b/source/funkin/ui/debug/charting/dialogs/ChartEditorCharacterIconSelectorMenu.hx
@@ -67,7 +67,7 @@ class ChartEditorCharacterIconSelectorMenu extends ChartEditorBaseMenu
 
     var charGrid = new Grid();
     charGrid.columns = 5;
-    charGrid.width = 100;
+    charGrid.width = this.width;
     charSelectScroll.addComponent(charGrid);
 
     var charIds:Array<String> = CharacterDataParser.listCharacterIds();


### PR DESCRIPTION
![image](https://github.com/FunkinCrew/Funkin/assets/22872042/8c83394c-060e-4ec0-ab93-0ce6969beecf)
This corrects an issue within the character dropdown grid of the chart editor, where the user cannot select them because of the previous hitbox width of the grid. Mention of this bug is found here: #2279 
![image](https://github.com/FunkinCrew/Funkin/assets/22872042/80e450fc-de3e-4503-baad-2187f2289ed9)
With this change it makes these characters selectable. No issues known so far