### PR TITLE
[BUGFIX] Fix Web Loading Bar (Again)

### DIFF
--- a/source/funkin/ui/transition/LoadingState.hx
+++ b/source/funkin/ui/transition/LoadingState.hx
@@ -57,8 +57,7 @@ class LoadingState extends MusicBeatSubState
     funkay.scrollFactor.set();
     funkay.screenCenter();
 
-    loadBar = new FunkinSprite(0, FlxG.height - 20).makeSolidColor(FlxG.width, 10, 0xFFff16d2);
-    loadBar.screenCenter(X);
+    loadBar = new FunkinSprite(0, FlxG.height - 20).makeSolidColor(0, 10, 0xFFff16d2);
     add(loadBar);
 
     initSongsManifest().onComplete(function(lib) {
@@ -163,8 +162,15 @@ class LoadingState extends MusicBeatSubState
       targetShit = FlxMath.remapToRange(callbacks.numRemaining / callbacks.length, 1, 0, 0, 1);
 
       var lerpWidth:Int = Std.int(FlxMath.lerp(loadBar.width, FlxG.width * targetShit, 0.2));
-      loadBar.setGraphicSize(lerpWidth, loadBar.height);
-      loadBar.updateHitbox();
+      // this if-check prevents the setGraphicSize function
+      // from setting the width of the loadBar to the height of the loadBar
+      // this is a behaviour that is implemented in the setGraphicSize function
+      // if the width parameter is equal to 0
+      if (lerpWidth > 0)
+      {
+        loadBar.setGraphicSize(lerpWidth, loadBar.height);
+        loadBar.updateHitbox();
+      }
       FlxG.watch.addQuick('percentage?', callbacks.numRemaining / callbacks.length);
     }
 


### PR DESCRIPTION
hi,
sorry for making another fix for the loading bar. I messed some stuff up.

- I made an oopsie when doing `setGraphicSize`, which lead the loading bar to go back and forth when no callbacks have been finished. The comment in the code explains that part.
- Set the width of the loading bar to 0 at the beginning so that the lerp doesn't start off wrong

I do have a question about the lerp though. Is there a particular reason why we are using `FlxMath.lerp` and using a hardcoded ratio instead of `elapsed`. Another thing i'd like to mention is that the loading bar doesn't reach the end when finishing all callbacks before switching to the next state because the lerp needs to take some time.