### PR TITLE
chore: Add a link to `credits.json`

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Please check out our [Contributor's guide](./CONTRIBUTORS.md) on how you can act
 
 # Credits and Special Thanks
 
-Full credits can be found in-game, or wherever the credits.json file is.
+Full credits can be found in-game, or in the `credits.json` file which is located [here](https://github.com/FunkinCrew/funkin.assets/blob/main/exclude/data/credits.json).
 
 ## Programming
 - [ninjamuffin99](https://twitter.com/ninja_muffin99) - Lead Programmer


### PR DESCRIPTION
This PR properly adds a link to `credits.json`. Someone made a PR for this at one point (#2325), but it was reverted in #2355 since it was merged into `main` instead of `develop`. It was never merged again to the proper branch, leaving this line unchanged.