### PR TITLE
Added support for video cutscenes in polymod using `hxvlc`.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -171,9 +171,9 @@
       "args": ["-debug", "-DANIMDEBUG", "-DFORCE_DEBUG_VERSION"]
     },
     {
-      "label": "Windows / Debug (Debug hxCodec)",
+      "label": "Windows / Debug (Debug hxvlc)",
       "target": "windows",
-      "args": ["-debug", "-DHXC_LIBVLC_LOGGING", "-DFORCE_DEBUG_VERSION"]
+      "args": ["-debug", "-DHXVLC_LOGGING", "-DHXVLC_VERBOSE=2", "-DFORCE_DEBUG_VERSION"]
     },
     {
       "label": "HashLink / Debug (Straight to Animation Editor)",

--- a/Project.xml
+++ b/Project.xml
@@ -123,7 +123,7 @@
 	<haxelib name="flixel-text-input" /> <!-- Improved text field rendering for HaxeUI -->
 	<haxelib name="polymod" /> <!-- Modding framework -->
 	<haxelib name="flxanimate" /> <!-- Texture atlas rendering -->
-	<haxelib name="hxvlc" if="desktop" unless="hl" /> <!-- Video playback -->
+	<haxelib name="hxvlc" if="desktop || mobile" unless="hl" /> <!-- Video playback -->
 	<haxelib name="funkin.vis"/>
 
 

--- a/Project.xml
+++ b/Project.xml
@@ -123,7 +123,7 @@
 	<haxelib name="flixel-text-input" /> <!-- Improved text field rendering for HaxeUI -->
 	<haxelib name="polymod" /> <!-- Modding framework -->
 	<haxelib name="flxanimate" /> <!-- Texture atlas rendering -->
-	<haxelib name="hxCodec" if="desktop" unless="hl" /> <!-- Video playback -->
+	<haxelib name="hxvlc" if="desktop" unless="hl" /> <!-- Video playback -->
 	<haxelib name="funkin.vis"/>
 
 

--- a/hmm.json
+++ b/hmm.json
@@ -79,7 +79,7 @@
     {
       "name": "hxvlc",
       "type": "haxelib",
-      "version": "1.5.4"
+      "version": "1.5.5"
     },
     {
       "name": "hxcpp",

--- a/hmm.json
+++ b/hmm.json
@@ -77,11 +77,9 @@
       "version": "2.5.0"
     },
     {
-      "name": "hxCodec",
-      "type": "git",
-      "dir": null,
-      "ref": "61b98a7a353b7f529a8fec84ed9afc919a2dffdd",
-      "url": "https://github.com/FunkinCrew/hxCodec"
+      "name": "hxvlc",
+      "type": "haxelib",
+      "version": "1.5.4"
     },
     {
       "name": "hxcpp",

--- a/hmm.json
+++ b/hmm.json
@@ -79,7 +79,7 @@
     {
       "name": "hxvlc",
       "type": "haxelib",
-      "version": "1.8.2"
+      "version": "1.8.3"
     },
     {
       "name": "hxcpp",

--- a/hmm.json
+++ b/hmm.json
@@ -79,7 +79,7 @@
     {
       "name": "hxvlc",
       "type": "haxelib",
-      "version": "1.6.0"
+      "version": "1.6.1"
     },
     {
       "name": "hxcpp",

--- a/hmm.json
+++ b/hmm.json
@@ -79,7 +79,7 @@
     {
       "name": "hxvlc",
       "type": "haxelib",
-      "version": "1.5.5"
+      "version": "1.6.0"
     },
     {
       "name": "hxcpp",

--- a/hmm.json
+++ b/hmm.json
@@ -79,7 +79,7 @@
     {
       "name": "hxvlc",
       "type": "haxelib",
-      "version": "1.7.1"
+      "version": "1.8.1"
     },
     {
       "name": "hxcpp",

--- a/hmm.json
+++ b/hmm.json
@@ -79,7 +79,7 @@
     {
       "name": "hxvlc",
       "type": "haxelib",
-      "version": "1.7.0"
+      "version": "1.7.1"
     },
     {
       "name": "hxcpp",

--- a/hmm.json
+++ b/hmm.json
@@ -79,7 +79,7 @@
     {
       "name": "hxvlc",
       "type": "haxelib",
-      "version": "1.8.1"
+      "version": "1.8.2"
     },
     {
       "name": "hxcpp",

--- a/hmm.json
+++ b/hmm.json
@@ -79,7 +79,7 @@
     {
       "name": "hxvlc",
       "type": "haxelib",
-      "version": "1.8.4"
+      "version": "1.8.5"
     },
     {
       "name": "hxcpp",

--- a/hmm.json
+++ b/hmm.json
@@ -79,7 +79,7 @@
     {
       "name": "hxvlc",
       "type": "haxelib",
-      "version": "1.6.2"
+      "version": "1.7.0"
     },
     {
       "name": "hxcpp",

--- a/hmm.json
+++ b/hmm.json
@@ -79,7 +79,7 @@
     {
       "name": "hxvlc",
       "type": "haxelib",
-      "version": "1.8.3"
+      "version": "1.8.4"
     },
     {
       "name": "hxcpp",

--- a/hmm.json
+++ b/hmm.json
@@ -79,7 +79,7 @@
     {
       "name": "hxvlc",
       "type": "haxelib",
-      "version": "1.6.1"
+      "version": "1.6.2"
     },
     {
       "name": "hxcpp",

--- a/source/funkin/graphics/video/FlxVideo.hx
+++ b/source/funkin/graphics/video/FlxVideo.hx
@@ -12,8 +12,8 @@ import openfl.net.NetStream;
 
 /**
  * Plays a video via a NetStream. Only works on HTML5.
- * This does NOT replace hxCodec, nor does hxCodec replace this.
- * hxCodec only works on desktop and does not work on HTML5!
+ * This does NOT replace hxvlc, nor does hxvlc replace this.
+ * hxvlc only works on desktop and does not work on HTML5!
  */
 class FlxVideo extends FunkinSprite
 {

--- a/source/funkin/play/cutscene/VideoCutscene.hx
+++ b/source/funkin/play/cutscene/VideoCutscene.hx
@@ -165,9 +165,11 @@ class VideoCutscene
       openfl.Assets.loadBytes(filePath).onComplete(function(bytes:openfl.utils.ByteArray):Void
       {
         if (vid.load(bytes))
+        {
           vid.play();
 
-        onVideoStarted.dispatch();
+          onVideoStarted.dispatch();
+        }
       });
     }
     else

--- a/source/funkin/play/cutscene/VideoCutscene.hx
+++ b/source/funkin/play/cutscene/VideoCutscene.hx
@@ -94,7 +94,7 @@ class VideoCutscene
     #if html5
     playVideoHTML5(rawFilePath);
     #elseif hxvlc
-    playVideoNative(rawFilePath);
+    playVideoNative(filePath);
     #else
     throw "No video support for this platform!";
     #end

--- a/source/funkin/play/cutscene/VideoCutscene.hx
+++ b/source/funkin/play/cutscene/VideoCutscene.hx
@@ -10,8 +10,8 @@ import flixel.util.FlxTimer;
 #if html5
 import funkin.graphics.video.FlxVideo;
 #end
-#if hxCodec
-import hxcodec.flixel.FlxVideoSprite;
+#if hxvlc
+import hxvlc.flixel.FlxVideoSprite;
 #end
 
 /**
@@ -25,7 +25,7 @@ class VideoCutscene
   #if html5
   static var vid:FlxVideo;
   #end
-  #if hxCodec
+  #if hxvlc
   static var vid:FlxVideoSprite;
   #end
 
@@ -93,7 +93,7 @@ class VideoCutscene
 
     #if html5
     playVideoHTML5(rawFilePath);
-    #elseif hxCodec
+    #elseif hxvlc
     playVideoNative(rawFilePath);
     #else
     throw "No video support for this platform!";
@@ -102,7 +102,7 @@ class VideoCutscene
 
   public static function isPlaying():Bool
   {
-    #if (html5 || hxCodec)
+    #if (html5 || hxvlc)
     return vid != null;
     #else
     return false;
@@ -135,7 +135,7 @@ class VideoCutscene
   }
   #end
 
-  #if hxCodec
+  #if hxvlc
   static function playVideoNative(filePath:String):Void
   {
     // Video displays OVER the FlxState.
@@ -152,10 +152,9 @@ class VideoCutscene
       PlayState.instance.add(vid);
 
       PlayState.instance.refresh();
-      vid.play(filePath, false);
 
       // Resize videos bigger or smaller than the screen.
-      vid.bitmap.onTextureSetup.add(() -> {
+      vid.bitmap.onFormatSetup.add(() -> {
         vid.setGraphicSize(FlxG.width, FlxG.height);
         vid.updateHitbox();
         vid.x = 0;
@@ -163,7 +162,13 @@ class VideoCutscene
         // vid.scale.set(0.5, 0.5);
       });
 
-      onVideoStarted.dispatch();
+      openfl.Assets.loadBytes(filePath).onComplete(function(bytes:openfl.utils.ByteArray):Void
+      {
+        if (vid.load(bytes))
+          vid.play();
+
+        onVideoStarted.dispatch();
+      });
     }
     else
     {
@@ -182,11 +187,12 @@ class VideoCutscene
     }
     #end
 
-    #if hxCodec
+    #if hxvlc
     if (vid != null)
     {
       // Seek to the start of the video.
       vid.bitmap.time = 0;
+
       if (resume)
       {
         // Resume the video if it was paused.
@@ -208,7 +214,7 @@ class VideoCutscene
     }
     #end
 
-    #if hxCodec
+    #if hxvlc
     if (vid != null)
     {
       vid.pause();
@@ -227,7 +233,7 @@ class VideoCutscene
     }
     #end
 
-    #if hxCodec
+    #if hxvlc
     if (vid != null)
     {
       vid.visible = false;
@@ -246,7 +252,7 @@ class VideoCutscene
     }
     #end
 
-    #if hxCodec
+    #if hxvlc
     if (vid != null)
     {
       vid.visible = true;
@@ -265,7 +271,7 @@ class VideoCutscene
     }
     #end
 
-    #if hxCodec
+    #if hxvlc
     if (vid != null)
     {
       vid.resume();
@@ -292,7 +298,7 @@ class VideoCutscene
     }
     #end
 
-    #if hxCodec
+    #if hxvlc
     if (vid != null)
     {
       vid.stop();
@@ -300,7 +306,7 @@ class VideoCutscene
     }
     #end
 
-    #if (html5 || hxCodec)
+    #if (html5 || hxvlc)
     vid.destroy();
     vid = null;
     #end

--- a/source/funkin/play/cutscene/VideoCutscene.hx
+++ b/source/funkin/play/cutscene/VideoCutscene.hx
@@ -162,15 +162,12 @@ class VideoCutscene
         // vid.scale.set(0.5, 0.5);
       });
 
-      openfl.Assets.loadBytes(filePath).onComplete(function(bytes:openfl.utils.ByteArray):Void
+      if (vid.load(openfl.Assets.getBytes(filePath)))
       {
-        if (vid.load(bytes))
-        {
-          vid.play();
+        vid.play();
 
-          onVideoStarted.dispatch();
-        }
-      });
+        onVideoStarted.dispatch();
+      }
     }
     else
     {

--- a/source/funkin/ui/title/AttractState.hx
+++ b/source/funkin/ui/title/AttractState.hx
@@ -17,7 +17,13 @@ import funkin.ui.MusicBeatState;
  */
 class AttractState extends MusicBeatState
 {
+  #if html5
   static final ATTRACT_VIDEO_PATH:String = Paths.stripLibrary(Paths.videos('toyCommercial'));
+  #end
+
+  #if hxvlc
+  static final ATTRACT_VIDEO_PATH:String = Paths.videos('toyCommercial');
+  #end
 
   public override function create():Void
   {

--- a/source/funkin/ui/title/AttractState.hx
+++ b/source/funkin/ui/title/AttractState.hx
@@ -3,8 +3,8 @@ package funkin.ui.title;
 #if html5
 import funkin.graphics.video.FlxVideo;
 #end
-#if hxCodec
-import hxcodec.flixel.FlxVideoSprite;
+#if hxvlc
+import hxvlc.flixel.FlxVideoSprite;
 #end
 import funkin.ui.MusicBeatState;
 
@@ -33,7 +33,7 @@ class AttractState extends MusicBeatState
     playVideoHTML5(ATTRACT_VIDEO_PATH);
     #end
 
-    #if hxCodec
+    #if hxvlc
     trace('Playing native video ${ATTRACT_VIDEO_PATH}');
     playVideoNative(ATTRACT_VIDEO_PATH);
     #end
@@ -61,7 +61,7 @@ class AttractState extends MusicBeatState
   }
   #end
 
-  #if hxCodec
+  #if hxvlc
   var vid:FlxVideoSprite;
 
   function playVideoNative(filePath:String):Void
@@ -73,9 +73,15 @@ class AttractState extends MusicBeatState
     {
       vid.zIndex = 0;
       vid.bitmap.onEndReached.add(onAttractEnd);
-
       add(vid);
-      vid.play(filePath, false);
+
+      openfl.Assets.loadBytes(filePath).onComplete(function(bytes:openfl.utils.ByteArray):Void
+      {
+        if (vid.load(bytes))
+          vid.play();
+
+        onVideoStarted.dispatch();
+      });
     }
     else
     {
@@ -108,7 +114,7 @@ class AttractState extends MusicBeatState
     }
     #end
 
-    #if hxCodec
+    #if hxvlc
     if (vid != null)
     {
       vid.stop();
@@ -116,7 +122,7 @@ class AttractState extends MusicBeatState
     }
     #end
 
-    #if (html5 || hxCodec)
+    #if (html5 || hxvlc)
     vid.destroy();
     vid = null;
     #end

--- a/source/funkin/ui/title/AttractState.hx
+++ b/source/funkin/ui/title/AttractState.hx
@@ -79,8 +79,6 @@ class AttractState extends MusicBeatState
       {
         if (vid.load(bytes))
           vid.play();
-
-        onVideoStarted.dispatch();
       });
     }
     else

--- a/source/funkin/ui/title/AttractState.hx
+++ b/source/funkin/ui/title/AttractState.hx
@@ -81,11 +81,8 @@ class AttractState extends MusicBeatState
       vid.bitmap.onEndReached.add(onAttractEnd);
       add(vid);
 
-      openfl.Assets.loadBytes(filePath).onComplete(function(bytes:openfl.utils.ByteArray):Void
-      {
-        if (vid.load(bytes))
-          vid.play();
-      });
+      if (vid.load(openfl.Assets.getBytes(filePath)))
+        vid.play();
     }
     else
     {

--- a/tests/unit/project.xml
+++ b/tests/unit/project.xml
@@ -24,7 +24,7 @@
 	<haxelib name="haxeui-flixel" /> <!-- Integrate HaxeUI with Flixel -->
 	<haxelib name="polymod" /> <!-- Modding framework -->
 	<haxelib name="flxanimate" /> <!-- Texture atlas rendering -->
-	<haxelib name="hxCodec" /> <!-- Video playback -->
+	<haxelib name="hxvlc" /> <!-- Video playback -->
 	<haxelib name="thx.semver" /> <!-- Semantic version handling -->
 	<haxelib name="json2object" /> <!-- JSON parsing -->
 

--- a/tests/unit/test.hxml
+++ b/tests/unit/test.hxml
@@ -13,7 +13,7 @@
 -lib haxeui-core
 -lib haxeui-flixel
 -lib flxanimate
--lib hxCodec
+-lib hxvlc
 -lib thx.semver
 -lib json2object
 -lib tink_json

--- a/tests/unit/test.hxml-old
+++ b/tests/unit/test.hxml-old
@@ -15,7 +15,7 @@
 -lib haxeui-core
 -lib haxeui-flixel
 -lib flxanimate
--lib hxCodec
+-lib hxvlc
 -lib thx.semver
 -lib json2object
 -lib tink_json
@@ -48,7 +48,7 @@
 -lib haxeui-flixel
 -lib polymod
 -lib flxanimate
--lib hxCodec
+-lib hxvlc
 -lib thx.semver
 -lib json2object
 -lib tink_json


### PR DESCRIPTION
By using `hxvlc`, `bitstream` playback is available, allowing video cutscenes to be played directly from byte streams. This enables video cutscenes to be played from polymod.