### PR TITLE
[BUGFIX] Made `changeDiff` not use the suffixed difficulty as the current difficulty on freeplay

### DIFF
--- a/source/funkin/ui/freeplay/FreeplayState.hx
+++ b/source/funkin/ui/freeplay/FreeplayState.hx
@@ -1785,14 +1785,13 @@ class FreeplayState extends MusicBeatSubState
       var songScore:Null<SaveScoreData> = Save.instance.getSongScore(daSong.songId, suffixedDifficulty);
       intendedScore = songScore?.score ?? 0;
       intendedCompletion = songScore == null ? 0.0 : ((songScore.tallies.sick + songScore.tallies.good) / songScore.tallies.totalNotes);
-      rememberedDifficulty = suffixedDifficulty;
     }
     else
     {
       intendedScore = 0;
       intendedCompletion = 0.0;
-      rememberedDifficulty = currentDifficulty;
     }
+    rememberedDifficulty = currentDifficulty;
 
     if (intendedCompletion == Math.POSITIVE_INFINITY || intendedCompletion == Math.NEGATIVE_INFINITY || Math.isNaN(intendedCompletion))
     {


### PR DESCRIPTION
<!-- Please check for duplicates or similar PRs before submitting this PR. -->
## Does this PR close any issues? If so, link them below.

Nope.

## Briefly describe the issue(s) fixed.

In the `changeDiff` method of `FreeplayState`, when the current song isn't "Random", `rememberedDifficulty` gets assigned to the suffixed version of  `currentDifficulty` instead of `currentDifficulty` itself. Later, when `generateSongList` gets called, `currentDifficulty` gets assigned to `rememberedDifficulty`, which means `currentDifficulty` changed to its suffixed version.

Because difficulty selection in freeplay doesn't use the suffixed versions of the difficulties, adding the suffix creates some bugs. From my testing (which I recorded a video of), I found that the bugs prevent freeplay from selecting custom difficulties on variations other than "default" and "erect", and even make freeplay display the remembered song incorrectly when coming back from another state. I'm using the term "custom difficulties" because the `pico` and `bf` variations are somehow not affected by any of this. Nevertheless, the fix I have here prevents `rememberedDifficulty` from getting assigned to the suffixed version of  `currentDifficulty` in the `changeDiff` method and fixes all of the problems without affecting the `pico` and `bf` variations.

## Include any relevant screenshots or videos.

# Before

https://github.com/user-attachments/assets/062fe911-1768-4d77-95ef-f180d7572a81

# After

As you can see at the end of the video, the `bf` variation in "Darnell (BF Mix)" doesn't get affected by this fix, and is still selectable. I also checked this in the pico remixes and everything there works the same.

https://github.com/user-attachments/assets/9f992f20-5f2b-4c6e-8e55-0a93804d4f33