### PR TITLE
[BUGFIX] Charting Editor Sustain Trails (2 bugs)

### DIFF
--- a/source/funkin/ui/debug/charting/ChartEditorState.hx
+++ b/source/funkin/ui/debug/charting/ChartEditorState.hx
@@ -4566,8 +4566,8 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
             }
 
             gridGhostHoldNote.visible = true;
-            gridGhostHoldNote.noteData = gridGhostNote.noteData;
-            gridGhostHoldNote.noteDirection = gridGhostNote.noteData.getDirection();
+            gridGhostHoldNote.noteData = currentPlaceNoteData;
+            gridGhostHoldNote.noteDirection = currentPlaceNoteData.getDirection();
             gridGhostHoldNote.setHeightDirectly(dragLengthPixels, true);
 
             gridGhostHoldNote.updateHoldNotePosition(renderedHoldNotes);

--- a/source/funkin/ui/debug/charting/components/ChartEditorHoldNoteSprite.hx
+++ b/source/funkin/ui/debug/charting/components/ChartEditorHoldNoteSprite.hx
@@ -36,6 +36,8 @@ class ChartEditorHoldNoteSprite extends SustainTrail
     zoom *= 0.7;
     zoom *= ChartEditorState.GRID_SIZE / Strumline.STRUMLINE_SIZE;
 
+    flipY = false;
+
     setup();
   }
 


### PR DESCRIPTION
This pull request fixes two bugs:
## Note Sustain Trails getting cut/inverted when is downscroll enabled
| Before                                                                                              |                                                After                                                |
|-----------------------------------------------------------------------------------------------------|:---------------------------------------------------------------------------------------------------:|
| ![image](https://github.com/FunkinCrew/Funkin/assets/55158797/983d8489-c8c3-441f-9832-ecd9f4617519) | ![image](https://github.com/FunkinCrew/Funkin/assets/55158797/eb06a2d0-f421-4787-b4d1-1fd53e68a145) |
## Incorrect Sustain Trails origin note (based on ghost note)
| Before                                                                                    |                                           After                                           |
|-------------------------------------------------------------------------------------------|:-----------------------------------------------------------------------------------------:|
| <video src=https://github.com/FunkinCrew/Funkin/assets/55158797/bc7e9a40-f92d-4330-b0f9-68deb65cd063> | <video src=https://github.com/FunkinCrew/Funkin/assets/55158797/fdcf01b4-5a73-4b60-ad09-71a78644579a> |

Hope this gets added soon =D