### PR TITLE
hmm.json: Fix funkVis commit

### DIFF
--- a/hmm.json
+++ b/hmm.json
@@ -49,7 +49,7 @@
       "name": "funkin.vis",
       "type": "git",
       "dir": null,
-      "ref": "98c9db09f0bbfedfe67a84538a5814aaef80bdea",
+      "ref": "d7f88b765a9e4ef51a1628d53354abfdea8b928d",
       "url": "https://github.com/FunkinCrew/funkVis"
     },
     {


### PR DESCRIPTION
The current commit, https://github.com/FunkinCrew/funkVis/commit/98c9db09f0bbfedfe67a84538a5814aaef80bdea, does not exist on the funkVis repo and confuses HMM, preventing it from continuing. This PR replaces the commit with a commit available on the repo with the same name, https://github.com/FunkinCrew/funkVis/commit/d7f88b765a9e4ef51a1628d53354abfdea8b928d.