### PR TITLE
[ENHANCEMENT]: Credits Menu Enhancements

### DIFF
--- a/source/funkin/ui/credits/CreditsState.hx
+++ b/source/funkin/ui/credits/CreditsState.hx
@@ -59,9 +59,14 @@ class CreditsState extends MusicBeatState
   static final CREDITS_SCROLL_BASE_SPEED = 100.0;
 
   /**
-   * The speed the credits scroll at while the button is held, in pixels per second.
+   * The speed the credits scroll at while accept keybind or spacebar is held, in pixels per second.
    */
   static final CREDITS_SCROLL_FAST_SPEED = CREDITS_SCROLL_BASE_SPEED * 4.0;
+
+  /**
+   * The speed the credits scroll at while the pause keybind is held, in pixels per second.
+   */
+  static final CREDITS_SCROLL_PAUSE_SPEED = 0.0;
 
   /**
    * The actual sprites and text used to display the credits.
@@ -173,23 +178,23 @@ class CreditsState extends MusicBeatState
       // TODO: Replace with whatever the special note button is.
       if (controls.ACCEPT || FlxG.keys.pressed.SPACE)
       {
-        // Move the whole group.
+        // Move the whole group by the base scroll speed.
         creditsGroup.y -= CREDITS_SCROLL_FAST_SPEED * elapsed;
+      }
+      else if (controls.PAUSE || FlxG.keys.pressed.SHIFT)
+      {
+        // Stop the whole group from moving.
+        creditsGroup.y -= CREDITS_SCROLL_PAUSE_SPEED * elapsed;
       }
       else
       {
-        // Move the whole group.
+        // Move the whole group by the base scroll speed.
         creditsGroup.y -= CREDITS_SCROLL_BASE_SPEED * elapsed;
       }
     }
-
     if (controls.BACK || hasEnded())
     {
       exit();
-    }
-    else if (controls.PAUSE)
-    {
-      // scrollPaused = !scrollPaused;
     }
   }
 


### PR DESCRIPTION
# This PR / Pull request adds the ability for the player / user to pause in the Credits.
**When the player / user holds the pause keybind, or the SHIFT keybind, it scrolls the credits at a speed of 0.0**