### PR TITLE
[DOCS] Add common troubleshooting steps to compiling guide

### DIFF
--- a/docs/COMPILING.md
+++ b/docs/COMPILING.md
@@ -8,10 +8,10 @@
 1. Run `git clone https://github.com/FunkinCrew/funkin.git` to clone the base repository.
 2. Run `git submodule update --init --recursive` to download the game's assets.
     - NOTE: By performing this operation, you are downloading Content which is proprietary and protected by national and international copyright and trademark laws. See [the LICENSE.md file for the Funkin.assets](https://github.com/FunkinCrew/funkin.assets/blob/main/LICENSE.md) repo for more information.
-2. Run `haxelib --global install hmm` and then `haxelib --global run hmm setup` to install hmm.json
-3. Run `hmm install` to install all haxelibs of the current branch
-4. Run `haxelib run lime setup` to set up lime
-5. Platform setup
+3. Run `haxelib --global install hmm` and then `haxelib --global run hmm setup` to install hmm.json
+4. Run `hmm install` to install all haxelibs of the current branch
+5. Run `haxelib run lime setup` to set up lime
+6. Platform setup
    - For Windows, download the [Visual Studio Build Tools](https://aka.ms/vs/17/release/vs_BuildTools.exe)
         - When prompted, select "Individual Components" and make sure to download the following:
         - MSVC v143 VS 2022 C++ x64/x86 build tools
@@ -19,10 +19,12 @@
     - Mac: [`lime setup mac` Documentation](https://lime.openfl.org/docs/advanced-setup/macos/)
     - Linux: [`lime setup linux` Documentation](https://lime.openfl.org/docs/advanced-setup/linux/)
     - HTML5: Compiles without any extra setup
-6. If you are targeting for native, you may need to run `lime rebuild PLATFORM` and `lime rebuild PLATFORM -debug`
-7. `lime test PLATFORM` ! Add `-debug` to enable several debug features such as time travel (`PgUp`/`PgDn` in Play State).
+7. If you are targeting for native, you may need to run `lime rebuild PLATFORM` and `lime rebuild PLATFORM -debug`
+8. `lime test PLATFORM` ! Add `-debug` to enable several debug features such as time travel (`PgUp`/`PgDn` in Play State).
 
-# Troubleshooting
+# Troubleshooting 
+## GO THROUGH THESE STEPS BEFORE OPENING ISSUES ON GITHUB!
 
 - During the cloning process, you may experience an error along the lines of `error: RPC failed; curl 92 HTTP/2 stream 0 was not closed cleanly: PROTOCOL_ERROR (err 1)` due to poor connectivity. A common fix is to run ` git config --global http.postBuffer 4096M`.
-
+- Check that your `assets` folder is not empty! If it is, go back to **Step 2** and follow the guide from there.
+- The compilation process often fails due to having the wrong versions of the required libraries. Many errors can be resolved by deleting the `.haxelib` folder and rerunning the commands listed in **Step 3** and onwards.

--- a/docs/COMPILING.md
+++ b/docs/COMPILING.md
@@ -8,12 +8,13 @@
 1. Run `cd the\directory\you\want\the\source\code\in` to specify which folder the command prompt is working in.
     - For example, `cd C:\Users\YOURNAME\Documents` would instruct the command prompt to perform the next steps in your Documents folder.
 2. Run `git clone https://github.com/FunkinCrew/funkin.git` to clone the base repository.
-3. Run `git submodule update --init --recursive` to download the game's assets.
+3. Run `cd funkin` to enter the cloned repository's directory.
+4. Run `git submodule update --init --recursive` to download the game's assets.
     - NOTE: By performing this operation, you are downloading Content which is proprietary and protected by national and international copyright and trademark laws. See [the LICENSE.md file for the Funkin.assets](https://github.com/FunkinCrew/funkin.assets/blob/main/LICENSE.md) repo for more information.
-4. Run `haxelib --global install hmm` and then `haxelib --global run hmm setup` to install hmm.json
-5. Run `hmm install` to install all haxelibs of the current branch
-6. Run `haxelib run lime setup` to set up lime
-7. Platform setup
+5. Run `haxelib --global install hmm` and then `haxelib --global run hmm setup` to install hmm.json
+6. Run `hmm install` to install all haxelibs of the current branch
+7. Run `haxelib run lime setup` to set up lime
+8. Platform setup
    - For Windows, download the [Visual Studio Build Tools](https://aka.ms/vs/17/release/vs_BuildTools.exe)
         - When prompted, select "Individual Components" and make sure to download the following:
         - MSVC v143 VS 2022 C++ x64/x86 build tools
@@ -21,12 +22,12 @@
     - Mac: [`lime setup mac` Documentation](https://lime.openfl.org/docs/advanced-setup/macos/)
     - Linux: [`lime setup linux` Documentation](https://lime.openfl.org/docs/advanced-setup/linux/)
     - HTML5: Compiles without any extra setup
-8. If you are targeting for native, you may need to run `lime rebuild PLATFORM` and `lime rebuild PLATFORM -debug`
-9. `lime test PLATFORM` ! Add `-debug` to enable several debug features such as time travel (`PgUp`/`PgDn` in Play State).
+9. If you are targeting for native, you may need to run `lime rebuild PLATFORM` and `lime rebuild PLATFORM -debug`
+10. `lime test PLATFORM` ! Add `-debug` to enable several debug features such as time travel (`PgUp`/`PgDn` in Play State).
 
 # Troubleshooting - GO THROUGH THESE STEPS BEFORE OPENING ISSUES ON GITHUB!
 
 - During the cloning process, you may experience an error along the lines of `error: RPC failed; curl 92 HTTP/2 stream 0 was not closed cleanly: PROTOCOL_ERROR (err 1)` due to poor connectivity. A common fix is to run ` git config --global http.postBuffer 4096M`.
-- Make sure your game directory has an `assets` folder! If it's missing, make sure you're in the right directory by running **Step 1**.
-- Check that your `assets` folder is not empty! If it is, go back to **Step 3** and follow the guide from there.
-- The compilation process often fails due to having the wrong versions of the required libraries. Many errors can be resolved by deleting the `.haxelib` folder and rerunning the commands listed in **Step 4** and onwards.
+- Make sure your game directory has an `assets` folder! If it's missing, copy the path to your `funkin` folder and run `cd the\path\you\copied`. Then follow the guide starting from **Step 4**. 
+- Check that your `assets` folder is not empty! If it is, go back to **Step 4** and follow the guide from there.
+- The compilation process often fails due to having the wrong versions of the required libraries. Many errors can be resolved by deleting the `.haxelib` folder and following the guide starting from **Step 5**.

--- a/docs/COMPILING.md
+++ b/docs/COMPILING.md
@@ -5,7 +5,7 @@
     - Download Git from [git-scm.com](https://www.git-scm.com)
     - Do NOT download the repository using the Download ZIP button on GitHub or you may run into errors!
     - Instead, open a command prompt and do the following steps...
-1. Run `cd the/directory/you/want/the/source/code/in` to specify which folder the command prompt is working in.
+1. Run `cd the\directory\you\want\the\source\code\in` to specify which folder the command prompt is working in.
     - For example, `cd C:\Users\YOURNAME\Documents` would instruct the command prompt to perform the next steps in your Documents folder.
 2. Run `git clone https://github.com/FunkinCrew/funkin.git` to clone the base repository.
 3. Run `git submodule update --init --recursive` to download the game's assets.

--- a/docs/COMPILING.md
+++ b/docs/COMPILING.md
@@ -5,13 +5,15 @@
     - Download Git from [git-scm.com](https://www.git-scm.com)
     - Do NOT download the repository using the Download ZIP button on GitHub or you may run into errors!
     - Instead, open a command prompt and do the following steps...
-1. Run `git clone https://github.com/FunkinCrew/funkin.git` to clone the base repository.
-2. Run `git submodule update --init --recursive` to download the game's assets.
+1. Run `cd the/directory/you/want/the/source/code/in` to specify which folder the command prompt is working in.
+    - For example, `cd C:\Users\YOURNAME\Documents` would instruct the command prompt to perform the next steps in your Documents folder.
+2. Run `git clone https://github.com/FunkinCrew/funkin.git` to clone the base repository.
+3. Run `git submodule update --init --recursive` to download the game's assets.
     - NOTE: By performing this operation, you are downloading Content which is proprietary and protected by national and international copyright and trademark laws. See [the LICENSE.md file for the Funkin.assets](https://github.com/FunkinCrew/funkin.assets/blob/main/LICENSE.md) repo for more information.
-3. Run `haxelib --global install hmm` and then `haxelib --global run hmm setup` to install hmm.json
-4. Run `hmm install` to install all haxelibs of the current branch
-5. Run `haxelib run lime setup` to set up lime
-6. Platform setup
+4. Run `haxelib --global install hmm` and then `haxelib --global run hmm setup` to install hmm.json
+5. Run `hmm install` to install all haxelibs of the current branch
+6. Run `haxelib run lime setup` to set up lime
+7. Platform setup
    - For Windows, download the [Visual Studio Build Tools](https://aka.ms/vs/17/release/vs_BuildTools.exe)
         - When prompted, select "Individual Components" and make sure to download the following:
         - MSVC v143 VS 2022 C++ x64/x86 build tools
@@ -19,12 +21,12 @@
     - Mac: [`lime setup mac` Documentation](https://lime.openfl.org/docs/advanced-setup/macos/)
     - Linux: [`lime setup linux` Documentation](https://lime.openfl.org/docs/advanced-setup/linux/)
     - HTML5: Compiles without any extra setup
-7. If you are targeting for native, you may need to run `lime rebuild PLATFORM` and `lime rebuild PLATFORM -debug`
-8. `lime test PLATFORM` ! Add `-debug` to enable several debug features such as time travel (`PgUp`/`PgDn` in Play State).
+8. If you are targeting for native, you may need to run `lime rebuild PLATFORM` and `lime rebuild PLATFORM -debug`
+9. `lime test PLATFORM` ! Add `-debug` to enable several debug features such as time travel (`PgUp`/`PgDn` in Play State).
 
-# Troubleshooting 
-## GO THROUGH THESE STEPS BEFORE OPENING ISSUES ON GITHUB!
+# Troubleshooting - GO THROUGH THESE STEPS BEFORE OPENING ISSUES ON GITHUB!
 
 - During the cloning process, you may experience an error along the lines of `error: RPC failed; curl 92 HTTP/2 stream 0 was not closed cleanly: PROTOCOL_ERROR (err 1)` due to poor connectivity. A common fix is to run ` git config --global http.postBuffer 4096M`.
-- Check that your `assets` folder is not empty! If it is, go back to **Step 2** and follow the guide from there.
-- The compilation process often fails due to having the wrong versions of the required libraries. Many errors can be resolved by deleting the `.haxelib` folder and rerunning the commands listed in **Step 3** and onwards.
+- Make sure your game directory has an `assets` folder! If it's missing, make sure you're in the right directory by running **Step 1**.
+- Check that your `assets` folder is not empty! If it is, go back to **Step 3** and follow the guide from there.
+- The compilation process often fails due to having the wrong versions of the required libraries. Many errors can be resolved by deleting the `.haxelib` folder and rerunning the commands listed in **Step 4** and onwards.


### PR DESCRIPTION
Due to the recent influx of compiling help issues, I've added a few troubleshooting steps to the Compiling Guide.

This should reduce the amount of work Eric has to do sorting through various compiling help issues.

Any additional troubleshooting steps are appreciated!