### PR TITLE
[BUGFIX?] Reset CWD before Preloader

### DIFF
--- a/source/funkin/ui/transition/preload/FunkinPreloader.hx
+++ b/source/funkin/ui/transition/preload/FunkinPreloader.hx
@@ -136,6 +136,8 @@ class FunkinPreloader extends FlxBasePreloader
     // We can't even call trace() yet, until Flixel loads.
     trace('Initializing custom preloader...');
 
+    funkin.util.CLIUtil.resetWorkingDir();
+
     this.siteLockTitleText = Constants.SITE_LOCK_TITLE;
     this.siteLockBodyText = Constants.SITE_LOCK_DESC;
   }


### PR DESCRIPTION
When running the game from the command line and the current working directory is not the executable's directory the Preloader will fail to find the files it needs, this PR aims to fix this problem. This could perhaps also fix #2444 although it seems to be kinda unrelated.

I know that ideally you'd use `lime run PLATFORM` to run the game without recompiling, but this would not be the case for when downloading the game, specially for Linux players that for whatever reason would like to run it through a terminal without having to change the CWD.

From what I tested it doesn't break anything. Here's a before and after of the problem:
 (Before was done in Windows cuz I'm too lazy to recompile, but it should be consistent regardless of the platform)

https://github.com/FunkinCrew/Funkin/assets/40342021/c0c9e1c3-9295-440d-8e5b-30c4c97d82d7

https://github.com/FunkinCrew/Funkin/assets/40342021/d3235fcb-ce9a-4b10-9b56-9fbc929d50ed


