### PR TITLE
[BUGFIX] Animation Editor not saving the file name

### DIFF
--- a/source/funkin/ui/debug/anim/DebugBoundingState.hx
+++ b/source/funkin/ui/debug/anim/DebugBoundingState.hx
@@ -576,7 +576,7 @@ class DebugBoundingState extends FlxState
       _file.addEventListener(Event.COMPLETE, onSaveComplete);
       _file.addEventListener(Event.CANCEL, onSaveCancel);
       _file.addEventListener(IOErrorEvent.IO_ERROR, onSaveError);
-      _file.save(saveString,);
+      _file.save(saveString, fileName);
     }
   }
 


### PR DESCRIPTION
<!-- Please check for duplicates or similar PRs before submitting this PR. -->
## Briefly describe the issue(s) fixed.

- This PR aims to fix an issue with the `Animation Editor` whenever a person tried to save offsets for the character, which didn't have the filename, thus making people write it themselves, which can be very annoying if you are making a mod with hundreds of characters.

## Include any relevant screenshots or videos.

**BEFORE / AFTER:**

https://github.com/user-attachments/assets/3921d47e-1d39-4b8c-83b4-5782cb55e053

