### PR TITLE
[Linux] Fix "Unexpected argument '&'" error when trying to open URL

### DIFF
--- a/source/funkin/util/WindowUtil.hx
+++ b/source/funkin/util/WindowUtil.hx
@@ -24,7 +24,7 @@ class WindowUtil
   {
     #if CAN_OPEN_LINKS
     #if linux
-    Sys.command('/usr/bin/xdg-open', [targetUrl, '&']);
+    Sys.command('/usr/bin/xdg-open ' + targetUrl + ' &');
     #else
     // This should work on Windows and HTML5.
     FlxG.openURL(targetUrl);

--- a/source/funkin/util/WindowUtil.hx
+++ b/source/funkin/util/WindowUtil.hx
@@ -24,7 +24,7 @@ class WindowUtil
   {
     #if CAN_OPEN_LINKS
     #if linux
-    Sys.command('/usr/bin/xdg-open ' + targetUrl + ' &');
+    Sys.command('/usr/bin/xdg-open $targetUrl &');
     #else
     // This should work on Windows and HTML5.
     FlxG.openURL(targetUrl);


### PR DESCRIPTION
Fixes the background thingie not being passed properly to the command line due to how Sys works, which causes an error and prevents the link from being opened

~~Could be something with my system for all I know, not sure if being on Ubuntu WSL2 changes how the command behaves.
If anyone else also compiles in Linux (no WSL) please confirm if this error happens to you too.~~

Edit: I tested this through native Ubuntu and also got the same error, so not related to WSL, unless it's related to Ubuntu in general.
Edit 2: This error is caused by how Haxe's Sys.command appends the arguments to the console, encasing them with single quotes. So the original code would cause the command to be `xdg-open 'https:/link.here' '&'` which makes xdg think that & is an argument, so not related to any Linux distro.