### PR TITLE
[BUGFIX] Fix bug where FPS counter was always displaying on startup even when disabled

### DIFF
--- a/source/Main.hx
+++ b/source/Main.hx
@@ -123,8 +123,6 @@ class Main extends Sprite
     game.debugger.interaction.addTool(new funkin.util.TrackerToolButtonUtil());
     #end
 
-    addChild(fpsCounter);
-
     #if hxcpp_debug_server
     trace('hxcpp_debug_server is enabled! You can now connect to the game with a debugger.');
     #else


### PR DESCRIPTION
<!-- Please check for duplicates or similar PRs before submitting this PR. -->
## Does this PR close any issues? If so, link them below.
N/A
## Briefly describe the issue(s) fixed.
Fixes a minor bug where the FPS counter object was added regardless of what the Debug Display option was set to.
## Include any relevant screenshots or videos.
https://github.com/user-attachments/assets/28119ba4-c710-43c2-870e-96fa8f1271e3

