### PR TITLE
[BUGFIX] Stop input spam on character select

### DIFF
--- a/source/funkin/ui/charSelect/CharSelectSubState.hx
+++ b/source/funkin/ui/charSelect/CharSelectSubState.hx
@@ -796,6 +796,11 @@ class CharSelectSubState extends MusicBeatSubState
 
       if (allowInput && !pressedSelect && controls.ACCEPT)
       {
+        spamUp = false;
+        spamDown = false;
+        spamLeft = false;
+        spamRight = false;
+
         cursorConfirmed.visible = true;
         cursorConfirmed.animation.play("idle", true);
 


### PR DESCRIPTION
<!-- Please check for duplicates or similar PRs before submitting this PR. -->
## Does this PR close any issues? If so, link them below.
None as far as I know?

## Briefly describe the issue(s) fixed.
Currently if you hold a key down and press enter on a character in the character select screen, the hold won't stop and the cursor will keep moving.

In some cases this can lead to the current character to be set to an invalid value and the game will crash.

## Include any relevant screenshots or videos.

https://github.com/user-attachments/assets/0065b7a7-b98a-4d1d-a3a1-5ef997855f64

