### PR TITLE
maybe fix null object reference

### DIFF
--- a/source/funkin/ui/freeplay/FreeplayState.hx
+++ b/source/funkin/ui/freeplay/FreeplayState.hx
@@ -195,6 +195,7 @@ class FreeplayState extends MusicBeatSubState
       {
         var song:Song = SongRegistry.instance.fetchEntry(songId);
 
+        if (song == null) continue;
         // Only display songs which actually have available charts for the current character.
         var availableDifficultiesForSong:Array<String> = song.listDifficulties(displayedVariations, false);
         if (availableDifficultiesForSong.length == 0) continue;


### PR DESCRIPTION
i was just spaming enter on menus and when i enter on freeplay, crash (null object reference)
![image](https://github.com/FunkinCrew/Funkin/assets/132299142/1f38c511-6b52-4064-b635-232cd37322bb)
this fix it ? maybe, idk