### PR TITLE
[FEATURE] Add Winning support to Legacy Health Icons

### DIFF
--- a/source/funkin/play/components/HealthIcon.hx
+++ b/source/funkin/play/components/HealthIcon.hx
@@ -373,6 +373,10 @@ class HealthIcon extends FunkinSprite
     // Don't flip BF's icon here! That's done later.
     this.animation.add(Idle, [0], 0, false, false);
     this.animation.add(Losing, [1], 0, false, false);
+    if (animation.numFrames >= 3)
+    {
+      this.animation.add(Winning, [2], 0, false, false);
+    }
   }
 
   function correctCharacterId(charId:Null<String>):String


### PR DESCRIPTION
It allows legacy health icons to have a Winning animation (just if the image has a 3rd frame)
## Examples:
![icon-niku](https://github.com/FunkinCrew/Funkin/assets/55158797/0598eb4f-6ce0-4628-8f18-9cf8dc4136b4)
![icon-bf](https://github.com/FunkinCrew/Funkin/assets/55158797/aebe9278-452b-42a7-9fa6-88f4c1808a6c)
_Boyfriend and Nikusa health icons from FNF: Entity mod_
These have a winning animation in the third image frame (usually any other mod does the same, having the winning animation on the third frame)
## After

https://github.com/FunkinCrew/Funkin/assets/55158797/33acc627-4eb4-4440-a499-2e20fb7a0a4f

