### PR TITLE
Fix silly little typo in Preferences and Save

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -6,41 +6,45 @@ body:
   - type: checkboxes
     attributes:
       label: Issue Checklist
+      description: Be sure to complete these steps to increase the chances of your issue being addressed!
       options:
-        - label: I have properly named the issue
-        - label: I have checked the issues/discussions pages to see if the issue has been previously reported
+        - label: I have properly named my issue
+        - label: I have checked the Issues/Discussions pages to see if my issue has already been reported
 
   - type: dropdown
     attributes:
-      label: What platform are you using?
+      label: Platform
+      description: Which platform are you playing on?
       options:
-        - Newgrounds (Web)
-        - Itch.io (Web)
+        - Newgrounds (Web/HTML5)
+        - Itch.io (Web/HTML5)
         - Itch.io (Downloadable Build) - Windows
         - Itch.io (Downloadable Build) - MacOS
         - Itch.io (Downloadable Build) - Linux
+        - Compiled from GitHub Source Code
     validations:
       required: true
 
   - type: dropdown
     attributes:
-      label: If you are playing on a browser, which one are you using?
+      label: Browser
+      description: (Web/HTML5 users only) Which browser are you playing on?
       options:
         - Google Chrome
         - Microsoft Edge
         - Firefox
         - Opera
         - Safari
-        - Other (Specify below)
+        - Other (Specify in Description field)
 
   - type: input
     attributes:
       label: Version
-      description: What version are you using?
-      placeholder: ex. 0.4.1
+      description: Which version are you playing on? The game version is in the bottom left corner of the main menu. 
+      placeholder: ex. 0.5.0
     validations:
       required: true
-
+  
   - type: markdown
     attributes:
       value: "## Describe your bug."
@@ -49,14 +53,16 @@ body:
     attributes:
       value: "### Please do not report issues from other engines. These must be reported in their respective repositories."
 
-  - type: markdown
-    attributes:
-      value: "#### Provide as many details as you can."
-
   - type: textarea
     attributes:
-      label: Context (Provide images, videos, etc.)
-
+      label: Description (include any images, videos, errors, or crash logs)
+      description: Provide as much detail as you can. The better others understand your issue, the more they can help you!  
+      placeholder: Describe your issue here...
+    validations:
+      required: true
+      
   - type: textarea
     attributes:
-      label: Steps to reproduce (or crash logs, errors, etc.)
+      label: Steps to Reproduce
+      description: What steps can other people take to reliably encounter this issue?
+      placeholder: 1. Open the game...

--- a/.github/ISSUE_TEMPLATE/crash.yml
+++ b/.github/ISSUE_TEMPLATE/crash.yml
@@ -6,65 +6,73 @@ body:
   - type: checkboxes
     attributes:
       label: Issue Checklist
+      description: Be sure to complete these steps to increase the chances of your issue being addressed!
       options:
-        - label: I have properly named the issue
-        - label: I have checked the issues/discussions pages to see if the issue has been previously reported
+        - label: I have properly named my issue
+        - label: I have checked the Issues/Discussions pages to see if my issue has already been reported
 
   - type: dropdown
     attributes:
-      label: What platform are you using?
+      label: Platform
+      description: Which platform are you playing on?
       options:
-        - Newgrounds (Web)
-        - Itch.io (Web)
+        - Newgrounds (Web/HTML5)
+        - Itch.io (Web/HTML5)
         - Itch.io (Downloadable Build) - Windows
         - Itch.io (Downloadable Build) - MacOS
         - Itch.io (Downloadable Build) - Linux
+        - Compiled from GitHub Source Code
     validations:
       required: true
 
   - type: dropdown
     attributes:
-      label: If you are playing on a browser, which one are you using?
+      label: Browser
+      description: (Web/HTML5 users only) Which browser are you playing on?
       options:
         - Google Chrome
         - Microsoft Edge
         - Firefox
         - Opera
         - Safari
-        - Other (Specify below)
+        - Other (Specify in Description field)
 
   - type: input
     attributes:
       label: Version
-      description: What version are you using?
-      placeholder: ex. 0.4.1
+      description: Which version are you playing on? The game version is in the bottom left corner of the main menu. 
+      placeholder: ex. 0.5.0
     validations:
       required: true
 
   - type: markdown
     attributes:
-      value: "## Describe your issue."
+      value: "## Describe the crash."
 
   - type: markdown
     attributes:
       value: "### Please do not report issues from other engines. These must be reported in their respective repositories."
 
-  - type: markdown
-    attributes:
-      value: "#### Provide as many details as you can."
-
   - type: textarea
     attributes:
-      label: Context (Provide screenshots or videos of the crash happening)
-
-  - type: textarea
-    attributes:
-      label: Steps to reproduce
+      label: Description
+      description: Include screenshots or videos of the crash happening. Provide as much detail as you can. 
+      placeholder: Describe the crash here...
     validations:
       required: true
 
   - type: textarea
     attributes:
-      label: Crash logs (can be found in the logs folder where Funkin.exe is)
+      label: Steps to Reproduce
+      description: What steps can other people take to reliably trigger this crash?
+      placeholder: 1. Open the game...
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Crash logs
+      description: These can be found in the logs folder where Funkin.exe is.
+      placeholder: Upload your logs here...
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/enhancement.yml
+++ b/.github/ISSUE_TEMPLATE/enhancement.yml
@@ -6,10 +6,13 @@ body:
   - type: checkboxes
     attributes:
       label: Issue Checklist
+      description: Be sure to complete these steps to increase the chances of your suggestion being considered!
       options:
-        - label: I have properly named the enhancement
-        - label: I have checked the issues/discussions pages to see if the enhancement has been previously suggested
+        - label: I have properly named my enhancement
+        - label: I have checked the Issues/Discussions pages to see if my enhancement has already been suggested
 
   - type: textarea
     attributes:
       label: What is your suggestion, and why should it be implemented?
+    validations:
+      required: true

--- a/source/funkin/Preferences.hx
+++ b/source/funkin/Preferences.hx
@@ -37,7 +37,7 @@ class Preferences
   }
 
   /**
-   * Whether some particularly fowl language is displayed.
+   * Whether some particularly foul language is displayed.
    * @default `true`
    */
   public static var naughtyness(get, set):Bool;

--- a/source/funkin/save/Save.hx
+++ b/source/funkin/save/Save.hx
@@ -1152,7 +1152,7 @@ typedef SaveDataOptions =
   var framerate:Int;
 
   /**
-   * Whether some particularly fowl language is displayed.
+   * Whether some particularly foul language is displayed.
    * @default `true`
    */
   var naughtyness:Bool;
@@ -1188,20 +1188,20 @@ typedef SaveDataOptions =
   var autoPause:Bool;
 
   /**
-   * Offset the users inputs by this many ms.
+   * Offset the user's inputs by this many ms.
    * @default `0`
    */
   var inputOffset:Int;
 
   /**
-   * Affects the delay between the audio and the visuals during gameplay
+   * Affects the delay between the audio and the visuals during gameplay.
    * @default `0`
    */
   var audioVisualOffset:Int;
 
   /**
    * If we want the framerate to be unlocked on HTML5.
-   * @default `false
+   * @default `false`
    */
   var unlockedFramerate:Bool;
 


### PR DESCRIPTION
I came across an instance of [fowl](https://github.com/user-attachments/assets/2fe6fb8f-c2ec-485f-a97e-d02441215012) in the phrase "foul language" so I changed both instances to the correct spelling.

I also fixed a few other lines that caught my eye in Save.hx to make things more consistent.