### PR TITLE
[FEATURE] Bopper Speed Event

### DIFF
--- a/source/funkin/play/PlayState.hx
+++ b/source/funkin/play/PlayState.hx
@@ -51,6 +51,7 @@ import funkin.play.notes.SustainTrail;
 import funkin.play.scoring.Scoring;
 import funkin.play.song.Song;
 import funkin.play.stage.Stage;
+import funkin.play.stage.Bopper;
 import funkin.save.Save;
 import funkin.ui.debug.charting.ChartEditorState;
 import funkin.ui.debug.stage.StageOffsetSubState;
@@ -191,6 +192,11 @@ class PlayState extends MusicBeatSubState
    * Gets disabled once resetting happens.
    */
   public var needsReset:Bool = false;
+
+  /**
+   * Map of the boppers that will reset their bop speed once the restart occurs.
+   */
+  public var resetBoppers:Map<Bopper, Int> = new Map<Bopper, Int>();
 
   /**
    * The current 'Blueball Counter' to display in the pause menu.
@@ -891,6 +897,12 @@ class PlayState extends MusicBeatSubState
       // Delete all notes and reset the arrays.
       regenNoteData();
 
+      if (resetBoppers.size() > 0) {
+        for (bopper => speed in resetBoppers) {
+          bopper.danceEvery = speed;
+        }
+      }
+
       // Reset camera zooming
       cameraBopIntensity = Constants.DEFAULT_BOP_INTENSITY;
       hudCameraZoomIntensity = (cameraBopIntensity - 1.0) * 2.0;
@@ -1005,8 +1017,6 @@ class PlayState extends MusicBeatSubState
     }
     FlxG.watch.addQuick('health', health);
     FlxG.watch.addQuick('cameraBopIntensity', cameraBopIntensity);
-
-    // TODO: Add a song event for Handle GF dance speed.
 
     // Handle player death.
     if (!isInCutscene && !disableKeys)

--- a/source/funkin/play/PlayState.hx
+++ b/source/funkin/play/PlayState.hx
@@ -194,11 +194,6 @@ class PlayState extends MusicBeatSubState
   public var needsReset:Bool = false;
 
   /**
-   * Map of the boppers that will reset their bop speed once the restart occurs.
-   */
-  public var resetBoppers:Map<Bopper, Int> = new Map<Bopper, Int>();
-
-  /**
    * The current 'Blueball Counter' to display in the pause menu.
    * Resets when you beat a song or go back to the main menu.
    */
@@ -896,12 +891,6 @@ class PlayState extends MusicBeatSubState
 
       // Delete all notes and reset the arrays.
       regenNoteData();
-
-      if (resetBoppers.size() > 0) {
-        for (bopper => speed in resetBoppers) {
-          bopper.danceEvery = speed;
-        }
-      }
 
       // Reset camera zooming
       cameraBopIntensity = Constants.DEFAULT_BOP_INTENSITY;

--- a/source/funkin/play/event/BopperSpeedEvent.hx
+++ b/source/funkin/play/event/BopperSpeedEvent.hx
@@ -22,7 +22,6 @@ class BopperSpeedEvent extends SongEvent
   }
 
   static final DEFAULT_DANCE_EVERY:Int = 1;
-  static final DEFAULT_DURATION:Float = 4.0;
 
   public override function handleEvent(data:SongEventData):Void
   {
@@ -31,9 +30,6 @@ class BopperSpeedEvent extends SongEvent
     var bopperName:String = data.getString('bopper');
 
     var speed:Int = data.getInt('danceEvery') ?? DEFAULT_DANCE_EVERY;
-
-    var duration:Float = data.getFloat('duration') ?? DEFAULT_DURATION;
-    var durSeconds:Float = Conductor.instance.stepLengthMs * duration / 1000;
 
     var bopperProp:FlxSprite = null;
 
@@ -58,11 +54,6 @@ class BopperSpeedEvent extends SongEvent
         bopper.danceEvery = speed;
         trace('Adding $bopperName to the list to reset the speed on restart.');
         PlayState.instance.resetBoppers.set(bopper, initEveryBeat);
-
-        new FlxTimer().start(durSeconds, function(tmr) {
-          trace('Resetting $bopperName speed back to $initEveryBeat.');
-          bopper.danceEvery = initEveryBeat;
-        });
       }
     }
   }
@@ -88,14 +79,6 @@ class BopperSpeedEvent extends SongEvent
         step: 1,
         min: 1,
         type: SongEventFieldType.INTEGER,
