### PR TITLE
[BUGFIX] Proper AnimOffsets for scaled Characters/Boppers

### DIFF
--- a/source/funkin/play/character/BaseCharacter.hx
+++ b/source/funkin/play/character/BaseCharacter.hx
@@ -124,8 +124,8 @@ class BaseCharacter extends Bopper
     if ((animOffsets[0] == value[0]) && (animOffsets[1] == value[1])) return value;
 
     // Make sure animOffets are halved when scale is 0.5.
-    var xDiff = (animOffsets[0] * this.scale.x / (this.isPixel ? 6 : 1)) - value[0];
-    var yDiff = (animOffsets[1] * this.scale.y / (this.isPixel ? 6 : 1)) - value[1];
+    var xDiff = (animOffsets[0] - value[0]) * (!this.isPixel ? this.scale.x : 1);
+    var yDiff = (animOffsets[1] - value[1]) * (!this.isPixel ? this.scale.y : 1);
 
     // Call the super function so that camera focus point is not affected.
     super.set_x(this.x + xDiff);

--- a/source/funkin/play/stage/Bopper.hx
+++ b/source/funkin/play/stage/Bopper.hx
@@ -95,8 +95,8 @@ class Bopper extends StageProp implements IPlayStateScriptedClass
     if (animOffsets == null) animOffsets = [0, 0];
     if ((animOffsets[0] == value[0]) && (animOffsets[1] == value[1])) return value;
 
-    var xDiff = animOffsets[0] - value[0];
-    var yDiff = animOffsets[1] - value[1];
+    var xDiff = (animOffsets[0] - value[0]) * (!this.isPixel ? this.scale.x : 1);
+    var yDiff = (animOffsets[1] - value[1]) * (!this.isPixel ? this.scale.y : 1);
 
     this.x += xDiff;
     this.y += yDiff;


### PR DESCRIPTION
Simply fixes applying animation offsets for scaled boppers/characters to not fly away. No side-effects, pixel week works perfectly.
(i would prefer #2310 solution, but if this is easier to approve im fine with that) 