### PR TITLE
Add `getPath()` to `funkin.Assets`

### DIFF
--- a/source/funkin/Assets.hx
+++ b/source/funkin/Assets.hx
@@ -11,6 +11,11 @@ class Assets
     return openfl.utils.Assets.getText(path);
   }
 
+  public static function getPath(path:String):String
+  {
+    return openfl.utils.Assets.getPath(path);
+  }
+
   public static function getMusic(path:String):openfl.media.Sound
   {
     return openfl.utils.Assets.getMusic(path);


### PR DESCRIPTION
<!-- Please check for duplicates or similar PRs before submitting this PR. -->
## Does this PR close any issues? If so, link them below.
Closes #3310

## Briefly describe the issue(s) fixed.
This PR adds OpenFL Assets' `getPath()` function to the `Assets` class. This function is really useful for when you need the full file path of something! (Especially when combined with `Paths`)

## Include any relevant screenshots or videos.
The before/after images use a test module that retrieves the path of Boyfriend's spritesheet and outputs a message if successful. (See #3310 for reference.)

Before
![image](https://github.com/user-attachments/assets/c351c72a-8123-4b6e-b0e0-83b716c55427)

After
![Screenshot 2024-09-16 at 5 10 36 PM](https://github.com/user-attachments/assets/2ef18e83-159a-4114-a50f-84395be86885)
