### PR TITLE
[ENHANCEMENT] Freeplay Icon Metadata

### DIFF
--- a/source/funkin/play/character/CharacterData.hx
+++ b/source/funkin/play/character/CharacterData.hx
@@ -376,7 +376,6 @@ class CharacterDataParser
   static final DEFAULT_LOOP:Bool = false;
   static final DEFAULT_NAME:String = 'Untitled Character';
   static final DEFAULT_OFFSETS:Array<Float> = [0, 0];
-  static final DEFAULT_FREEPLAYICON_OFFSETS:Array<Float> = [100, 20];
   static final DEFAULT_RENDERTYPE:CharacterRenderType = CharacterRenderType.Sparrow;
   static final DEFAULT_SCALE:Float = 1;
   static final DEFAULT_SCROLL:Array<Float> = [0, 0];
@@ -496,7 +495,7 @@ class CharacterDataParser
 
     if (input.freeplayIcon.offsets == null)
     {
-      input.freeplayIcon.offsets = DEFAULT_FREEPLAYICON_OFFSETS;
+      input.freeplayIcon.offsets = DEFAULT_OFFSETS;
     }
 
     if (input.startingAnimation == null)
@@ -770,12 +769,13 @@ typedef FreeplayIconData =
    * The scale of the freeplay icon.
    */
   var scale:Null<Float>;
+
   /**
    * Whether to flip the freeplay icon horizontally.
    * @default false
    */
-
   var flipX:Null<Bool>;
+
   /**
    * The offset of the freeplay icon, in pixels.
    * @default [100, 25]

--- a/source/funkin/play/character/CharacterData.hx
+++ b/source/funkin/play/character/CharacterData.hx
@@ -283,36 +283,19 @@ class CharacterDataParser
   /**
    * TODO: Hardcode this.
    */
-  public static function getCharPixelIconAsset(char:String):String
+  public static function getCharacterPixelIcon(iconData:Null<FreeplayIconData>, ?charId:String):String
   {
-    var icon:String = char;
+    var basePath:String = 'freeplay/icons/';
+    var icon:String = iconData.name;
 
-    switch (icon)
-    {
-      case "bf-christmas" | "bf-car" | "bf-pixel" | "bf-holding-gf":
-        icon = "bf";
-      case "monster-christmas":
-        icon = "monster";
-      case "mom" | "mom-car":
-        icon = "mommy";
-      case "pico-blazin" | "pico-playable" | "pico-speaker":
-        icon = "pico";
-      case "gf-christmas" | "gf-car" | "gf-pixel" | "gf-tankmen":
-        icon = "gf";
-      case "dad":
-        icon = "daddy";
-      case "darnell-blazin":
-        icon = "darnell";
-      case "senpai-angry":
-        icon = "senpai";
-      case "tankman" | "tankman-atlas":
-        icon = "tankmen";
-    }
+    var iconPath:String = Paths.image(basePath + icon);
+    if (Assets.exists(iconPath)) return iconPath;
 
-    var path = Paths.image("freeplay/icons/" + icon + "pixel");
-    if (Assets.exists(path)) return path;
+    // Trying to have a 'pixel' suffix due to how it was handled previously.
+    if (!Assets.exists(iconPath)) return Paths.image(basePath + charId + 'pixel');
 
-    // TODO: Hardcode some additional behavior or a fallback.
+    // TODO: make a pixel icon for 'unknown', so that we can have a fallback!
+    // return Paths.image(basePath + DEFAULT_CHAR_ID.toLowerCase() + 'pixel');
     return null;
   }
 
@@ -393,7 +376,7 @@ class CharacterDataParser
   static final DEFAULT_LOOP:Bool = false;
   static final DEFAULT_NAME:String = 'Untitled Character';
   static final DEFAULT_OFFSETS:Array<Float> = [0, 0];
-  static final DEFAULT_HEALTHICON_OFFSETS:Array<Int> = [0, 25];
+  static final DEFAULT_FREEPLAYICON_OFFSETS:Array<Float> = [100, 20];
   static final DEFAULT_RENDERTYPE:CharacterRenderType = CharacterRenderType.Sparrow;
   static final DEFAULT_SCALE:Float = 1;
   static final DEFAULT_SCROLL:Array<Float> = [0, 0];
@@ -483,6 +466,37 @@ class CharacterDataParser
     if (input.healthIcon.offsets == null)
     {
       input.healthIcon.offsets = DEFAULT_OFFSETS;
+    }
+
+    if (input.freeplayIcon == null)
+    {
+      input.freeplayIcon =
+      {
+        name: null,
+        scale: null,
+        flipX: null,
+        offsets: null
+      }
+    }
+
+    if (input.freeplayIcon.name == null)
+    {
+      input.freeplayIcon.name = id;
+    }
+
+    if (input.freeplayIcon.scale == null)
+    {
+      input.freeplayIcon.scale = 2;
+    }
+
+    if (input.freeplayIcon.flipX == null)
+    {
+      input.freeplayIcon.flipX = DEFAULT_FLIPX;
+    }
+
+    if (input.freeplayIcon.offsets == null)
+    {
+      input.freeplayIcon.offsets = DEFAULT_FREEPLAYICON_OFFSETS;
     }
 
     if (input.startingAnimation == null)
