### PR TITLE
[BUGFIX/ENHANCEMENT] Sustain trail alpha fix

### DIFF
--- a/source/funkin/play/notes/SustainTrail.hx
+++ b/source/funkin/play/notes/SustainTrail.hx
@@ -125,8 +125,6 @@ class SustainTrail extends FlxSprite
 
     flipY = Preferences.downscroll;
 
-    // alpha = 0.6;
-    alpha = 1.0;
     // calls updateColorTransform(), which initializes processedGraphic!
     updateColorTransform();
 
@@ -151,6 +149,7 @@ class SustainTrail extends FlxSprite
       triggerRedraw();
     }
     previousScrollSpeed = parentStrumline?.scrollSpeed ?? 1.0;
+    alpha = 0.6;
   }
 
   /**


### PR DESCRIPTION
Sustain trail alpha would always default to 1 regardless of what alpha value was defined. Simply moving the alpha value into `update()` fixes this issue. This is similar to pre-rewrite sustain trails which were also semi-transparent. 