### PR TITLE
Character Pixel Icon Data Accessed via Character Metadata

### DIFF
--- a/hmm.json
+++ b/hmm.json
@@ -49,7 +49,7 @@
       "name": "funkin.vis",
       "type": "git",
       "dir": null,
-      "ref": "98c9db09f0bbfedfe67a84538a5814aaef80bdea",
+      "ref": "2aa654b974507ab51ab1724d2d97e75726fd7d78",
       "url": "https://github.com/FunkinCrew/funkVis"
     },
     {

--- a/source/funkin/play/PlayState.hx
+++ b/source/funkin/play/PlayState.hx
@@ -2549,12 +2549,20 @@ class PlayState extends MusicBeatSubState
     // Redirect to the chart editor playing the current song.
     if (controls.DEBUG_CHART)
     {
-      disableKeys = true;
-      persistentUpdate = false;
-      FlxG.switchState(() -> new ChartEditorState(
-        {
-          targetSongId: currentSong.id,
-        }));
+      if (isChartingMode)
+      {
+        if (FlxG.sound.music != null) FlxG.sound.music.pause(); // Don't reset song position!
+        this.close(); // This only works because PlayState is a substate!
+      }
+      else
+      {
+        disableKeys = true;
+        persistentUpdate = false;
+        FlxG.switchState(() -> new ChartEditorState(
+          {
+            targetSongId: currentSong.id,
+          }));
+      }
     }
     #end
 

--- a/source/funkin/play/character/CharacterData.hx
+++ b/source/funkin/play/character/CharacterData.hx
@@ -281,39 +281,64 @@ class CharacterDataParser
   }
 
   /**
-   * TODO: Hardcode this.
+   * Fetches the character's pixel icon data.
+   * @param charId The character to load.
+   * @return The pixel icon data, or null if validation failed.
    */
-  public static function getCharPixelIconAsset(char:String):String
+  public static function getCharPixelIconData(charId:String):Null<PixelIconData>
   {
-    var icon:String = char;
-
-    switch (icon)
+    if (charId == null || charId == '' || !characterCache.exists(charId))
     {
-      case "bf-christmas" | "bf-car" | "bf-pixel" | "bf-holding-gf":
-        icon = "bf";
-      case "monster-christmas":
-        icon = "monster";
-      case "mom" | "mom-car":
-        icon = "mommy";
-      case "pico-blazin" | "pico-playable" | "pico-speaker":
-        icon = "pico";
-      case "gf-christmas" | "gf-car" | "gf-pixel" | "gf-tankmen":
-        icon = "gf";
-      case "dad":
-        icon = "daddy";
-      case "darnell-blazin":
-        icon = "darnell";
-      case "senpai-angry":
-        icon = "senpai";
-      case "tankman" | "tankman-atlas":
-        icon = "tankmen";
+      trace('Failed to fetch pixel icon, character not found in cache: ${charId}');
+      return null;
     }
 
-    var path = Paths.image("freeplay/icons/" + icon + "pixel");
-    if (Assets.exists(path)) return path;
+    var charData:CharacterData = characterCache.get(charId);
 
-    // TODO: Hardcode some additional behavior or a fallback.
-    return null;
+    if (charData != null && charData.pixelIcon != null)
+    {
+      return charData.pixelIcon;
+    }
+    else
+    {
+      trace('Pixel icon data not found for character: ${charId}');
+      return null;
+    }
+  }
+
+  /**
+   * Fetches the character's pixel icon path.
+   * @param charId The character to load.
+   * @return The pixel icon path, or null if validation failed.
+   */
+  public static function getCharPixelIconAsset(charId:String):String
+  {
+    if (charId == null || charId == '' || !characterCache.exists(charId))
+    {
+      trace('Failed to fetch pixel icon, character not found in cache: ${charId}');
+      return null;
+    }
+
+    var charData:CharacterData = characterCache.get(charId);
+    var path = Paths.image("freeplay/icons/" + charData.pixelIcon.id + "pixel");
+
+    if (charData != null && charData.pixelIcon != null)
+    {
+      if (Assets.exists(path))
+      {
+        return path;
+      }
+      else
+      {
+        trace('Pixel icon file does not exist: ${path}');
+        return null;
+      }
+    }
+    else
+    {
+      trace('Pixel icon data not found for character: ${charId}');
+      return null;
+    }
   }
 
   /**
@@ -394,6 +419,7 @@ class CharacterDataParser
   static final DEFAULT_NAME:String = 'Untitled Character';
   static final DEFAULT_OFFSETS:Array<Float> = [0, 0];
   static final DEFAULT_HEALTHICON_OFFSETS:Array<Int> = [0, 25];
+  static final DEFAULT_PIXELICON_ORIGIN:Array<Int> = [100, 0];
   static final DEFAULT_RENDERTYPE:CharacterRenderType = CharacterRenderType.Sparrow;
   static final DEFAULT_SCALE:Float = 1;
   static final DEFAULT_SCROLL:Array<Float> = [0, 0];
@@ -483,6 +509,31 @@ class CharacterDataParser
     if (input.healthIcon.offsets == null)
     {
       input.healthIcon.offsets = DEFAULT_OFFSETS;
+    }
+
+    if (input.pixelIcon == null)
+    {
+      input.pixelIcon =
+        {
+          id: null,
+          flipX: null,
+          origin: null
+        };
+    }
+
+    if (input.pixelIcon.id == null)
+    {
+      input.pixelIcon.id = id;
+    }
+
+    if (input.pixelIcon.flipX == null)
+    {
+      input.pixelIcon.flipX = DEFAULT_FLIPX;
+    }
+
+    if (input.pixelIcon.origin == null)
+    {
+      input.pixelIcon.origin = DEFAULT_PIXELICON_ORIGIN;
     }
 
     if (input.startingAnimation == null)
@@ -641,6 +692,11 @@ typedef CharacterData =
    */
   var healthIcon:Null<HealthIconData>;
 
