### PR TITLE
[FEATURE] Add Ghost Tapping to the Preferences Menu, and an option to center the strumline

### DIFF
--- a/source/funkin/Preferences.hx
+++ b/source/funkin/Preferences.hx
@@ -46,6 +46,25 @@ class Preferences
   }
 
   /**
+   * If enabled, the strumline is moved to the middle of the screen.
+   * @default `false`
+   */
+  public static var centerStrumlines(get, set):Bool;
+
+  static function get_centerStrumlines():Bool
+  {
+    return Save?.instance?.options?.centerStrumlines;
+  }
+
+  static function set_centerStrumlines(value:Bool):Bool
+  {
+    var save:Save = Save.instance;
+    save.options.centerStrumlines = value;
+    save.flush();
+    return value;
+  }
+
+  /**
    * If disabled, flashing lights in the main menu and other areas will be less intense.
    * @default `true`
    */

--- a/source/funkin/Preferences.hx
+++ b/source/funkin/Preferences.hx
@@ -65,6 +65,25 @@ class Preferences
   }
 
   /**
+   * If enabled, pressing any note buttons will not count as a miss.
+   * @default `false`
+   */
+  public static var ghostTapping(get, set):Bool;
+
+  static function get_ghostTapping():Bool
+  {
+    return Save?.instance?.options?.ghostTapping;
+  }
+
+  static function set_ghostTapping(value:Bool):Bool
+  {
+    var save:Save = Save.instance;
+    save.options.ghostTapping = value;
+    save.flush();
+    return value;
+  }
+
+  /**
    * If disabled, flashing lights in the main menu and other areas will be less intense.
    * @default `true`
    */

--- a/source/funkin/play/PlayState.hx
+++ b/source/funkin/play/PlayState.hx
@@ -1744,8 +1744,14 @@ class PlayState extends MusicBeatSubState
     add(opponentStrumline);
 
     // Position the player strumline on the right half of the screen
-    playerStrumline.x = FlxG.width / 2 + Constants.STRUMLINE_X_OFFSET; // Classic style
-    if (Preferences.centerStrumlines) playerStrumline.x = FlxG.width - playerStrumline.width - Constants.STRUMLINE_X_OFFSET; // Centered style
+    if (Preferences.centerStrumlines)
+    {
+      playerStrumline.x = FlxG.width - playerStrumline.width - Constants.STRUMLINE_X_OFFSET; // Centered style
+    }
+    else
+    {
+      playerStrumline.x = FlxG.width / 2 + Constants.STRUMLINE_X_OFFSET; // Classic style
+    }
     playerStrumline.y = Preferences.downscroll ? FlxG.height - playerStrumline.height - Constants.STRUMLINE_Y_OFFSET : Constants.STRUMLINE_Y_OFFSET;
     playerStrumline.zIndex = 1001;
     playerStrumline.cameras = [camHUD];
@@ -1763,7 +1769,15 @@ class PlayState extends MusicBeatSubState
     }
 
     // Toggle ghost tapping depending on the user's preferences.
-    if (Preferences.ghostTapping) Constants.GHOST_TAPPING = true;
+    if (Preferences.ghostTapping)
+    {
+      Constants.GHOST_TAPPING = true;
+    }
+    else
+    {
+      // Ensure that ghost tapping is off.
+      Constants.GHOST_TAPPING = false;
+    }
   }
 
   /**

--- a/source/funkin/play/PlayState.hx
+++ b/source/funkin/play/PlayState.hx
@@ -1745,7 +1745,7 @@ class PlayState extends MusicBeatSubState
 
     // Position the player strumline on the right half of the screen
     playerStrumline.x = FlxG.width / 2 + Constants.STRUMLINE_X_OFFSET; // Classic style
-    // playerStrumline.x = FlxG.width - playerStrumline.width - Constants.STRUMLINE_X_OFFSET; // Centered style
+    if (Preferences.centerStrumlines) playerStrumline.x = FlxG.width - playerStrumline.width - Constants.STRUMLINE_X_OFFSET; // Centered style
     playerStrumline.y = Preferences.downscroll ? FlxG.height - playerStrumline.height - Constants.STRUMLINE_Y_OFFSET : Constants.STRUMLINE_Y_OFFSET;
     playerStrumline.zIndex = 1001;
     playerStrumline.cameras = [camHUD];

--- a/source/funkin/play/PlayState.hx
+++ b/source/funkin/play/PlayState.hx
@@ -1761,6 +1761,9 @@ class PlayState extends MusicBeatSubState
       playerStrumline.fadeInArrows();
       opponentStrumline.fadeInArrows();
     }
+
+    // Toggle ghost tapping depending on the user's preferences.
+    if (Preferences.ghostTapping) Constants.GHOST_TAPPING = true;
   }
 
   /**

--- a/source/funkin/play/notes/Strumline.hx
+++ b/source/funkin/play/notes/Strumline.hx
@@ -16,7 +16,6 @@ import funkin.data.song.SongData.SongNoteData;
 import funkin.ui.options.PreferencesMenu;
 import funkin.util.SortUtil;
 import funkin.modding.events.ScriptEvent;
-import funkin.util.Constants;
 
 /**
  * A group of sprites which handles the receptor, the note splashes, and the notes (with sustains) for a given player.
@@ -99,8 +98,6 @@ class Strumline extends FlxSpriteGroup
   public function new(noteStyle:NoteStyle, isPlayer:Bool)
   {
     super();
-
-    if (Preferences.centerStrumlines) Constants.STRUMLINE_X_OFFSET = 96;
     
     this.isPlayer = isPlayer;
     this.noteStyle = noteStyle;

--- a/source/funkin/play/notes/Strumline.hx
+++ b/source/funkin/play/notes/Strumline.hx
@@ -16,6 +16,7 @@ import funkin.data.song.SongData.SongNoteData;
 import funkin.ui.options.PreferencesMenu;
 import funkin.util.SortUtil;
 import funkin.modding.events.ScriptEvent;
+import funkin.util.Constants;
 
 /**
  * A group of sprites which handles the receptor, the note splashes, and the notes (with sustains) for a given player.
@@ -99,6 +100,8 @@ class Strumline extends FlxSpriteGroup
   {
     super();
 
+    if (Preferences.centerStrumlines) Constants.STRUMLINE_X_OFFSET = 96;
+    
     this.isPlayer = isPlayer;
     this.noteStyle = noteStyle;
 

--- a/source/funkin/save/Save.hx
+++ b/source/funkin/save/Save.hx
@@ -848,6 +848,12 @@ typedef SaveDataOptions =
   var downscroll:Bool;
 
   /**
+   * If enabled, the strumline is moved to the middle of the screen.
+   * @default `false`
+   */
+  var centerStrumlines:Bool;
+
+  /**
    * If disabled, flashing lights in the main menu and other areas will be less intense.
    * @default `true`
    */

