### PR TITLE
[ENHANCEMENT] small scriptable class additions / reorganization

### DIFF
--- a/source/funkin/graphics/ScriptedFunkinSprite.hx
+++ b/source/funkin/graphics/ScriptedFunkinSprite.hx
@@ -1,0 +1,8 @@
+package funkin.graphics;
+
+/**
+ * A script that can be tied to an FunkinSprite.
+ * Create a scripted class that extends FunkinSprite to use this.
+ */
+@:hscriptClass
+class ScriptedFunkinSprite extends funkin.graphics.FunkinSprite implements polymod.hscript.HScriptedClass {}

--- a/source/funkin/modding/PolymodHandler.hx
+++ b/source/funkin/modding/PolymodHandler.hx
@@ -232,6 +232,11 @@ class PolymodHandler
     // NOTE: Scripted classes are automatically aliased to their parent class.
     Polymod.addImportAlias('flixel.math.FlxPoint', flixel.math.FlxPoint.FlxBasePoint);
 
+    // Backward compatibility for certain scripted classes outside `funkin.modding.base`.
+    Polymod.addImportAlias('funkin.modding.base.ScriptedFunkinSprite', funkin.graphics.ScriptedFunkinSprite);
+    Polymod.addImportAlias('funkin.modding.base.ScriptedMusicBeatState', funkin.ui.ScriptedMusicBeatState);
+    Polymod.addImportAlias('funkin.modding.base.ScriptedMusicBeatSubState', funkin.ui.ScriptedMusicBeatSubState);
+
     // Add blacklisting for prohibited classes and packages.
 
     // `Sys`

--- a/source/funkin/modding/base/Object.hx
+++ b/source/funkin/modding/base/Object.hx
@@ -1,0 +1,13 @@
+package funkin.modding.base;
+
+/**
+ * An empty base class meant to be extended by scripts.
+ */
+
+class Object {
+  public function new() {}
+
+  public function toString():String {
+    return "(Object)";
+  }
+}

--- a/source/funkin/modding/base/ScriptedFlxBasic.hx
+++ b/source/funkin/modding/base/ScriptedFlxBasic.hx
@@ -1,0 +1,8 @@
+package funkin.modding.base;
+
+/**
+ * A script that can be tied to an FlxBasic.
+ * Create a scripted class that extends FlxBasic to use this.
+ */
+@:hscriptClass
+class ScriptedFlxBasic extends flixel.FlxBasic implements HScriptedClass {}

--- a/source/funkin/modding/base/ScriptedFlxObject.hx
+++ b/source/funkin/modding/base/ScriptedFlxObject.hx
@@ -1,0 +1,8 @@
+package funkin.modding.base;
+
+/**
+ * A script that can be tied to an FlxObject.
+ * Create a scripted class that extends FlxObject to use this.
+ */
+@:hscriptClass
+class ScriptedFlxObject extends flixel.FlxObject implements HScriptedClass {}

--- a/source/funkin/modding/base/ScriptedFunkinSprite.hx
+++ b/source/funkin/modding/base/ScriptedFunkinSprite.hx
@@ -1,8 +1,0 @@
-package funkin.modding.base;
-
-/**
- * A script that can be tied to an FlxSprite.
- * Create a scripted class that extends FlxSprite to use this.
- */
-@:hscriptClass
-class ScriptedFunkinSprite extends funkin.graphics.FunkinSprite implements HScriptedClass {}

--- a/source/funkin/modding/base/ScriptedObject.hx
+++ b/source/funkin/modding/base/ScriptedObject.hx
@@ -1,0 +1,8 @@
+package funkin.modding.base;
+
+/**
+ * A script that can be tied to an Object (empty base class).
+ * Create a scripted class that extends Object to use this.
+ */
+@:hscriptClass
+class ScriptedObject extends funkin.modding.base.Object implements HScriptedClass {}

--- a/source/funkin/ui/ScriptedMusicBeatState.hx
+++ b/source/funkin/ui/ScriptedMusicBeatState.hx
@@ -1,8 +1,8 @@
-package funkin.modding.base;
+package funkin.ui;
 
 /**
  * A script that can be tied to a MusicBeatState.
  * Create a scripted class that extends MusicBeatState to use this.
  */
 @:hscriptClass
-class ScriptedMusicBeatState extends funkin.ui.MusicBeatState implements HScriptedClass {}
+class ScriptedMusicBeatState extends funkin.ui.MusicBeatState implements polymod.hscript.HScriptedClass {}

--- a/source/funkin/ui/ScriptedMusicBeatSubState.hx
+++ b/source/funkin/ui/ScriptedMusicBeatSubState.hx
@@ -1,8 +1,8 @@
-package funkin.modding.base;
+package funkin.ui;
 
 /**
  * A script that can be tied to a MusicBeatSubState.
  * Create a scripted class that extends MusicBeatSubState to use this.
  */
 @:hscriptClass
-class ScriptedMusicBeatSubState extends funkin.ui.MusicBeatSubState implements HScriptedClass {}
+class ScriptedMusicBeatSubState extends funkin.ui.MusicBeatSubState implements polymod.hscript.HScriptedClass {}


### PR DESCRIPTION
- added scriptable blank `Object` class for custom objects (more convenient than having a module to set up anonymous objects)
- added scriptable `FlxBasic`s and `FlxObject`s
- moved `funkin` package scriptable classes out of `funkin.modding.base` and into their base class packages (and added import aliases for backwards compatibility)