### PR TITLE
[FEATURE] Scroll Speed Event

### DIFF
--- a/source/funkin/play/PlayState.hx
+++ b/source/funkin/play/PlayState.hx
@@ -3294,6 +3294,7 @@ class PlayState extends MusicBeatSubState
         tween.cancel();
       }
     }
+    scrollSpeedTweens = [];
   }
 
   #if (debug || FORCE_DEBUG_VERSION)

--- a/source/funkin/play/PlayState.hx
+++ b/source/funkin/play/PlayState.hx
@@ -827,6 +827,8 @@ class PlayState extends MusicBeatSubState
     {
       if (!assertChartExists()) return;
 
+      prevScrollTargets = [];
+
       dispatchEvent(new ScriptEvent(SONG_RETRY));
 
       resetCamera();
@@ -3272,8 +3274,8 @@ class PlayState extends MusicBeatSubState
     // Snap to previous event value to prevent the tween breaking when another event cancels the previous tween.
     for (i in prevScrollTargets)
     {
-      var value:Float = i[1];
-      var strum:Strumline = Reflect.getProperty(this, i[0]);
+      var value:Float = i[0];
+      var strum:Strumline = Reflect.getProperty(this, i[1]);
       strum.scrollSpeed = value;
     }
 

--- a/source/funkin/play/PlayState.hx
+++ b/source/funkin/play/PlayState.hx
@@ -239,7 +239,7 @@ class PlayState extends MusicBeatSubState
   /**
    * An FlxTween that changes the additive speed to the desired amount.
    */
-  public var additiveScrollSpeedTween:FlxTween;
+  public var scrollSpeedTweens:Array<FlxTween> = [];
 
   /**
    * The camera follow point from the last stage.
@@ -1184,10 +1184,14 @@ class PlayState extends MusicBeatSubState
         cameraZoomTween.active = false;
         cameraTweensPausedBySubState.add(cameraZoomTween);
       }
-      if (additiveScrollSpeedTween != null && additiveScrollSpeedTween.active)
+
+      for (tween in scrollSpeedTweens)
       {
-        additiveScrollSpeedTween.active = false;
-        cameraTweensPausedBySubState.add(additiveScrollSpeedTween);
+        if (tween != null && tween.active)
+        {
+          tween.active = false;
+          cameraTweensPausedBySubState.add(tween);
+        }
       }
 
       // Pause the countdown.
@@ -3035,7 +3039,7 @@ class PlayState extends MusicBeatSubState
 
     // Cancel camera and scroll tweening if it's active.
     cancelAllCameraTweens();
-    cancelAdditiveScrollSpeedTween();
+    cancelScrollSpeedTweens();
 
     // If the opponent is GF, zoom in on the opponent.
     // Else, if there is no GF, zoom in on BF.
@@ -3256,37 +3260,39 @@ class PlayState extends MusicBeatSubState
   }
 
   /**
-   * The magical function that shall tween the additive scroll speed.
+   * The magical function that shall tween the scroll speed.
    */
-  public function tweenAdditiveScrollSpeed(?speed:Float, ?duration:Float, ?ease:Null<Float->Float>):Void
+  public function tweenScrollSpeed(?speed:Float, ?duration:Float, ?ease:Null<Float->Float>, strumlines:Array<String>):Void
   {
     // Cancel the current tween if it's active.
-    cancelAdditiveScrollSpeedTween();
-    var strumLineTargets:Array<Float> = [
-      playerStrumline.scrollSpeedAdditive + speed,
-      opponentStrumline.scrollSpeedAdditive + speed
-    ];
+    cancelScrollSpeedTweens();
+    for (i in strumlines)
+    {
+      var value:Float = speed;
+      var strum:Strumline = Reflect.getProperty(this, i);
 
-    if (duration == 0)
-    {
-      playerStrumline.scrollSpeedAdditive = strumLineTargets[0];
-      opponentStrumline.scrollSpeedAdditive = strumLineTargets[1];
-    }
-    else
-    {
-      additiveScrollSpeedTween = FlxTween.tween(this,
-        {
-          "playerStrumline.scrollSpeedAdditive": strumLineTargets[0],
-          "opponentStrumline.scrollSpeedAdditive": strumLineTargets[1]
-        }, duration, {ease: ease});
+      if (duration == 0)
+      {
+        strum.scrollSpeed = value;
+      }
+      else
+      {
+        scrollSpeedTweens.push(FlxTween.tween(strum,
+          {
+            'scrollSpeed': value
+          }, duration, {ease: ease}));
+      }
     }
   }
 
-  public function cancelAdditiveScrollSpeedTween()
+  public function cancelScrollSpeedTweens()
   {
-    if (additiveScrollSpeedTween != null)
+    for (tween in scrollSpeedTweens)
     {
-      additiveScrollSpeedTween.cancel();
+      if (tween != null)
+      {
+        tween.cancel();
+      }
     }
   }
 

--- a/source/funkin/play/PlayState.hx
+++ b/source/funkin/play/PlayState.hx
@@ -237,6 +237,11 @@ class PlayState extends MusicBeatSubState
   public var cameraZoomTween:FlxTween;
 
   /**
+   * An FlxTween that changes the additive speed to the desired amount.
+   */
+  public var additiveScrollSpeedTween:FlxTween;
+
+  /**
    * The camera follow point from the last stage.
    * Used to persist the position of the `cameraFollowPosition` between levels.
    */
@@ -1178,6 +1183,11 @@ class PlayState extends MusicBeatSubState
       {
         cameraZoomTween.active = false;
         cameraTweensPausedBySubState.add(cameraZoomTween);
+      }
+      if (additiveScrollSpeedTween != null && additiveScrollSpeedTween.active)
+      {
+        additiveScrollSpeedTween.active = false;
+        cameraTweensPausedBySubState.add(additiveScrollSpeedTween);
       }
 
       // Pause the countdown.
@@ -3023,8 +3033,9 @@ class PlayState extends MusicBeatSubState
     // Stop camera zooming on beat.
     cameraZoomRate = 0;
 
-    // Cancel camera tweening if it's active.
+    // Cancel camera and scroll tweening if it's active.
     cancelAllCameraTweens();
+    cancelAdditiveScrollSpeedTween();
 
     // If the opponent is GF, zoom in on the opponent.
     // Else, if there is no GF, zoom in on BF.
@@ -3242,6 +3253,41 @@ class PlayState extends MusicBeatSubState
   {
     cancelCameraFollowTween();
     cancelCameraZoomTween();
+  }
+
+  /**
+   * The magical function that shall tween the additive scroll speed.
+   */
+  public function tweenAdditiveScrollSpeed(?speed:Float, ?duration:Float, ?ease:Null<Float->Float>):Void
+  {
+    // Cancel the current tween if it's active.
+    cancelAdditiveScrollSpeedTween();
+    var strumLineTargets:Array<Float> = [
+      playerStrumline.scrollSpeedAdditive + speed,
+      opponentStrumline.scrollSpeedAdditive + speed
+    ];
+
+    if (duration == 0)
+    {
+      playerStrumline.scrollSpeedAdditive = strumLineTargets[0];
+      opponentStrumline.scrollSpeedAdditive = strumLineTargets[1];
+    }
+    else
+    {
+      additiveScrollSpeedTween = FlxTween.tween(this,
+        {
+          "playerStrumline.scrollSpeedAdditive": strumLineTargets[0],
+          "opponentStrumline.scrollSpeedAdditive": strumLineTargets[1]
+        }, duration, {ease: ease});
+    }
+  }
+
+  public function cancelAdditiveScrollSpeedTween()
+  {
+    if (additiveScrollSpeedTween != null)
+    {
+      additiveScrollSpeedTween.cancel();
+    }
   }
 
   #if (debug || FORCE_DEBUG_VERSION)

--- a/source/funkin/play/PlayState.hx
+++ b/source/funkin/play/PlayState.hx
@@ -3259,6 +3259,8 @@ class PlayState extends MusicBeatSubState
     cancelCameraZoomTween();
   }
 
+  var prevScrollTargets:Array<Dynamic> = []; // used to snap scroll speed when things go unruely
+
   /**
    * The magical function that shall tween the scroll speed.
    */
@@ -3266,6 +3268,18 @@ class PlayState extends MusicBeatSubState
   {
     // Cancel the current tween if it's active.
     cancelScrollSpeedTweens();
+
+    // Snap to previous event value to prevent the tween breaking when another event cancels the previous tween.
+    for (i in prevScrollTargets)
+    {
+      var value:Float = i[1];
+      var strum:Strumline = Reflect.getProperty(this, i[0]);
+      strum.scrollSpeed = value;
+    }
+
+    // for next event, clean array.
+    prevScrollTargets = [];
+
     for (i in strumlines)
     {
       var value:Float = speed;
@@ -3282,6 +3296,8 @@ class PlayState extends MusicBeatSubState
             'scrollSpeed': value
           }, duration, {ease: ease}));
       }
