### PR TITLE
Fix duplicate combo counter on combo break

### DIFF
--- a/source/funkin/play/PlayState.hx
+++ b/source/funkin/play/PlayState.hx
@@ -2562,8 +2562,8 @@ class PlayState extends MusicBeatSubState
         healthChange = Constants.HEALTH_BAD_BONUS;
         isComboBreak = Constants.JUDGEMENT_BAD_COMBO_BREAK;
       case 'shit':
-        isComboBreak = Constants.JUDGEMENT_SHIT_COMBO_BREAK;
         healthChange = Constants.HEALTH_SHIT_BONUS;
+        isComboBreak = Constants.JUDGEMENT_SHIT_COMBO_BREAK;
     }
 
     // Send the note hit event.
@@ -2632,8 +2632,6 @@ class PlayState extends MusicBeatSubState
       }
     }
     vocals.playerVolume = 0;
-
-    if (Highscore.tallies.combo != 0) if (Highscore.tallies.combo >= 10) comboPopUps.displayCombo(0);
 
     applyScore(-10, 'miss', healthChange, true);
 
@@ -2853,7 +2851,7 @@ class PlayState extends MusicBeatSubState
       }
     }
     comboPopUps.displayRating(daRating);
-    if (combo >= 10 || combo == 0) comboPopUps.displayCombo(combo);
+    if (combo >= 10) comboPopUps.displayCombo(combo);
 
     vocals.playerVolume = 1;
   }


### PR DESCRIPTION
This PR fixes a bug where the function onNoteMiss calls applyScore, creating two sets of "000" whenever a note goes off the screen with a combo of 10 or more.

Also removes the "== 0" condition from popUpScore to prevent double displays after Bad or Shit ratings.

Subsequently, this PR removes the "000" display after getting a Bad or Shit rating with a combo of less than 10.

**Question for the devs:** 
Do you intend for the "000" to appear after every Bad and Shit rating regardless of your combo?

## Original Behavior (0.5.0)

**Double combo break display**

https://github.com/FunkinCrew/Funkin/assets/170126004/ccf725f7-0f09-4cfb-af3c-471b7b40ff3b

**Combo break display when combo <10 (bad/shit ratings but not for misses)**

https://github.com/FunkinCrew/Funkin/assets/170126004/292abfda-fd09-4862-ac48-38afb27b5c8f

## Pull Request Behavior

**Fixed double combo break display**

https://github.com/FunkinCrew/Funkin/assets/170126004/d9a40b17-c632-470e-a24e-1b16a738e229

**Combo break no longer displays when combo <10**

https://github.com/FunkinCrew/Funkin/assets/170126004/b515fdd9-8987-4e9d-a1c6-67e8e16c6f7b