### PR TITLE
[ENHANCEMENT] Custom pre-death music loop & animation behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,7 +58,6 @@ This patch resolves a critical issue that could cause user's save data to become
 
 * @Kn1ghtNight made their first contribution in [#2853](https://github.com/FunkinCrew/Funkin/pull/2853)
 * @Cartridge-Man made their first contribution in [#3082](https://github.com/FunkinCrew/Funkin/pull/3082)
-* @KoloInDaCrib made their first contribution in [#3482](https://github.com/FunkinCrew/Funkin/pull/3482)
 * @afreetoplaynoob made their first contribution in [#3537](https://github.com/FunkinCrew/Funkin/pull/3537)
 * @amyspark-ng made their first contribution in [#3552](https://github.com/FunkinCrew/Funkin/pull/3552)
 * @DaWaterMalone made their first contribution in [#3577](https://github.com/FunkinCrew/Funkin/pull/3577)
@@ -140,7 +139,7 @@ This patch resolves a critical issue that could cause user's save data to become
 - The FPS counter no longer displays if Debug Display is turned off. ([community fix by Lethrial](https://github.com/FunkinCrew/Funkin/pull/3356))
 - The Chart Editor can now be interacted with properly. ([community fix by Kade-github](https://github.com/FunkinCrew/Funkin/pull/3337))
 - Selecting the area to the left of the Chart Editor no longer selects some of the player's notes. ([community fix by NotHyper-474](https://github.com/FunkinCrew/Funkin/pull/3093))
-- Pixel icons now display correctly in the Chart Editor. ([community fix by Techniktil](https://github.com/FunkinCrew/Funkin/pull/3339))
+- Pixel icons now display correctly in the Chart Editor. ([community fix by TechnikTil](https://github.com/FunkinCrew/Funkin/pull/3339))
 - Audio offsets now interact with the Chart Editor properly. ([community fix by Kade-github](https://github.com/FunkinCrew/Funkin/pull/3384))
 - Players can no longer crash the game by interacting with Character Select during the unlock sequence. ([community fix by ActualMandM](https://github.com/FunkinCrew/Funkin/pull/3355))
 - `Stage.addCharacter` now properly assigns the `characterType`. ([community fix by Kade-github](https://github.com/FunkinCrew/Funkin/pull/3357))
@@ -151,6 +150,7 @@ This patch resolves a critical issue that could cause user's save data to become
 
 * @dombomb64 made their first contribution in [#3351](https://github.com/FunkinCrew/Funkin/pull/3351)
 * @Lethrial made their first contribution in [#3356](https://github.com/FunkinCrew/Funkin/pull/3356)
+* @KoloInDaCrib made their first contribution in [#3371](https://github.com/FunkinCrew/Funkin/pull/3371)
 
 
 
@@ -243,9 +243,11 @@ This patch resolves a critical issue that could cause user's save data to become
 * @Sword352 made their first contribution in [#2310](https://github.com/FunkinCrew/Funkin/pull/2310)
 * @cyn0x8 made their first contribution in [#2494](https://github.com/FunkinCrew/Funkin/pull/2494)
 * @KarimAkra made their first contribution in [#2713](https://github.com/FunkinCrew/Funkin/pull/2713)
+* @tposejank made their first contribution in [#2717](https://github.com/FunkinCrew/Funkin/pull/2717)
 * @AppleHair made their first contribution in [#2742](https://github.com/FunkinCrew/Funkin/pull/2742)
 * @JVNpixels made their first contribution in [#2873](https://github.com/FunkinCrew/Funkin/pull/2873)
 * @Flooferland made their first contribution in [#2942](https://github.com/FunkinCrew/Funkin/pull/2942)
+* @Punkinator7 made their first contribution in [#2962](https://github.com/FunkinCrew/Funkin/pull/2962)
 * @anysad made their first contribution in [#3007](https://github.com/FunkinCrew/Funkin/pull/3007)
 * @7oltan made their first contribution in [#3035](https://github.com/FunkinCrew/Funkin/pull/3035)
 
@@ -287,8 +289,9 @@ This patch resolves a critical issue that could cause user's save data to become
 
 ## New Contributors for 0.4.1
 
-* @Hundrec made their first contribution in [#2683](https://github.com/FunkinCrew/Funkin/pull/2683)
+* @Hundrec made their first contribution in [#2661](https://github.com/FunkinCrew/Funkin/pull/2661)
 * @DMMaster636 made their first contribution in [#2709](https://github.com/FunkinCrew/Funkin/pull/2709)
+* @eltociear made their first contribution in [#2730](https://github.com/FunkinCrew/Funkin/pull/2730)
 
 
 
@@ -353,12 +356,17 @@ This patch resolves a critical issue that could cause user's save data to become
 
 * @Noobz4Life made their first contribution in [#2472](https://github.com/FunkinCrew/Funkin/pull/2472)
 * @MaybeMaru made their first contribution in [#2488](https://github.com/FunkinCrew/Funkin/pull/2488)
+* @NotHyper-474 made their first contribution in [#2490](https://github.com/FunkinCrew/Funkin/pull/2490)
 * @richTrash21 made their first contribution in [#2493](https://github.com/FunkinCrew/Funkin/pull/2493)
+* @TechnikTil made their first contribution in [#2508](https://github.com/FunkinCrew/Funkin/pull/2508)
+* @SanicBTW made their first contribution in [#2544](https://github.com/FunkinCrew/Funkin/pull/2544)
+* @EnterTheVoid-x86 made their first contribution in [#2573](https://github.com/FunkinCrew/Funkin/pull/2573)
 * @Keoiki made their first contribution in [#2581](https://github.com/FunkinCrew/Funkin/pull/2581)
 * @sector-a made their first contribution in [#2585](https://github.com/FunkinCrew/Funkin/pull/2585)
 * @PurSnake made their first contribution in [#2610](https://github.com/FunkinCrew/Funkin/pull/2610)
 * @Ethan-makes-music made their first contribution in [#2624](https://github.com/FunkinCrew/Funkin/pull/2624)
-* @NotHyper-474 made their first contribution in [#2629](https://github.com/FunkinCrew/Funkin/pull/2629)
+* @An-enderman made their first contribution in [#2662](https://github.com/FunkinCrew/Funkin/pull/2662)
+* @moondroidcoder made their first contribution in [#2701](https://github.com/FunkinCrew/Funkin/pull/2701)
 
 
 
@@ -388,6 +396,7 @@ This patch resolves a critical issue that could cause user's save data to become
 
 ## New Contributors for 0.3.3
 
+* @Chubercik made their first contribution in [#2297](https://github.com/FunkinCrew/Funkin/pull/2297)
 * @TheGaloXx made their first contribution in [#2300](https://github.com/FunkinCrew/Funkin/pull/2300)
 * @Burgerballs made their first contribution in [#2308](https://github.com/FunkinCrew/Funkin/pull/2308)
 * @ImCodist made their first contribution in [#2309](https://github.com/FunkinCrew/Funkin/pull/2309)

--- a/source/funkin/modding/IScriptedClass.hx
+++ b/source/funkin/modding/IScriptedClass.hx
@@ -141,6 +141,11 @@ interface IPlayStateScriptedClass extends INoteScriptedClass extends IBPMSyncedS
   public function onGameOver(event:ScriptEvent):Void;
 
   /**
+   * Called as the player enters game over substate, but before the start of music.
+   */
+  public function onGameOverLoop(event:GameOverLoopScriptEvent):Void;
+
+  /**
    * Called when the player restarts the song, either via pause menu or restarting after a game over.
    */
   public function onSongRetry(event:SongRetryEvent):Void;

--- a/source/funkin/modding/events/ScriptEvent.hx
+++ b/source/funkin/modding/events/ScriptEvent.hx
@@ -227,6 +227,31 @@ class GhostMissNoteScriptEvent extends ScriptEvent
   }
 }
 
+class GameOverLoopScriptEvent extends ScriptEvent
+{
+
+  /**
+   * Whether to play the game over music.
+   */
+  public var shouldPlayMusic(default, default):Bool;
+
+  /**
+   * How loud the game over music should play (unless it isn't due to shouldPlayMusic being `false`).
+   */
+  public var musicVolume(default, default):Float;
+
+  public function new(shouldPlayMusic:Bool, musicVolume:Float):Void {
+    super(GAME_OVER_LOOP, true);
+    this.shouldPlayMusic = shouldPlayMusic;
+    this.musicVolume = musicVolume;
+  }
+
+  public override function toString():String
+  {
+    return 'GameOverLoopScriptEvent(shouldPlayMusic=' + shouldPlayMusic + ', musicVolume=' + musicVolume + ')';
+  }
+}
+
 /**
  * An event that is fired when the song reaches an event.
  */

--- a/source/funkin/modding/events/ScriptEventDispatcher.hx
+++ b/source/funkin/modding/events/ScriptEventDispatcher.hx
@@ -129,6 +129,8 @@ class ScriptEventDispatcher
         case GAME_OVER:
           t.onGameOver(event);
           return;
+        case GAME_OVER_LOOP:
+          t.onGameOverLoop(cast event);
         case PAUSE:
           t.onPause(cast event);
           return;

--- a/source/funkin/modding/events/ScriptEventType.hx
+++ b/source/funkin/modding/events/ScriptEventType.hx
@@ -151,6 +151,14 @@ enum abstract ScriptEventType(String) from String to String
    */
   var GAME_OVER = 'GAME_OVER';
 
+
+  /**
+   * Called after the game over screen triggers, but before the death loop animation plays.
+   *
+   * This event is cancelable.
+   */
+  var GAME_OVER_LOOP = 'GAME_OVER_LOOP';
+
   /**
    * Called after the player presses a key to restart the game.
    * This can happen from the pause menu or the game over screen.

--- a/source/funkin/modding/module/Module.hx
+++ b/source/funkin/modding/module/Module.hx
@@ -83,6 +83,8 @@ class Module implements IPlayStateScriptedClass implements IStateChangingScripte
 
   public function onGameOver(event:ScriptEvent) {}
 
+  public function onGameOverLoop(event:GameOverLoopScriptEvent) {}
+
   public function onNoteIncoming(event:NoteScriptEvent) {}
 
   public function onNoteHit(event:HitNoteScriptEvent) {}

--- a/source/funkin/play/GameOverSubState.hx
+++ b/source/funkin/play/GameOverSubState.hx
@@ -300,27 +300,16 @@ class GameOverSubState extends MusicBeatSubState
       }
       else
       {
-        // Music hasn't started yet.
-        switch (PlayStatePlaylist.campaignId)
+        // Start music at normal volume once the initial death animation finishes.
+        if (boyfriend.getCurrentAnimation().startsWith('firstDeath') && boyfriend.isAnimationFinished())
         {
-          // TODO: Make the behavior for playing Jeff's voicelines generic or un-hardcoded.
-          // This will simplify the class and make it easier for mods to add death quotes.
-          case 'week7':
-            if (boyfriend.getCurrentAnimation().startsWith('firstDeath') && boyfriend.isAnimationFinished() && !playingJeffQuote)
-            {
-              playingJeffQuote = true;
-              playJeffQuote();
-              // Start music at lower volume
-              startDeathMusic(0.2, false);
-              boyfriend.playAnimation('deathLoop' + animationSuffix);
-            }
-          default:
-            // Start music at normal volume once the initial death animation finishes.
-            if (boyfriend.getCurrentAnimation().startsWith('firstDeath') && boyfriend.isAnimationFinished())
-            {
-              startDeathMusic(1.0, false);
-              boyfriend.playAnimation('deathLoop' + animationSuffix);
-            }
+          var event:GameOverLoopScriptEvent = new GameOverLoopScriptEvent(true, 1.0);
+          dispatchEvent(event);
+
+          if (!event.eventCanceled) {
+            if (event.shouldPlayMusic) startDeathMusic(event.musicVolume, false);
+            boyfriend.playAnimation('deathLoop' + animationSuffix);
+          }
         }
       }
     }
@@ -395,6 +384,10 @@ class GameOverSubState extends MusicBeatSubState
     super.dispatchEvent(event);
 
     ScriptEventDispatcher.callEvent(boyfriend, event);
+
+    // Modules, stages, characters.
+    @:privateAccess
+    PlayState.instance.dispatchEvent(event);
   }
 
   /**
@@ -485,27 +478,6 @@ class GameOverSubState extends MusicBeatSubState
     {
       FlxG.log.error('Missing blue ball sound effect: ' + Paths.sound('gameplay/gameover/fnf_loss_sfx' + blueBallSuffix));
     }
-  }
-
-  var playingJeffQuote:Bool = false;
-
-  /**
-   * Week 7-specific hardcoded behavior, to play a custom death quote.
-   * TODO: Make this a module somehow.
-   */
-  function playJeffQuote():Void
-  {
-    var randomCensor:Array<Int> = [];
-
-    if (!Preferences.naughtyness) randomCensor = [1, 3, 8, 13, 17, 21];
-
-    FunkinSound.playOnce(Paths.sound('jeffGameover/jeffGameover-' + FlxG.random.int(1, 25, randomCensor)), function() {
-      // Once the quote ends, fade in the game over music.
-      if (!isEnding && gameOverMusic != null)
-      {
-        gameOverMusic.fadeIn(4, 0.2, 1);
-      }
-    });
   }
 
   public override function destroy():Void

--- a/source/funkin/play/PlayState.hx
+++ b/source/funkin/play/PlayState.hx
@@ -918,8 +918,12 @@ class PlayState extends MusicBeatSubState
 
       Conductor.instance.update(Conductor.instance.songPosition + elapsed * 1000, false); // Normal conductor update.
 
-      // Fallback in case music's onComplete function doesn't get called.
-      if (FlxG.sound.music.time >= (FlxG.sound.music.endTime ?? FlxG.sound.music.length) && mayPauseGame) endSong(skipEndingTransition);
+      // If, after updating the conductor, the instrumental has finished, end the song immediately.
+      // This helps prevent a major bug where the level suddenly loops back to the start or middle.
+      if (Conductor.instance.songPosition >= (FlxG.sound.music.endTime ?? FlxG.sound.music.length))
+      {
+        if (mayPauseGame) endSong(skipEndingTransition);
+      }
     }
 
     var androidPause:Bool = false;
@@ -2062,7 +2066,7 @@ class PlayState extends MusicBeatSubState
     }
 
     FlxG.sound.music.onComplete = function() {
-      endSong(skipEndingTransition);
+      if (mayPauseGame) endSong(skipEndingTransition);
     };
     // A negative instrumental offset means the song skips the first few milliseconds of the track.
     // This just gets added into the startTimestamp behavior so we don't need to do anything extra.

--- a/source/funkin/play/PlayState.hx
+++ b/source/funkin/play/PlayState.hx
@@ -917,6 +917,9 @@ class PlayState extends MusicBeatSubState
       }
 
       Conductor.instance.update(Conductor.instance.songPosition + elapsed * 1000, false); // Normal conductor update.
+
+      // Fallback in case music's onComplete function doesn't get called.
+      if (FlxG.sound.music.time >= (FlxG.sound.music.endTime ?? FlxG.sound.music.length) && mayPauseGame) endSong(skipEndingTransition);
     }
 
     var androidPause:Bool = false;
@@ -1440,7 +1443,7 @@ class PlayState extends MusicBeatSubState
       var playerVoicesError:Float = 0;
       var opponentVoicesError:Float = 0;
 
-      if (vocals != null)
+      if (vocals != null && vocals.playing)
       {
         @:privateAccess // todo: maybe make the groups public :thinking:
         {

--- a/source/funkin/play/song/Song.hx
+++ b/source/funkin/play/song/Song.hx
@@ -643,11 +643,13 @@ class Song implements IPlayStateScriptedClass implements IRegistryEntry<SongMeta
 
   public function onGameOver(event:ScriptEvent):Void {};
 
-  public function onSongRetry(event:SongRetryEvent):Void {};
+  public function onGameOverLoop(event:GameOverLoopScriptEvent):Void {};
 
-  public function onNoteIncoming(event:NoteScriptEvent) {};
+  public function onSongRetry(event:ScriptEvent):Void {};
 
-  public function onNoteHit(event:HitNoteScriptEvent) {};
+  public function onNoteIncoming(event:NoteScriptEvent) {}
+
+  public function onNoteHit(event:HitNoteScriptEvent) {}
 
   public function onNoteMiss(event:NoteScriptEvent):Void {};
 

--- a/source/funkin/play/stage/Bopper.hx
+++ b/source/funkin/play/stage/Bopper.hx
@@ -371,6 +371,8 @@ class Bopper extends StageProp implements IPlayStateScriptedClass
 
   public function onGameOver(event:ScriptEvent) {}
 
+  public function onGameOverLoop(event:GameOverLoopScriptEvent) {}
+
   public function onNoteIncoming(event:NoteScriptEvent) {}
 
   public function onNoteHit(event:HitNoteScriptEvent) {}

--- a/source/funkin/play/stage/Stage.hx
+++ b/source/funkin/play/stage/Stage.hx
@@ -889,6 +889,8 @@ class Stage extends FlxSpriteGroup implements IPlayStateScriptedClass implements
 
   public function onGameOver(event:ScriptEvent) {}
 
+  public function onGameOverLoop(event:GameOverLoopScriptEvent) {}
+
   public function onCountdownStart(event:CountdownScriptEvent) {}
 
   public function onCountdownStep(event:CountdownScriptEvent) {}


### PR DESCRIPTION
<!-- Please check for duplicates or similar PRs before submitting this PR. -->
## Briefly describe the issue(s) fixed.
- This PR aims to add an event dedicated to adding custom logic before the music and animation starts. As one of the devs (probably [EliteMasterEric](https://github.com/EliteMasterEric) himself) put it:
`TODO: Make the behavior for playing Jeff's voicelines generic or un-hardcoded.`
`This will simplify the class and make it easier for mods to add death quotes.`
- By utilizing this new event, this PR also softcodes Jeff's voicelines (aka Tankman in week 7). Just because it's convenient.
- And last but not least. `eventn` -> `event` 🙂

## Include any relevant screenshots or videos.
- Just to put it out here, this event uses two parameters. The first one is whether the game over music should play in the first place, and the second parameter is the volume of said game over music.
![image](https://github.com/user-attachments/assets/1ad64119-ddd8-49d2-bca7-2e5d9b844ed3)
