### PR TITLE
[FEATURE] Run the garbage collection process after purging cache.

### DIFF
--- a/source/funkin/graphics/FunkinSprite.hx
+++ b/source/funkin/graphics/FunkinSprite.hx
@@ -7,6 +7,7 @@ import flixel.tweens.FlxTween;
 import openfl.display3D.textures.TextureBase;
 import funkin.graphics.framebuffer.FixedBitmapData;
 import openfl.display.BitmapData;
+import openfl.system.System;
 
 /**
  * An FlxSprite with additional functionality.
@@ -219,6 +220,8 @@ class FunkinSprite extends FlxSprite
       graphic.destroy();
       previousCachedTextures.remove(graphicKey);
     }
+
+    System.gc();
   }
 
   static function isGraphicCached(graphic:FlxGraphic):Bool


### PR DESCRIPTION
By running the garbage collector after destroying some textures from the `previousCachedTextures` map, some memory will be freed.