### PR TITLE
chore: Update ScriptedFunkinSprite.hx

### DIFF
--- a/source/funkin/modding/base/ScriptedFunkinSprite.hx
+++ b/source/funkin/modding/base/ScriptedFunkinSprite.hx
@@ -1,8 +1,8 @@
 package funkin.modding.base;
 
 /**
- * A script that can be tied to an FlxSprite.
- * Create a scripted class that extends FlxSprite to use this.
+ * A script that can be tied to a FunkinSprite.
+ * Create a scripted class that extends FunkinSprite to use this.
  */
 @:hscriptClass
 class ScriptedFunkinSprite extends funkin.graphics.FunkinSprite implements HScriptedClass {}


### PR DESCRIPTION
`ScriptedFunkinSprite.hx` erroneously references `FlxSprite` in the comments. This PR changes it so it properly references `FunkinSprite` instead.