### PR TITLE
[BUGFIX] ChartingState GameOver Crashes

### DIFF
--- a/source/funkin/play/GameOverSubState.hx
+++ b/source/funkin/play/GameOverSubState.hx
@@ -162,6 +162,8 @@ class GameOverSubState extends MusicBeatSubState
   @:nullSafety(Off)
   function setCameraTarget():Void
   {
+    if (PlayState.instance.isMinimalMode || boyfriend == null) return;
+
     // Assign a camera follow point to the boyfriend's position.
     cameraFollowPoint = new FlxObject(PlayState.instance.cameraFollowPoint.x, PlayState.instance.cameraFollowPoint.y, 1, 1);
     cameraFollowPoint.x = boyfriend.getGraphicMidpoint().x;
@@ -254,6 +256,7 @@ class GameOverSubState extends MusicBeatSubState
         this.close();
         if (FlxG.sound.music != null) FlxG.sound.music.pause(); // Don't reset song position!
         PlayState.instance.close(); // This only works because PlayState is a substate!
+        return;
       }
       else if (PlayStatePlaylist.isStoryMode)
       {

--- a/source/funkin/play/PlayState.hx
+++ b/source/funkin/play/PlayState.hx
@@ -1092,8 +1092,11 @@ class PlayState extends MusicBeatSubState
 
     healthBar.value = healthLerp;
 
-    iconP1.updatePosition();
-    iconP2.updatePosition();
+    if (!isMinimalMode)
+    {
+      iconP1.updatePosition();
+      iconP2.updatePosition();
+    }
 
     // Transition to the game over substate.
     var gameOverSubState = new GameOverSubState(


### PR DESCRIPTION
Leaving Game Over screen while playtesting from Charting crashed the game.
Also dying when minimal mode crashed.