@@ -641,6 +655,11 @@ typedef CharacterData =
    */
   var healthIcon:Null<HealthIconData>;
 
+  /**
+   * Optional data about the freeplay icon for the character.
+   */
+  var freeplayIcon:Null<FreeplayIconData>;
+
   var death:Null<DeathData>;
 
   /**
@@ -732,6 +751,34 @@ typedef HealthIconData =
   /**
    * The offset of the health icon, in pixels.
    * @default [0, 25]
+   */
+  var offsets:Null<Array<Float>>;
+}
+
+/**
+ * The JSON data schema used to define the freeplay icon for a character.
+ */
+typedef FreeplayIconData =
+{
+  /**
+   * The name to use for the freeplay icon.
+   * @default The character's ID
+   */
+  var name:Null<String>;
+
+  /**
+   * The scale of the freeplay icon.
+   */
+  var scale:Null<Float>;
+  /**
+   * Whether to flip the freeplay icon horizontally.
+   * @default false
+   */
+
+  var flipX:Null<Bool>;
+  /**
+   * The offset of the freeplay icon, in pixels.
+   * @default [100, 25]
    */
   var offsets:Null<Array<Float>>;
 }

--- a/source/funkin/ui/debug/charting/dialogs/ChartEditorCharacterIconSelectorMenu.hx
+++ b/source/funkin/ui/debug/charting/dialogs/ChartEditorCharacterIconSelectorMenu.hx
@@ -95,7 +95,7 @@ class ChartEditorCharacterIconSelectorMenu extends ChartEditorBaseMenu
       }
 
       var LIMIT = 6;
