### PR TITLE
Polish for the transition from GameOverSubState back into PlayState.

### DIFF
--- a/source/funkin/play/PlayState.hx
+++ b/source/funkin/play/PlayState.hx
@@ -826,6 +826,8 @@ class PlayState extends MusicBeatSubState
 
       resetCamera();
 
+      var fromDeathState = isPlayerDying;
+
       persistentUpdate = true;
       persistentDraw = true;
 
@@ -863,8 +865,11 @@ class PlayState extends MusicBeatSubState
 
       if (currentStage != null) currentStage.resetStage();
 
-      playerStrumline.vwooshNotes();
-      opponentStrumline.vwooshNotes();
+      if (!fromDeathState)
+      {
+        playerStrumline.vwooshNotes();
+        opponentStrumline.vwooshNotes();
+      }
 
       playerStrumline.clean();
       opponentStrumline.clean();
@@ -1075,6 +1080,22 @@ class PlayState extends MusicBeatSubState
 
   function moveToGameOver():Void
   {
+    // Reset and update a bunch of values in advance for the transition back from the game over substate.
+    playerStrumline.clean();
+    opponentStrumline.clean();
+
+    songScore = 0;
+    updateScoreText();
+
+    health = Constants.HEALTH_STARTING;
+    healthLerp = health;
+
+    healthBar.value = healthLerp;
+
+    iconP1.updatePosition();
+    iconP2.updatePosition();
+
+    // Transition to the game over substate.
     var gameOverSubState = new GameOverSubState(
       {
         isChartingMode: isChartingMode,


### PR DESCRIPTION
When retrying from the GameOverSubState the current implementation has some issues due to being a sub state now.
This PR attempts to fix those issues.

Things that are altered:
- The "vwoosh" transition is removed from game overs.
- Notes are cleaned before entering the sub state, fixing a flicker effect while the black fade out is playing.
- The health bar (and its icons) no longer lerp back to the default value upon returning to PlayState.
- The score is no longer retained for one frame.

The way this is done is admittedly a little hacky, but is (what i believe to be) the best way around it without making any major alterations to the code. _(Scary)_

I am unsure if the vwoosh transition and the health bar lerp is intended when retrying a song through the GameOverSubState. So those changes are subjective.
Completely understand if this isn't merged due to my lack of information on that regard.

Heres a before and after video:

https://github.com/FunkinCrew/Funkin/assets/50346006/52a36d30-abf1-4ca0-bd85-0b19bd609dde

