### PR TITLE
[BUGFIX] FunkinSound persistence

### DIFF
--- a/source/funkin/audio/FunkinSound.hx
+++ b/source/funkin/audio/FunkinSound.hx
@@ -543,11 +543,12 @@ class FunkinSound extends FlxSound implements ICloneable<FunkinSound>
   /**
    * Stop all sounds in the pool and allow them to be recycled.
    */
-  public static function stopAllAudio(musicToo:Bool = false):Void
+  public static function stopAllAudio(musicToo:Bool = false, persistToo:Bool = false):Void
   {
     for (sound in pool)
     {
       if (sound == null) continue;
+      if (!persistToo && sound.persist) continue;
       if (!musicToo && sound == FlxG.sound.music) continue;
       sound.destroy();
     }


### PR DESCRIPTION
## Briefly describe the issue(s) fixed.

fixes `FunkinSound`s being destroyed on `MusicBeatState` state changes regardless of the `persist` property