### PR TITLE
Replace hmm lib funkin.vis commit hash with 'new' one

### DIFF
--- a/hmm.json
+++ b/hmm.json
@@ -49,7 +49,7 @@
       "name": "funkin.vis",
       "type": "git",
       "dir": null,
-      "ref": "98c9db09f0bbfedfe67a84538a5814aaef80bdea",
+      "ref": "d7f88b765a9e4ef51a1628d53354abfdea8b928d",
       "url": "https://github.com/FunkinCrew/funkVis"
     },
     {


### PR DESCRIPTION
As I mentioned in https://github.com/FunkinCrew/Funkin/issues/2298, currently `hmm.json` contains an outdated hash for a funkVis commit which causes `hmm install` to fail.