### PR TITLE
[ENHANCEMENT] Properly implement combo### and drop### animations for GF Character types

### DIFF
--- a/source/funkin/play/character/BaseCharacter.hx
+++ b/source/funkin/play/character/BaseCharacter.hx
@@ -60,8 +60,7 @@ class BaseCharacter extends Bopper
   public var dropNoteCounts(default, null):Array<Int>;
 
   /**
-   * A Map that keeps track of which combo animations have already been played.
-   * Ensures each animation only plays once.
+   * A Map that keeps track of which combo animations have already been played, ensures that each animation only plays once.
    * This will reset when the combo is broken.
    */
   var comboAnimPlayed:Map<String, Bool> = [];

--- a/source/funkin/play/character/BaseCharacter.hx
+++ b/source/funkin/play/character/BaseCharacter.hx
@@ -271,6 +271,7 @@ class BaseCharacter extends Bopper
         {
           trace('Playing GF combo drop animation: ${dropAnim}');
           this.playAnimation(dropAnim, true, true);
+          comboAnimPlayed.clear();
         }
       case "combo":
         for (count in comboNoteCounts)
@@ -582,7 +583,6 @@ class BaseCharacter extends Bopper
     else if (event.note.noteData.getMustHitNote() && characterType == GF)
     {
       playCountAnimation("drop");
-      comboAnimPlayed.clear();
     }
   }
 

--- a/source/funkin/play/character/BaseCharacter.hx
+++ b/source/funkin/play/character/BaseCharacter.hx
@@ -551,9 +551,9 @@ class BaseCharacter extends Bopper
     else if (event.note.noteData.getMustHitNote() && characterType == GF)
     {
       if (event.isComboBreak)
-        playComboAnim("drop");
+        playCountAnimation("drop");
       else
-        playComboAnim("combo");
+        playCountAnimation("combo");
     }
   }
 
@@ -577,7 +577,7 @@ class BaseCharacter extends Bopper
     }
     else if (event.note.noteData.getMustHitNote() && characterType == GF)
     {
-      playComboAnim("drop");
+      playCountAnimation("drop");
       comboAnimPlayed.clear();
     }
   }

--- a/source/funkin/play/character/BaseCharacter.hx
+++ b/source/funkin/play/character/BaseCharacter.hx
@@ -248,9 +248,8 @@ class BaseCharacter extends Bopper
   }
 
   /**
-   * Plays a count animation based on the animation type.
-   * The "drop" type will play when a combo with a certain threshold is broken.
-   * The "combo" type will play when a combo reaches a certain threshold.
+   * Plays a count animation.
+   * @param animType The animation type to use.
    */
   function playCountAnimation(animType:String)
   {

--- a/source/funkin/play/character/BaseCharacter.hx
+++ b/source/funkin/play/character/BaseCharacter.hx
@@ -247,6 +247,11 @@ class BaseCharacter extends Bopper
     return result;
   }
 
+  /**
+   * Plays a count animation based on the animation type.
+   * The "drop" type will play when a combo with a certain threshold is broken.
+   * The "combo" type will play when a combo reaches a certain threshold.
+   */
   function playCountAnimation(animType:String)
   {
     var dropAnim = '';


### PR DESCRIPTION
(Fixes #2822)

This PR aims to resolve an issue where drop### animations a GF Character has would not play. The issue was due to the code handing the animations only running in `onNoteMiss`. That's not all though, it was also using `event.comboCount` which for some reason doesn't seem to work properly with misses? When first tinkering with this code, I changed `event.comboCount` to `Highscore.tallies.combo`, and that made the code work.

I moved the drop### logic into its own function, which is called inside BaseCharacter. I've also taken the liberty of implementing combo### animations as well! (comboNoteCounts exists as a variable, but wasn't used for anything.)

Before (Taken from #2822):

https://github.com/FunkinCrew/Funkin/assets/86753001/6927a007-da2f-4d7a-9c26-aad5fa9f661e


After:


https://github.com/FunkinCrew/Funkin/assets/86753001/27c4c72b-d6f5-4809-bd02-0e4118bc3997



Changing values also seems to work! Here, I set the combo threshold to 10, and the drop threshold to 5.



https://github.com/FunkinCrew/Funkin/assets/86753001/a6d02246-bddc-4f7e-b8d0-0f3267a4e399



One thing I'd like to mention however, that this PR ***will break Nene***! For some reason, her combo and drop animations just hang indefinitely. I'm not entirely sure why this is the case. [I've created a PR on funkin.assets that removes her combo and drop animations for now until it's fixed.](https://github.com/FunkinCrew/funkin.assets/pull/40)

https://github.com/FunkinCrew/Funkin/assets/86753001/469a7f68-7f41-46ac-bb1d-1e4592dea7c2

