### PR TITLE
[BUGFIX/ENHANCEMENT] Fix Soundtray Aliasing / Smoothing

### DIFF
--- a/source/funkin/ui/options/FunkinSoundTray.hx
+++ b/source/funkin/ui/options/FunkinSoundTray.hx
@@ -33,6 +33,7 @@ class FunkinSoundTray extends FlxSoundTray
     var bg:Bitmap = new Bitmap(Assets.getBitmapData(Paths.image("soundtray/volumebox")));
     bg.scaleX = graphicScale;
     bg.scaleY = graphicScale;
+    bg.smoothing = true;
     addChild(bg);
 
     y = -height;
@@ -44,6 +45,7 @@ class FunkinSoundTray extends FlxSoundTray
     backingBar.y = 5;
     backingBar.scaleX = graphicScale;
     backingBar.scaleY = graphicScale;
+    backingBar.smoothing = true;
     addChild(backingBar);
     backingBar.alpha = 0.4;
 
@@ -60,6 +62,7 @@ class FunkinSoundTray extends FlxSoundTray
       bar.y = 5;
       bar.scaleX = graphicScale;
       bar.scaleY = graphicScale;
+      bar.smoothing = true;
       addChild(bar);
       _bars.push(bar);
     }


### PR DESCRIPTION
This simple pull request allows for the bars and main soundtray container to be anti-aliased, allowing for a more readable look.

Before
<img src="https://github.com/FunkinCrew/Funkin/assets/89167668/2d4b4c04-1378-4389-9cbc-9ac249d4cb9c">

After
![image](https://github.com/FunkinCrew/Funkin/assets/89167668/cc6db16c-e71c-4227-952a-348824c810ce)

Screenshots are in different sizes and do not serve this change justice, but is more noticeable in-game than here.
