### PR TITLE
[ENHANCEMENT] Add `fromOrigin` to character positioning

### DIFF
--- a/source/funkin/data/stage/StageData.hx
+++ b/source/funkin/data/stage/StageData.hx
@@ -203,6 +203,16 @@ typedef StageDataCharacter =
   var position:Array<Float>;
 
   /**
+   * If set to true, when positioning the character, the position origin will be at vertical bottom and horizontal center of the sprite.
+   * If set to false, when positioning the character, the position origin will be at the top-left of the sprite.
+   * This prevents characters from not being properly positioned.
+   * @default true
+   */
+  @:optional
+  @:default(true)
+  var fromOrigin:Bool;
+
+  /**
    * The scale to render the character at.
    */
   @:optional

--- a/source/funkin/play/character/BaseCharacter.hx
+++ b/source/funkin/play/character/BaseCharacter.hx
@@ -267,8 +267,9 @@ class BaseCharacter extends Bopper
   /**
    * Set the character's sprite scale to the appropriate value.
    * @param scale The desired scale.
+   * @param fromOrigin If true, it will reposition the character from its origin.
    */
-  public function setScale(scale:Null<Float>):Void
+  public function setScale(scale:Null<Float>, fromOrigin:Bool = true):Void
   {
     if (scale == null) scale = 1.0;
 
@@ -276,9 +277,12 @@ class BaseCharacter extends Bopper
     this.scale.x = scale;
     this.scale.y = scale;
     this.updateHitbox();
-    // Reposition with newly scaled sprite.
-    this.x = feetPos.x - characterOrigin.x + globalOffsets[0];
-    this.y = feetPos.y - characterOrigin.y + globalOffsets[1];
+    if (fromOrigin)
+    {
+      // Reposition with newly scaled sprite.
+      this.x = feetPos.x - characterOrigin.x + globalOffsets[0];
+      this.y = feetPos.y - characterOrigin.y + globalOffsets[1];
+    }
   }
 
   /**

--- a/source/funkin/play/stage/Stage.hx
+++ b/source/funkin/play/stage/Stage.hx
@@ -111,7 +111,7 @@ class Stage extends FlxSpriteGroup implements IPlayStateScriptedClass implements
       // Reapply the camera offsets.
       var stageCharData:StageDataCharacter = _data.characters.bf;
       var finalScale:Float = getBoyfriend().getBaseScale() * stageCharData.scale;
-      getBoyfriend().setScale(finalScale);
+      getBoyfriend().setScale(finalScale, stageCharData.fromOrigin);
       getBoyfriend().cameraFocusPoint.x += stageCharData.cameraOffsets[0];
       getBoyfriend().cameraFocusPoint.y += stageCharData.cameraOffsets[1];
     }
@@ -125,7 +125,7 @@ class Stage extends FlxSpriteGroup implements IPlayStateScriptedClass implements
       // Reapply the camera offsets.
       var stageCharData:StageDataCharacter = _data.characters.gf;
       var finalScale:Float = getGirlfriend().getBaseScale() * stageCharData.scale;
-      getGirlfriend().setScale(finalScale);
+      getGirlfriend().setScale(finalScale, stageCharData.fromOrigin);
       getGirlfriend().cameraFocusPoint.x += stageCharData.cameraOffsets[0];
       getGirlfriend().cameraFocusPoint.y += stageCharData.cameraOffsets[1];
     }
@@ -135,7 +135,7 @@ class Stage extends FlxSpriteGroup implements IPlayStateScriptedClass implements
       // Reapply the camera offsets.
       var stageCharData:StageDataCharacter = _data.characters.dad;
       var finalScale:Float = getDad().getBaseScale() * stageCharData.scale;
-      getDad().setScale(finalScale);
+      getDad().setScale(finalScale, stageCharData.fromOrigin);
       getDad().cameraFocusPoint.x += stageCharData.cameraOffsets[0];
       getDad().cameraFocusPoint.y += stageCharData.cameraOffsets[1];
     }
@@ -432,8 +432,17 @@ class Stage extends FlxSpriteGroup implements IPlayStateScriptedClass implements
       // Start with the per-stage character position.
       // Subtracting the origin ensures characters are positioned relative to their feet.
       // Subtracting the global offset allows positioning on a per-character basis.
-      character.x = stageCharData.position[0] - character.characterOrigin.x + character.globalOffsets[0];
-      character.y = stageCharData.position[1] - character.characterOrigin.y + character.globalOffsets[1];
+      character.x = stageCharData.position[0];
+      character.y = stageCharData.position[1];
+
+      if (stageCharData.fromOrigin)
+      {
+        character.x -= character.characterOrigin.x;
+        character.y -= character.characterOrigin.y;
+      }
+
+      character.x += character.globalOffsets[0];
+      character.y += character.globalOffsets[1];
 
       @:privateAccess(funkin.play.stage.Bopper)
       {
@@ -443,7 +452,7 @@ class Stage extends FlxSpriteGroup implements IPlayStateScriptedClass implements
       }
 
       var finalScale = character.getBaseScale() * stageCharData.scale;
-      character.setScale(finalScale); // Don't use scale.set for characters!
+      character.setScale(finalScale, stageCharData.fromOrigin); // Don't use scale.set for characters!
       character.cameraFocusPoint.x += stageCharData.cameraOffsets[0];
       character.cameraFocusPoint.y += stageCharData.cameraOffsets[1];
 


### PR DESCRIPTION
Adds a `fromOrigin` property to stage character data (defaults to true)
```
"bf": {
	"zIndex": 300,
	"position": [4200, 2850],
	"fromOrigin": false,
	"cameraOffsets": [-300, -300]
},
```
It set to true, everything just acts like normal, but if you turn it off, it positions the character in absolute coordinates (also using character position offsets), ignoring the feet position and horizontal center. Pretty useful when moving stuff from old engines.