### PR TITLE
[ENHANCEMENT] A better way to limit variations by characters

### DIFF
--- a/source/funkin/data/song/SongData.hx
+++ b/source/funkin/data/song/SongData.hx
@@ -62,6 +62,10 @@ class SongMetadata implements ICloneable<SongMetadata>
 
   public var timeChanges:Array<SongTimeChange>;
 
+  @:optional
+  @:default(funkin.util.Constants.DEFAULT_CHARACTER)
+  public var campaignCharacter:String;
+
   /**
    * Defaults to `Constants.DEFAULT_VARIATION`. Populated later.
    */
@@ -85,6 +89,7 @@ class SongMetadata implements ICloneable<SongMetadata>
     this.playData.stage = 'mainStage';
     this.playData.noteStyle = Constants.DEFAULT_NOTE_STYLE;
     this.generatedBy = SongRegistry.DEFAULT_GENERATEDBY;
+    this.campaignCharacter = Constants.DEFAULT_CHARACTER;
     // Variation ID.
     this.variation = (variation == null) ? Constants.DEFAULT_VARIATION : variation;
   }

--- a/source/funkin/play/song/Song.hx
+++ b/source/funkin/play/song/Song.hx
@@ -80,6 +80,8 @@ class Song implements IPlayStateScriptedClass implements IRegistryEntry<SongMeta
   // key = variation id, value = metadata
   final _metadata:Map<String, SongMetadata>;
   final difficulties:Map<String, SongDifficulty>;
+  // key = character id, value = allowed variation ids
+  final charVariations:Map<String, Array<String>>;
 
   /**
    * The list of variations a song has.
@@ -150,7 +152,13 @@ class Song implements IPlayStateScriptedClass implements IRegistryEntry<SongMeta
 
     _data = _fetchData(id);
 
-    _metadata = _data == null ? [] : [Constants.DEFAULT_VARIATION => _data];
+    _metadata = new Map<String, SongMetadata>();
+    charVariations = new Map<String, Array<String>>();
+    if (_data != null)
+    {
+      _metadata.set(Constants.DEFAULT_VARIATION, _data);
+      charVariations.set(_data.campaignCharacter, [Constants.DEFAULT_VARIATION]);
+    }
 
     if (_data != null && _data.playData != null)
     {
@@ -160,6 +168,15 @@ class Song implements IPlayStateScriptedClass implements IRegistryEntry<SongMeta
         if (variMeta != null)
         {
           _metadata.set(variMeta.variation, variMeta);
+          var variChar:Null<Array<String>> = charVariations.get(variMeta.campaignCharacter);
+          if (variChar != null)
+          {
+            variChar.push(variMeta.variation);
+          }
+          else
+          {
+            charVariations.set(variMeta.campaignCharacter, [variMeta.variation]);
+          }
           trace('  Loaded variation: $vari');
         }
         else
@@ -428,16 +445,7 @@ class Song implements IPlayStateScriptedClass implements IRegistryEntry<SongMeta
   public function getVariationsByCharId(?charId:String):Array<String>
   {
     if (charId == null) charId = Constants.DEFAULT_CHARACTER;
-
-    if (variations.contains(charId))
-    {
-      return [charId];
-    }
-    else
-    {
-      // TODO: How to exclude character variations while keeping other custom variations?
-      return variations;
-    }
+    return charVariations.get(charId) ?? [];
   }
 
   /**

--- a/source/funkin/ui/freeplay/FreeplayState.hx
+++ b/source/funkin/ui/freeplay/FreeplayState.hx
@@ -1579,7 +1579,7 @@ class FreeplayState extends MusicBeatSubState
         FlxG.log.warn('WARN: could not find song with id (${grpCapsules.members[curSelected].songData.songId})');
         return;
       }
-      var targetVariation:String = targetSong.getFirstValidVariation(currentDifficulty);
+      var targetVariation:String = targetSong.getFirstValidVariation(currentDifficulty, targetSong.getVariationsByCharId(currentCharacter));
 
       // TODO: This line of code makes me sad, but you can't really fix it without a breaking migration.
       var suffixedDifficulty = (targetVariation != Constants.DEFAULT_VARIATION
@@ -1720,7 +1720,7 @@ class FreeplayState extends MusicBeatSubState
       return;
     }
     var targetDifficultyId:String = currentDifficulty;
-    var targetVariation:String = targetSong.getFirstValidVariation(targetDifficultyId);
+    var targetVariation:String = targetSong.getFirstValidVariation(targetDifficultyId, targetSong.getVariationsByCharId(currentCharacter));
     PlayStatePlaylist.campaignId = cap.songData.levelId;
 
     var targetDifficulty:SongDifficulty = targetSong.getDifficulty(targetDifficultyId, targetVariation);


### PR DESCRIPTION
`"TODO: How to exclude character variations while keeping other custom variations?"` - `Song.hx`, line 438

Well, I have a straightforward solution, which doesn't break anything which already exists in the game or in the mods I tested.

I added a new optional variable to the song metadata format called `campaignCharacter` (not to be confused with other "character" related variables) which defaults to `"bf"` (`Constants.DEFAULT_CHARACTER`). Then, I added a new map to the `Song` class called `charVariations`, which will split the variations of the song between different character IDs, according to the character IDs in each `campaignCharacter` variable of the song's metadata files. Finally, I edited the `getVariationsByCharId` method to use the provided character ID as a key to the `charVariations` map to get the appropriate array of allowed variations.

So now, if I want to make a variation in my song appear only when a character other than Boyfriend is selected, I'll need to add the `campaignCharacter` variable to that variation's metadata and assign it to the appropriate character ID of the character I want this variation to appear for.

> [!NOTE]
> You will notice that I also edited `FreeplayState.hx` to always use `getVariationsByCharId(currentCharacter)` as the second argument to the `getFirstValidVariation` function because my testing showed that this is required for this feature to work as intended.