### PR TITLE
[ENHANCEMENT] Chart Editor: Offset the waveform visually by it's vocal offset

### DIFF
--- a/source/funkin/ui/debug/charting/ChartEditorState.hx
+++ b/source/funkin/ui/debug/charting/ChartEditorState.hx
@@ -404,11 +404,18 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
       {
         gridTiledSprite.y = -scrollPositionInPixels + (GRID_INITIAL_Y_POS);
         measureTicks.y = gridTiledSprite.y;
-
+        var id = 0;
         for (member in audioWaveforms.members)
         {
-          member.time = scrollPositionInMs / Constants.MS_PER_SEC;
-
+          if (id == 1)
+          {
+            member.time = (scrollPositionInMs - currentVocalOffsetOpponent) / Constants.MS_PER_SEC;
+          }
+          else
+          {
+            member.time = (scrollPositionInMs - currentVocalOffsetPlayer) / Constants.MS_PER_SEC;
+          }
+          id++;
           // Doing this desyncs the waveforms from the grid.
           // member.y = Math.max(this.gridTiledSprite?.y ?? 0.0, ChartEditorState.GRID_INITIAL_Y_POS - ChartEditorState.GRID_TOP_PAD);
         }

--- a/source/funkin/ui/debug/charting/ChartEditorState.hx
+++ b/source/funkin/ui/debug/charting/ChartEditorState.hx
@@ -409,11 +409,11 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
         {
           if (id == 1)
           {
-            member.time = (scrollPositionInMs - currentVocalOffsetOpponent) / Constants.MS_PER_SEC;
+            member.time = ((scrollPositionInMs - currentVocalOffsetOpponent) - currentInstrumentalOffset) / Constants.MS_PER_SEC;
           }
           else
           {
-            member.time = (scrollPositionInMs - currentVocalOffsetPlayer) / Constants.MS_PER_SEC;
+            member.time = ((scrollPositionInMs - currentVocalOffsetOpponent) - currentInstrumentalOffset) / Constants.MS_PER_SEC;
           }
           id++;
           // Doing this desyncs the waveforms from the grid.


### PR DESCRIPTION
<!-- Please check for duplicates or similar PRs before submitting this PR. -->
## Does this PR close any issues? If so, link them below.
N/A
## Briefly describe the issue(s) fixed.
Before you couldn't tell if the offset was even doing anything visually to vocals, now it shows an actual change on the main view.
## Include any relevant screenshots or videos.
![image](https://github.com/user-attachments/assets/cc263b76-c68e-4c11-a215-b53c74758c48)
![image](https://github.com/user-attachments/assets/2bae257b-830e-4f9b-bb14-46d50f10d92c)
