### PR TITLE
[BUGFIX/ENHANCEMENT] Changes instances of FlxG.mouse.screen(x/y) to FlxG.mouse.view(x/y) in ChartEditorState.hx (and more)

### DIFF
--- a/source/funkin/ui/debug/charting/ChartEditorState.hx
+++ b/source/funkin/ui/debug/charting/ChartEditorState.hx
@@ -5139,10 +5139,11 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
     }
 
     var songPos:Float = Conductor.instance.songPosition + Conductor.instance.instrumentalOffset;
+    var songPosMilliseconds:String = Std.string(Math.floor(Math.abs(songPos) % 1000)).lpad('0', 2);
     var songPosSeconds:String = Std.string(Math.floor((Math.abs(songPos) / 1000) % 60)).lpad('0', 2);
     var songPosMinutes:String = Std.string(Math.floor((Math.abs(songPos) / 1000) / 60)).lpad('0', 2);
     if (songPos < 0) songPosMinutes = '-' + songPosMinutes;
-    var songPosString:String = '${songPosMinutes}:${songPosSeconds}';
+    var songPosString:String = '${songPosMinutes}:${songPosSeconds}:${songPosMilliseconds}';
 
     if (playbarSongPos.value != songPosString) playbarSongPos.value = songPosString;
 

--- a/source/funkin/ui/debug/charting/ChartEditorState.hx
+++ b/source/funkin/ui/debug/charting/ChartEditorState.hx
@@ -5139,7 +5139,7 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
     }
 
     var songPos:Float = Conductor.instance.songPosition + Conductor.instance.instrumentalOffset;
-    var songPosMilliseconds:String = Std.string(Math.floor(Math.abs(songPos) % 1000)).lpad('0', 2);
+    var songPosMilliseconds:String = Std.string(Math.floor(Math.abs(songPos) % 1000)).lpad('0', 2).substr(0, 2);
     var songPosSeconds:String = Std.string(Math.floor((Math.abs(songPos) / 1000) % 60)).lpad('0', 2);
     var songPosMinutes:String = Std.string(Math.floor((Math.abs(songPos) / 1000) / 60)).lpad('0', 2);
     if (songPos < 0) songPosMinutes = '-' + songPosMinutes;

