### PR TITLE
[ENHANCEMENT] More Note Splash data customization

### DIFF
--- a/source/funkin/data/notestyle/NoteStyleData.hx
+++ b/source/funkin/data/notestyle/NoteStyleData.hx
@@ -65,6 +65,7 @@ typedef NoteStyleAssetsData =
 
   /**
    * The sprites for the note splashes.
+   * @default The sprites from the fallback note style.
    */
   @:optional
   var noteSplash:NoteStyleAssetData<NoteStyleData_NoteSplash>;
@@ -244,6 +245,30 @@ typedef NoteStyleData_NoteStrumline =
 
 typedef NoteStyleData_NoteSplash =
 {
+  @:optional
+  var splash1Left:UnnamedAnimationData;
+
+  @:optional
+  var splash1Down:UnnamedAnimationData;
+
+  @:optional
+  var splash1Up:UnnamedAnimationData;
+
+  @:optional
+  var splash1Right:UnnamedAnimationData;
+
+  @:optional
+  var splash2Left:UnnamedAnimationData;
+
+  @:optional
+  var splash2Down:UnnamedAnimationData;
+
+  @:optional
+  var splash2Up:UnnamedAnimationData;
+
+  @:optional
+  var splash2Right:UnnamedAnimationData;
+
   /**
    * If false, note splashes are entirely hidden on this note style.
    * @default Note splashes are enabled.

--- a/source/funkin/play/notes/NoteSplash.hx
+++ b/source/funkin/play/notes/NoteSplash.hx
@@ -1,6 +1,7 @@
 package funkin.play.notes;
 
 import funkin.play.notes.NoteDirection;
+import funkin.play.notes.notestyle.NoteStyle;
 import flixel.graphics.frames.FlxFramesCollection;
 import flixel.FlxG;
 import flixel.graphics.frames.FlxAtlasFrames;
@@ -8,23 +9,17 @@ import flixel.FlxSprite;
 
 class NoteSplash extends FlxSprite
 {
+  public var offsets:Array<Float> = [0.0, 0.0];
+
   static final ALPHA:Float = 0.6;
   static final FRAMERATE_DEFAULT:Int = 24;
   static final FRAMERATE_VARIANCE:Int = 2;
 
-  static var frameCollection:FlxFramesCollection;
-
-  public static function preloadFrames():Void
-  {
-    frameCollection = Paths.getSparrowAtlas('noteSplashes');
-    frameCollection.parent.persist = true;
-  }
-
-  public function new()
+  public function new(noteStyle:NoteStyle)
   {
     super(0, 0);
 
-    setup();
+    setup(noteStyle);
 
     this.alpha = ALPHA;
     this.animation.finishCallback = this.onAnimationFinished;
@@ -33,21 +28,10 @@ class NoteSplash extends FlxSprite
   /**
    * Add ALL the animations to this sprite. We will recycle and reuse the FlxSprite multiple times.
    */
-  function setup():Void
+  function setup(noteStyle:NoteStyle):Void
   {
-    if (frameCollection?.parent?.isDestroyed ?? false) frameCollection = null;
-    if (frameCollection == null) preloadFrames();
-
-    this.frames = frameCollection;
-
-    this.animation.addByPrefix('splash1Left', 'note impact 1 purple0', FRAMERATE_DEFAULT, false, false, false);
-    this.animation.addByPrefix('splash1Down', 'note impact 1  blue0', FRAMERATE_DEFAULT, false, false, false);
-    this.animation.addByPrefix('splash1Up', 'note impact 1 green0', FRAMERATE_DEFAULT, false, false, false);
-    this.animation.addByPrefix('splash1Right', 'note impact 1 red0', FRAMERATE_DEFAULT, false, false, false);
-    this.animation.addByPrefix('splash2Left', 'note impact 2 purple0', FRAMERATE_DEFAULT, false, false, false);
-    this.animation.addByPrefix('splash2Down', 'note impact 2 blue0', FRAMERATE_DEFAULT, false, false, false);
-    this.animation.addByPrefix('splash2Up', 'note impact 2 green0', FRAMERATE_DEFAULT, false, false, false);
-    this.animation.addByPrefix('splash2Right', 'note impact 2 red0', FRAMERATE_DEFAULT, false, false, false);
+    noteStyle.buildSplashSprite(this);
+    updateHitbox();
 
     if (this.animation.getAnimationList().length < 8)
     {

--- a/source/funkin/play/notes/Strumline.hx
+++ b/source/funkin/play/notes/Strumline.hx
@@ -754,9 +754,10 @@ class Strumline extends FlxSpriteGroup
       splash.x = this.x;
       splash.x += getXPos(direction);
       splash.x += INITIAL_OFFSET;
+      splash.x += splash.offsets[0];
       splash.y = this.y;
       splash.y -= INITIAL_OFFSET;
-      splash.y += 0;
+      splash.y += splash.offsets[1];
     }
   }
 
@@ -852,7 +853,7 @@ class Strumline extends FlxSpriteGroup
     if (noteSplashes.length < noteSplashes.maxSize)
     {
       // Create a new note splash.
-      result = new NoteSplash();
+      result = new NoteSplash(noteStyle);
       this.noteSplashes.add(result);
     }
     else

--- a/source/funkin/play/notes/notestyle/NoteStyle.hx
+++ b/source/funkin/play/notes/notestyle/NoteStyle.hx
@@ -203,6 +203,135 @@ class NoteStyle implements IRegistryEntry<NoteStyleData>
     return result ?? fallback?.fetchNoteAnimationData(dir);
   }
 