+      // make sure charts dont break if the charter is dumb and stupid
+      prevScrollTargets.push([value, i]);
     }
   }
 

--- a/source/funkin/play/event/AdditiveScrollSpeedEvent.hx
+++ b/source/funkin/play/event/AdditiveScrollSpeedEvent.hx
@@ -1,0 +1,138 @@
+package funkin.play.event;
+
+import flixel.tweens.FlxTween;
+import flixel.FlxCamera;
+import flixel.tweens.FlxEase;
+// Data from the chart
+import funkin.data.song.SongData;
+import funkin.data.song.SongData.SongEventData;
+// Data from the event schema
+import funkin.play.event.SongEvent;
+import funkin.data.event.SongEventSchema;
+import funkin.data.event.SongEventSchema.SongEventFieldType;
+
+/**
+ * This class represents a handler for scroll speed events.
+ *
+ * Example: Scroll speed change of both strums from 1x to 1.3x:
+ * ```
+ * {
+ *   'e': 'AdditiveScrollSpeed',
+ *   "v": {
+ *      "scroll": "0.3",
+ *      "duration": "4",
+ *      "ease": "linear"
+ *    }
+ * }
+ * ```
+ */
+class AdditiveScrollSpeedEvent extends SongEvent
+{
+  public function new()
+  {
+    super('AdditiveScrollSpeed');
+  }
+
+  static final DEFAULT_SCROLL:Float = 0;
+  static final DEFAULT_DURATION:Float = 4.0;
+  static final DEFAULT_EASE:String = 'linear';
+
+  public override function handleEvent(data:SongEventData):Void
+  {
+    // Does nothing if there is no PlayState camera or stage.
+    if (PlayState.instance == null || PlayState.instance.currentStage == null) return;
+
+    var scroll:Float = data.getFloat('scroll') ?? DEFAULT_SCROLL;
+
+    var duration:Float = data.getFloat('duration') ?? DEFAULT_DURATION;
+
+    var ease:String = data.getString('ease') ?? DEFAULT_EASE;
+
+    // If it's a string, check the value.
+    switch (ease)
+    {
+      case 'INSTANT':
+        PlayState.instance.tweenAdditiveScrollSpeed(scroll, 0);
+      default:
+        var durSeconds = Conductor.instance.stepLengthMs * duration / 1000;
+        var easeFunction:Null<Float->Float> = Reflect.field(FlxEase, ease);
+        if (easeFunction == null)
+        {
+          trace('Invalid ease function: $ease');
+          return;
+        }
+
+        PlayState.instance.tweenAdditiveScrollSpeed(scroll, durSeconds, easeFunction);
+    }
+  }
+
+  public override function getTitle():String
+  {
+    return 'Additive Scroll Speed';
+  }
+
+  /**
+   * ```
+   * {
+   *   'scroll': FLOAT, // Target additive scroll level.
+   *   'duration': FLOAT, // Duration in steps.
+   *   'ease': ENUM, // Easing function.
+   * }
+   * @return SongEventSchema
+   */
+  public override function getEventSchema():SongEventSchema
+  {
+    return new SongEventSchema([
+      {
+        name: 'scroll',
+        title: 'Additive Scroll Amount',
+        defaultValue: 0.0,
+        step: 0.1,
+        type: SongEventFieldType.FLOAT,
+        units: 'x'
+      },
+      {
+        name: 'duration',
+        title: 'Duration',
+        defaultValue: 4.0,
+        step: 0.5,
+        type: SongEventFieldType.FLOAT,
+        units: 'steps'
+      },
+      {
+        name: 'ease',
+        title: 'Easing Type',
+        defaultValue: 'linear',
+        type: SongEventFieldType.ENUM,
+        keys: [
+          'Linear' => 'linear',
+          'Instant' => 'INSTANT',
+          'Sine In' => 'sineIn',
+          'Sine Out' => 'sineOut',
+          'Sine In/Out' => 'sineInOut',
+          'Quad In' => 'quadIn',
+          'Quad Out' => 'quadOut',
+          'Quad In/Out' => 'quadInOut',
+          'Cube In' => 'cubeIn',
+          'Cube Out' => 'cubeOut',
+          'Cube In/Out' => 'cubeInOut',
+          'Quart In' => 'quartIn',
+          'Quart Out' => 'quartOut',
+          'Quart In/Out' => 'quartInOut',
+          'Quint In' => 'quintIn',
+          'Quint Out' => 'quintOut',
+          'Quint In/Out' => 'quintInOut',
+          'Expo In' => 'expoIn',
+          'Expo Out' => 'expoOut',
+          'Expo In/Out' => 'expoInOut',
+          'Smooth Step In' => 'smoothStepIn',
+          'Smooth Step Out' => 'smoothStepOut',
+          'Smooth Step In/Out' => 'smoothStepInOut',
+          'Elastic In' => 'elasticIn',
+          'Elastic Out' => 'elasticOut',
+          'Elastic In/Out' => 'elasticInOut'
+        ]
+      }
+    ]);
+  }
+}

