### PR TITLE
Bump hxCodec commit (fixes Linux issue where it crashes after load)

### DIFF
--- a/hmm.json
+++ b/hmm.json
@@ -80,7 +80,7 @@
       "name": "hxCodec",
       "type": "git",
       "dir": null,
-      "ref": "c0c7f2680cc190c932a549c2e2fdd9b0ba2bd10e",
+      "ref": "2aa654b974507ab51ab1724d2d97e75726fd7d78",
       "url": "https://github.com/FunkinCrew/hxCodec"
     },
     {

--- a/hmm.json
+++ b/hmm.json
@@ -80,7 +80,7 @@
       "name": "hxCodec",
       "type": "git",
       "dir": null,
-      "ref": "2aa654b974507ab51ab1724d2d97e75726fd7d78",
+      "ref": "61b98a7a353b7f529a8fec84ed9afc919a2dffdd",
       "url": "https://github.com/FunkinCrew/hxCodec"
     },
     {


### PR DESCRIPTION
Currently the game will immediately close after loading on Linux builds, but the newest version of hxCodec fixes this

Should fix #2428 