### PR TITLE
FunkinCamera improvements

### DIFF
--- a/source/funkin/graphics/FunkinCamera.hx
+++ b/source/funkin/graphics/FunkinCamera.hx
@@ -47,6 +47,9 @@ class FunkinCamera extends FlxCamera
 
   public var shouldDraw:Bool = true;
 
+  // The camera's world rotation in degrees.
+  public var rotation:Float = 15;
+
   // Used to identify the camera during debugging.
   final id:String = 'unknown';
 
@@ -182,6 +185,16 @@ class FunkinCamera extends FlxCamera
       ?shader:FlxShader):Void
   {
     if (!shouldDraw) return;
+
+    if (rotation % 360 != 0)
+    {
+      // rotate about camera center
+      final centerX:Float = width / 2;
+      final centerY:Float = height / 2;
+      matrix.translate(-centerX, -centerY);
+      matrix.rotate(rotation * Math.PI / 180);
+      matrix.translate(centerX, centerY);
+    }
 
     if ( switch blend
       {

--- a/source/funkin/graphics/FunkinCamera.hx
+++ b/source/funkin/graphics/FunkinCamera.hx
@@ -48,7 +48,7 @@ class FunkinCamera extends FlxCamera
   public var shouldDraw:Bool = true;
 
   // The camera's world rotation in degrees.
-  public var rotation:Float = 15;
+  public var rotation:Float = 0;
 
   // Used to identify the camera during debugging.
   final id:String = 'unknown';

--- a/source/funkin/play/PlayState.hx
+++ b/source/funkin/play/PlayState.hx
@@ -1528,9 +1528,9 @@ class PlayState extends MusicBeatSubState
   {
     camGame = new FunkinCamera('playStateCamGame');
     camGame.bgColor = BACKGROUND_COLOR; // Show a pink background behind the stage.
-    camHUD = new FlxCamera();
+    camHUD = new FunkinCamera('playStateCamHUD');
     camHUD.bgColor.alpha = 0; // Show the game scene behind the camera.
-    camCutscene = new FlxCamera();
+    camCutscene = new FunkinCamera('playStateCamCutscene');
     camCutscene.bgColor.alpha = 0; // Show the game scene behind the camera.
 
     FlxG.cameras.reset(camGame);


### PR DESCRIPTION
there are a few things about `FlxCamera`/`FunkinCamera` id like to change...

---

for one, rotation!! you can move the camera frame around, or move around its world space with `scroll`. you can scale the camera frame, or scale its world space with `zoom`. you can rotate the camera frame... but there is no equivalent for rotating its world space as of right now.

using `angle` to rotate the camera also breaks any shaders applied to the camera. it resizes the bitmap used for the shader, often ending up larger than the actual bounds of the camera for some reason, and also lag spikes at every arbitrary resize?? i first encountered this while working with Psych Engine and spent a while trying to figure out the cause of this to no avail.

https://github.com/FunkinCrew/Funkin/assets/58795684/6f759e68-97a6-4804-b7d9-2560bcd92227

the bandaid fix i settled on was to scale the camera such that itll always fit the screen while rotated, and then use a shader for rotation, but this comes with its own downsides:
- the game has to render ~4x as many pixels (cuz its ~2x the size) which is prettyy bad for performance, especially with shaders.
- to look the same, shaders need modified tex coords + modified texture function to scale back down to fit screen space.

id rather not have to do this, though... the solution im pursuing is to rotate anything drawn to the camera internally during rendering with a `rotation` camera property.

---

second, i would like to change the shaking behavior such that it only affects the world space position during rendering than acting on the camera itself, which will get rid of the "black border" issue