### PR TITLE
Fix Web Loading Bar

### DIFF
--- a/source/funkin/ui/transition/LoadingState.hx
+++ b/source/funkin/ui/transition/LoadingState.hx
@@ -162,7 +162,8 @@ class LoadingState extends MusicBeatSubState
     {
       targetShit = FlxMath.remapToRange(callbacks.numRemaining / callbacks.length, 1, 0, 0, 1);
 
-      loadBar.scale.x = FlxMath.lerp(loadBar.scale.x, targetShit, 0.50);
+      loadBar.setGraphicSize(Std.int(FlxG.width * targetShit), loadBar.height);
+      loadBar.updateHitbox();
       FlxG.watch.addQuick('percentage?', callbacks.numRemaining / callbacks.length);
     }
 


### PR DESCRIPTION
I noticed (at least for me) that the loading bar starts from the middle which is probably because previously scale.x was used. And another issue is that it just doesn't move at all.
I fixed this issue by using setGraphicSize and updateHitbox afterwards
I removed the lerp since it made the loading bar look weird