### PR TITLE
[ENHANCEMENT] Adjustable transparency background behind gameplay

### DIFF
--- a/source/funkin/Preferences.hx
+++ b/source/funkin/Preferences.hx
@@ -129,6 +129,27 @@ class Preferences
   }
 
   /**
+   * How dark the black screen behind gameplay should be.
+   *
+   * 0 = fully transparent. 100 = opaque.
+   * @default `0`
+   */
+  public static var gameplayBackgroundAlpha(get, set):Int;
+
+  static function get_gameplayBackgroundAlpha():Int
+  {
+    return Save?.instance?.options?.gameplayBackgroundAlpha ?? 0;
+  }
+
+  static function set_gameplayBackgroundAlpha(value:Int):Int
+  {
+    var save:Save = Save.instance;
+    save.options.gameplayBackgroundAlpha = value;
+    save.flush();
+    return value;
+  }
+
+  /**
    * Loads the user's preferences from the save data and apply them.
    */
   public static function init():Void

--- a/source/funkin/play/PlayState.hx
+++ b/source/funkin/play/PlayState.hx
@@ -6,6 +6,7 @@ import flixel.addons.transition.Transition;
 import flixel.FlxCamera;
 import flixel.FlxObject;
 import flixel.FlxState;
+import flixel.FlxSprite;
 import flixel.FlxSubState;
 import flixel.math.FlxMath;
 import flixel.math.FlxPoint;
@@ -480,6 +481,11 @@ class PlayState extends MusicBeatSubState
    * The health icon representing the opponent.
    */
   public var iconP2:HealthIcon;
+
+  /**
+   * The background behind the active player's strumline.
+   */
+  public var strumlineBackground:FlxSprite;
 
   /**
    * The sprite group containing active player's strumline notes.
@@ -1765,9 +1771,16 @@ class PlayState extends MusicBeatSubState
 
     playerStrumline = new Strumline(noteStyle, !isBotPlayMode);
     playerStrumline.onNoteIncoming.add(onStrumlineNoteIncoming);
+
+    strumlineBackground = new FlxSprite();
+    // Pad the background 15 pixels on each side
+    strumlineBackground.makeGraphic(Strumline.NOTE_SPACING * 4 + 30, 5000, FlxColor.BLACK);
+
     opponentStrumline = new Strumline(noteStyle, false);
     opponentStrumline.onNoteIncoming.add(onStrumlineNoteIncoming);
+
     add(playerStrumline);
+    add(strumlineBackground);
     add(opponentStrumline);
 
     // Position the player strumline on the right half of the screen
@@ -1782,6 +1795,18 @@ class PlayState extends MusicBeatSubState
     opponentStrumline.y = Preferences.downscroll ? FlxG.height - opponentStrumline.height - Constants.STRUMLINE_Y_OFFSET : Constants.STRUMLINE_Y_OFFSET;
     opponentStrumline.zIndex = 1000;
     opponentStrumline.cameras = [camHUD];
+
+    // NOTE: Preferences.gameplayBackgroundAlpha is a percentage stored as an int
+    // i.e. `50%` is stored as `50`
+    // Dividing it by 100 gives us the real Float value we need to create a transparent object
+    var realBackgroundAlpha:Float = Preferences.gameplayBackgroundAlpha * 1.0;
+    realBackgroundAlpha /= 100;
+    strumlineBackground.alpha = realBackgroundAlpha;
+    // Position the background slightly offset from the strumbar for a bit of padding
+    strumlineBackground.x = (FlxG.width / 2 + Constants.STRUMLINE_X_OFFSET) - 15;
+    strumlineBackground.y = 0;
+    strumlineBackground.zIndex = 600; // Renders beneath the health bar
+    strumlineBackground.cameras = [camHUD];
 
     if (!PlayStatePlaylist.isStoryMode)
     {

--- a/source/funkin/save/Save.hx
+++ b/source/funkin/save/Save.hx
@@ -97,6 +97,7 @@ class Save
           autoPause: true,
           inputOffset: 0,
           audioVisualOffset: 0,
+          gameplayBackgroundAlpha: 0,
 
           controls:
             {
@@ -1102,6 +1103,13 @@ typedef SaveDataOptions =
    * @default `0`
    */
   var audioVisualOffset:Int;
+
+  /**
+   * How dark the background behind the strumline and approaching arrows should be.
+   *
+   * 0 = transparent, 1 = fully opaque.
+   */
+  var gameplayBackgroundAlpha:Int;
 
   var controls:
     {

--- a/source/funkin/ui/options/PreferencesMenu.hx
+++ b/source/funkin/ui/options/PreferencesMenu.hx
@@ -31,8 +31,11 @@ class PreferencesMenu extends Page
     menuCamera.bgColor = 0x0;
     camera = menuCamera;
 
-    add(items = new TextMenuList());
-    add(preferenceItems = new FlxTypedSpriteGroup<FlxSprite>());
+    items = new TextMenuList();
+    preferenceItems = new FlxTypedSpriteGroup<FlxSprite>();
+
+    add(items);
+    add(preferenceItems);
 
     createPrefItems();
 
@@ -72,6 +75,9 @@ class PreferencesMenu extends Page
     createPrefItemCheckbox('Auto Pause', 'Automatically pause the game when it loses focus', function(value:Bool):Void {
       Preferences.autoPause = value;
     }, Preferences.autoPause);
+    createPrefItemPercentage('<Gameplay Bg Opacity>', 'How dark the background behind gameplay should be', function(value:Int):Void {
+      Preferences.gameplayBackgroundAlpha = value;
+    }, Preferences.gameplayBackgroundAlpha, 0, 100);
   }
 
   override function update(elapsed:Float):Void
@@ -122,7 +128,7 @@ class PreferencesMenu extends Page
       var value = !checkbox.currentValue;
       onChange(value);
       checkbox.currentValue = value;
-    });
+    }, false);
 
     preferenceItems.add(checkbox);
   }

--- a/source/funkin/ui/options/PreferencesMenu.hx
+++ b/source/funkin/ui/options/PreferencesMenu.hx
@@ -137,7 +137,7 @@ class PreferencesMenu extends Page
    * @param step The value to increment/decrement by (default = 0.1)
    * @param precision Rounds decimals up to a `precision` amount of digits (ex: 4 -> 0.1234, 2 -> 0.12)
    */
-  function createPrefItemNumber(prefName:String, prefDesc:String, onChange:Float->Void, ?valueFormatter:Float->String, defaultValue:Int, min:Int, max:Int,
+  function createPrefItemNumber(prefName:String, prefDesc:String, onChange:Float->Void, ?valueFormatter:Float->String, defaultValue:Float, min:Int, max:Int,
       step:Float = 0.1, precision:Int):Void
   {
     var item = new NumberPreferenceItem(0, (120 * items.length) + 30, prefName, defaultValue, min, max, step, precision, onChange, valueFormatter);


### PR DESCRIPTION
Previously I made the PR #2380. This is a re-make of that PR using features from the changes in PR #2942 (merge that one first for clean history)

This uses the new `createPrefItemPercentage` function to create an adjustable percent option in gameplay preferences to adjust the transparency.

![image](https://github.com/FunkinCrew/Funkin/assets/60671867/b617c3d2-38e2-4653-bf45-040a2caef772)

Pinging since interest on #2380: @EliteMasterEric 