### PR TITLE
[BUGFIX] Allow Volume Keys while watching Toy Commercial (AttractState)

### DIFF
--- a/source/funkin/ui/title/AttractState.hx
+++ b/source/funkin/ui/title/AttractState.hx
@@ -89,7 +89,7 @@ class AttractState extends MusicBeatState
     super.update(elapsed);
 
     // If the user presses any button, skip the video.
-    if (FlxG.keys.justPressed.ANY)
+    if (FlxG.keys.justPressed.ANY && !controls.VOLUME_MUTE && !controls.VOLUME_UP && !controls.VOLUME_DOWN)
     {
       onAttractEnd();
     }


### PR DESCRIPTION
When pressing any volume key (mute, up or down) the toy commercial closes and was really frustrating