### PR TITLE
[ENHANCEMENT] Move the week directory to be loaded from PlayStatePlaylist to StageData, alongside some other changes to StageDataProp

### DIFF
--- a/source/funkin/data/stage/StageData.hx
+++ b/source/funkin/data/stage/StageData.hx
@@ -20,6 +20,10 @@ class StageData
   @:optional
   public var cameraZoom:Null<Float>;
 
+  @:default("shared")
+  @:optional
+  public var directory:Null<String>;
+
   public function new()
   {
     this.version = StageRegistry.STAGE_DATA_VERSION;
@@ -182,6 +186,32 @@ typedef StageDataProp =
   @:default("sparrow")
   @:optional
   var animType:String;
+
+  /**
+   * The angle of the prop, as a float.
+   * @default 1.0
+   */
+  @:optional
+  @:default(0.0)
+  var angle:Float;
+
+  /**
+   * The blend mode of the prop, as a string.
+   * Just like in photoshop.
+   * @default Nothing.
+   */
+  @:default("")
+  @:optional
+  var blend:String;
+
+  /**
+   * The color of the prop overlay, as a hex string.
+   * White overlays, or the ones with the value #FFFFFF, do not appear.
+   * @default `#FFFFFF`
+   */
+  @:default("#FFFFFF")
+  @:optional
+  var color:String;
 };
 
 typedef StageDataCharacter =

--- a/source/funkin/play/stage/Stage.hx
+++ b/source/funkin/play/stage/Stage.hx
@@ -256,6 +256,10 @@ class Stage extends FlxSpriteGroup implements IPlayStateScriptedClass implements
       propSprite.scrollFactor.x = dataProp.scroll[0];
       propSprite.scrollFactor.y = dataProp.scroll[1];
 
+      propSprite.angle = dataProp.angle;
+      propSprite.color = FlxColor.fromString(dataProp.color);
+      propSprite.blend = BlendMode.fromString(dataProp.blend);
+
       propSprite.zIndex = dataProp.zIndex;
 
       switch (dataProp.animType)

--- a/source/funkin/play/stage/Stage.hx
+++ b/source/funkin/play/stage/Stage.hx
@@ -258,7 +258,7 @@ class Stage extends FlxSpriteGroup implements IPlayStateScriptedClass implements
 
       propSprite.angle = dataProp.angle;
       propSprite.color = FlxColor.fromString(dataProp.color);
-      propSprite.blend = BlendMode.fromString(dataProp.blend);
+      @:privateAccess propSprite.blend = BlendMode.fromString(dataProp.blend);
 
       propSprite.zIndex = dataProp.zIndex;
 

--- a/source/funkin/ui/transition/LoadingState.hx
+++ b/source/funkin/ui/transition/LoadingState.hx
@@ -87,7 +87,7 @@ class LoadingState extends MusicBeatSubState
       }
 
       checkLibrary('shared');
-      checkLibrary(PlayStatePlaylist.campaignId);
+      checkLibrary(stageDirectory);
       checkLibrary('tutorial');
 
       var fadeTime:Float = 0.5;
@@ -205,6 +205,8 @@ class LoadingState extends MusicBeatSubState
     return Paths.inst(PlayState.instance.currentSong.id);
   }
 
+  static var stageDirectory:String = "shared";
+
   /**
    * Starts the transition to a new `PlayState` to start a new song.
    * First switches to the `LoadingState` if assets need to be loaded.
@@ -214,7 +216,13 @@ class LoadingState extends MusicBeatSubState
    */
   public static function loadPlayState(params:PlayStateParams, shouldStopMusic = false, asSubState = false, ?onConstruct:PlayState->Void):Void
   {
-    Paths.setCurrentLevel(PlayStatePlaylist.campaignId);
+    var daChart = params.targetSong.getDifficulty(params.targetDifficulty ?? Constants.DEFAULT_DIFFICULTY,
+      params.targetVariation ?? Constants.DEFAULT_VARIATION);
+
+    var daStage = funkin.data.stage.StageRegistry.instance.fetchEntry(daChart.stage);
+    stageDirectory = daStage.directory ?? "shared";
+    Paths.setCurrentLevel(stageDirectory);
+
     var playStateCtor:() -> PlayState = function() {
       return new PlayState(params);
     };

--- a/source/funkin/ui/transition/LoadingState.hx
+++ b/source/funkin/ui/transition/LoadingState.hx
@@ -220,7 +220,7 @@ class LoadingState extends MusicBeatSubState
       params.targetVariation ?? Constants.DEFAULT_VARIATION);
 
     var daStage = funkin.data.stage.StageRegistry.instance.fetchEntry(daChart.stage);
-    stageDirectory = daStage.directory ?? "shared";
+		stageDirectory = daStage?._data?.directory ?? "shared";
     Paths.setCurrentLevel(stageDirectory);
 
     var playStateCtor:() -> PlayState = function() {


### PR DESCRIPTION
## Does this PR close any issues? If so, link them below.
N/A

## Briefly describe the issue(s) fixed.
Adds a new field to [StageData](./source/funkin/data/stage/StageData.hx), "directory", which is read by [LoadingState](./source/funkin/ui/transition/LoadingState.hx) and sets the current level of Paths to the field's value and then loads it. The default value is "shared".

Alongside it, it adds three new fields to StageDataProp, "angle" (Float, default value 0.0), "blend" (String, default value "") and "color" (String, default value "#FFFFFF"), which are read in [Stage](./source/funkin/play/stage/Stage.hx) and set to the corresponding StageProps. 

## Include any relevant screenshots or videos.
N/A

## Note
If this gets accepted, stage files would need to be updated to at least contain the "directory" field.