### PR TITLE
Fix note and receptor scaling and note tail offsets

### DIFF
--- a/source/funkin/play/notes/StrumlineNote.hx
+++ b/source/funkin/play/notes/StrumlineNote.hx
@@ -85,7 +85,8 @@ class StrumlineNote extends FlxSprite
     noteStyle.applyStrumlineFrames(this);
     noteStyle.applyStrumlineAnimations(this, this.direction);
 
-    this.scale.set(noteStyle.getStrumlineScale());
+    var scale = noteStyle.getStrumlineScale();
+    this.scale.set(scale, scale);
     this.updateHitbox();
     noteStyle.applyStrumlineOffsets(this);
 

--- a/source/funkin/play/notes/StrumlineNote.hx
+++ b/source/funkin/play/notes/StrumlineNote.hx
@@ -85,7 +85,7 @@ class StrumlineNote extends FlxSprite
     noteStyle.applyStrumlineFrames(this);
     noteStyle.applyStrumlineAnimations(this, this.direction);
 
-    this.setGraphicSize(Std.int(Strumline.STRUMLINE_SIZE * noteStyle.getStrumlineScale()));
+    this.scale.set(noteStyle.getStrumlineScale());
     this.updateHitbox();
     noteStyle.applyStrumlineOffsets(this);
 

--- a/source/funkin/play/notes/SustainTrail.hx
+++ b/source/funkin/play/notes/SustainTrail.hx
@@ -87,6 +87,7 @@ class SustainTrail extends FlxSprite
   public var bottomClip:Float = 0.9;
 
   public var isPixel:Bool;
+  public var noteStyleOffsets:Array<Float>;
 
   var graphicWidth:Float = 0;
   var graphicHeight:Float = 0;
@@ -107,6 +108,7 @@ class SustainTrail extends FlxSprite
     this.noteDirection = noteDirection;
 
     setupHoldNoteGraphic(noteStyle);
+    noteStyleOffsets = noteStyle.getHoldNoteOffsets();
 
     indices = new DrawData<Int>(12, true, TRIANGLE_VERTEX_INDICES);
 
@@ -137,7 +139,6 @@ class SustainTrail extends FlxSprite
 
     zoom = 1.0;
     zoom *= noteStyle.fetchHoldNoteScale();
-    zoom *= 0.7;
 
     // CALCULATE SIZE
     graphicWidth = graphic.width / 8 * zoom; // amount of notes * 2
@@ -202,7 +203,7 @@ class SustainTrail extends FlxSprite
   {
     width = graphicWidth;
     height = graphicHeight;
-    offset.set(0, 0);
+    offset.set(noteStyleOffsets[0], noteStyleOffsets[1]);
     origin.set(width * 0.5, height * 0.5);
   }
 

--- a/source/funkin/play/notes/notestyle/NoteStyle.hx
+++ b/source/funkin/play/notes/notestyle/NoteStyle.hx
@@ -93,7 +93,7 @@ class NoteStyle implements IRegistryEntry<NoteStyleData>
     buildNoteAnimations(target);
 
     // Set the scale.
-    target.setGraphicSize(Strumline.STRUMLINE_SIZE * getNoteScale());
+    target.scale.set(getNoteScale());
     target.updateHitbox();
   }
 

--- a/source/funkin/play/notes/notestyle/NoteStyle.hx
+++ b/source/funkin/play/notes/notestyle/NoteStyle.hx
@@ -93,7 +93,8 @@ class NoteStyle implements IRegistryEntry<NoteStyleData>
     buildNoteAnimations(target);
 
     // Set the scale.
-    target.scale.set(getNoteScale());
+    var scale = getNoteScale();
+    target.scale.set(scale, scale);
     target.updateHitbox();
   }
 
@@ -224,6 +225,13 @@ class NoteStyle implements IRegistryEntry<NoteStyleData>
     return data?.scale ?? 1.0;
   }
 
+  public function getHoldNoteOffsets():Array<Float>
+  {
+    var data = _data?.assets?.holdNote;
+    if (data == null && fallback != null) return fallback.getHoldNoteOffsets();
+    return data?.offsets ?? [0.0, 0.0];
+  }
+
   public function applyStrumlineFrames(target:StrumlineNote):Void
   {
     // TODO: Add support for multi-Sparrow.
@@ -304,9 +312,16 @@ class NoteStyle implements IRegistryEntry<NoteStyleData>
     return thx.Arrays.filterNull(result);
   }
 
+  public function getStrumlineOffsets():Array<Float>
+  {
+    var data = _data?.assets?.noteStrumline;
+    if (data == null && fallback != null) return fallback.getStrumlineOffsets();
+    return data?.offsets ?? [0.0, 0.0];
+  }
+
   public function applyStrumlineOffsets(target:StrumlineNote):Void
   {
-    var offsets = _data?.assets?.noteStrumline?.offsets ?? [0.0, 0.0];
+    var offsets = getStrumlineOffsets();
     target.x += offsets[0];
     target.y += offsets[1];
   }


### PR DESCRIPTION
<!-- Please check for duplicates or similar PRs before submitting this PR. -->
## Does this PR close any issues? If so, link them below.
~~#3323~~ (Actually wait only some of the things mentioned there are fixed, only the third bullet and maybe the second one, if you count my duct-tape fix of putting offsets for the hold notes to counteract the offset that I couldn’t find the cause of as an actual fix)

## Briefly describe the issue(s) fixed.
- Made note asset scaling easier to understand. Before, there was some math going on behind the scenes (the hardcoded scaling stuff was probably added before the JSON scaling was implemented), but now, it just uses the scale in the JSON as the scale to apply to the sprites.
- Added offset functionality to the note tail sprites. The attached JSON for the pixel art notes uses this to pretty much fix the tails' offsets.
- In turn, I was able to make the pixel art notes have a scale factor that doesn't have mixels. The tails' scale has also been updated to keep a consistent pixel size.

## Include any relevant screenshots or videos.
Note tails before adding offset functionality (but after fixing receptor and note scaling)
![Note tails before adding offset functionality (but after fixing receptor and note scaling)](https://github.com/user-attachments/assets/5cf31b7a-4d8c-49e2-a40c-c296645d7d6b)

## NOTE:
If this pull request is accepted, these are the new JSON files for the note styles.
[funkin.json](https://github.com/user-attachments/files/17034954/funkin.json)
[pixel.json](https://github.com/user-attachments/files/17034973/pixel.json)