-      },
-      {
-        name: 'duration',
-        title: 'Duration',
-        defaultValue: 4.0,
-        step: 0.5,
-        type: SongEventFieldType.FLOAT,
-        units: 'steps'
       }
     ]);
   }

--- a/source/funkin/play/event/BopperSpeedEvent.hx
+++ b/source/funkin/play/event/BopperSpeedEvent.hx
@@ -1,0 +1,101 @@
+package funkin.play.event;
+
+// Data from the chart
+import funkin.play.character.BaseCharacter;
+import funkin.play.stage.StageProp;
+import funkin.data.song.SongData;
+import funkin.data.song.SongData.SongEventData;
+// Data from the event schema
+import funkin.play.event.SongEvent;
+import funkin.data.event.SongEventSchema;
+import funkin.data.event.SongEventSchema.SongEventFieldType;
+
+import funkin.play.stage.Bopper;
+import flixel.FlxSprite;
+import flixel.util.FlxTimer;
+
+class BopperSpeedEvent extends SongEvent
+{
+  public function new()
+  {
+    super("BopperSpeed");
+  }
+
+  static final DEFAULT_DANCE_EVERY:Int = 1;
+  static final DEFAULT_DURATION:Float = 4.0;
+
+  public override function handleEvent(data:SongEventData):Void
+  {
+    if (PlayState.instance == null || PlayState.instance.currentStage == null) return;
+
+    var bopperName:String = data.getString('bopper');
+
+    var speed:Int = data.getInt('danceEvery') ?? DEFAULT_DANCE_EVERY;
+
+    var duration:Float = data.getFloat('duration') ?? DEFAULT_DURATION;
+    var durSeconds:Float = Conductor.instance.stepLengthMs * duration / 1000;
+
+    var bopperProp:FlxSprite = null;
+
+    switch(bopperName)
+    {
+      case 'boyfriend' | 'bf' | 'player':
+        bopperProp = PlayState.instance.currentStage.getBoyfriend();
+      case 'dad' | 'opponent':
+        bopperProp = PlayState.instance.currentStage.getDad();
+      case 'girlfriend' | 'gf':
+        bopperProp = PlayState.instance.currentStage.getGirlfriend();
+      default:
+        bopperProp = PlayState.instance.currentStage.getNamedProp(bopperName);
+    }
+
+    if(bopperProp != null) {
+      if ((Std.isOfType(bopperProp, Bopper)) || (Std.isOfType(bopperProp, BaseCharacter)))
+      {
+        var bopper = cast(bopperProp, Bopper);
+        var initEveryBeat = bopper.danceEvery;
+        trace('Setting $bopperName speed to $speed.');
+        bopper.danceEvery = speed;
+        trace('Adding $bopperName to the list to reset the speed on restart.');
+        PlayState.instance.resetBoppers.set(bopper, initEveryBeat);
+
+        new FlxTimer().start(durSeconds, function(tmr) {
+          trace('Resetting $bopperName speed back to $initEveryBeat.');
+          bopper.danceEvery = initEveryBeat;
+        });
+      }
+    }
+  }
+
+  public override function getTitle():String
+  {
+    return 'Set Bopper Speed';
+  }
+
+  public override function getEventSchema():SongEventSchema
+  {
+    return new SongEventSchema([
+      {
+        name: 'bopper',
+        title: 'Target (ID)',
+        type: SongEventFieldType.STRING,
+        defaultValue: 'girlfriend',
+      },
+      {
+        name: 'danceEvery',
+        title: 'Dance Every Value',
+        defaultValue: 1,
+        step: 1,
+        type: SongEventFieldType.INTEGER,
+      },
+      {
+        name: 'duration',
+        title: 'Duration',
+        defaultValue: 4.0,
+        step: 0.5,
+        type: SongEventFieldType.FLOAT,
+        units: 'steps'
+      }
+    ]);
+  }
+}

--- a/source/funkin/play/event/BopperSpeedEvent.hx
+++ b/source/funkin/play/event/BopperSpeedEvent.hx
@@ -86,6 +86,7 @@ class BopperSpeedEvent extends SongEvent
         title: 'Dance Every Value',
         defaultValue: 1,
         step: 1,