-      charButton.icon = CharacterDataParser.getCharPixelIconAsset(charId);
+      charButton.icon = CharacterDataParser.getCharacterPixelIcon(charData.freeplayIcon);
       charButton.text = charData.name.length > LIMIT ? '${charData.name.substr(0, LIMIT)}.' : '${charData.name}';
 
       charButton.onClick = _ -> {

--- a/source/funkin/ui/debug/charting/toolboxes/ChartEditorMetadataToolbox.hx
+++ b/source/funkin/ui/debug/charting/toolboxes/ChartEditorMetadataToolbox.hx
@@ -221,7 +221,7 @@ class ChartEditorMetadataToolbox extends ChartEditorBaseToolbox
     var charDataOpponent:Null<CharacterData> = CharacterDataParser.fetchCharacterData(chartEditorState.currentSongMetadata.playData.characters.opponent);
     if (charDataOpponent != null)
     {
-      buttonCharacterOpponent.icon = CharacterDataParser.getCharPixelIconAsset(chartEditorState.currentSongMetadata.playData.characters.opponent);
+      buttonCharacterOpponent.icon = CharacterDataParser.getCharacterPixelIcon(charDataOpponent.freeplayIcon);
       buttonCharacterOpponent.text = charDataOpponent.name.length > LIMIT ? '${charDataOpponent.name.substr(0, LIMIT)}.' : '${charDataOpponent.name}';
     }
     else
@@ -233,7 +233,7 @@ class ChartEditorMetadataToolbox extends ChartEditorBaseToolbox
     var charDataGirlfriend:Null<CharacterData> = CharacterDataParser.fetchCharacterData(chartEditorState.currentSongMetadata.playData.characters.girlfriend);
     if (charDataGirlfriend != null)
     {
-      buttonCharacterGirlfriend.icon = CharacterDataParser.getCharPixelIconAsset(chartEditorState.currentSongMetadata.playData.characters.girlfriend);
+      buttonCharacterGirlfriend.icon = CharacterDataParser.getCharacterPixelIcon(charDataGirlfriend.freeplayIcon);
       buttonCharacterGirlfriend.text = charDataGirlfriend.name.length > LIMIT ? '${charDataGirlfriend.name.substr(0, LIMIT)}.' : '${charDataGirlfriend.name}';
     }
     else
@@ -245,7 +245,7 @@ class ChartEditorMetadataToolbox extends ChartEditorBaseToolbox
     var charDataPlayer:Null<CharacterData> = CharacterDataParser.fetchCharacterData(chartEditorState.currentSongMetadata.playData.characters.player);
     if (charDataPlayer != null)
     {
-      buttonCharacterPlayer.icon = CharacterDataParser.getCharPixelIconAsset(chartEditorState.currentSongMetadata.playData.characters.player);
+      buttonCharacterPlayer.icon = CharacterDataParser.getCharacterPixelIcon(charDataPlayer.freeplayIcon);
       buttonCharacterPlayer.text = charDataPlayer.name.length > LIMIT ? '${charDataPlayer.name.substr(0, LIMIT)}.' : '${charDataPlayer.name}';
     }
     else

--- a/source/funkin/ui/freeplay/SongMenuItem.hx
+++ b/source/funkin/ui/freeplay/SongMenuItem.hx
@@ -24,6 +24,8 @@ import funkin.play.scoring.Scoring.ScoringRank;
 import funkin.save.Save;
 import funkin.save.Save.SaveScoreData;
 import flixel.util.FlxColor;
+import funkin.play.character.CharacterData;
+import funkin.play.character.CharacterData.CharacterDataParser;
 
 class SongMenuItem extends FlxSpriteGroup
 {
@@ -527,46 +529,24 @@ class SongMenuItem extends FlxSpriteGroup
    * @param char The character ID used by this song.
    *             If the character has no freeplay icon, a warning will be thrown and nothing will display.
    */
-  public function setCharacter(char:String):Void
+  public function setCharacter(charId:String):Void
   {
-    var charPath:String = "freeplay/icons/";
+    var charData:CharacterData = CharacterDataParser.fetchCharacterData(charId);
+    var charPath:String = CharacterDataParser.getCharacterPixelIcon(charData.freeplayIcon, charId);
 
-    // TODO: Put this in the character metadata where it belongs.
-    // TODO: Also, can use CharacterDataParser.getCharPixelIconAsset()
-    switch (char)
+    if (!openfl.utils.Assets.exists(charPath))
     {
-      case 'monster-christmas':
-        charPath += 'monsterpixel';
-      case 'mom-car':
-        charPath += 'mommypixel';
-      case 'dad':
-        charPath += 'daddypixel';
-      case 'darnell-blazin':
-        charPath += 'darnellpixel';
-      case 'senpai-angry':
-        charPath += 'senpaipixel';
-      default:
-        charPath += '${char}pixel';
-    }
-
-    if (!openfl.utils.Assets.exists(Paths.image(charPath)))
-    {
-      trace('[WARN] Character ${char} has no freeplay icon.');
+      trace('[WARN] Character ${charId} has no freeplay icon.');
       return;
     }
 
-    pixelIcon.loadGraphic(Paths.image(charPath));
-    pixelIcon.scale.x = pixelIcon.scale.y = 2;
+    pixelIcon.loadGraphic(charPath);
+    pixelIcon.scale.x = pixelIcon.scale.y = charData.freeplayIcon.scale ?? 2.0;
 
-    switch (char)
-    {
-      case 'parents-christmas':
-        pixelIcon.origin.x = 140;
-      default:
-        pixelIcon.origin.x = 100;
-    }
-    // pixelIcon.origin.x = capsule.origin.x;
-    // pixelIcon.offset.x -= pixelIcon.origin.x;
+    pixelIcon.origin.x = charData.freeplayIcon.offsets[0] ?? 100.0;
+    pixelIcon.origin.y = charData.freeplayIcon.offsets[1] ?? 0.0;
+
+    pixelIcon.flipX = charData.freeplayIcon.flipX ?? false;
   }
 
   var frameInTicker:Float = 0;

--- a/source/funkin/ui/freeplay/SongMenuItem.hx
+++ b/source/funkin/ui/freeplay/SongMenuItem.hx
@@ -543,8 +543,11 @@ class SongMenuItem extends FlxSpriteGroup
     pixelIcon.loadGraphic(charPath);
     pixelIcon.scale.x = pixelIcon.scale.y = charData.freeplayIcon.scale ?? 2.0;
 
-    pixelIcon.origin.x = charData.freeplayIcon.offsets[0] ?? 100.0;
-    pixelIcon.origin.y = charData.freeplayIcon.offsets[1] ?? 0.0;
+    pixelIcon.origin.x = 100;
+    pixelIcon.origin.y = 25;
+
+    pixelIcon.origin.x += charData.freeplayIcon.offsets[0] ?? 0.0;
+    pixelIcon.origin.y += charData.freeplayIcon.offsets[1] ?? 0.0;
 
     pixelIcon.flipX = charData.freeplayIcon.flipX ?? false;
   }


### PR DESCRIPTION
<!-- Please check for duplicates or similar PRs before submitting this PR. -->
## Briefly describe the issue(s) fixed.
- This PR aims to fix freeplay pixel icons being hardcoded, and give modders the opportunity to have the name of the icon whatever they want
- This PR also fixes some offsets for the characters in the freeplay menu.
## Include any relevant screenshots or videos.
- The freeplay icon metadata takes 4 params: `name`, `scale`, `flipX` and `offsets`
![image](https://github.com/user-attachments/assets/220b6e6e-8645-49bb-a2e6-174f21e6b4cb)
