### PR TITLE
[BUGFIX] Chart Editor/Gameplay: Fixes countdown and audio artifacts with offsets

### DIFF
--- a/source/funkin/Conductor.hx
+++ b/source/funkin/Conductor.hx
@@ -397,9 +397,12 @@ class Conductor
    */
   public function update(?songPos:Float, applyOffsets:Bool = true, forceDispatch:Bool = false)
   {
+    var currentTime:Float = (FlxG.sound.music != null) ? FlxG.sound.music.time : 0.0;
+    var currentLength:Float = (FlxG.sound.music != null) ? FlxG.sound.music.length : 0.0;
+
     if (songPos == null)
     {
-      songPos = (FlxG.sound.music != null) ? FlxG.sound.music.time : 0.0;
+      songPos = currentTime;
     }
 
     // Take into account instrumental and file format song offsets.
@@ -410,7 +413,7 @@ class Conductor
     var oldStep:Float = this.currentStep;
 
     // Set the song position we are at (for purposes of calculating note positions, etc).
-    this.songPosition = songPos;
+    this.songPosition = Math.min(currentLength, Math.max(0, songPos));
 
     currentTimeChange = timeChanges[0];
     if (this.songPosition > 0.0)
@@ -430,7 +433,8 @@ class Conductor
     else if (currentTimeChange != null && this.songPosition > 0.0)
     {
       // roundDecimal prevents representing 8 as 7.9999999
-      this.currentStepTime = FlxMath.roundDecimal((currentTimeChange.beatTime * Constants.STEPS_PER_BEAT) + (this.songPosition - currentTimeChange.timeStamp) / stepLengthMs, 6);
+      this.currentStepTime = FlxMath.roundDecimal((currentTimeChange.beatTime * Constants.STEPS_PER_BEAT)
+        + (this.songPosition - currentTimeChange.timeStamp) / stepLengthMs, 6);
       this.currentBeatTime = currentStepTime / Constants.STEPS_PER_BEAT;
       this.currentMeasureTime = currentStepTime / stepsPerMeasure;
       this.currentStep = Math.floor(currentStepTime);

--- a/source/funkin/Conductor.hx
+++ b/source/funkin/Conductor.hx
@@ -412,8 +412,17 @@ class Conductor
     var oldBeat:Float = this.currentBeat;
     var oldStep:Float = this.currentStep;
 
+    // If the song is playing, limit the song position to the length of the song or beginning of the song.
+    if (FlxG.sound.music != null && FlxG.sound.music.playing)
+    {
+      this.songPosition = Math.min(currentLength, Math.max(0, songPos));
+    }
+    else
+    {
+      this.songPosition = songPos;
+    }
+
     // Set the song position we are at (for purposes of calculating note positions, etc).
-    this.songPosition = Math.min(currentLength, Math.max(0, songPos));
 
     currentTimeChange = timeChanges[0];
     if (this.songPosition > 0.0)

--- a/source/funkin/play/Countdown.hx
+++ b/source/funkin/play/Countdown.hx
@@ -30,6 +30,11 @@ class Countdown
   public static var soundSuffix:String = '';
 
   /**
+   * Whether the countdown has finished.
+   */
+  public static var finished:Bool = false;
+
+  /**
    * Which alternate graphic on countdown to use.
    * You can set this via script.
    * For example, in Week 6 it is `-pixel`.
@@ -53,6 +58,7 @@ class Countdown
    */
   public static function performCountdown():Bool
   {
+    finished = false;
     countdownStep = BEFORE;
     var cancelled:Bool = propagateCountdownEvent(countdownStep);
     if (cancelled)
@@ -101,6 +107,7 @@ class Countdown
 
       if (countdownStep == AFTER)
       {
+        finished = true;
         stopCountdown();
       }
     }, 5); // Before, 3, 2, 1, GO!, After

--- a/source/funkin/play/Countdown.hx
+++ b/source/funkin/play/Countdown.hx
@@ -30,11 +30,6 @@ class Countdown
   public static var soundSuffix:String = '';
 
   /**
-   * Whether the countdown has finished.
-   */
-  public static var finished:Bool = false;
-
-  /**
    * Which alternate graphic on countdown to use.
    * You can set this via script.
    * For example, in Week 6 it is `-pixel`.
@@ -58,7 +53,6 @@ class Countdown
    */
   public static function performCountdown():Bool
   {
-    finished = false;
     countdownStep = BEFORE;
     var cancelled:Bool = propagateCountdownEvent(countdownStep);
     if (cancelled)
@@ -107,7 +101,6 @@ class Countdown
 
       if (countdownStep == AFTER)
       {
-        finished = true;
         stopCountdown();
       }
     }, 5); // Before, 3, 2, 1, GO!, After

