### PR TITLE
Enable auto-pause for Video Cutscenes

### DIFF
--- a/source/funkin/play/PlayState.hx
+++ b/source/funkin/play/PlayState.hx
@@ -1301,12 +1301,18 @@ class PlayState extends MusicBeatSubState
     super.closeSubState();
   }
 
-  #if discord_rpc
   /**
    * Function called when the game window gains focus.
    */
   public override function onFocus():Void
   {
+    if (VideoCutscene.isPlaying() && FlxG.autoPause && isGamePaused) VideoCutscene.pauseVideo();
+    #if html5
+    else
+      VideoCutscene.resumeVideo();
+    #end
+
+    #if discord_rpc
     if (health > Constants.HEALTH_MIN && !paused && FlxG.autoPause)
     {
       if (Conductor.instance.songPosition > 0.0) DiscordClient.changePresence(detailsText, currentSong.song
@@ -1318,6 +1324,7 @@ class PlayState extends MusicBeatSubState
       else
         DiscordClient.changePresence(detailsText, currentSong.song + ' (' + storyDifficultyText + ')', iconRPC);
     }
+    #end
 
     super.onFocus();
   }
@@ -1327,12 +1334,17 @@ class PlayState extends MusicBeatSubState
    */
   public override function onFocusLost():Void
   {
+    #if html5
+    if (FlxG.autoPause) VideoCutscene.pauseVideo();
+    #end
+
+    #if discord_rpc
     if (health > Constants.HEALTH_MIN && !paused && FlxG.autoPause) DiscordClient.changePresence(detailsPausedText,
       currentSong.song + ' (' + storyDifficultyText + ')', iconRPC);
+    #end
 
     super.onFocusLost();
   }
-  #end
 
   /**
    * Removes any references to the current stage, then clears the stage cache,

--- a/source/funkin/play/cutscene/VideoCutscene.hx
+++ b/source/funkin/play/cutscene/VideoCutscene.hx
@@ -145,7 +145,7 @@ class VideoCutscene
     {
       vid.zIndex = 0;
       vid.bitmap.onEndReached.add(finishVideo.bind(0.5));
-      vid.autoPause = false;
+      vid.autoPause = FlxG.autoPause;
 
       vid.cameras = [PlayState.instance.camCutscene];
 


### PR DESCRIPTION
A pretty small issue I noticed with Video Cutscenes is that they don't seem to pause when the game loses focus, even with the "Auto Pause" option enabled in the Options menu. Looking at the source code, it's kind of obvious why (autoPause is set to false).
Video Cutscenes will now pause on focus loss depending on if "Auto Pause" is enabled or not!

For HTML5, FlxVideo (the method of Video Playback HTML5 uses) doesn't seem to have an autoPause parameter like hxCodec does, so we're just manually pausing and resuming the Video in PlayState's `onFocus()` and `onFocusLost()` functions.

Another thing I'd like to mention is that there's a weird bug with autoPause where if you're on the Pause Screen and regain focus, the Video will resume in the background despite the game being paused. I took the liberty of fixing that, basically we just re-pause the video when we regain focus. It's not *that* elegant, but it does seem to work from the testing I've done.

Before:

https://github.com/FunkinCrew/Funkin/assets/86753001/9621dc72-60ce-43e8-ae33-e14d445793e5

After:

https://github.com/FunkinCrew/Funkin/assets/86753001/85262462-d9df-42d1-b426-45a2a3123b2f