--- a/source/funkin/play/event/ScrollSpeedEvent.hx
+++ b/source/funkin/play/event/ScrollSpeedEvent.hx
@@ -36,6 +36,7 @@ class ScrollSpeedEvent extends SongEvent
   static final DEFAULT_SCROLL:Float = 1;
   static final DEFAULT_DURATION:Float = 4.0;
   static final DEFAULT_EASE:String = 'linear';
+  static final DEFAULT_ABSOLUTE:Bool = false;
   static final DEFAULT_STRUMLINE:String = 'both'; // my special little trick
 
   public override function handleEvent(data:SongEventData):Void
@@ -51,12 +52,14 @@ class ScrollSpeedEvent extends SongEvent
 
     var strumline:String = data.getString('strumline') ?? DEFAULT_STRUMLINE;
 
+    var absolute:Bool = data.getBool('absolute') ?? DEFAULT_ABSOLUTE;
+
     var strumlineNames:Array<String> = [];
 
-    if (scroll == 0)
+    if (!absolute)
     {
-      // if the parameter is set to 0, reset the scroll speed to normal.
-      scroll = PlayState.instance?.currentChart?.scrollSpeed ?? 1.0;
+      // If absolute is set to false, do the awesome multiplicative thing
+      scroll = scroll * (PlayState.instance?.currentChart?.scrollSpeed ?? 1.0);
     }
 
     switch (strumline)