--- a/source/funkin/play/PlayState.hx
+++ b/source/funkin/play/PlayState.hx
@@ -1403,7 +1403,7 @@ class PlayState extends MusicBeatSubState
     {
       var correctSync:Float = Math.min(FlxG.sound.music.length, Math.max(0, Conductor.instance.songPosition - Conductor.instance.instrumentalOffset));
 
-      if (!startingSong && (Math.abs(FlxG.sound.music.time - correctSync) > 100 || Math.abs(vocals.checkSyncError(correctSync)) > 100))
+      if (!startingSong && (Math.abs(FlxG.sound.music.time - correctSync) > 5 || Math.abs(vocals.checkSyncError(correctSync)) > 5))
       {
         trace("VOCALS NEED RESYNC");
         if (vocals != null) trace(vocals.checkSyncError(correctSync));

--- a/source/funkin/play/PlayState.hx
+++ b/source/funkin/play/PlayState.hx
@@ -1979,6 +1979,7 @@ class PlayState extends MusicBeatSubState
     vocals.play();
     vocals.volume = 1.0;
     vocals.pitch = playbackRate;
+    vocals.time = startTimestamp;
     resyncVocals();
 
     #if FEATURE_DISCORD_RPC

--- a/source/funkin/play/PlayState.hx
+++ b/source/funkin/play/PlayState.hx
@@ -915,7 +915,11 @@ class PlayState extends MusicBeatSubState
       {
         // Do NOT apply offsets at this point, because they already got applied the previous frame!
         Conductor.instance.update(Conductor.instance.songPosition + elapsed * 1000, false);
-        if (Conductor.instance.songPosition >= (startTimestamp)) startSong();
+        if (Conductor.instance.songPosition - Conductor.instance.instrumentalOffset >= (startTimestamp) && Countdown.finished)
+        {
+          trace("started song at " + Conductor.instance.songPosition);
+          startSong();
+        }
       }
     }
     else
@@ -1391,14 +1395,16 @@ class PlayState extends MusicBeatSubState
       // activeNotes.sort(SortUtil.byStrumtime, FlxSort.DESCENDING);
     }
 
+    var correctSync:Float = Math.min(FlxG.sound.music.length, Math.max(0, Conductor.instance.songPosition - Conductor.instance.instrumentalOffset));
+
     if (!startingSong
       && FlxG.sound.music != null
-      && (Math.abs(FlxG.sound.music.time - (Conductor.instance.songPosition + Conductor.instance.instrumentalOffset)) > 100
-        || Math.abs(vocals.checkSyncError(Conductor.instance.songPosition + Conductor.instance.instrumentalOffset)) > 100))
+      && (Math.abs(FlxG.sound.music.time - correctSync) > 100 || Math.abs(vocals.checkSyncError(correctSync)) > 100))
     {
       trace("VOCALS NEED RESYNC");
-      if (vocals != null) trace(vocals.checkSyncError(Conductor.instance.songPosition + Conductor.instance.instrumentalOffset));
-      trace(FlxG.sound.music.time - (Conductor.instance.songPosition + Conductor.instance.instrumentalOffset));
+      if (vocals != null) trace(vocals.checkSyncError(correctSync));
+      trace(FlxG.sound.music.time);
+      trace(correctSync);
       resyncVocals();
     }
 
