### PR TITLE
Recycle Credit Lines

### DIFF
--- a/source/funkin/ui/credits/CreditsState.hx
+++ b/source/funkin/ui/credits/CreditsState.hx
@@ -6,6 +6,8 @@ import funkin.audio.FunkinSound;
 import flixel.FlxSprite;
 import funkin.ui.mainmenu.MainMenuState;
 import flixel.group.FlxSpriteGroup;
+import funkin.ui.credits.CreditsData.CreditsDataRole;
+import funkin.ui.credits.CreditsData.CreditsDataMember;
 
 /**
  * The state used to display the credits scroll.
@@ -76,6 +78,9 @@ class CreditsState extends MusicBeatState
 
   var scrollPaused:Bool = false;
 
+  var backersToBuild:Array<String>;
+  var entriesToBuild:Array<CreditsEntry>;
+
   public function new()
   {
     super();
@@ -84,6 +89,22 @@ class CreditsState extends MusicBeatState
   public override function create():Void
   {
     super.create();
+
+    backersToBuild = CreditsDataHandler.fetchBackerEntries();
+
+    entriesToBuild = [];
+    for (entry in CreditsDataHandler.CREDITS_DATA.entries)
+    {
+      entriesToBuild.push(
+        {
+          data: entry,
+          lineIndexToBuild: 0,
+          backerIndexToBuild: 0,
+          hasBuiltHeader: (entry.header == null),
+          hasBuiltBody: (entry.body.length == 0),
+          hasBuiltBackers: (!entry.appendBackers || backersToBuild.length == 0)
+        });
+    }
 
     // Background
     var bg = new FlxSprite(Paths.image('menuDesat'));
@@ -104,7 +125,7 @@ class CreditsState extends MusicBeatState
     creditsGroup.x = SCREEN_PAD;
     creditsGroup.y = STARTING_HEIGHT;
 
-    buildCreditsGroup();
+    // buildCreditsGroup();
 
     add(creditsGroup);
 
@@ -119,39 +140,44 @@ class CreditsState extends MusicBeatState
     FlxG.sound.music.fadeIn(6, 0, 0.8);
   }
 
-  function buildCreditsGroup():Void
+  var creditsLineY:Float = 0;
+
+  function buildCreditsEntryLine(entry:CreditsEntry):Void
   {
-    var y:Float = 0;
-
-    for (entry in CreditsDataHandler.CREDITS_DATA.entries)
+    if (!entry.hasBuiltHeader)
     {
-      if (entry.header != null)
-      {
-        var header = buildCreditsLine(entry.header, y, true, CreditsSide.Left);
-        header.bold = true;
-        creditsGroup.add(header);
-        y += CREDITS_HEADER_FONT_SIZE + (header.textField.numLines * CREDITS_HEADER_FONT_SIZE);
-      }
+      var header:FlxText = buildCreditsLine(entry.data.header, creditsLineY, true, CreditsSide.Left);
+      creditsLineY += CREDITS_HEADER_FONT_SIZE + (header.textField.numLines * CREDITS_HEADER_FONT_SIZE);
+      entry.hasBuiltHeader = true;
+      return;
+    }
 
-      for (line in entry?.body ?? [])
-      {
-        var entry = buildCreditsLine(line.line, y, false, CreditsSide.Left);
-        creditsGroup.add(entry);
-        y += CREDITS_FONT_SIZE * entry.textField.numLines;
-      }
+    if (!entry.hasBuiltBody)
+    {
+      var lineData:CreditsDataMember = entry.data.body[entry.lineIndexToBuild];
+      var line:FlxText = buildCreditsLine(lineData.line, creditsLineY, false, CreditsSide.Left);
+      creditsLineY += CREDITS_FONT_SIZE * line.textField.numLines;
+      entry.lineIndexToBuild++;
 
-      if (entry.appendBackers)
+      if (entry.lineIndexToBuild >= entry.data.body.length)
       {
-        var backers = CreditsDataHandler.fetchBackerEntries();
-        for (backer in backers)
-        {
-          creditsGroup.add(buildCreditsLine(backer, y, false, CreditsSide.Left));
-          y += CREDITS_FONT_SIZE;
-        }
+        entry.hasBuiltBody = true;
       }
+      return;
+    }
 
-      // Padding between each role.
-      y += CREDITS_FONT_SIZE * 2.5;
+    if (!entry.hasBuiltBackers)
+    {
+      var backer:String = backersToBuild[entry.backerIndexToBuild];
+      creditsGroup.add(buildCreditsLine(backer, creditsLineY, false, CreditsSide.Left));
+      creditsLineY += CREDITS_FONT_SIZE;
+
+      entry.backerIndexToBuild++;
+      if (entry.backerIndexToBuild >= backersToBuild.length)
+      {
+        entry.hasBuiltBackers = true;
+      }
+      return;
     }
   }
 
@@ -164,15 +190,65 @@ class CreditsState extends MusicBeatState
     var width = (side == CreditsSide.Center) ? FULL_WIDTH : (FULL_WIDTH / 2);
     var size = header ? CREDITS_HEADER_FONT_SIZE : CREDITS_FONT_SIZE;
 
-    var creditsLine:FlxText = new FlxText(xPos, yPos, width, text);
+    // using a cast since creditsGroup is FlxSpriteGroup
+    // we could also do FlxTypedSpriteGroup<FlxText>
+    var creditsLine:FlxText = cast(creditsGroup.recycle(() -> new FlxText()), FlxText);
+    creditsLine.x = xPos + creditsGroup.x;
+    creditsLine.y = yPos + creditsGroup.y;
+    creditsLine.fieldWidth = width;
+    creditsLine.text = text;
+    creditsLine.bold = header;
     creditsLine.setFormat(CREDITS_FONT, size, CREDITS_FONT_COLOR, FlxTextAlign.LEFT, FlxTextBorderStyle.OUTLINE, CREDITS_FONT_STROKE_COLOR, true);
 
     return creditsLine;
   }
 
+  function killOffScreenLines():Void
+  {
+    creditsGroup.forEachExists(function(creditsLine:FlxSprite) {
+      if (creditsLine.y + creditsLine.height <= 0)
+      {
+        creditsLine.kill();
+        trace("killed line");
+      }
+    });
+  }
+
+  function buildNextLine():Void
+  {
+    // no more entriesToBuild
+    if (entriesToBuild.length == 0)
+    {
+      return;
+    }
+
+    // line is off-screen
+    if (creditsGroup.y + creditsLineY >= FlxG.height)
+    {
+      return;
+    }
+
+    var entry:CreditsEntry = entriesToBuild[0];
+    buildCreditsEntryLine(entry);
+
+    // check if everything has been built
+    if (!entry.hasBuiltHeader || !entry.hasBuiltBody || !entry.hasBuiltBackers)
+    {
+      return;
+    }
+
+    entriesToBuild.shift();
+
+    // offset that each entry has
+    creditsLineY += CREDITS_FONT_SIZE * 2.5;
+  }
+
   public override function update(elapsed:Float):Void
   {
     super.update(elapsed);
+
+    killOffScreenLines();
+    buildNextLine();
 
     if (!scrollPaused)
     {
@@ -201,7 +277,7 @@ class CreditsState extends MusicBeatState
 
   function hasEnded():Bool
   {
-    return creditsGroup.y < -creditsGroup.height;
+    return creditsGroup.getFirstExisting() == null && entriesToBuild.length == 0;
   }
 
   function exit():Void
@@ -220,4 +296,14 @@ enum CreditsSide
   Left;
   Center;
   Right;
+}
+
+typedef CreditsEntry =
+{
+  var data:CreditsDataRole;
+  var lineIndexToBuild:Int;
+  var backerIndexToBuild:Int;
+  var hasBuiltHeader:Bool;
+  var hasBuiltBody:Bool;
+  var hasBuiltBackers:Bool;
 }


### PR DESCRIPTION
this pr changes the behaviour of the credits line, to not be all created at the beginning, but rather that they get recycled once a new line appears on the screen.
this should improve memory usage, especially when backers entries are supported