### PR TITLE
[BUGFIX?] SaveData using a player 2 controls instead of player1 controls

### DIFF
--- a/source/funkin/save/Save.hx
+++ b/source/funkin/save/Save.hx
@@ -53,7 +53,8 @@ class Save
   public function new(?data:RawSaveData)
   {
     if (data == null) this.data = Save.getDefault();
-    else this.data = data;
+    else
+      this.data = data;
   }
 
   public static function getDefault():RawSaveData
@@ -559,9 +560,9 @@ class Save
     switch (inputType)
     {
       case Keys:
-        return (playerId == 0) ? data?.options?.controls?.p1.keyboard : data?.options?.controls?.p2.keyboard;
+        return (playerId == 1) ? data?.options?.controls?.p1.keyboard : data?.options?.controls?.p2.keyboard;
       case Gamepad(_):
-        return (playerId == 0) ? data?.options?.controls?.p1.gamepad : data?.options?.controls?.p2.gamepad;
+        return (playerId == 1) ? data?.options?.controls?.p1.gamepad : data?.options?.controls?.p2.gamepad;
     }
   }
 
@@ -576,27 +577,7 @@ class Save
 
   public function setControls(playerId:Int, inputType:Device, controls:SaveControlsData):Void
   {
-    switch (inputType)
-    {
-      case Keys:
-        if (playerId == 0)
-        {
-          data.options.controls.p1.keyboard = controls;
-        }
-        else
-        {
-          data.options.controls.p2.keyboard = controls;
-        }
-      case Gamepad(_):
-        if (playerId == 0)
-        {
-          data.options.controls.p1.gamepad = controls;
-        }
-        else
-        {
-          data.options.controls.p2.gamepad = controls;
-        }
-    }
+    getControls(playerId, inputType) = controls;
 
     flush();
   }

--- a/source/funkin/save/Save.hx
+++ b/source/funkin/save/Save.hx
@@ -53,8 +53,7 @@ class Save
   public function new(?data:RawSaveData)
   {
     if (data == null) this.data = Save.getDefault();
-    else
-      this.data = data;
+    else this.data = data;
   }
 
   public static function getDefault():RawSaveData


### PR DESCRIPTION
SaveData was using player2 controls because of an incorrect check (assumed playerId 0 is for player1, so always used player2 instead).

> [!WARNING]  
> This change will wipe user's controls.
> Could be fixed with some kind of migration of the save data, maybe increasing savedata version and moving player2 controls to player1 controls, and emptying player2 controls