### PR TITLE
[BUGFIX] Unscripted Stage Log Trace (missing toString for Stage)

### DIFF
--- a/source/funkin/data/BaseRegistry.hx
+++ b/source/funkin/data/BaseRegistry.hx
@@ -117,7 +117,7 @@ abstract class BaseRegistry<T:(IRegistryEntry<J> & Constructible<EntryConstructo
         var entry:T = createEntry(entryId);
         if (entry != null)
         {
-          trace('  Loaded entry data: ${entry}');
+          trace('  Loaded entry data: ${entry.id}');
           entries.set(entry.id, entry);
         }
       }

--- a/source/funkin/data/BaseRegistry.hx
+++ b/source/funkin/data/BaseRegistry.hx
@@ -117,7 +117,7 @@ abstract class BaseRegistry<T:(IRegistryEntry<J> & Constructible<EntryConstructo
         var entry:T = createEntry(entryId);
         if (entry != null)
         {
-          trace('  Loaded entry data: ${entry.id}');
+          trace('  Loaded entry data: ${entry}');
           entries.set(entry.id, entry);
         }
       }

--- a/source/funkin/play/stage/Stage.hx
+++ b/source/funkin/play/stage/Stage.hx
@@ -852,6 +852,11 @@ class Stage extends FlxSpriteGroup implements IPlayStateScriptedClass implements
     }
   }
 
+  public override function toString():String
+  {
+    return 'Stage($id)';
+  }
+
   static function _fetchData(id:String):Null<StageData>
   {
     return StageRegistry.instance.parseEntryDataWithMigration(id, StageRegistry.instance.fetchEntryVersion(id));


### PR DESCRIPTION
Before:
```
source/funkin/data/BaseRegistry.hx:120:   Loaded entry data: (x: 0 | y: 0 | w: 0 | h: 0 | visible: true | velocity: (x: 0 | y: 0))
source/funkin/data/BaseRegistry.hx:120:   Loaded entry data: (x: 0 | y: 0 | w: 0 | h: 0 | visible: true | velocity: (x: 0 | y: 0))
source/funkin/data/BaseRegistry.hx:120:   Loaded entry data: (x: 0 | y: 0 | w: 0 | h: 0 | visible: true | velocity: (x: 0 | y: 0))
```
After:
```
source/funkin/data/BaseRegistry.hx:120:   Loaded entry data: mainStage
source/funkin/data/BaseRegistry.hx:120:   Loaded entry data: mallEvil
source/funkin/data/BaseRegistry.hx:120:   Loaded entry data: mallXmas
```