### PR TITLE
Fix audio muffling/low audio quality by changing OpenAL's default settings

### DIFF
--- a/Project.xml
+++ b/Project.xml
@@ -102,6 +102,8 @@ xsi:schemaLocation="http://lime.openfl.org/project/1.0.4 http://lime.openfl.org/
 		THEN UHHH I USED THE NAME OF THE FONT WITH SETFORMAT() ON THE TEXT!!!
 		NOT USING A DIRECT THING TO THE ASSET!!!
 	-->
+		
+	<assets path="alsoft.ini" />
 	<assets path="assets/fonts" embed="true" />
 
 	<!-- If compiled via github actions, show debug version number. -->

--- a/alsoft.ini
+++ b/alsoft.ini
@@ -1,0 +1,15 @@
+[general]
+channels=stereo
+sample-type=float32
+stereo-mode=speakers
+stereo-encoding=panpot
+hrtf=false
+cf_level=0
+resampler=fast_bsinc24
+front-stablizer=false
+output-limiter=false
+volume-adjust=0
+[decoder]
+hq-mode=false
+distance-comp=false
+nfc=false


### PR DESCRIPTION
<!-- Please check for duplicates or similar PRs before submitting this PR. -->
## Does this PR close any issues? If so, link them below.
https://github.com/FunkinCrew/Funkin/issues/2980

## Briefly describe the issue(s) fixed.
Lime's OpenALSoft has a gain limiter on by default which causes audio muffling/lower audio quality. There are also more settings that could cause spatialization etc. to occur resulting in the audio not sounding like it's supposed to compared to outside media players. Adding a default alsoft.ini file fixes this, as it gets automatically detected when it's in the same directory as the executable and applied. This could work for multiple platforms but testing has only been done on Windows


## Include any relevant screenshots or videos.

--
