### PR TITLE
[BUGFIX] Chart Editor: Implement Animated Pixel Icons

### DIFF
--- a/hmm.json
+++ b/hmm.json
@@ -77,7 +77,7 @@
       "name": "haxeui-flixel",
       "type": "git",
       "dir": null,
-      "ref": "28bb710d0ae5d94b5108787593052165be43b980",
+      "ref": "3ecdd9ff311a0a4da0e5fc41e33f500a60f12d5e",
       "url": "https://github.com/haxeui/haxeui-flixel"
     },
     {

--- a/source/funkin/play/character/CharacterData.hx
+++ b/source/funkin/play/character/CharacterData.hx
@@ -315,12 +315,6 @@ class CharacterDataParser
         '${char}pixel';
     }
 
-    if (!Assets.exists(Paths.image("freeplay/icons/" + charPath)))
-    {
-      trace('[WARN] Character ${char} has no freeplay icon.');
-      return null;
-    }
-
     return charPath;
   }
 
@@ -330,13 +324,13 @@ class CharacterDataParser
    */
   public static function getCharPixelIconAsset(char:String):FlxFrame
   {
-    var charPath:String = "freeplay/icons/";
+    var charPath:String = "freeplay/icons/" + getCharPixelIcon(char);
 
-    var convertChar:Null<String> = getCharPixelIcon(char);
-    if(convertChar != null)
+    if (!Assets.exists(Paths.image(charPath)))
+    {
+      trace('[WARN] Character ${char} has no freeplay icon.');
       return null;
-
-    charPath += convertChar;
+    }
 
     var isAnimated = Assets.exists(Paths.file('images/$charPath.xml'));
     var frame:FlxFrame = null;
@@ -355,12 +349,7 @@ class CharacterDataParser
         return null;
       }
 