@@ -103,8 +106,8 @@ class ScrollSpeedEvent extends SongEvent
     return new SongEventSchema([
       {
         name: 'scroll',
-        title: 'Scroll Amount',
-        defaultValue: 0.0,
+        title: 'Target Value',
+        defaultValue: 1.0,
         step: 0.1,
         type: SongEventFieldType.FLOAT,
         units: 'x'
@@ -157,6 +160,12 @@ class ScrollSpeedEvent extends SongEvent
         defaultValue: 'both',
         type: SongEventFieldType.ENUM,
         keys: ['Both' => 'both', 'Player' => 'player', 'Opponent' => 'opponent']
+      },
+      {
+        name: 'absolute',
+        title: 'Absolute',
+        defaultValue: false,
+        type: SongEventFieldType.BOOL,
       }
     ]);
   }

--- a/source/funkin/play/notes/Strumline.hx
+++ b/source/funkin/play/notes/Strumline.hx
@@ -52,6 +52,15 @@ class Strumline extends FlxSpriteGroup
    */
   public var conductorInUse(get, set):Conductor;
 
+  // Used in-game to control the scroll speed within a song, for example if a song has an additive scroll speed of 1 and the base scroll speed is 1, it will be 2 - burgerballs
+  public var scrollSpeedAdditive:Float = 0;
+  public var scrollSpeed(get, never):Float;
+
+  function get_scrollSpeed():Float
+  {
+    return (PlayState.instance?.currentChart?.scrollSpeed ?? 1.0) + scrollSpeedAdditive;
+  }
+
   var _conductorInUse:Null<Conductor>;
 
   function get_conductorInUse():Conductor
