### PR TITLE
[BUGFIX] When testing a chart, pressing R (or dying) then pressing ESC to go back to the chart editor, it no longer crashes

### DIFF
--- a/source/funkin/play/GameOverSubState.hx
+++ b/source/funkin/play/GameOverSubState.hx
@@ -276,7 +276,7 @@ class GameOverSubState extends MusicBeatSubState
     }
     else if (boyfriend != null)
     {
-      if (PlayState.instance.isMinimalMode)
+      if (PlayState.instance != null && PlayState.instance.isMinimalMode)
       {
         // startDeathMusic(1.0, false);
       }

--- a/source/funkin/play/GameOverSubState.hx
+++ b/source/funkin/play/GameOverSubState.hx
@@ -244,7 +244,7 @@ class GameOverSubState extends MusicBeatSubState
     }
 
     // KEYBOARD ONLY: Return to the menu when pressing the assigned key.
-    if (controls.BACK && !mustNotExit && !isEnding)
+    if (controls.BACK && !mustNotExit)
     {
       blueballed = false;
       PlayState.instance.deathCounter = 0;

--- a/source/funkin/play/GameOverSubState.hx
+++ b/source/funkin/play/GameOverSubState.hx
@@ -244,7 +244,7 @@ class GameOverSubState extends MusicBeatSubState
     }
 
     // KEYBOARD ONLY: Return to the menu when pressing the assigned key.
-    if (controls.BACK && !mustNotExit)
+    if (controls.BACK && !mustNotExit && !isEnding)
     {
       blueballed = false;
       PlayState.instance.deathCounter = 0;


### PR DESCRIPTION
When testing a song via the chart editor, dying (or pressing R), then pressing ESCAPE it crashes. This is because of `playstate.instance` returning `null`.

Fixes issue #2715 