### PR TITLE
[BUGFIX] Modding (Polymod): Make addCharacter actually set the characters type

### DIFF
--- a/source/funkin/play/stage/Stage.hx
+++ b/source/funkin/play/stage/Stage.hx
@@ -464,6 +464,9 @@ class Stage extends FlxSpriteGroup implements IPlayStateScriptedClass implements
       #end
     }
 
+    // Set the characters type
+    character.characterType = charType;
+
     // Add the character to the scene.
     this.add(character);
 


### PR DESCRIPTION
<!-- Please check for duplicates or similar PRs before submitting this PR. -->
## Does this PR close any issues? If so, link them below.
N/A
## Briefly describe the issue(s) fixed.
Fixes a call to addCharacter in where if you were to create a custom character in an hscript and then try to add it to the stage, it wouldn't have it's character type get set. Meaning it would not react to any notes being played.
## Include any relevant screenshots or videos.
N/A