@@ -208,6 +217,11 @@ class Strumline extends FlxSpriteGroup
     return null;
   }
 
+  public function resetScrollSpeed():Void
+  {
+    scrollSpeedAdditive = 0;
+  }
+
   public function getHoldNoteSprite(noteData:SongNoteData):SustainTrail
   {
     if (noteData == null || ((noteData.length ?? 0.0) <= 0.0)) return null;
@@ -283,7 +297,6 @@ class Strumline extends FlxSpriteGroup
     // var vwoosh:Float = (strumTime < Conductor.songPosition) && vwoosh ? 2.0 : 1.0;
     // ^^^ commented this out... do NOT make it move faster as it moves offscreen!
     var vwoosh:Float = 1.0;
-    var scrollSpeed:Float = PlayState.instance?.currentChart?.scrollSpeed ?? 1.0;
 
     return
       Constants.PIXELS_PER_MS * (conductorInUse.songPosition - strumTime - Conductor.instance.inputOffset) * scrollSpeed * vwoosh * (Preferences.downscroll ? 1 : -1);
@@ -539,6 +552,7 @@ class Strumline extends FlxSpriteGroup
     {
       playStatic(dir);
     }
+    scrollSpeedAdditive = 0;
   }
 
   public function applyNoteData(data:Array<SongNoteData>):Void
@@ -705,6 +719,7 @@ class Strumline extends FlxSpriteGroup
 
     if (holdNoteSprite != null)
     {
+      holdNoteSprite.parentStrumline = this;
       holdNoteSprite.noteData = note;
       holdNoteSprite.strumTime = note.time;
       holdNoteSprite.noteDirection = note.getDirection();

--- a/source/funkin/play/notes/Strumline.hx
+++ b/source/funkin/play/notes/Strumline.hx
@@ -52,13 +52,12 @@ class Strumline extends FlxSpriteGroup
    */
   public var conductorInUse(get, set):Conductor;
 
-  // Used in-game to control the scroll speed within a song, for example if a song has an additive scroll speed of 1 and the base scroll speed is 1, it will be 2 - burgerballs
-  public var scrollSpeedAdditive:Float = 0;
-  public var scrollSpeed(get, never):Float;
+  // Used in-game to control the scroll speed within a song
+  public var scrollSpeed:Float = 1.0;
 
-  function get_scrollSpeed():Float
+  public function resetScrollSpeed():Void
   {
-    return (PlayState.instance?.currentChart?.scrollSpeed ?? 1.0) + scrollSpeedAdditive;
+    scrollSpeed = PlayState.instance?.currentChart?.scrollSpeed ?? 1.0;
   }
 
   var _conductorInUse:Null<Conductor>;
@@ -143,6 +142,7 @@ class Strumline extends FlxSpriteGroup
     this.refresh();
 
     this.onNoteIncoming = new FlxTypedSignal<NoteSprite->Void>();
+    resetScrollSpeed();
 
     for (i in 0...KEY_COUNT)
     {
@@ -215,11 +215,6 @@ class Strumline extends FlxSpriteGroup
     }
 
     return null;
-  }
-
-  public function resetScrollSpeed():Void
-  {
-    scrollSpeedAdditive = 0;
   }
 
   public function getHoldNoteSprite(noteData:SongNoteData):SustainTrail
