### PR TITLE
[BUGFIX]: Disable Screenshotting on HTML5 builds

### DIFF
--- a/source/funkin/util/plugins/ScreenshotPlugin.hx
+++ b/source/funkin/util/plugins/ScreenshotPlugin.hx
@@ -79,10 +79,12 @@ class ScreenshotPlugin extends FlxBasic
   {
     super.update(elapsed);
 
+    #if !html5
     if (hasPressedScreenshot())
     {
       capture();
     }
+    #end
   }
 
   /**


### PR DESCRIPTION
<!-- Please check for duplicates or similar PRs before submitting this PR. -->
## Does this PR close any issues? If so, link them below.
Unsure, when I searched "screenshots" it has nothing related to it most likely due to how the issue format is.

## Briefly describe the issue(s) fixed.
On HTML5, when the player would take a screenshot, it would crash since there was no "screenshots" directory due to it not being a windows build.

## Include any relevant screenshots or videos.
![image](https://github.com/user-attachments/assets/8a232aa3-b5db-4926-ba34-f73e2a98a2d5)
# Note:
I was spamming the screenshot button in this video
I changed the key to 8 since F3 would interfere with my browser, no actual code is set for it to be defaulted to 8, it is still F3.
https://github.com/user-attachments/assets/f815a48d-7b9b-400a-b031-229d4a255cb2

