### PR TITLE
[BUGFIX] Fixed memory counter displaying negative numbers

### DIFF
--- a/source/funkin/ui/debug/MemoryCounter.hx
+++ b/source/funkin/ui/debug/MemoryCounter.hx
@@ -36,7 +36,7 @@ class MemoryCounter extends TextField
   @:noCompletion
   #if !flash override #end function __enterFrame(deltaTime:Float):Void
   {
-    var mem:Float = Math.round(MemoryUtil.getMemoryUsed() / BYTES_PER_MEG / ROUND_TO) * ROUND_TO;
+    var mem:Float = Math.fround(MemoryUtil.getMemoryUsed() / BYTES_PER_MEG / ROUND_TO) * ROUND_TO;
 
     if (mem > memPeak) memPeak = mem;
 

--- a/source/funkin/util/MemoryUtil.hx
+++ b/source/funkin/util/MemoryUtil.hx
@@ -48,11 +48,11 @@ class MemoryUtil
    * Calculate the total memory usage of the program, in bytes.
    * @return Int
    */
-  public static function getMemoryUsed():Int
+  public static function getMemoryUsed():#if cpp Float #else Int #end
   {
     #if cpp
     // There is also Gc.MEM_INFO_RESERVED, MEM_INFO_CURRENT, and MEM_INFO_LARGE.
-    return cpp.vm.Gc.memInfo(cpp.vm.Gc.MEM_INFO_USAGE);
+    return cpp.vm.Gc.memInfo64(cpp.vm.Gc.MEM_INFO_USAGE);
     #else
     return openfl.system.System.totalMemory;
     #end


### PR DESCRIPTION
when the Gc memory usage exceeds what's around 2GB, the memory counter dies and display negative numbers which is due to the limit of Int32

![Screenshot_20240507_223802_dev beefers vendetta](https://github.com/FunkinCrew/Funkin/assets/144803230/28c58429-612e-49d6-b428-75cee11166f7)

(Note for testing: easiest way to achieve this is by going through every stage in the game)

now the bytes are retrieved as a Float (on cpp targets only) so the memory counter will likely never show negative mem usage (unless you're playing on a nasa PC and got a huge memory leak lol?)

![Screenshot 2024-06-09 011647](https://github.com/FunkinCrew/Funkin/assets/144803230/81272fe4-0c6c-4f92-8112-b82f4363250d)

