### PR TITLE
Looping of character sing and strumline confirm animations on hold notes

### DIFF
--- a/source/funkin/play/character/BaseCharacter.hx
+++ b/source/funkin/play/character/BaseCharacter.hx
@@ -346,6 +346,16 @@ class BaseCharacter extends Bopper
     }
   }
 
+  /**
+   * Stored the direction of the last note that was hit by this player.
+   */
+  var lastNoteDirection:Null<NoteDirection> = null;
+
+  /**
+   * Stores the time at which the player should stop looping the sing animation when pressing a hold note.
+   */
+  var lastHoldFinish:Null<Float> = null;
+
   public override function onUpdate(event:UpdateScriptEvent):Void
   {
     super.onUpdate(event);
@@ -388,6 +398,17 @@ class BaseCharacter extends Bopper
 
       // Without this check here, the player character would only play the `sing` animation
       // for one beat, as opposed to holding it as long as the player is holding the button.
+
+      // Repeat the sing animation when pressing a hold note just like in the old input system.
+      if ((this.characterType != BF || isHoldingNote())
+        && this.animation.curAnim.curFrame >= 3
+        && lastNoteDirection != null
+        && (lastHoldFinish != null && lastHoldFinish >= Conductor.instance.songPosition))
+      {
+        this.playSingAnimation(lastNoteDirection, false);
+        holdTimer = 0;
+      }
+
       var shouldStopSinging:Bool = (this.characterType == BF) ? !isHoldingNote() : true;
 
       FlxG.watch.addQuick('singTimeSec-${characterId}', singTimeSec);
@@ -480,6 +501,15 @@ class BaseCharacter extends Bopper
   }
 
   /**
+   * Resets the hold data values to stop the animation from looping
+   */
+  function stopHolding()
+  {
+    lastNoteDirection = null;
+    lastHoldFinish = null;
+  }
+
+  /**
    * Every time a note is hit, check if the note is from the same strumline.
    * If it is, then play the sing animation.
    */
@@ -487,17 +517,16 @@ class BaseCharacter extends Bopper
   {
     super.onNoteHit(event);
 
-    if (event.note.noteData.getMustHitNote() && characterType == BF)
+    var noteDirection:NoteDirection = event.note.noteData.getDirection();
+
+    if ((event.note.noteData.getMustHitNote() && characterType == BF) || (!event.note.noteData.getMustHitNote() && characterType == DAD))
     {
       // If the note is from the same strumline, play the sing animation.
-      this.playSingAnimation(event.note.noteData.getDirection(), false);
+      this.playSingAnimation(noteDirection, false);
       holdTimer = 0;
-    }
-    else if (!event.note.noteData.getMustHitNote() && characterType == DAD)
-    {
-      // If the note is from the same strumline, play the sing animation.
-      this.playSingAnimation(event.note.noteData.getDirection(), false);
-      holdTimer = 0;
+
+      lastNoteDirection = noteDirection;
+      if (event.note.noteData.isHoldNote) lastHoldFinish = event.note.strumTime + event.note.noteData.length;
     }
   }
 
@@ -540,6 +569,8 @@ class BaseCharacter extends Bopper
         this.playAnimation(dropAnim, true, true);
       }
     }
+
+    stopHolding();
   }
 
   /**
@@ -561,6 +592,8 @@ class BaseCharacter extends Bopper
       // trace('Playing ghost miss animation...');
       this.playSingAnimation(event.dir, true);
     }
+
+    stopHolding();
   }
 
   public override function onDestroy(event:ScriptEvent):Void

--- a/source/funkin/play/notes/Strumline.hx
+++ b/source/funkin/play/notes/Strumline.hx
@@ -445,7 +445,8 @@ class Strumline extends FlxSpriteGroup
       else if (conductorInUse.songPosition > holdNote.strumTime && holdNote.hitNote)
       {
         // Hold note is currently being hit, clip it off.
-        holdConfirm(holdNote.noteDirection);
+        /* holdConfirm(holdNote.noteDirection); */
+        playConfirmHold(holdNote.noteDirection);
         holdNote.visible = true;
 
         holdNote.sustainLength = (holdNote.strumTime + holdNote.fullSustainLength) - conductorInUse.songPosition;
@@ -641,6 +642,11 @@ class Strumline extends FlxSpriteGroup
   public function playConfirm(direction:NoteDirection):Void
   {
     getByDirection(direction).playConfirm();
+  }
+
+  public function playConfirmHold(direction:NoteDirection):Void
+  {
+    getByDirection(direction).playConfirmHold();
   }
 
   public function holdConfirm(direction:NoteDirection):Void

--- a/source/funkin/play/notes/StrumlineNote.hx
+++ b/source/funkin/play/notes/StrumlineNote.hx
@@ -111,6 +111,15 @@ class StrumlineNote extends FlxSprite
     this.playAnimation('confirm', true);
   }
 
+  public function playConfirmHold():Void
+  {
+    if (getCurrentAnimationFrame() >= 3)
+    {
+      this.active = true;
+      this.playAnimation('confirm', true);
+    }
+  }
+
   public function isConfirm():Bool
   {
     return getCurrentAnimation().startsWith('confirm');
@@ -136,6 +145,11 @@ class StrumlineNote extends FlxSprite
     {
       this.playAnimation('confirm', false, false);
     }
+  }
+
+  public function getCurrentAnimationFrame():Int
+  {
+    return this.animation.curAnim.curFrame;
   }
 
   /**


### PR DESCRIPTION
Now, whenever the player or CPU/NPC hit a hold note, the character corresponding to that player and the strumline which the note belongs to will now play their sing and confirm animations respectively on "loop".
This used to be a feature in funkin versions prior to 0.3 but has been lost due to the re-write of how the game renders, stored and uses hold notes, but with this re-implementation, this lost feature has been revived into the new engine, with the added bonus of animation loop rates not being song BPM dependent but instead being a constant value that determines at what frame of the animation it should loop back to the starting frame.

### Note:
At line 448 of `Strumline.hx`, the `holdConfirm` function has been commented out as its functionality was replaced with the new `playConfirmHold` function, however the function declaration for `holdConfirm` was left in the code-base as I do not have any idea if the presence of that function call is critical for the game's function, therefore anything related to that function was not tinkered with, but if decided that the function should no longer have a use in the code-base, I made sure that it could be removed without worry of breaking other functionalities.
![image](https://github.com/FunkinCrew/Funkin/assets/102032123/b16bd649-e910-4e3c-bc8a-cf3436e01bfd)

https://github.com/FunkinCrew/Funkin/assets/102032123/22da1f99-a97d-4b03-95b8-a2ad9d6dc6fe

