### PR TITLE
[DOCS] Automatically assign 'status: pending triage' label to all new issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -10,7 +10,7 @@ OR ELSE YOUR ISSUE WILL BE LESS LIKELY TO BE SOLVED!
 
 Do not post about issues from other FNF mod engines!
 We cannot and probably won't solve those!
-You can hopefully go to their respective GitHub issues and report them there, thank you :)
+You can hopefully go to their respective GitHub issues pages and report them there, thank you :)
 
 Please check for duplicates or similar issues, as well as performing simple troubleshooting steps (such as clearing cookies, clearing AppData, trying another browser) before submitting an issue.
 
@@ -48,4 +48,4 @@ Remember to mark the area in the application that's impacted. -->
 ## Additional Context
 <!-- Add any other context about the problem here. -->
 
-<!-- If your game is FROZEN and you're playing a web version, press F12 to open up browser dev window, go to the console, and copy-paste whatever red error you're getting -->
+<!-- If your game is FROZEN and you're playing a web version, press F12 to open up the browser dev window, go to the "Console" tab, and copy-paste whatever red error you're getting below -->

--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -2,7 +2,7 @@
 name: Bug Report
 about: Report a bug or critical performance issue
 title: 'Bug Report: [DESCRIBE YOUR BUG IN DETAIL HERE]'
-labels: bug
+labels: 'status: pending triage'
 ---
 
 <!-- FILL THIS ISSUE THING OUT AS MUCH AS POSSIBLE
@@ -12,7 +12,7 @@ Do not post about issues from other FNF mod engines!
 We cannot and probably won't solve those!
 You can hopefully go to their respective GitHub issues and report them there, thank you :)
 
-Please check for duplicates or similar issues, as well performing simple troubleshooting steps (such as clearing cookies, clearing AppData, trying another browser) before submitting an issue.
+Please check for duplicates or similar issues, as well as performing simple troubleshooting steps (such as clearing cookies, clearing AppData, trying another browser) before submitting an issue.
 
 From Joel On Software:
 
@@ -24,27 +24,28 @@ From Joel On Software:
 
 -->
 
-## Describe the bug
+## Describe the Bug
 <!-- A clear and concise description of what the bug is. -->
 
 ## To Reproduce
-<!-- Describe in DETAIL how to reproduce the bug/issue you are running into. -->
-## Expected behavior
+<!-- Describe IN DETAIL how to reproduce the bug/issue you are running into. -->
+
+## Expected Behavior
 <!-- A clear and concise description of what you expected to happen. -->
 
 ## Screenshots/Video
 <!-- If applicable, add screenshots/video to help explain your problem.
-Remember to mark the area in the application thats impacted. -->
+Remember to mark the area in the application that's impacted. -->
 
 ## Desktop
  - OS:
  <!-- [e.g. Windows 10, 11, Mac, Linux Mint, Ubuntu, Arch (btw)] -->
- - Browser
- <!-- [e.g. chrome, safari, firefox, edge, operaGX] -->
+ - Browser:
+ <!-- [e.g. Chrome, Safari, Firefox, Edge, OperaGX, or None if you're playing the downloaded version!] -->
  - Version:
  <!-- [e.g. 0.4.0, 0.3.3, this can be found in the bottom left corner of the main menu!] -->
 
 ## Additional context
 <!-- Add any other context about the problem here. -->
 
-<!-- If you're game is FROZEN and you're playing a web version, press F12 to open up browser dev window, and go to console, and copy-paste whatever red error you're getting -->
+<!-- If your game is FROZEN and you're playing a web version, press F12 to open up browser dev window, go to the console, and copy-paste whatever red error you're getting -->

--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -45,7 +45,7 @@ Remember to mark the area in the application that's impacted. -->
  - Version:
  <!-- [e.g. 0.4.0, 0.3.3, this can be found in the bottom left corner of the main menu!] -->
 
-## Additional context
+## Additional Context
 <!-- Add any other context about the problem here. -->
 
 <!-- If your game is FROZEN and you're playing a web version, press F12 to open up browser dev window, go to the console, and copy-paste whatever red error you're getting -->

--- a/.github/ISSUE_TEMPLATE/enhancement.md
+++ b/.github/ISSUE_TEMPLATE/enhancement.md
@@ -2,7 +2,7 @@
 name: Enhancement
 about: Suggest a new feature
 title: 'Enhancement: '
-labels: enhancement
+labels: 'status: pending triage'
 ---
-#### Please check for duplicates or similar issues before creating this issue.
+#### Please check for duplicates or similar issues before submitting this suggestion.
 ## What is your suggestion, and why should it be implemented?

--- a/.github/PULL_REQUEST_TEMPLATE/bug.md
+++ b/.github/PULL_REQUEST_TEMPLATE/bug.md
@@ -2,9 +2,9 @@
 name: Bug Fix
 about: Fix a bug or critical performance issue
 title: 'Bug Fix: '
-labels: bug
+labels: 'status: pending triage'
 ---
-#### Please check for duplicates or similar PRs before creating this issue.
-## Does this PR close any issue(s)? If so, link them below.
+#### Please check for duplicates or similar PRs before submitting this PR.
+## Does this PR close any issues? If so, link them below.
 
 ## Briefly describe the issue(s) fixed.

--- a/.github/PULL_REQUEST_TEMPLATE/enhancement.md
+++ b/.github/PULL_REQUEST_TEMPLATE/enhancement.md
@@ -2,7 +2,7 @@
 name: Enhancement
 about: Add a new feature
 title: 'Enhancement: '
-labels: 'status: pending triage"
+labels: 'status: pending triage'
 ---
 #### Please check for duplicates or similar PRs before submitting this PR.
 ## Does this PR close any issues? If so, link them below.

--- a/.github/PULL_REQUEST_TEMPLATE/enhancement.md
+++ b/.github/PULL_REQUEST_TEMPLATE/enhancement.md
@@ -2,9 +2,9 @@
 name: Enhancement
 about: Add a new feature
 title: 'Enhancement: '
-labels: enhancement
+labels: 'status: pending triage"
 ---
-#### Please check for duplicates or similar PRs before creating this issue.
-## Does this PR close any issue(s)? If so, link them below.
+#### Please check for duplicates or similar PRs before submitting this PR.
+## Does this PR close any issues? If so, link them below.
 
-## What do your change(s) add, and why should they be implemented?
+## What do your changes add, and why should they be implemented?


### PR DESCRIPTION
This PR should automatically apply the 'status: pending triage' label to every new issue.

Also includes some polish for each issue and PR template.

Question: Should enhancements also automatically receive the 'type: enhancement' label or would you prefer to assign type labels manually?