+  /**
+   * Optional data about the pixel icon for the character.
+   */
+  var pixelIcon:Null<PixelIconData>;
+
   var death:Null<DeathData>;
 
   /**
@@ -734,6 +790,30 @@ typedef HealthIconData =
    * @default [0, 25]
    */
   var offsets:Null<Array<Float>>;
+}
+
+/**
+ * The JSON data schema used to define the pixel icon for a character.
+ */
+typedef PixelIconData =
+{
+  /**
+   * The ID to use for the pixel icon.
+   * @default The character's ID
+   */
+  var id:Null<String>;
+
+  /**
+   * Whether to flip the pixel icon horizontally.
+   * @default false
+   */
+  var flipX:Null<Bool>;
+
+  /**
+   * The origin of the pixel icon, in pixels.
+   * @default [100, 0]
+   */
+  var origin:Null<Array<Int>>;
 }
 
 typedef DeathData =

--- a/source/funkin/play/event/PlayAnimationSongEvent.hx
+++ b/source/funkin/play/event/PlayAnimationSongEvent.hx
@@ -31,25 +31,13 @@ class PlayAnimationSongEvent extends SongEvent
 
     switch (targetName)
     {
-      case 'boyfriend':
+      case 'boyfriend' || 'bf' || 'player':
         trace('Playing animation $anim on boyfriend.');
         target = PlayState.instance.currentStage.getBoyfriend();
-      case 'bf':
-        trace('Playing animation $anim on boyfriend.');
-        target = PlayState.instance.currentStage.getBoyfriend();
-      case 'player':
-        trace('Playing animation $anim on boyfriend.');
-        target = PlayState.instance.currentStage.getBoyfriend();
-      case 'dad':
+      case 'dad' || 'opponent':
         trace('Playing animation $anim on dad.');
         target = PlayState.instance.currentStage.getDad();
-      case 'opponent':
-        trace('Playing animation $anim on dad.');
-        target = PlayState.instance.currentStage.getDad();
-      case 'girlfriend':
-        trace('Playing animation $anim on girlfriend.');
-        target = PlayState.instance.currentStage.getGirlfriend();
-      case 'gf':
+      case 'girlfriend' || 'gf':
         trace('Playing animation $anim on girlfriend.');
         target = PlayState.instance.currentStage.getGirlfriend();
       default:

--- a/source/funkin/play/event/PlayAnimationSongEvent.hx
+++ b/source/funkin/play/event/PlayAnimationSongEvent.hx
@@ -31,13 +31,13 @@ class PlayAnimationSongEvent extends SongEvent
 
     switch (targetName)
     {
-      case 'boyfriend' || 'bf' || 'player':
+      case 'boyfriend' | 'bf' | 'player':
         trace('Playing animation $anim on boyfriend.');
         target = PlayState.instance.currentStage.getBoyfriend();
-      case 'dad' || 'opponent':
+      case 'dad' | 'opponent':
         trace('Playing animation $anim on dad.');
         target = PlayState.instance.currentStage.getDad();
-      case 'girlfriend' || 'gf':
+      case 'girlfriend' | 'gf':
         trace('Playing animation $anim on girlfriend.');
         target = PlayState.instance.currentStage.getGirlfriend();
       default:

--- a/source/funkin/play/notes/Strumline.hx
+++ b/source/funkin/play/notes/Strumline.hx
@@ -576,6 +576,8 @@ class Strumline extends FlxSpriteGroup
       note.holdNoteSprite.hitNote = true;
       note.holdNoteSprite.missedNote = false;
       note.holdNoteSprite.alpha = 1.0;
+
+      note.holdNoteSprite.sustainLength = (note.holdNoteSprite.strumTime + note.holdNoteSprite.fullSustainLength) - conductorInUse.songPosition;
     }
   }
 

