### PR TITLE
add simple PR auto labelling action

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,12 @@
+# Add Documentation tag to PR's changing markdown files, or anyhting in the docs folder
+Documentation:
+- changed-files:
+  - any-glob-to-any-file:
+  - any-glob-to-any-file:
+      - docs/*
+      - '**/*.md'
+
+# Adds Haxe tag to PR's changing haxe code files
+Haxe:
+- changed-files:
+  - any-glob-to-any-file: '**/*.hx'

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,6 +1,6 @@
 name: "Pull Request Labeler"
 on:
-- pull_request
+- pull_request_target
 
 jobs:
   labeler:

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,14 @@
+name: "Pull Request Labeler"
+on:
+- pull_request
+
+jobs:
+  labeler:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/labeler@v5
+      with:
+        sync-labels: true


### PR DESCRIPTION
This should add a github action that automatically labels PR

Currently it:
- Labels `Documentation` to any PRs that change anything in the `docs/` folder, or any `.md` file.
- Labels `Haxe` to any PRs that change `.hx` files

We can do further config as we please, for now I think this one should be enough for the lil prototype 

NOTE: right now this aciton runs on `pull_request`, this is purely for review/testing. After approval, and before merging, we need to change it to `pull_request_target`. See [here](https://github.com/marketplace/actions/labeler#updating-major-version-of-the-labeler)