@@ -552,7 +547,7 @@ class Strumline extends FlxSpriteGroup
     {
       playStatic(dir);
     }
-    scrollSpeedAdditive = 0;
+    resetScrollSpeed();
   }
 
   public function applyNoteData(data:Array<SongNoteData>):Void

--- a/source/funkin/play/notes/SustainTrail.hx
+++ b/source/funkin/play/notes/SustainTrail.hx
@@ -168,7 +168,6 @@ class SustainTrail extends FlxSprite
     if (s < 0.0) s = 0.0;
 
     if (sustainLength == s) return s;
-    graphicHeight = sustainHeight(s, parentStrumline?.scrollSpeed ?? 1.0);
     this.sustainLength = s;
     triggerRedraw();
     return this.sustainLength;
@@ -176,6 +175,7 @@ class SustainTrail extends FlxSprite
 
   function triggerRedraw()
   {
+    graphicHeight = sustainHeight(sustainLength, parentStrumline?.scrollSpeed ?? 1.0);
     updateClipping();
     updateHitbox();
   }

--- a/source/funkin/play/notes/SustainTrail.hx
+++ b/source/funkin/play/notes/SustainTrail.hx
@@ -168,6 +168,7 @@ class SustainTrail extends FlxSprite
     if (s < 0.0) s = 0.0;
 
     if (sustainLength == s) return s;
+    graphicHeight = sustainHeight(s, parentStrumline?.scrollSpeed ?? 1.0);
     this.sustainLength = s;
     triggerRedraw();
     return this.sustainLength;
@@ -175,7 +176,6 @@ class SustainTrail extends FlxSprite
 
   function triggerRedraw()
   {
-    graphicHeight = sustainHeight(sustainLength, parentStrumline?.scrollSpeed ?? 1.0);
     updateClipping();
     updateHitbox();
   }

--- a/source/funkin/ui/debug/charting/components/ChartEditorHoldNoteSprite.hx
+++ b/source/funkin/ui/debug/charting/components/ChartEditorHoldNoteSprite.hx
@@ -58,11 +58,11 @@ class ChartEditorHoldNoteSprite extends SustainTrail
   {
     if (lerp)
     {
-      sustainLength = FlxMath.lerp(sustainLength, h / (getScrollSpeed() * Constants.PIXELS_PER_MS), 0.25);
+      sustainLength = FlxMath.lerp(sustainLength, h / (getBaseScrollSpeed() * Constants.PIXELS_PER_MS), 0.25);
     }
     else
     {
-      sustainLength = h / (getScrollSpeed() * Constants.PIXELS_PER_MS);
+      sustainLength = h / (getBaseScrollSpeed() * Constants.PIXELS_PER_MS);
     }
 
     fullSustainLength = sustainLength;


### PR DESCRIPTION
https://github.com/FunkinCrew/Funkin/assets/107233412/d0626047-9dad-4ac7-8e01-3ced7b20f69f

What this PR does is implement a new event that sets the current scroll speed. As well as a public ``scrollSpeed`` variable in Strumline. Without adding any sustain-related rendering issues.

![image](https://github.com/FunkinCrew/Funkin/assets/107233412/4c3bb100-3b74-474e-8f0b-5d34507d5acc)

This PR also adds a ``parentStrumline`` variable to SustainTrail, and a way for it to redraw once the scroll speed changes.

https://github.com/FunkinCrew/Funkin/assets/107233412/8b5fe4d9-e78b-4000-afc0-7cb744b5d234

The event can also affect either strumline, an example of this is the video above!

![image](https://github.com/FunkinCrew/Funkin/assets/107233412/5f51c12f-7355-4330-b3d1-3efe4160f75c)
This event can also set the base scroll directly instead of acting as a multiplier (disabled by default)!

Setting the value to 1 with Absolute disabled will set the speed to the default. (important)

PS; i **ACTUALLY** tested it this time