--- a/source/funkin/save/Save.hx
+++ b/source/funkin/save/Save.hx
@@ -82,6 +82,8 @@ class Save
           // Reasonable defaults.
           naughtyness: true,
           downscroll: false,
+          centerStrumlines: false,
+          ghostTapping: false,
           flashingLights: true,
           zoomCamera: true,
           debugDisplay: false,
@@ -852,6 +854,12 @@ typedef SaveDataOptions =
    * @default `false`
    */
   var centerStrumlines:Bool;
+
+  /**
+   * If enabled, pressing any note buttons will not count as a miss.
+   * @default `false`
+   */
+   var ghostTapping:Bool;
 
   /**
    * If disabled, flashing lights in the main menu and other areas will be less intense.

--- a/source/funkin/ui/options/PreferencesMenu.hx
+++ b/source/funkin/ui/options/PreferencesMenu.hx
@@ -55,6 +55,9 @@ class PreferencesMenu extends Page
     createPrefItemCheckbox('Downscroll', 'Enable to make notes move downwards', function(value:Bool):Void {
       Preferences.downscroll = value;
     }, Preferences.downscroll);
+    createPrefItemCheckbox('Ghost Tapping', 'Enable to stop you from taking damage when no notes are on a lane.', function(value:Bool):Void {
+      Preferences.ghostTapping = value;
+    }, Preferences.ghostTapping);
     createPrefItemCheckbox('Center Strumline', 'Enable to move the strumline to the middle of the screen.', function(value:Bool):Void {
       Preferences.centerStrumlines = value;
     }, Preferences.centerStrumlines);

--- a/source/funkin/ui/options/PreferencesMenu.hx
+++ b/source/funkin/ui/options/PreferencesMenu.hx
@@ -55,6 +55,9 @@ class PreferencesMenu extends Page
     createPrefItemCheckbox('Downscroll', 'Enable to make notes move downwards', function(value:Bool):Void {
       Preferences.downscroll = value;
     }, Preferences.downscroll);
+    createPrefItemCheckbox('Center Strumline', 'Enable to move the strumline to the middle of the screen.', function(value:Bool):Void {
+      Preferences.centerStrumlines = value;
+    }, Preferences.centerStrumlines);
     createPrefItemCheckbox('Flashing Lights', 'Disable to dampen flashing effects', function(value:Bool):Void {
       Preferences.flashingLights = value;
     }, Preferences.flashingLights);

--- a/source/funkin/util/Constants.hx
+++ b/source/funkin/util/Constants.hx
@@ -497,7 +497,7 @@ class Constants
    * If true, the player will not receive the ghost miss penalty if there are no notes within the hit window.
    * This is the thing people have been begging for forever lolol.
    */
-  public static final GHOST_TAPPING:Bool = false;
+  public static var GHOST_TAPPING:Bool = false;
 
   /**
    * The maximum number of previous file paths for the Chart Editor to remember.


### PR DESCRIPTION
![image](https://github.com/FunkinCrew/Funkin/assets/64978924/ae922b00-9ed6-4634-a99c-7d5ed9430acf)
![image](https://github.com/FunkinCrew/Funkin/assets/64978924/2f381820-c02e-4d43-97d5-bcc94121f678)

This is a follow up to my original pull request that fixed the strumline offset so it was no longer off center, I noticed that ghost tapping support was toggle-able from the source code so I also added an option for that too. 