### PR TITLE
Center strumlines

### DIFF
--- a/source/funkin/util/Constants.hx
+++ b/source/funkin/util/Constants.hx
@@ -522,7 +522,7 @@ class Constants
   /**
    * The horizontal offset of the strumline from the left edge of the screen.
    */
-  public static final STRUMLINE_X_OFFSET:Float = 48;
+  public static final STRUMLINE_X_OFFSET:Float = 96;
 
   /**
    * The vertical offset of the strumline from the top edge of the screen.


### PR DESCRIPTION
Self explanitory. Moves strumlines to the middle of the screen, fixing the odd offset.