@@ -1993,7 +1999,9 @@ class PlayState extends MusicBeatSubState
 
     // Skip this if the music is paused (GameOver, Pause menu, start-of-song offset, etc.)
     if (!(FlxG.sound.music?.playing ?? false)) return;
-    var timeToPlayAt:Float = Conductor.instance.songPosition - Conductor.instance.instrumentalOffset;
+
+    var timeToPlayAt:Float = Math.min(FlxG.sound.music.length, Math.max(0, Conductor.instance.songPosition - Conductor.instance.instrumentalOffset));
+    trace('Resyncing vocals to ${timeToPlayAt}');
     FlxG.sound.music.pause();
     vocals.pause();
 

--- a/source/funkin/play/PlayState.hx
+++ b/source/funkin/play/PlayState.hx
@@ -687,7 +687,11 @@ class PlayState extends MusicBeatSubState
     }
 
     Conductor.instance.mapTimeChanges(currentChart.timeChanges);
-    Conductor.instance.update((Conductor.instance.beatLengthMs * -5) + startTimestamp);
+    var pre:Float = (Conductor.instance.beatLengthMs * -5) + startTimestamp;
+
+    trace('Attempting to start at ' + pre);
+
+    Conductor.instance.update(pre);
 
     // The song is now loaded. We can continue to initialize the play state.
     initCameras();
@@ -915,7 +919,7 @@ class PlayState extends MusicBeatSubState
       {
         // Do NOT apply offsets at this point, because they already got applied the previous frame!
         Conductor.instance.update(Conductor.instance.songPosition + elapsed * 1000, false);
-        if (Conductor.instance.songPosition - Conductor.instance.instrumentalOffset >= (startTimestamp) && Countdown.finished)
+        if (Conductor.instance.songPosition >= (startTimestamp + Conductor.instance.instrumentalOffset))
         {
           trace("started song at " + Conductor.instance.songPosition);
           startSong();
@@ -1395,17 +1399,18 @@ class PlayState extends MusicBeatSubState
       // activeNotes.sort(SortUtil.byStrumtime, FlxSort.DESCENDING);
     }
 
-    var correctSync:Float = Math.min(FlxG.sound.music.length, Math.max(0, Conductor.instance.songPosition - Conductor.instance.instrumentalOffset));
-
-    if (!startingSong
-      && FlxG.sound.music != null
-      && (Math.abs(FlxG.sound.music.time - correctSync) > 100 || Math.abs(vocals.checkSyncError(correctSync)) > 100))
+    if (FlxG.sound.music != null)
     {
-      trace("VOCALS NEED RESYNC");
-      if (vocals != null) trace(vocals.checkSyncError(correctSync));
-      trace(FlxG.sound.music.time);
-      trace(correctSync);
-      resyncVocals();
+      var correctSync:Float = Math.min(FlxG.sound.music.length, Math.max(0, Conductor.instance.songPosition - Conductor.instance.instrumentalOffset));
+
+      if (!startingSong && (Math.abs(FlxG.sound.music.time - correctSync) > 100 || Math.abs(vocals.checkSyncError(correctSync)) > 100))
+      {
+        trace("VOCALS NEED RESYNC");
+        if (vocals != null) trace(vocals.checkSyncError(correctSync));
+        trace(FlxG.sound.music.time);
+        trace(correctSync);
+        resyncVocals();
+      }
     }
 
     // Only bop camera if zoom level is below 135%


### PR DESCRIPTION
<!-- Please check for duplicates or similar PRs before submitting this PR. -->
## Does this PR close any issues? If so, link them below.
Don't think anyone uses these so no.
## Briefly describe the issue(s) fixed.
Fixes an issue with offsets that would cause it to mass resync vocals, or go forward in time and back really quickly. Causing a lot of artifacts, lagging the game, and being unpleasant.

This also fixes the song starting before the countdown (due to the offset).
## Include any relevant screenshots or videos.

This shows blammed at +1 second of instrumental offset.

https://github.com/user-attachments/assets/021e5b06-f67c-491a-8e17-d77bddf9c8be
(2nd clip is accidently the normal version of blammed instead of hard, but the point stands)