### PR TITLE
Fix tankmanpixel icon in Chart Editor

### DIFF
--- a/source/funkin/play/character/CharacterData.hx
+++ b/source/funkin/play/character/CharacterData.hx
@@ -305,8 +305,8 @@ class CharacterDataParser
         icon = "darnell";
       case "senpai-angry":
         icon = "senpai";
-      case "tankman" | "tankman-atlas":
-        icon = "tankmen";
+      case "tankman-atlas":
+        icon = "tankman";
     }
 
     var path = Paths.image("freeplay/icons/" + icon + "pixel");


### PR DESCRIPTION
Changed an e to an a to bring Tankman's pixel icon to the Chart Editor

## Original Behavior (0.4.1)
![image](https://github.com/FunkinCrew/Funkin/assets/170126004/268ce650-b83d-44bb-8e5e-258ad5b519de)

## PR Behavior
![image](https://github.com/FunkinCrew/Funkin/assets/170126004/788abf96-fb60-4550-9662-bff59ca613d2)
