### PR TITLE
Fix Judging For Notes When Using Input Offset

### DIFF
--- a/docs/COMPILING.md
+++ b/docs/COMPILING.md
@@ -5,8 +5,9 @@
     - Download Git from [git-scm.com](https://www.git-scm.com)
     - Do NOT download the repository using the Download ZIP button on GitHub or you may run into errors!
     - Instead, open a command prompt and do the following steps...
-1. Run `git clone --recurse-submodules https://github.com/FunkinCrew/funkin.git` to clone the repository with the necessary assets submodule
-    - _If you accidentally cloned without the `assets` submodule (aka didn't follow the step above), you can run `git submodule update --init --recursive` to get the assets in a foolproof way._
+1. Run `git clone https://github.com/FunkinCrew/funkin.git` to clone the base repository.
+2. Run `git submodule update --init --recursive` to download the game's assets.
+    - NOTE: By performing this operation, you are downloading Content which is proprietary and protected by national and international copyright and trademark laws. See [the LICENSE.md file for the Funkin.assets](https://github.com/FunkinCrew/funkin.assets/blob/main/LICENSE.md) repo for more information.
 2. Run `haxelib --global install hmm` and then `haxelib --global run hmm setup` to install hmm.json
 3. Run `hmm install` to install all haxelibs of the current branch
 4. Run `haxelib run lime setup` to set up lime

--- a/source/funkin/play/PlayState.hx
+++ b/source/funkin/play/PlayState.hx
@@ -2437,7 +2437,7 @@ class PlayState extends MusicBeatSubState
 
     // Get the offset and compensate for input latency.
     // Round inward (trim remainder) for consistency.
-    var noteDiff:Int = Std.int(Conductor.instance.songPosition - note.noteData.time - inputLatencyMs + Conductor.instance.inputOffset);
+    var noteDiff:Int = Std.int(Math.abs(Conductor.instance.songPosition - note.noteData.time) - inputLatencyMs + Conductor.instance.inputOffset);
 
     var score = Scoring.scoreNote(noteDiff, PBOT1);
     var daRating = Scoring.judgeNote(noteDiff, PBOT1);

--- a/source/funkin/play/PlayState.hx
+++ b/source/funkin/play/PlayState.hx
@@ -2437,7 +2437,7 @@ class PlayState extends MusicBeatSubState
 
     // Get the offset and compensate for input latency.
     // Round inward (trim remainder) for consistency.
-    var noteDiff:Int = Std.int(Math.abs(Conductor.instance.songPosition - note.noteData.time) - inputLatencyMs + Conductor.instance.inputOffset);
+    var noteDiff:Int = Std.int(Conductor.instance.songPosition - note.noteData.time - inputLatencyMs + Conductor.instance.inputOffset);
 
     var score = Scoring.scoreNote(noteDiff, PBOT1);
     var daRating = Scoring.judgeNote(noteDiff, PBOT1);

--- a/source/funkin/play/PlayState.hx
+++ b/source/funkin/play/PlayState.hx
@@ -2437,7 +2437,7 @@ class PlayState extends MusicBeatSubState
 
     // Get the offset and compensate for input latency.
     // Round inward (trim remainder) for consistency.
-    var noteDiff:Int = Std.int(Conductor.instance.songPosition - note.noteData.time - inputLatencyMs);
+    var noteDiff:Int = Std.int(Conductor.instance.songPosition - note.noteData.time - inputLatencyMs + Conductor.instance.inputOffset);
 
     var score = Scoring.scoreNote(noteDiff, PBOT1);
     var daRating = Scoring.judgeNote(noteDiff, PBOT1);


### PR DESCRIPTION
This pr fixes an issue where the notes are wrongly judged when using an input offset.

This #2969 describes also another the problem in detail, which is that seemingly that above the strum is a shorter hit window than below. This is not yet fixed. (Im not sure if we are all just crazy)

To demonstrate the issue more clearly im using extremely large offsets.
Using:
Input Offset: 160ms
Visual Offset: 0ms

### Before

https://github.com/FunkinCrew/Funkin/assets/87707926/1a378317-e739-4947-ba71-36868366e17c

### After

https://github.com/FunkinCrew/Funkin/assets/87707926/c246b8f7-a974-4e18-ac8d-ff8062ecd809

