### PR TITLE
[ENHANCEMENT] Color Event Field Type

### DIFF
--- a/source/funkin/data/event/SongEventSchema.hx
+++ b/source/funkin/data/event/SongEventSchema.hx
@@ -74,6 +74,8 @@ abstract SongEventSchema(SongEventSchemaRaw)
           if (Std.string(field.keys.get(key)) == valueString) return key;
         }
         return valueString;
+      case SongEventFieldType.COLOR:
+        return Std.string(value);
       default:
         return 'Unknown';
     }
@@ -174,4 +176,9 @@ enum abstract SongEventFieldType(String) from String to String
    * Make sure to specify the `keys` field in the schema.
    */
   var ENUM = "enum";
+
+  /**
+   * The COLOR type will display as a Color Picker.
+   */
+  var COLOR = "color";
 }

--- a/source/funkin/data/song/SongData.hx
+++ b/source/funkin/data/song/SongData.hx
@@ -6,6 +6,7 @@ import funkin.data.event.SongEventSchema;
 import funkin.data.song.SongRegistry;
 import thx.semver.Version;
 import funkin.util.tools.ICloneable;
+import flixel.util.FlxColor;
 
 /**
  * Data containing information about a song.
@@ -775,6 +776,15 @@ abstract SongEventData(SongEventDataRaw) from SongEventDataRaw to SongEventDataR
   public inline function getBool(key:String):Null<Bool>
   {
     return this.value == null ? null : cast Reflect.field(this.value, key);
+  }
+
+  public inline function getColor(key:String):Null<FlxColor>
+  {
+    if(this.value == null) return null;
+    var stringResult = Reflect.field(this.value, key);
+    var resultToHex = '#' + StringTools.hex(Std.parseInt(stringResult), 6);
+    var result = FlxColor.fromString(resultToHex);
+    return cast result;
   }
 
   public inline function getInt(key:String):Null<Int>

--- a/source/funkin/data/song/SongData.hx
+++ b/source/funkin/data/song/SongData.hx
@@ -782,6 +782,7 @@ abstract SongEventData(SongEventDataRaw) from SongEventDataRaw to SongEventDataR
   {
     if(this.value == null) return null;
     var stringResult = Reflect.field(this.value, key);
+    if(stringResult == null) return null;
     var resultToHex = '#' + StringTools.hex(Std.parseInt(stringResult), 6);
     var result = FlxColor.fromString(resultToHex);
     return cast result;

--- a/source/funkin/ui/debug/charting/toolboxes/ChartEditorEventDataToolbox.hx
+++ b/source/funkin/ui/debug/charting/toolboxes/ChartEditorEventDataToolbox.hx
@@ -281,7 +281,7 @@ class ChartEditorEventDataToolbox extends ChartEditorBaseToolbox
             value = event.target.value.value;
           case COLOR:
             var clr:ColorPicker = cast event.target;
-            value = clr.currentColor.toHex();
+            value = clr.currentColor;
           case BOOL:
             var chk:CheckBox = cast event.target;
             value = cast(chk.selected, Null<Bool>); // Need to cast to nullable bool or the compiler will get mad.

--- a/source/funkin/ui/debug/charting/toolboxes/ChartEditorEventDataToolbox.hx
+++ b/source/funkin/ui/debug/charting/toolboxes/ChartEditorEventDataToolbox.hx
@@ -25,6 +25,7 @@ import haxe.ui.data.ArrayDataSource;
 import haxe.ui.containers.Grid;
 import haxe.ui.components.DropDown;
 import haxe.ui.containers.Frame;
+import haxe.ui.components.ColorPicker;
 
 /**
  * The toolbox which allows modifying information like Song Title, Scroll Speed, Characters/Stages, and starting BPM.
@@ -151,6 +152,9 @@ class ChartEditorEventDataToolbox extends ChartEditorBaseToolbox
           case Std.isOfType(_, TextField) => true:
             var textField:TextField = cast field;
             textField.text = value;
+          case Std.isOfType(_, ColorPicker) => true:
+            var colorPicker:ColorPicker = cast field;
+            colorPicker.currentColor = value;
           default:
             throw 'ChartEditorToolboxHandler.refresh() - Field "${fieldId}" is of unknown type "${Type.getClassName(Type.getClass(field))}".';
         }
@@ -207,6 +211,14 @@ class ChartEditorEventDataToolbox extends ChartEditorBaseToolbox
           checkBox.id = field.name;
           if (field.defaultValue != null) checkBox.selected = field.defaultValue;
           input = checkBox;
+        case COLOR:
+          var colorPicker:ColorPicker = new ColorPicker();
+          colorPicker.addClass("no-sliders");
+          colorPicker.id = field.name;
+          colorPicker.width = 200.0;
+          colorPicker.height = 250.0;
+          if (field.defaultValue != null) colorPicker.currentColor = field.defaultValue;
+          input = colorPicker;
         case ENUM:
           var dropDown:DropDown = new DropDown();
           dropDown.id = field.name;
@@ -261,15 +273,20 @@ class ChartEditorEventDataToolbox extends ChartEditorBaseToolbox
 
       // Update the value of the event data.
       input.onChange = function(event:UIEvent) {
-        var value = event.target.value;
-        if (field.type == ENUM)
+        var value:Null<Dynamic>;
+
+        switch (field.type)
         {
-          value = event.target.value.value;
-        }
-        else if (field.type == BOOL)
-        {
-          var chk:CheckBox = cast event.target;
-          value = cast(chk.selected, Null<Bool>); // Need to cast to nullable bool or the compiler will get mad.
+          case ENUM:
+            value = event.target.value.value;
+          case COLOR:
+            var clr:ColorPicker = cast event.target;
+            value = clr.currentColor.toHex();
+          case BOOL:
+            var chk:CheckBox = cast event.target;
+            value = cast(chk.selected, Null<Bool>); // Need to cast to nullable bool or the compiler will get mad.
+          default:
+            value = event.target.value;
         }
 
         trace('ChartEditorToolboxHandler.buildEventDataFormFromSchema() - ${event.target.id} = ${value}');

--- a/source/funkin/ui/debug/charting/toolboxes/ChartEditorEventDataToolbox.hx
+++ b/source/funkin/ui/debug/charting/toolboxes/ChartEditorEventDataToolbox.hx
@@ -215,8 +215,8 @@ class ChartEditorEventDataToolbox extends ChartEditorBaseToolbox
           var colorPicker:ColorPicker = new ColorPicker();
           colorPicker.addClass("no-sliders");
           colorPicker.id = field.name;
-          colorPicker.width = 200.0;
-          colorPicker.height = 250.0;
+          colorPicker.width = 215.0;
+          colorPicker.height = 230.0;
           if (field.defaultValue != null) colorPicker.currentColor = field.defaultValue;
           input = colorPicker;
         case ENUM:


### PR DESCRIPTION
- This PR adds the new option to choose from the types for the event.
- Players have the ability to change HEX value or RGB/HSB.
- _data.getColor()_ function lets you easily grab FlxColor without having to do a bunch of shenanigans.

Image preview (the event does NOT come along with the color type):
![image](https://github.com/FunkinCrew/Funkin/assets/69017727/fcf0e5f5-5163-46b1-baec-27ff0106b114)

Video preview (custom event is used):
_**‼️‼️‼️ SEIZURE WARNING ‼️‼️‼️**_

https://github.com/FunkinCrew/Funkin/assets/69017727/23a5d0f7-320a-49ad-8463-534bb76774b8