### PR TITLE
[BUGFIX] Make % Cleared not save to a lower amount when the song is completed with the same 

### DIFF
--- a/source/funkin/save/Save.hx
+++ b/source/funkin/save/Save.hx
@@ -598,11 +598,15 @@ class Save
       return;
     }
 
+    //percent also accounts for different ranks
+    var oldPerc = (previousScoreData.tallies.sick + previousScoreData.tallies.good) / previousScoreData.tallies.totalNotes;
+    var newPerc = (newScoreData.tallies.sick + newScoreData.tallies.good) / newScoreData.tallies.totalNotes;
+
     // Set the high score and the high rank separately.
     var newScore:SaveScoreData =
       {
-        score: (previousScoreData.score > newScoreData.score) ? previousScoreData.score : newScoreData.score,
-        tallies: (previousRank > newRank) ? previousScoreData.tallies : newScoreData.tallies
+        score: Std.int(Math.max(previousScoreData.score, newScoreData.score)),
+        tallies: (oldPerc > newPerc ? previousScoreData.tallies : newScoreData.tallies)
       };
 
     song.set(difficultyId, newScore);


### PR DESCRIPTION
## Does this PR close any issues? If so, link them below.

[2821](https://github.com/FunkinCrew/Funkin/issues/2821) (theres probs more idk)

## Briefly describe the issue(s) fixed.

Fixes the issue of the song % being overriden by a lower one when the song is completed with the same rank. It modifies the applySongRank function in [Save](./source/funkin/save/Save.hx) to check for percentage differences (percentage formula copied from FreeplayState lol) instead of rank differences when saving the tallies. 

Image shows previous %, video shows the latest % (in video form to show da code change !) 

## Include any relevant screenshots or videos.
![image](https://github.com/user-attachments/assets/c60197d0-8eb0-4761-8746-eb4324cd92ba)

https://github.com/user-attachments/assets/871d9ffd-0ae8-46e7-8bff-ca65e0dcb1aa