### PR TITLE
[BUGFIX] Fixed ranks not appearing in freeplay for custom variations

### DIFF
--- a/source/funkin/ui/freeplay/FreeplayState.hx
+++ b/source/funkin/ui/freeplay/FreeplayState.hx
@@ -2094,8 +2094,13 @@ class FreeplaySongData
     {
       this.albumId = songDifficulty.album;
     }
+    
+    // TODO: This line of code makes me sad, but you can't really fix it without a breaking migration.
+    // `easy`, `erect`, `normal-pico`, etc.
+    var suffixedDifficulty = (songDifficulty.variation != Constants.DEFAULT_VARIATION
+      && songDifficulty.variation != 'erect') ? '$currentDifficulty-${songDifficulty.variation}' : currentDifficulty;
 
-    this.scoringRank = Save.instance.getSongRank(songId, currentDifficulty);
+    this.scoringRank = Save.instance.getSongRank(songId, suffixedDifficulty);
 
     this.isNew = song.isSongNew(currentDifficulty);
   }


### PR DESCRIPTION
Freeplay tries to access a song's rank using the current difficulty name alone, but custom variation ranks are being saved with a variation prefix. This PR makes freeplay look for the variation prefix when necessary and attaches the associated TODO.