+  public function buildSplashSprite(target:NoteSplash):Void
+  {
+    // Apply the note sprite frames.
+    var atlas:FlxAtlasFrames = buildSplashFrames(false);
+
+    if (atlas == null)
+    {
+      throw 'Could not load spritesheet for note style: $id';
+    }
+
+    target.frames = atlas;
+
+    target.scale.x = fetchSplashScale();
+    target.scale.y = fetchSplashScale();
+    target.antialiasing = !fetchSplashPixel();
+    target.offsets = fetchSplashOffsets();
+
+    // Apply the animations.
+    buildSplashAnimations(target);
+  }
+
+  var splashFrames:FlxAtlasFrames = null;
+
+  function buildSplashFrames(force:Bool = false):FlxAtlasFrames
+  {
+    if (!FunkinSprite.isTextureCached(Paths.image(getSplashAssetPath())))
+    {
+      FlxG.log.warn('Note splash texture is not cached: ${getSplashAssetPath()}');
+    }
+
+    // Purge the note frames if the cached atlas is invalid.
+    if (splashFrames?.parent?.isDestroyed ?? false) splashFrames = null;
+
+    if (splashFrames != null && !force) return splashFrames;
+
+    splashFrames = Paths.getSparrowAtlas(getSplashAssetPath(), getSplashAssetLibrary());
+
+    if (splashFrames == null)
+    {
+      throw 'Could not load splash frames for note style: $id';
+    }
+
+    return splashFrames;
+  }
+
+  function getSplashAssetPath(raw:Bool = false):String
+  {
+    if (raw)
+    {
+      var rawPath:Null<String> = _data?.assets?.noteSplash?.assetPath;
+      if (rawPath == null) return fallback.getSplashAssetPath(true);
+      return rawPath;
+    }
+
+    // library:path
+    var parts = getSplashAssetPath(true).split(Constants.LIBRARY_SEPARATOR);
+    if (parts.length == 1) return getSplashAssetPath(true);
+    return parts[1];
+  }
+
+  function getSplashAssetLibrary():Null<String>
+  {
+    // library:path
+    var parts = getSplashAssetPath(true).split(Constants.LIBRARY_SEPARATOR);
+    if (parts.length == 1) return null;
+    return parts[0];
+  }
+
+  function buildSplashAnimations(target:NoteSplash):Void
+  {
+    applySplashAnimations(target, LEFT);
+    applySplashAnimations(target, DOWN);
+    applySplashAnimations(target, UP);
+    applySplashAnimations(target, RIGHT);
+  }
+
+  public function fetchSplashScale():Float
+  {
+    var data = _data?.assets?.noteSplash;
+    if (data == null) return fallback.fetchSplashScale();
+    return data.scale;
+  }
+
+  public function fetchSplashPixel():Bool
+  {
+    var data = _data?.assets?.noteSplash;
+    if (data == null) return fallback.fetchSplashPixel();
+    return data.isPixel;
+  }
+
+  public function fetchSplashOffsets():Array<Float>
+  {
+    var data = _data?.assets?.noteSplash;
+    if (data == null) return fallback.fetchSplashOffsets();
+    return data.offsets;
+  }
+
+  public function applySplashAnimations(target:NoteSplash, dir:NoteDirection):Void
+  {
+    FlxAnimationUtil.addAtlasAnimations(target, fetchSplashAnimationData(dir));
+  }
+
+  function fetchSplashAnimationData(dir:NoteDirection):Array<AnimationData>
+  {
+    var result:Null<Array<AnimationData>> = switch (dir)
+    {
+      case LEFT: [
+          _data?.assets?.noteSplash?.data?.splash1Left?.toNamed('splash1Left'),
+          _data?.assets?.noteSplash?.data?.splash2Left?.toNamed('splash2Left')
+        ];
+      case DOWN: [
+          _data?.assets?.noteSplash?.data?.splash1Down?.toNamed('splash1Down'),
+          _data?.assets?.noteSplash?.data?.splash2Down?.toNamed('splash2Down')
+        ];
+      case UP: [
+          _data?.assets?.noteSplash?.data?.splash1Up?.toNamed('splash1Up'),
+          _data?.assets?.noteSplash?.data?.splash2Up?.toNamed('splash2Up')
+        ];
+      case RIGHT: [
+          _data?.assets?.noteSplash?.data?.splash1Right?.toNamed('splash1Right'),
+          _data?.assets?.noteSplash?.data?.splash2Right?.toNamed('splash2Right')
+        ];
+    };
+
+    // TODO: Null check doesn't work here.
+    if (result == null) return fallback.fetchSplashAnimationData(dir);
+    return result;
+  }
+
   public function getHoldNoteAssetPath(raw:Bool = false):Null<String>
   {
     if (raw)


### PR DESCRIPTION
### THIS PULL REQUEST ALSO REQUIRES FunkinCrew/funkin.assets#41 TO BE PUSHED!

# What is this PR?
This pull request adds onto the note splash data and adds more customization to them!

## This adds/now supports:
- `assetPath` (String)
- `scale` (Float)
- `offsets` (Array (Float))
- `isPixel` (Bool)
- `data/splash1Left` (String)
- `data/splash2Left` (String)
- `data/splash1Down` (String)
- `data/splash2Down` (String)
- `data/splash1Up` (String)
- `data/splash2Up` (String)
- `data/splash1Right` (String)
- `data/splash2Right` (String)

## Known Issues:
- Honestly the only one I know of is that if any data/splashVarientDir doesn't exist, it won't call the fallback one. If a note splash is disabled though it won't be a problem.