### PR TITLE
Bandaid fix for GF's crying animation

### DIFF
--- a/source/funkin/play/PlayState.hx
+++ b/source/funkin/play/PlayState.hx
@@ -2673,6 +2673,11 @@ class PlayState extends MusicBeatSubState
     health += healthChange;
     if (isComboBreak)
     {
+      // BANDAID FIX: Play GF's crying animation if combo of 70 or more is broken.
+      // TODO: Handle this in play.character.BaseCharacter instead!
+      if (Highscore.tallies.combo >= 70)
+        currentStage.getGirlfriend().playAnimation('drop70', true);
+
       // Break the combo, but don't increment tallies.misses.
       if (Highscore.tallies.combo >= 10) comboPopUps.displayCombo(0);
       Highscore.tallies.combo = 0;

--- a/source/funkin/play/character/BaseCharacter.hx
+++ b/source/funkin/play/character/BaseCharacter.hx
@@ -519,6 +519,12 @@ class BaseCharacter extends Bopper
       // If the note is from the same strumline, play the sing animation.
       this.playSingAnimation(event.note.noteData.getDirection(), true);
     }
+    
+    /**  
+     * This GF animation code only runs when the player lets a note fly off the screen.
+     * Run this for all combo breaks instead (bad/shit).
+     * Maybe add a new public function called onComboBreak in play.stage.Bopper?
+     */
     else if (event.note.noteData.getMustHitNote() && characterType == GF)
     {
       var dropAnim = '';


### PR DESCRIPTION
Addresses this bug report: https://github.com/FunkinCrew/Funkin/issues/2822

Temporarily reimplements Girlfriend's crying animation in `PlayState.hx`.
When a combo of 70 or more is broken, GF's 'drop70' animation plays.

This isn't an ideal long-term solution, so I've added some comments to suggest a way to fix the code in `BaseCharacter.hx`.
The main problem is that the GF combo drop animation code only runs when `onNoteMiss` is called. This means that combo breaks caused by Bad or Shit ratings won't cause the animation to play.

