### PR TITLE
Dont SNAP camera on CLASSIC focus event

### DIFF
--- a/source/funkin/play/PlayState.hx
+++ b/source/funkin/play/PlayState.hx
@@ -3172,24 +3172,21 @@ class PlayState extends MusicBeatSubState
   /**
    * Resets the camera's zoom level and focus point.
    */
-  public function resetCamera(?resetZoom:Bool = true, ?cancelTweens:Bool = true):Void
+  public function resetCamera(?resetZoom:Bool = true, ?cancelTweens:Bool = true, ?snapCamera:Bool = true):Void
   {
     // Cancel camera tweens if any are active.
     if (cancelTweens)
-    {
       cancelAllCameraTweens();
-    }
 
     FlxG.camera.follow(cameraFollowPoint, LOCKON, Constants.DEFAULT_CAMERA_FOLLOW_RATE);
     FlxG.camera.targetOffset.set();
 
     if (resetZoom)
-    {
       resetCameraZoom();
-    }
 
     // Snap the camera to the follow point immediately.
-    FlxG.camera.focusOn(cameraFollowPoint.getPosition());
+    if (snapCamera)
+      FlxG.camera.focusOn(cameraFollowPoint.getPosition());
   }
 
   /**

--- a/source/funkin/play/event/FocusCameraSongEvent.hx
+++ b/source/funkin/play/event/FocusCameraSongEvent.hx
@@ -127,7 +127,7 @@ class FocusCameraSongEvent extends SongEvent
     switch (ease)
     {
       case 'CLASSIC': // Old-school. No ease. Just set follow point.
-        PlayState.instance.resetCamera(false, true);
+        PlayState.instance.resetCamera(false, true, false);
         PlayState.instance.cameraFollowPoint.setPosition(targetX, targetY);
       case 'INSTANT': // Instant ease. Duration is automatically 0.
         PlayState.instance.tweenCameraToPosition(targetX, targetY, 0);


### PR DESCRIPTION
If there are several CLASSIC events nearby, camera WILL JERK.
If you need to SNAP camera, then use INSTANT ease for it.