--- a/source/funkin/ui/debug/charting/ChartEditorState.hx
+++ b/source/funkin/ui/debug/charting/ChartEditorState.hx
@@ -3830,7 +3830,7 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
   function handleScrollKeybinds():Void
   {
     // Don't scroll when the user is interacting with the UI, unless a playbar button (the << >> ones) is pressed.
-    if ((isHaxeUIFocused || isHaxeUIDialogOpen) && playbarButtonPressed == null) return;
+    if ((isHaxeUIFocused || isCursorOverHaxeUI) && playbarButtonPressed == null) return;
 
     var scrollAmount:Float = 0; // Amount to scroll the grid.
     var playheadAmount:Float = 0; // Amount to scroll the playhead relative to the grid.

--- a/source/funkin/ui/debug/charting/ChartEditorState.hx
+++ b/source/funkin/ui/debug/charting/ChartEditorState.hx
@@ -700,7 +700,7 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
 
   function get_isCursorOverHaxeUI():Bool
   {
-    return Screen.instance.hasSolidComponentUnderPoint(FlxG.mouse.screenX, FlxG.mouse.screenY);
+    return Screen.instance.hasSolidComponentUnderPoint(FlxG.mouse.viewX, FlxG.mouse.viewY);
   }
 
   /**
@@ -3830,7 +3830,7 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
   function handleScrollKeybinds():Void
   {
     // Don't scroll when the user is interacting with the UI, unless a playbar button (the << >> ones) is pressed.
-    if ((isHaxeUIFocused || isCursorOverHaxeUI) && playbarButtonPressed == null) return;
+    if ((isHaxeUIFocused || isHaxeUIDialogOpen) && playbarButtonPressed == null) return;
 
     var scrollAmount:Float = 0; // Amount to scroll the grid.
     var playheadAmount:Float = 0; // Amount to scroll the playhead relative to the grid.
@@ -3840,7 +3840,7 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
     // Handle scroll anchor
     if (scrollAnchorScreenPos != null)
     {
-      var currentScreenPos = new FlxPoint(FlxG.mouse.screenX, FlxG.mouse.screenY);
+      var currentScreenPos = new FlxPoint(FlxG.mouse.viewX, FlxG.mouse.viewX);
       var distance = currentScreenPos - scrollAnchorScreenPos;
 
       var verticalDistance = distance.y;
@@ -4121,8 +4121,8 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
       var overlapsRenderedEvents:Bool = FlxG.mouse.overlaps(renderedEvents);
 
       // Cursor position relative to the grid.
-      var cursorX:Float = FlxG.mouse.screenX - gridTiledSprite.x;
-      var cursorY:Float = FlxG.mouse.screenY - gridTiledSprite.y;
+      var cursorX:Float = FlxG.mouse.viewX - gridTiledSprite.x;
+      var cursorY:Float = FlxG.mouse.viewY - gridTiledSprite.y;
 
       var overlapsSelectionBorder:Bool = overlapsGrid
         && ((cursorX % 40) < (GRID_SELECTION_BORDER_WIDTH / 2)
@@ -4137,7 +4137,7 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
       {
         if (scrollAnchorScreenPos == null)
         {
-          scrollAnchorScreenPos = new FlxPoint(FlxG.mouse.screenX, FlxG.mouse.screenY);
+          scrollAnchorScreenPos = new FlxPoint(FlxG.mouse.viewX, FlxG.mouse.viewY);
           selectionBoxStartPos = null;
         }
         else
@@ -4159,11 +4159,11 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
         else if (notePreview != null && FlxG.mouse.overlaps(notePreview) && !isCursorOverHaxeUI)
         {
           // Clicked note preview
-          notePreviewScrollAreaStartPos = new FlxPoint(FlxG.mouse.screenX, FlxG.mouse.screenY);
+          notePreviewScrollAreaStartPos = new FlxPoint(FlxG.mouse.viewX, FlxG.mouse.viewY);
         }
         else if (!isCursorOverHaxeUI && (!overlapsGrid || overlapsSelectionBorder))
         {
-          selectionBoxStartPos = new FlxPoint(FlxG.mouse.screenX, FlxG.mouse.screenY);
+          selectionBoxStartPos = new FlxPoint(FlxG.mouse.viewX, FlxG.mouse.viewY);
           // Drawing selection box.
           targetCursorMode = Crosshair;
         }
@@ -4188,7 +4188,7 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
       {
         // Clicked on the playhead scroll area.
         // Move the playhead to the cursor position.
-        this.playheadPositionInPixels = FlxG.mouse.screenY - (GRID_INITIAL_Y_POS);
+        this.playheadPositionInPixels = FlxG.mouse.viewY - (GRID_INITIAL_Y_POS);
         moveSongToScrollPosition();
 
         // Cursor should be a grabby hand.
@@ -4313,27 +4313,27 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
             // Clicking and dragging.
 
             // Scroll the screen if the mouse is above or below the grid.
-            if (FlxG.mouse.screenY < MENU_BAR_HEIGHT)
+            if (FlxG.mouse.viewY < MENU_BAR_HEIGHT)
             {
               // Scroll up.
-              var diff:Float = MENU_BAR_HEIGHT - FlxG.mouse.screenY;
+              var diff:Float = MENU_BAR_HEIGHT - FlxG.mouse.viewY;
               scrollPositionInPixels -= diff * 0.5; // Too fast!
               moveSongToScrollPosition();
             }
-            else if (FlxG.mouse.screenY > (playbarHeadLayout?.y ?? 0.0))
+            else if (FlxG.mouse.viewY > (playbarHeadLayout?.y ?? 0.0))
             {
               // Scroll down.
-              var diff:Float = FlxG.mouse.screenY - (playbarHeadLayout?.y ?? 0.0);
+              var diff:Float = FlxG.mouse.viewY - (playbarHeadLayout?.y ?? 0.0);
               scrollPositionInPixels += diff * 0.5; // Too fast!
               moveSongToScrollPosition();
             }
 
             // Render the selection box.
             var selectionRect:FlxRect = new FlxRect();
-            selectionRect.x = Math.min(FlxG.mouse.screenX, selectionBoxStartPos.x);
-            selectionRect.y = Math.min(FlxG.mouse.screenY, selectionBoxStartPos.y);
-            selectionRect.width = Math.abs(FlxG.mouse.screenX - selectionBoxStartPos.x);
-            selectionRect.height = Math.abs(FlxG.mouse.screenY - selectionBoxStartPos.y);
+            selectionRect.x = Math.min(FlxG.mouse.viewX, selectionBoxStartPos.x);
+            selectionRect.y = Math.min(FlxG.mouse.viewY, selectionBoxStartPos.y);
+            selectionRect.width = Math.abs(FlxG.mouse.viewX - selectionBoxStartPos.x);
+            selectionRect.height = Math.abs(FlxG.mouse.viewY - selectionBoxStartPos.y);
             setSelectionBoxBounds(selectionRect);
 
             targetCursorMode = Crosshair;
@@ -4461,8 +4461,8 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
         // Player is clicking and holding on note preview to scrub around.
         targetCursorMode = Grabbing;
 
-        var clickedPosInPixels:Float = FlxMath.remapToRange(FlxG.mouse.screenY, (notePreview?.y ?? 0.0),
-          (notePreview?.y ?? 0.0) + (notePreview?.height ?? 0.0), 0, songLengthInPixels);
+        var clickedPosInPixels:Float = FlxMath.remapToRange(FlxG.mouse.viewY, (notePreview?.y ?? 0.0), (notePreview?.y ?? 0.0) + (notePreview?.height ?? 0.0),
+          0, songLengthInPixels);
 
         scrollPositionInPixels = clickedPosInPixels;
         moveSongToScrollPosition();
@@ -4520,17 +4520,17 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
           targetCursorMode = Grabbing;
 
           // Scroll the screen if the mouse is above or below the grid.
-          if (FlxG.mouse.screenY < MENU_BAR_HEIGHT)
+          if (FlxG.mouse.viewY < MENU_BAR_HEIGHT)
           {
             // Scroll up.
-            var diff:Float = MENU_BAR_HEIGHT - FlxG.mouse.screenY;
+            var diff:Float = MENU_BAR_HEIGHT - FlxG.mouse.viewY;
             scrollPositionInPixels -= diff * 0.5; // Too fast!
             moveSongToScrollPosition();
           }
-          else if (FlxG.mouse.screenY > (playbarHeadLayout?.y ?? 0.0))
+          else if (FlxG.mouse.viewY > (playbarHeadLayout?.y ?? 0.0))
           {
             // Scroll down.
-            var diff:Float = FlxG.mouse.screenY - (playbarHeadLayout?.y ?? 0.0);
+            var diff:Float = FlxG.mouse.viewY - (playbarHeadLayout?.y ?? 0.0);
             scrollPositionInPixels += diff * 0.5; // Too fast!
             moveSongToScrollPosition();
           }
@@ -4811,11 +4811,11 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
               // Show the context menu connected to the note.
               if (useSingleNoteContextMenu)
               {
-                this.openNoteContextMenu(FlxG.mouse.screenX, FlxG.mouse.screenY, highlightedNote.noteData);
+                this.openNoteContextMenu(FlxG.mouse.viewX, FlxG.mouse.viewY, highlightedNote.noteData);
               }
               else
               {
-                this.openSelectionContextMenu(FlxG.mouse.screenX, FlxG.mouse.screenY);
+                this.openSelectionContextMenu(FlxG.mouse.viewX, FlxG.mouse.viewY);
               }
             }
             else
@@ -4835,11 +4835,11 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
                 || (isHighlightedEventSelected && currentEventSelection.length == 1);
               if (useSingleEventContextMenu)
               {
-                this.openEventContextMenu(FlxG.mouse.screenX, FlxG.mouse.screenY, highlightedEvent.eventData);
+                this.openEventContextMenu(FlxG.mouse.viewX, FlxG.mouse.viewY, highlightedEvent.eventData);
               }
               else
               {
-                this.openSelectionContextMenu(FlxG.mouse.screenX, FlxG.mouse.screenY);
+                this.openSelectionContextMenu(FlxG.mouse.viewX, FlxG.mouse.viewY);
               }
             }
             else
@@ -4860,11 +4860,11 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
               // Show the context menu connected to the note.
               if (useSingleNoteContextMenu)
               {
-                this.openHoldNoteContextMenu(FlxG.mouse.screenX, FlxG.mouse.screenY, highlightedHoldNote.noteData);
+                this.openHoldNoteContextMenu(FlxG.mouse.viewX, FlxG.mouse.viewY, highlightedHoldNote.noteData);
               }
               else
               {
-                this.openSelectionContextMenu(FlxG.mouse.screenX, FlxG.mouse.screenY);
+                this.openSelectionContextMenu(FlxG.mouse.viewX, FlxG.mouse.viewY);
               }
             }
             else


### PR DESCRIPTION
<!-- Please check for duplicates or similar PRs before submitting this PR. -->
## Does this PR close any issues? If so, link them below.
Fixes https://github.com/FunkinCrew/Funkin/issues/3147,
## Briefly describe the issue(s) fixed.
Changes any instance of screenX/screenY to viewX/viewY as the former is depreciated. Causing the editor to not function due to https://github.com/HaxeFlixel/flixel/pull/3210

Also adds a millisecond part of the playbar :D
## Include any relevant screenshots or videos.
![image](https://github.com/user-attachments/assets/bbf6d199-7850-431b-9ebe-5239bdd44171)
