### PR TITLE
[ENHANCEMENT] Implement a better Strumline Note Confirm Animation

### DIFF
--- a/source/funkin/play/notes/StrumlineNote.hx
+++ b/source/funkin/play/notes/StrumlineNote.hx
@@ -16,7 +16,7 @@ class StrumlineNote extends FlxSprite
 
   var confirmHoldTimer:Float = -1;
 
-  static final CONFIRM_HOLD_TIME:Float = 0.1;
+  static final CONFIRM_HOLD_TIME:Float = 0.15;
 
   function set_direction(value:NoteDirection):NoteDirection
   {
@@ -48,7 +48,7 @@ class StrumlineNote extends FlxSprite
     // Run a timer before we stop playing the confirm animation.
     // On opponent, this prevent issues with hold notes.
     // On player, this allows holding the confirm key to fall back to press.
-    if (name == 'confirm')
+    if (name == 'confirm' && isPlayer)
     {
       confirmHoldTimer = 0;
     }
@@ -109,6 +109,7 @@ class StrumlineNote extends FlxSprite
   {
     this.active = true;
     this.playAnimation('confirm', true);
+    if (!isPlayer) confirmHoldTimer = 0;
   }
 
   public function isConfirm():Bool

--- a/source/funkin/play/notes/StrumlineNote.hx
+++ b/source/funkin/play/notes/StrumlineNote.hx
@@ -109,7 +109,7 @@ class StrumlineNote extends FlxSprite
   {
     this.active = true;
     this.playAnimation('confirm', true);
-    if (!isPlayer) confirmHoldTimer = 0;
+    confirmHoldTimer = isPlayer ? -1 : 0;
   }
 
   public function isConfirm():Bool


### PR DESCRIPTION
The opponent strumline notes confirm animation were too long and didn't looked great. I increased `CONFIRM_HOLD_TIME` up to 0.15 and start the timer right when the animation is started and not when finished, just for opponents/botplay, the player confirm animation is almost the same, i just fixed a premature static animation playing when hitting a double note.

resumed list:
 - Opponent/Botplay strumline notes confirm animation is stopped earlier so it looks nicer (by starting the stop timer when playing the confirm animation and not when finishing it)
- Player/controlled strumline notes confirm animation is a little bit longer so it doesnt start the "press" animation too early and look weird.

Sorry for not being able to provide a video comparation but i couldnt record it properly