### PR TITLE
[ENHANCEMENT] Add `flipX` and `flipY` to Stage Props

### DIFF
--- a/source/funkin/data/stage/StageData.hx
+++ b/source/funkin/data/stage/StageData.hx
@@ -119,6 +119,22 @@ typedef StageDataProp =
   var isPixel:Bool;
 
   /**
+   * If set to true, the prop will be flipped horizontally.
+   * @default false
+   */
+  @:optional
+  @:default(false)
+  var flipX:Bool;
+
+  /**
+   * If set to true, the prop will be flipped vertically.
+   * @default false
+   */
+  @:optional
+  @:default(false)
+  var flipY:Bool;
+
+  /**
    * Either the scale of the prop as a float, or the [w, h] scale as an array of two floats.
    * Pro tip: On pixel-art levels, save the sprite small and set this value to 6 or so to save memory.
    */

--- a/source/funkin/play/stage/Stage.hx
+++ b/source/funkin/play/stage/Stage.hx
@@ -258,6 +258,9 @@ class Stage extends FlxSpriteGroup implements IPlayStateScriptedClass implements
 
       propSprite.zIndex = dataProp.zIndex;
 
+      propSprite.flipX = dataProp.flipX;
+      propSprite.flipY = dataProp.flipY;
+
       switch (dataProp.animType)
       {
         case 'packer':


### PR DESCRIPTION
Closes #3466

This is a simple PR that adds `flipX` and `flipY` as valid parameters in the stage data. This should be relatively self-explanatory.
![Screenshot 2024-09-27 at 3 51 05 PM](https://github.com/user-attachments/assets/69a766fc-88ad-485e-9355-76ae2486a3a1)
![Screenshot 2024-09-27 at 3 51 43 PM](https://github.com/user-attachments/assets/176115a9-803c-41ad-885a-94a3c3e4a778)


Below is a screenshot showcasing an example!
![screenshot-2024-09-27-15-49-26](https://github.com/user-attachments/assets/6e08bcd6-9843-4212-937b-76aad95e1593)
