### PR TITLE
Opponent StrumlineNote Confirm Animation

### DIFF
--- a/source/funkin/play/notes/StrumlineNote.hx
+++ b/source/funkin/play/notes/StrumlineNote.hx
@@ -136,7 +136,8 @@ class StrumlineNote extends FunkinSprite
 
   public function playConfirm():Void
   {
-    this.active = (forceActive || isAnimationDynamic('confirm'));
+    this.active = true;
+    this.confirmHoldTimer = -1;
     this.playAnimation('confirm', true);
   }
 


### PR DESCRIPTION
this pr fixes the confirm hold timer, since the animation sometimes got cut off. its kind of hard to accurately explain what it fixes, so i suggest watching the before and after.

### BEFORE:

https://github.com/FunkinCrew/Funkin/assets/87707926/4cad4d6b-0089-4ead-a6c8-119c55bf3c49

### AFTER:

https://github.com/FunkinCrew/Funkin/assets/87707926/d3071804-9ca2-447c-aee8-878cec32ca54

