### PR TITLE
[BUGFIX] Fix for strange ChartingState hitsounds offset, i hope

### DIFF
--- a/source/funkin/ui/debug/charting/ChartEditorState.hx
+++ b/source/funkin/ui/debug/charting/ChartEditorState.hx
@@ -283,6 +283,11 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
   public static final WELCOME_MUSIC_FADE_IN_DURATION:Float = 10.0;
 
   /**
+	 * Hitsounds are played with a strange offset and this should not happen.
+	 */
+	public static final HITSOUND_OFFSET:Float = -13;
+
+  /**
    * INSTANCE DATA
    */
   // ==============================
@@ -6290,10 +6295,10 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
     {
       // Check for notes between the old and new song positions.
 
-      if (noteData.time < oldSongPosition) // Note is in the past.
+     if (noteData.time < (oldSongPosition - HITSOUND_OFFSET)) // Note is in the past.
         continue;
 
-      if (noteData.time > newSongPosition) // Note is in the future.
+    if (noteData.time > (newSongPosition - HITSOUND_OFFSET)) // Note is in the future.
         return; // Assume all notes are also in the future.
 
       // Note was just hit.

--- a/source/funkin/ui/debug/charting/ChartEditorState.hx
+++ b/source/funkin/ui/debug/charting/ChartEditorState.hx
@@ -283,9 +283,9 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
   public static final WELCOME_MUSIC_FADE_IN_DURATION:Float = 10.0;
 
   /**
-	 * Hitsounds are played with a strange offset and this should not happen.
-	 */
-	public static final HITSOUND_OFFSET:Float = -13;
+   * Hitsounds are played with a strange offset and this should not happen.
+   */
+  public static final HITSOUND_OFFSET:Float = -60;
 
   /**
    * INSTANCE DATA


### PR DESCRIPTION
Hitsounds had wierd offset, not they dont.
(Flixel thing, i guess)

_(Yes, I had to use clideo to compress the video, 10mb for video is CRAZY)_

**Before:**
https://github.com/user-attachments/assets/8fbe0f58-075d-42fe-94e4-0fd8d7f06f3c

**After:**
https://github.com/user-attachments/assets/9e70898f-08e2-40a5-a60e-327bcfda2373

Aannd DadBattle Erect with fixed hitsounds offsets, because it's charted normally:
https://github.com/user-attachments/assets/afe3a551-a7d4-435b-bb2e-bb232955308e


