### PR TITLE
[BUGFIX] Take visual offset into account when resyncing vocals.

### DIFF
--- a/source/funkin/play/PlayState.hx
+++ b/source/funkin/play/PlayState.hx
@@ -1393,12 +1393,15 @@ class PlayState extends MusicBeatSubState
 
     if (!startingSong
       && FlxG.sound.music != null
-      && (Math.abs(FlxG.sound.music.time - (Conductor.instance.songPosition + Conductor.instance.instrumentalOffset)) > 100
-        || Math.abs(vocals.checkSyncError(Conductor.instance.songPosition + Conductor.instance.instrumentalOffset)) > 100))
+      && (Math.abs(FlxG.sound.music.time
+        - (Conductor.instance.songPosition + Conductor.instance.instrumentalOffset - Conductor.instance.audioVisualOffset)) > 100
+        || Math.abs(vocals.checkSyncError(Conductor.instance.songPosition +
+          Conductor.instance.instrumentalOffset - Conductor.instance.audioVisualOffset)) > 100))
     {
       trace("VOCALS NEED RESYNC");
-      if (vocals != null) trace(vocals.checkSyncError(Conductor.instance.songPosition + Conductor.instance.instrumentalOffset));
-      trace(FlxG.sound.music.time - (Conductor.instance.songPosition + Conductor.instance.instrumentalOffset));
+      if (vocals != null) trace(vocals.checkSyncError(Conductor.instance.songPosition + Conductor.instance.instrumentalOffset
+        - Conductor.instance.audioVisualOffset));
+      trace(FlxG.sound.music.time - (Conductor.instance.songPosition + Conductor.instance.instrumentalOffset - Conductor.instance.audioVisualOffset));
       resyncVocals();
     }
 


### PR DESCRIPTION
<!-- Please check for duplicates or similar PRs before submitting this PR. -->
## Does this PR close any issues? If so, link them below.
Fixes #3380 

## Briefly describe the issue(s) fixed.
When setting extreme values for Visual Offset (ex. 200 or -400), the song behaves in ways that makes it annoying to play.
For example: Setting a really high *positive* value makes the song skip and resemble a swing tempo, whereas setting a really high *negative* value causes the song to not start at all!

The code that checks if a desync occurs never took Conductor's `audioVisualOffset` parameter into account, causing the aforementioned issues!

## Include any relevant screenshots or videos.
### Before (Visual Offset set to -150):

https://github.com/user-attachments/assets/344757c0-145e-4493-8e32-7dd22de235ab

### Before (Visual Offset set to 150):

https://github.com/user-attachments/assets/66c42764-0bde-4d8d-822f-f94aec3d23a0

### After (Visual Offset set to -150):

https://github.com/user-attachments/assets/2e80f26c-8b83-4324-910d-844801ec7d3a

### After (Visual Offset set to 150):

https://github.com/user-attachments/assets/e03ee6ad-cad4-4e4a-ac7c-bdab24c61cb3