--- a/source/funkin/ui/debug/charting/dialogs/ChartEditorCharacterIconSelectorMenu.hx
+++ b/source/funkin/ui/debug/charting/dialogs/ChartEditorCharacterIconSelectorMenu.hx
@@ -67,7 +67,7 @@ class ChartEditorCharacterIconSelectorMenu extends ChartEditorBaseMenu
 
     var charGrid = new Grid();
     charGrid.columns = 5;
-    charGrid.width = 100;
+    charGrid.width = this.width;
     charSelectScroll.addComponent(charGrid);
 
     var charIds:Array<String> = CharacterDataParser.listCharacterIds();

--- a/source/funkin/ui/freeplay/SongMenuItem.hx
+++ b/source/funkin/ui/freeplay/SongMenuItem.hx
@@ -5,6 +5,8 @@ import funkin.graphics.shaders.HSVShader;
 import funkin.graphics.shaders.GaussianBlurShader;
 import flixel.group.FlxGroup;
 import flixel.FlxSprite;
+import funkin.play.character.CharacterData;
+import funkin.play.character.CharacterData.CharacterDataParser;
 import flixel.graphics.frames.FlxAtlasFrames;
 import flixel.group.FlxSpriteGroup.FlxTypedSpriteGroup;
 import flixel.group.FlxSpriteGroup;
@@ -182,23 +184,14 @@ class SongMenuItem extends FlxSpriteGroup
   {
     var charPath:String = "freeplay/icons/";
 
-    // TODO: Put this in the character metadata where it belongs.
-    // TODO: Also, can use CharacterDataParser.getCharPixelIconAsset()
-    switch (char)
+    var charPixelIconData = CharacterDataParser.getCharPixelIconData(char);
+    if (charPixelIconData == null)
     {
-      case 'monster-christmas':
-        charPath += 'monsterpixel';
-      case 'mom-car':
-        charPath += 'mommypixel';
-      case 'dad':
-        charPath += 'daddypixel';
-      case 'darnell-blazin':
-        charPath += 'darnellpixel';
-      case 'senpai-angry':
-        charPath += 'senpaipixel';
-      default:
-        charPath += '${char}pixel';
+      trace('[WARN] Character ${char} has no pixel icon data.');
+      return;
     }
+
+    charPath += '${charPixelIconData.id}pixel';
 
     if (!openfl.utils.Assets.exists(Paths.image(charPath)))
     {
@@ -209,15 +202,10 @@ class SongMenuItem extends FlxSpriteGroup
     pixelIcon.loadGraphic(Paths.image(charPath));
     pixelIcon.scale.x = pixelIcon.scale.y = 2;
 
-    switch (char)
-    {
-      case 'parents-christmas':
-        pixelIcon.origin.x = 140;
-      default:
-        pixelIcon.origin.x = 100;
-    }
-    // pixelIcon.origin.x = capsule.origin.x;
-    // pixelIcon.offset.x -= pixelIcon.origin.x;
+    // Set the pixel icon x origin for position adjustments
+    pixelIcon.origin.x = charPixelIconData.origin[0];
+    // Set whether or not to flip the pixel icon
+    pixelIcon.flipX = charPixelIconData.flipX;
   }
 
   var frameInTicker:Float = 0;

--- a/source/funkin/ui/mainmenu/MainMenuState.hx
+++ b/source/funkin/ui/mainmenu/MainMenuState.hx
@@ -139,10 +139,6 @@ class MainMenuState extends MusicBeatState
 
     resetCamStuff();
 
-    subStateClosed.add(_ -> {
-      resetCamStuff();
-    });
-
     subStateOpened.add(sub -> {
       if (Type.getClass(sub) == FreeplayState)
       {

--- a/source/funkin/ui/title/TitleState.hx
+++ b/source/funkin/ui/title/TitleState.hx
@@ -283,6 +283,7 @@ class TitleState extends MusicBeatState
 
     if (FlxG.keys.justPressed.Y)
     {
+      FlxTween.cancelTweensOf(FlxG.stage.window, ['x', 'y']);
       FlxTween.tween(FlxG.stage.window, {x: FlxG.stage.window.x + 300}, 1.4, {ease: FlxEase.quadInOut, type: PINGPONG, startDelay: 0.35});
       FlxTween.tween(FlxG.stage.window, {y: FlxG.stage.window.y + 100}, 0.7, {ease: FlxEase.quadInOut, type: PINGPONG});
     }


### PR DESCRIPTION
Freeplay and the chart editor now read from character metadata instead of hard-coding assigned character pixel icons. Character metadata files updated with respective icons previously assigned in the source code. Additionally, the ability to flip the icons horizontally and adjusting the origin offset is now included via the metadata.
No issues found after testing.