+        min: 1,
         type: SongEventFieldType.INTEGER,
       },
       {

--- a/source/funkin/play/event/BopperSpeedEvent.hx
+++ b/source/funkin/play/event/BopperSpeedEvent.hx
@@ -2,7 +2,6 @@ package funkin.play.event;
 
 // Data from the chart
 import funkin.play.character.BaseCharacter;
-import funkin.play.stage.StageProp;
 import funkin.data.song.SongData;
 import funkin.data.song.SongData.SongEventData;
 // Data from the event schema
@@ -49,11 +48,8 @@ class BopperSpeedEvent extends SongEvent
       if ((Std.isOfType(bopperProp, Bopper)) || (Std.isOfType(bopperProp, BaseCharacter)))
       {
         var bopper = cast(bopperProp, Bopper);
-        var initEveryBeat = bopper.danceEvery;
         trace('Setting $bopperName speed to $speed.');
         bopper.danceEvery = speed;
-        trace('Adding $bopperName to the list to reset the speed on restart.');
-        PlayState.instance.resetBoppers.set(bopper, initEveryBeat);
       }
     }
   }

--- a/source/funkin/play/stage/Stage.hx
+++ b/source/funkin/play/stage/Stage.hx
@@ -23,6 +23,8 @@ import funkin.data.stage.StageData;
 import funkin.data.stage.StageData.StageDataCharacter;
 import funkin.data.stage.StageRegistry;
 import funkin.play.stage.StageProp;
+import funkin.play.character.CharacterData;
+import funkin.play.character.CharacterData.CharacterDataParser;
 import funkin.util.SortUtil;
 import funkin.util.assets.FlxAnimationUtil;
 
@@ -105,39 +107,19 @@ class Stage extends FlxSpriteGroup implements IPlayStateScriptedClass implements
   public function resetStage():Void
   {
     // Reset positions of characters.
-    if (getBoyfriend() != null)
-    {
-      getBoyfriend().resetCharacter(true);
+    for (id => character in characters) {
+      var char = getCharacter(id);
+
+      char.resetCharacter(true);
+
       // Reapply the camera offsets.
-      var stageCharData:StageDataCharacter = _data.characters.bf;
-      var finalScale:Float = getBoyfriend().getBaseScale() * stageCharData.scale;
-      getBoyfriend().setScale(finalScale);
-      getBoyfriend().cameraFocusPoint.x += stageCharData.cameraOffsets[0];
-      getBoyfriend().cameraFocusPoint.y += stageCharData.cameraOffsets[1];
-    }
-    else
-    {
-      trace('STAGE RESET: No boyfriend found.');
-    }
-    if (getGirlfriend() != null)
-    {
-      getGirlfriend().resetCharacter(true);
-      // Reapply the camera offsets.
-      var stageCharData:StageDataCharacter = _data.characters.gf;
-      var finalScale:Float = getGirlfriend().getBaseScale() * stageCharData.scale;
-      getGirlfriend().setScale(finalScale);
-      getGirlfriend().cameraFocusPoint.x += stageCharData.cameraOffsets[0];
-      getGirlfriend().cameraFocusPoint.y += stageCharData.cameraOffsets[1];
-    }
-    if (getDad() != null)
-    {
-      getDad().resetCharacter(true);
-      // Reapply the camera offsets.
-      var stageCharData:StageDataCharacter = _data.characters.dad;
-      var finalScale:Float = getDad().getBaseScale() * stageCharData.scale;
-      getDad().setScale(finalScale);
-      getDad().cameraFocusPoint.x += stageCharData.cameraOffsets[0];
-      getDad().cameraFocusPoint.y += stageCharData.cameraOffsets[1];
+      var stageCharData:StageDataCharacter = Reflect.field(_data.characters, id);
+      var charData:CharacterData = CharacterDataParser.fetchCharacterData(character.characterId);
+      var finalScale:Float = char.getBaseScale() * stageCharData.scale;
+      char.setScale(finalScale);
+      char.cameraFocusPoint.x += stageCharData.cameraOffsets[0];
+      char.cameraFocusPoint.y += stageCharData.cameraOffsets[1];
+      char.danceEvery = charData.danceEvery;
     }
 
     // Reset positions of named props.
@@ -152,6 +134,12 @@ class Stage extends FlxSpriteGroup implements IPlayStateScriptedClass implements
         prop.x = dataProp.position[0];
         prop.y = dataProp.position[1];
         prop.zIndex = dataProp.zIndex;
+        // Reset bop speed.
+        if (Std.isOfType(prop, Bopper))
+        {
+          var bopper = cast(prop, Bopper);
+          bopper.danceEvery = dataProp.danceEvery;
+        }
       }
     }
 


### PR DESCRIPTION
- This PR aims to make players control the speed of each prop in the stage that is a _Bopper_ type.
- Players can control: characters (boyfriend, girlfriend, opponent/dad) and other Boppers within the stage.

Video Showcase:

https://github.com/FunkinCrew/Funkin/assets/69017727/16589409-f08f-4985-9e70-86a4f5eb4f48