-      // so, haxe.ui.backend.AssetsImpl uses the parent width and height, which makes the image go crazy when rendered
-      // so this is a work around so that it uses the actual width and height
-      var imageGraphic = flixel.graphics.FlxGraphic.fromFrame(idleFrame);
-
-      var imageFrame = flixel.graphics.frames.FlxImageFrame.fromImage(imageGraphic);
-      frame = imageFrame.frame;
+      frame = idleFrame;
     }
     else
     {

--- a/source/funkin/play/character/CharacterData.hx
+++ b/source/funkin/play/character/CharacterData.hx
@@ -282,46 +282,61 @@ class CharacterDataParser
   }
 
   /**
+   * Returns the Freeplay Icon version of a character.
+   * This was made to avoid copy and pasting.
+   */
+  public static function getCharPixelIcon(char:String):String
+  {
+    var charPath = switch (char)
+    {
+      case "bf-christmas" | "bf-car" | "bf-pixel" | "bf-holding-gf" | "bf-dark":
+        "bfpixel";
+      case "monster-christmas":
+        "monsterpixel";
+      case "mom" | "mom-car":
+        "mommypixel";
+      case "pico-blazin" | "pico-playable" | "pico-speaker":
+        "picopixel";
+      case "gf-christmas" | "gf-car" | "gf-pixel" | "gf-tankmen" | "gf-dark":
+        "gfpixel";
+      case "dad":
+        "dadpixel";
+      case "darnell-blazin":
+        "darnellpixel";
+      case "senpai-angry":
+        "senpaipixel";
+      case "spooky-dark":
+        "spookypixel";
+      case "tankman-atlas":
+        "tankmanpixel";
+      case "pico-christmas" | "pico-dark":
+        "picopixel";
+      default:
+        '${char}pixel';
+    }
+
+    if (!Assets.exists(Paths.image("freeplay/icons/" + charPath)))
+    {
+      trace('[WARN] Character ${char} has no freeplay icon.');
+      return null;
+    }
+
+    return charPath;
+  }
+
+  /**
    * Returns the idle frame of a character.
+   * @author TechnikTil
    */
   public static function getCharPixelIconAsset(char:String):FlxFrame
   {
     var charPath:String = "freeplay/icons/";
 
-    // FunkinCrew please dont skin me alive for copying pixelated icon and changing it a tiny bit
-    switch (char)
-    {
-      case "bf-christmas" | "bf-car" | "bf-pixel" | "bf-holding-gf" | "bf-dark":
-        charPath += "bfpixel";
-      case "monster-christmas":
-        charPath += "monsterpixel";
-      case "mom" | "mom-car":
-        charPath += "mommypixel";
-      case "pico-blazin" | "pico-playable" | "pico-speaker":
-        charPath += "picopixel";
-      case "gf-christmas" | "gf-car" | "gf-pixel" | "gf-tankmen" | "gf-dark":
-        charPath += "gfpixel";
-      case "dad":
-        charPath += "dadpixel";
-      case "darnell-blazin":
-        charPath += "darnellpixel";
-      case "senpai-angry":
-        charPath += "senpaipixel";
-      case "spooky-dark":
-        charPath += "spookypixel";
-      case "tankman-atlas":
-        charPath += "tankmanpixel";
-      case "pico-christmas" | "pico-dark":
-        charPath += "picopixel";
-      default:
-        charPath += '${char}pixel';
-    }
-
-    if (!Assets.exists(Paths.image(charPath)))
-    {
-      trace('[WARN] Character ${char} has no freeplay icon.');
+    var convertChar:Null<String> = getCharPixelIcon(char);
+    if(convertChar != null)
       return null;
-    }
+
+    charPath += convertChar;
 
     var isAnimated = Assets.exists(Paths.file('images/$charPath.xml'));
     var frame:FlxFrame = null;

--- a/source/funkin/play/character/CharacterData.hx
+++ b/source/funkin/play/character/CharacterData.hx
@@ -342,7 +342,7 @@ class CharacterDataParser
 
       // so, haxe.ui.backend.AssetsImpl uses the parent width and height, which makes the image go crazy when rendered
       // so this is a work around so that it uses the actual width and height
-      var imageGraphic = flixel.graphics.FlxGraphic.fromFrame(idleFrame, false, null, false);
+      var imageGraphic = flixel.graphics.FlxGraphic.fromFrame(idleFrame);
 
       var imageFrame = flixel.graphics.frames.FlxImageFrame.fromImage(imageGraphic);
       frame = imageFrame.frame;

--- a/source/funkin/play/character/CharacterData.hx
+++ b/source/funkin/play/character/CharacterData.hx
@@ -12,6 +12,7 @@ import funkin.util.assets.DataAssets;
 import funkin.util.VersionUtil;
 import haxe.Json;
 import openfl.utils.Assets;
+import flixel.graphics.frames.FlxFrame;
 
 class CharacterDataParser
 {
@@ -281,41 +282,78 @@ class CharacterDataParser
   }
 
   /**
-   * TODO: Hardcode this.
+   * Returns the idle frame of a character.
    */
-  public static function getCharPixelIconAsset(char:String):String
+  public static function getCharPixelIconAsset(char:String):FlxFrame
   {
-    var icon:String = char;
+    var charPath:String = "freeplay/icons/";
 
-    switch (icon)
+    // FunkinCrew please dont skin me alive for copying pixelated icon and changing it a tiny bit
+    switch (char)
     {
-      case "bf-christmas" | "bf-car" | "bf-pixel" | "bf-holding-gf":
-        icon = "bf";
+      case "bf-christmas" | "bf-car" | "bf-pixel" | "bf-holding-gf" | "bf-dark":
+        charPath += "bfpixel";
       case "monster-christmas":
-        icon = "monster";
+        charPath += "monsterpixel";
       case "mom" | "mom-car":
-        icon = "mommy";
+        charPath += "mommypixel";
       case "pico-blazin" | "pico-playable" | "pico-speaker":
-        icon = "pico";
-      case "gf-christmas" | "gf-car" | "gf-pixel" | "gf-tankmen":
-        icon = "gf";
+        charPath += "picopixel";
+      case "gf-christmas" | "gf-car" | "gf-pixel" | "gf-tankmen" | "gf-dark":
+        charPath += "gfpixel";
       case "dad":
-        icon = "daddy";
+        charPath += "dadpixel";
       case "darnell-blazin":
-        icon = "darnell";
+        charPath += "darnellpixel";
       case "senpai-angry":
-        icon = "senpai";
+        charPath += "senpaipixel";
       case "spooky-dark":
-        icon = "spooky";
+        charPath += "spookypixel";
       case "tankman-atlas":
-        icon = "tankman";
+        charPath += "tankmanpixel";
+      case "pico-christmas" | "pico-dark":
+        charPath += "picopixel";
+      default:
+        charPath += '${char}pixel';
     }
 
-    var path = Paths.image("freeplay/icons/" + icon + "pixel");
-    if (Assets.exists(path)) return path;
+    if (!Assets.exists(Paths.image(charPath)))
+    {
+      trace('[WARN] Character ${char} has no freeplay icon.');
+      return null;
+    }
 
-    // TODO: Hardcode some additional behavior or a fallback.
-    return null;
+    var isAnimated = Assets.exists(Paths.file('images/$charPath.xml'));
+    var frame:FlxFrame = null;
+
+    if (isAnimated)
+    {
+      var frames = Paths.getSparrowAtlas(charPath);
+
+      var idleFrame:FlxFrame = frames.frames.find(function(frame:FlxFrame):Bool {
+        return frame.name.startsWith('idle');
+      });
+
+      if (idleFrame == null)
+      {
+        trace('[WARN] Character ${char} has no idle in their freeplay icon.');
+        return null;
+      }
+
+      // so, haxe.ui.backend.AssetsImpl uses the parent width and height, which makes the image go crazy when rendered
+      // so this is a work around so that it uses the actual width and height
+      var imageGraphic = flixel.graphics.FlxGraphic.fromFrame(idleFrame, false, null, false);
+
+      var imageFrame = flixel.graphics.frames.FlxImageFrame.fromImage(imageGraphic);
+      frame = imageFrame.frame;
+    }
+    else
+    {
+      var imageFrame = flixel.graphics.frames.FlxImageFrame.fromImage(Paths.image(charPath));
+      frame = imageFrame.frame;
+    }
+
+    return frame;
   }
 
   /**

--- a/source/funkin/ui/PixelatedIcon.hx
+++ b/source/funkin/ui/PixelatedIcon.hx
@@ -24,7 +24,7 @@ class PixelatedIcon extends FlxFilteredSprite
 
     var convertChar:Null<String> = CharacterDataParser.getCharPixelIcon(char);
     if(convertChar != null)
-      return null;
+      return;
 
     charPath += convertChar;
 

--- a/source/funkin/ui/PixelatedIcon.hx
+++ b/source/funkin/ui/PixelatedIcon.hx
@@ -20,14 +20,13 @@ class PixelatedIcon extends FlxFilteredSprite
 
   public function setCharacter(char:String):Void
   {
-    var charPath:String = "freeplay/icons/";
+    var charPath:String = "freeplay/icons/" + CharacterDataParser.getCharPixelIcon(char);
 
-    var convertChar:Null<String> = CharacterDataParser.getCharPixelIcon(char);
-    if(convertChar != null)
+    if (!openfl.utils.Assets.exists(Paths.image(charPath)))
+    {
+      trace('[WARN] Character ${char} has no freeplay icon.');
       return;
-
-    charPath += convertChar;
-
+    }
     var isAnimated = openfl.utils.Assets.exists(Paths.file('images/$charPath.xml'));
 
     if (isAnimated)

--- a/source/funkin/ui/PixelatedIcon.hx
+++ b/source/funkin/ui/PixelatedIcon.hx
@@ -2,6 +2,7 @@ package funkin.ui;
 
 import flixel.FlxSprite;
 import funkin.graphics.FlxFilteredSprite;
+import funkin.play.character.CharacterData.CharacterDataParser;
 
 /**
  * The icon that gets used for Freeplay capsules and char select
@@ -21,37 +22,11 @@ class PixelatedIcon extends FlxFilteredSprite
   {
     var charPath:String = "freeplay/icons/";
 
-    switch (char)
-    {
-      case "bf-christmas" | "bf-car" | "bf-pixel" | "bf-holding-gf":
-        charPath += "bfpixel";
-      case "monster-christmas":
-        charPath += "monsterpixel";
-      case "mom" | "mom-car":
-        charPath += "mommypixel";
-      case "pico-blazin" | "pico-playable" | "pico-speaker":
-        charPath += "picopixel";
-      case "gf-christmas" | "gf-car" | "gf-pixel" | "gf-tankmen":
-        charPath += "gfpixel";
-      case "dad":
-        charPath += "dadpixel";
-      case "darnell-blazin":
-        charPath += "darnellpixel";
-      case "senpai-angry":
-        charPath += "senpaipixel";
-      case "spooky-dark":
-        charPath += "spookypixel";
-      case "tankman-atlas":
-        charPath += "tankmanpixel";
-      default:
-        charPath += '${char}pixel';
-    }
+    var convertChar:Null<String> = CharacterDataParser.getCharPixelIcon(char);
+    if(convertChar != null)
+      return null;
 
-    if (!openfl.utils.Assets.exists(Paths.image(charPath)))
-    {
-      trace('[WARN] Character ${char} has no freeplay icon.');
-      return;
-    }
+    charPath += convertChar;
 
     var isAnimated = openfl.utils.Assets.exists(Paths.file('images/$charPath.xml'));
 

--- a/source/funkin/ui/debug/charting/dialogs/ChartEditorCharacterIconSelectorMenu.hx
+++ b/source/funkin/ui/debug/charting/dialogs/ChartEditorCharacterIconSelectorMenu.hx
@@ -95,7 +95,7 @@ class ChartEditorCharacterIconSelectorMenu extends ChartEditorBaseMenu
       }
 
       var LIMIT = 6;
-      charButton.icon = CharacterDataParser.getCharPixelIconAsset(charId);
+      charButton.icon = haxe.ui.util.Variant.fromImageData(CharacterDataParser.getCharPixelIconAsset(charId));
       charButton.text = charData.name.length > LIMIT ? '${charData.name.substr(0, LIMIT)}.' : '${charData.name}';
 
       charButton.onClick = _ -> {

--- a/source/funkin/ui/debug/charting/toolboxes/ChartEditorMetadataToolbox.hx
+++ b/source/funkin/ui/debug/charting/toolboxes/ChartEditorMetadataToolbox.hx
@@ -221,7 +221,7 @@ class ChartEditorMetadataToolbox extends ChartEditorBaseToolbox
     var charDataOpponent:Null<CharacterData> = CharacterDataParser.fetchCharacterData(chartEditorState.currentSongMetadata.playData.characters.opponent);
     if (charDataOpponent != null)
     {
-      buttonCharacterOpponent.icon = CharacterDataParser.getCharPixelIconAsset(chartEditorState.currentSongMetadata.playData.characters.opponent);
+      buttonCharacterOpponent.icon = haxe.ui.util.Variant.fromImageData(CharacterDataParser.getCharPixelIconAsset(chartEditorState.currentSongMetadata.playData.characters.opponent));
       buttonCharacterOpponent.text = charDataOpponent.name.length > LIMIT ? '${charDataOpponent.name.substr(0, LIMIT)}.' : '${charDataOpponent.name}';
     }
     else
@@ -233,7 +233,7 @@ class ChartEditorMetadataToolbox extends ChartEditorBaseToolbox
     var charDataGirlfriend:Null<CharacterData> = CharacterDataParser.fetchCharacterData(chartEditorState.currentSongMetadata.playData.characters.girlfriend);
     if (charDataGirlfriend != null)
     {
-      buttonCharacterGirlfriend.icon = CharacterDataParser.getCharPixelIconAsset(chartEditorState.currentSongMetadata.playData.characters.girlfriend);
+      buttonCharacterGirlfriend.icon = haxe.ui.util.Variant.fromImageData(CharacterDataParser.getCharPixelIconAsset(chartEditorState.currentSongMetadata.playData.characters.girlfriend));
       buttonCharacterGirlfriend.text = charDataGirlfriend.name.length > LIMIT ? '${charDataGirlfriend.name.substr(0, LIMIT)}.' : '${charDataGirlfriend.name}';
     }
     else
@@ -245,7 +245,7 @@ class ChartEditorMetadataToolbox extends ChartEditorBaseToolbox
     var charDataPlayer:Null<CharacterData> = CharacterDataParser.fetchCharacterData(chartEditorState.currentSongMetadata.playData.characters.player);
     if (charDataPlayer != null)
     {
-      buttonCharacterPlayer.icon = CharacterDataParser.getCharPixelIconAsset(chartEditorState.currentSongMetadata.playData.characters.player);
+      buttonCharacterPlayer.icon = haxe.ui.util.Variant.fromImageData(CharacterDataParser.getCharPixelIconAsset(chartEditorState.currentSongMetadata.playData.characters.player));
       buttonCharacterPlayer.text = charDataPlayer.name.length > LIMIT ? '${charDataPlayer.name.substr(0, LIMIT)}.' : '${charDataPlayer.name}';
     }
     else


### PR DESCRIPTION
<!-- Please check for duplicates or similar PRs before submitting this PR. -->
## Does this PR close any issues? If so, link them below.
#3299 #3222 #3148 (might be more, idk)

## Briefly describe the issue(s) fixed.
This PR fixes Animated Pixel Icons showing their spritesheets by extracting the first frame of their idle from them. This is all done in-game to simplify implementation, and save storage space.

## Include any relevant screenshots or videos.
### Before:
![before-image](https://github.com/user-attachments/assets/734f2d71-25bf-45c6-b5dc-316ca7e2176a)

### After:
![after-image](https://github.com/user-attachments/assets/82718d92-8709-4cf3-a13e-97d2718422a0)
(dont mind my fps)

## "TODO":
- [x] Extract specific frame from spritesheets.
- [x] Figure out how to load FlxFrame/FlxGraphic in a button
- [x] Figure out why the resolution is going wonk.
- [x] Change Width/Height to actual frame resolution.
<!-- - [ ] Maybe reduce lag when opening things containing these? -->
<!-- - [ ] Maybe add the confirm animation when selecting icons (I feel this is unnessecary) -->


