### PR TITLE
[ENHANCEMENT] More centered note splashes

### DIFF
--- a/source/funkin/play/notes/NoteSplash.hx
+++ b/source/funkin/play/notes/NoteSplash.hx
@@ -58,7 +58,7 @@ class NoteSplash extends FlxSprite
     animation.curAnim.frameRate = splashFramerate + FlxG.random.int(-splashFramerateVariance, splashFramerateVariance);
 
     // Center the animation on the note splash.
-    offset.set(width * 0.3, height * 0.3);
+    offset.set(width * 0.2, height * 0.3);
   }
 
   public function onAnimationFinished(animationName:String):Void


### PR DESCRIPTION
<!-- Please check for duplicates or similar PRs before submitting this PR. -->
## Does this PR close any issues? If so, link them below.
Fixes #3427

## Briefly describe the issue(s) fixed.
The note splashes width offset gets changed from `0.3` to `0.2`

## Include any relevant screenshots or videos.
# Before:
![image](https://github.com/user-attachments/assets/653ebce1-8f07-45e2-b694-e163c769a6db)
![image](https://github.com/user-attachments/assets/9cdcb16a-2f3b-4d80-9f42-96b442e16058)
![image](https://github.com/user-attachments/assets/b83c18a3-ece7-4580-a2f9-f9eb9949a0ab)
![image](https://github.com/user-attachments/assets/3c28355f-5888-4a16-be72-d3704e5274e9)

# After:
![image](https://github.com/user-attachments/assets/e4973408-573a-47d4-b645-befe64cf972b)
![image](https://github.com/user-attachments/assets/0abd335a-094d-473c-a0d9-0277af66314e)
![image](https://github.com/user-attachments/assets/142ce048-13c4-45fc-9665-4419eb3d5bca)
![image](https://github.com/user-attachments/assets/2d3eb193-c2b2-41de-bbce-0f2b2836f4e6)



