### PR TITLE
Fix Pico's songs not appearing on Freeplay

### DIFF
--- a/source/funkin/play/song/Song.hx
+++ b/source/funkin/play/song/Song.hx
@@ -98,7 +98,7 @@ class Song implements IPlayStateScriptedClass implements IRegistryEntry<SongMeta
   }
 
   // this returns false so that any new song can override this and return true when needed
-  public function isSongNew(currentDifficulty:String):Bool
+  public function isSongNew(currentDifficulty:String, currentVariation:String):Bool
   {
     return false;
   }
@@ -434,17 +434,25 @@ class Song implements IPlayStateScriptedClass implements IRegistryEntry<SongMeta
     return null;
   }
 
+  /**
+   * Returns the first valid variation that matches both the difficulty id, and the current character / possible input variations
+   * @param diffId
+   * @param currentCharacter
+   * @param possibleVariations
+   * @return Null<String>
+   */
   public function getFirstValidVariation(?diffId:String, ?currentCharacter:PlayableCharacter, ?possibleVariations:Array<String>):Null<String>
   {
     if (possibleVariations == null)
     {
       possibleVariations = getVariationsByCharacter(currentCharacter);
     }
+
     if (diffId == null) diffId = listDifficulties(null, possibleVariations)[0];
 
     for (variationId in possibleVariations)
     {
-      if (difficulties.exists('$variationId')) return variationId;
+      if (difficulties.get('$variationId')?.exists(diffId) ?? false) return variationId;
     }
 
     return null;

--- a/source/funkin/play/song/Song.hx
+++ b/source/funkin/play/song/Song.hx
@@ -15,6 +15,7 @@ import funkin.data.song.SongRegistry;
 import funkin.modding.IScriptedClass.IPlayStateScriptedClass;
 import funkin.modding.events.ScriptEvent;
 import funkin.ui.freeplay.charselect.PlayableCharacter;
+import funkin.data.freeplay.player.PlayerRegistry;
 import funkin.util.SortUtil;
 
 /**
@@ -79,7 +80,12 @@ class Song implements IPlayStateScriptedClass implements IRegistryEntry<SongMeta
 
   // key = variation id, value = metadata
   final _metadata:Map<String, SongMetadata>;
-  final difficulties:Map<String, SongDifficulty>;
+
+  /**
+   * holds the difficulties (as in SongDifficulty) for each variation
+   * difficulties.get('default').get('easy') would return the easy difficulty for the default variation
+   */
+  final difficulties:Map<String, Map<String, SongDifficulty>>;
 
   /**
    * The list of variations a song has.
@@ -146,7 +152,7 @@ class Song implements IPlayStateScriptedClass implements IRegistryEntry<SongMeta
   {
     this.id = id;
 
-    difficulties = new Map<String, SongDifficulty>();
+    difficulties = new Map<String, Map<String, SongDifficulty>>();
 
     _data = _fetchData(id);
 
@@ -156,7 +162,8 @@ class Song implements IPlayStateScriptedClass implements IRegistryEntry<SongMeta
     {
       for (vari in _data.playData.songVariations)
       {
-        if (!validateVariationId(vari)) {
+        if (!validateVariationId(vari))
+        {
           trace('  [WARN] Variation id "$vari" is invalid, skipping...');
           continue;
         }
@@ -249,20 +256,37 @@ class Song implements IPlayStateScriptedClass implements IRegistryEntry<SongMeta
    * List the album IDs for each variation of the song.
    * @return A map of variation IDs to album IDs.
    */
-  public function listAlbums():Map<String, String>
+  public function listAlbums(variation:String):Map<String, String>
   {
     var result:Map<String, String> = new Map<String, String>();
 
-    for (difficultyId in difficulties.keys())
+    for (variationMap in difficulties)
     {
-      var meta:Null<SongDifficulty> = difficulties.get(difficultyId);
-      if (meta != null && meta.album != null)
+      for (difficultyId in variationMap.keys())
       {
-        result.set(difficultyId, meta.album);
+        var meta:Null<SongDifficulty> = variationMap.get(difficultyId);
+        if (meta != null && meta.album != null)
+        {
+          result.set(difficultyId, meta.album);
+        }
       }
     }
 
     return result;
+  }
+
+  /**
+   * Input a difficulty ID and a variation ID, and get the album ID.
+   * @param diffId
+   * @param variation
+   * @return String
+   */
+  public function getAlbumId(diffId:String, variation:String):String
+  {
+    var diff:Null<SongDifficulty> = getDifficulty(diffId, variation);
+    if (diff == null) return '';
+
+    return diff.album ?? '';
   }
 
   /**
@@ -284,6 +308,9 @@ class Song implements IPlayStateScriptedClass implements IRegistryEntry<SongMeta
         trace('[SONG] Warning: Song $id (variation ${metadata.variation}) has no difficulties listed in metadata!');
         continue;
       }
+
+      // This resides within difficulties
+      var difficultyMap:Map<String, SongDifficulty> = new Map<String, SongDifficulty>();
 
       // There may be more difficulties in the chart file than in the metadata,
       // (i.e. non-playable charts like the one used for Pico on the speaker in Stress)
@@ -309,10 +336,9 @@ class Song implements IPlayStateScriptedClass implements IRegistryEntry<SongMeta
         difficulty.noteStyle = metadata.playData.noteStyle;
 
         difficulty.characters = metadata.playData.characters;
-
-        var variationSuffix = (metadata.variation != Constants.DEFAULT_VARIATION) ? '-${metadata.variation}' : '';
-        difficulties.set('$diffId$variationSuffix', difficulty);
+        difficultyMap.set(diffId, difficulty);
       }
+      difficulties.set(metadata.variation, difficultyMap);
     }
   }
 
@@ -345,15 +371,18 @@ class Song implements IPlayStateScriptedClass implements IRegistryEntry<SongMeta
 
     for (diffId in chartNotes.keys())
     {
-      // Retrieve the cached difficulty data.
-      var variationSuffix = (variation != Constants.DEFAULT_VARIATION) ? '-$variation' : '';
-      var difficulty:Null<SongDifficulty> = difficulties.get('$diffId$variationSuffix');
-      if (difficulty == null)
+      // Retrieve the cached difficulty data. This one could potentially be null.
+      var nullDiff:Null<SongDifficulty> = getDifficulty(diffId, variation);
+
+      // if the difficulty doesn't exist, create a new one, and then proceed to fill it with data.
+      // I mostly do this since I don't wanna throw around ? everywhere for null check lol?
+      var difficulty:SongDifficulty = nullDiff ?? new SongDifficulty(this, diffId, variation);
+
+      if (nullDiff == null)
       {
         trace('Fabricated new difficulty for $diffId.');
-        difficulty = new SongDifficulty(this, diffId, variation);
         var metadata = _metadata.get(variation);
-        difficulties.set('$diffId$variationSuffix', difficulty);
+        difficulties.get(variation)?.set(diffId, difficulty);
 
         if (metadata != null)
         {
@@ -396,11 +425,9 @@ class Song implements IPlayStateScriptedClass implements IRegistryEntry<SongMeta
 
     for (currentVariation in variations)
     {
-      var variationSuffix = (currentVariation != Constants.DEFAULT_VARIATION) ? '-$currentVariation' : '';
-
-      if (difficulties.exists('$diffId$variationSuffix'))
+      if (difficulties.get(currentVariation)?.exists(diffId) ?? false)
       {
-        return difficulties.get('$diffId$variationSuffix');
+        return difficulties.get(currentVariation)?.get(diffId);
       }
     }
 
@@ -417,8 +444,7 @@ class Song implements IPlayStateScriptedClass implements IRegistryEntry<SongMeta
 
     for (variationId in possibleVariations)
     {
-      var variationSuffix = (variationId != Constants.DEFAULT_VARIATION) ? '-$variationId' : '';
-      if (difficulties.exists('$diffId$variationSuffix')) return variationId;
+      if (difficulties.exists('$variationId')) return variationId;
     }
 
     return null;
@@ -440,7 +466,6 @@ class Song implements IPlayStateScriptedClass implements IRegistryEntry<SongMeta
     }
 
     var result = [];
-    trace('Evaluating variations for ${this.id} ${char.id}: ${this.variations}');
     for (variation in variations)
     {
       var metadata = _metadata.get(variation);
@@ -457,6 +482,19 @@ class Song implements IPlayStateScriptedClass implements IRegistryEntry<SongMeta
     result.sort(SortUtil.defaultsThenAlphabetically.bind(Constants.DEFAULT_VARIATION_LIST));
 
     return result;
+  }
+
+  /**
+   * Nearly the same thing as getVariationsByCharacter, but takes a character ID instead.
+   * @param charId
+   * @return Array<String>
+   * @see getVariationsByCharacter
+   */
+  public function getVariationsByCharacterId(?charId:String):Array<String>
+  {
+    var charPlayer = PlayerRegistry.instance.fetchEntry(charId ?? '');
+
+    return getVariationsByCharacter(charPlayer);
   }
 
   /**
@@ -501,6 +539,7 @@ class Song implements IPlayStateScriptedClass implements IRegistryEntry<SongMeta
   /**
    * TODO: This line of code makes me sad, but you can't really fix it without a breaking migration.
    * @return `easy`, `erect`, `normal-pico`, etc.
+   * @deprecated This function is deprecated, Funkin no longer uses suffixed difficulties.
    */
   public function listSuffixedDifficulties(variationIds:Array<String>, ?showLocked:Bool, ?showHidden:Bool):Array<String>
   {
@@ -529,8 +568,7 @@ class Song implements IPlayStateScriptedClass implements IRegistryEntry<SongMeta
 
     for (targetVariation in variationIds)
     {
-      var variationSuffix = (targetVariation != Constants.DEFAULT_VARIATION) ? '-$targetVariation' : '';
-      if (difficulties.exists('$diffId$variationSuffix')) return true;
+      if (difficulties.get(targetVariation)?.exists(diffId) ?? false) return true;
     }
     return false;
   }
@@ -565,13 +603,16 @@ class Song implements IPlayStateScriptedClass implements IRegistryEntry<SongMeta
   }
 
   /**
-   * Purge the cached chart data for each difficulty of this song.
+   * Purge the cached chart data for each difficulty/variation of this song.
    */
   public function clearCharts():Void
   {
-    for (diff in difficulties)
+    for (variationMap in difficulties)
     {
-      diff.clearChart();
+      for (diff in variationMap)
+      {
+        diff.clearChart();
+      }
     }
   }
 
@@ -647,7 +688,8 @@ class Song implements IPlayStateScriptedClass implements IRegistryEntry<SongMeta
    * Auto-accept if it's one of the base game default variations.
    * Reject if the ID starts with a number, or contains invalid characters.
    */
-  static function validateVariationId(variation:String):Bool {
+  static function validateVariationId(variation:String):Bool
+  {
     if (Constants.DEFAULT_VARIATION_LIST.contains(variation)) return true;
 
     return VARIATION_REGEX.match(variation);

--- a/source/funkin/save/Save.hx
+++ b/source/funkin/save/Save.hx
@@ -678,18 +678,31 @@ class Save
 
   /**
    * Has the provided song been beaten on one of the listed difficulties?
+   * Note: This function can still take in the 'difficulty-variation' format for the difficultyList parameter
+   * as it is used in the old save data format. However inputting a variation will append it to the difficulty
+   * so you can do `hasBeatenSong('dadbattle', ['easy-pico'])` to check if you've beaten the Pico mix on easy.
+   * or you can do `hasBeatenSong('dadbattle', ['easy'], 'pico')` to check if you've beaten the Pico mix on easy.
+   * however you should not mix the two as it will append '-pico' to the 'easy-pico' if it's inputted into the array.
    * @param songId The song ID to check.
    * @param difficultyList The difficulties to check. Defaults to `easy`, `normal`, and `hard`.
+   * @param variation The variation to check. Defaults to empty string. Appended to difficulty list with `-`, e.g. `easy-pico`.
+   *                  This is our old format for getting difficulty/variation information, however we don't want to mess around with
+   *                  save migration just yet.
    * @return Whether the song has been beaten on any of the listed difficulties.
    */
-  public function hasBeatenSong(songId:String, ?difficultyList:Array<String>):Bool
+  public function hasBeatenSong(songId:String, ?difficultyList:Array<String>, ?variation:String):Bool
   {
     if (difficultyList == null)
     {
       difficultyList = ['easy', 'normal', 'hard'];
     }
+
+    if (variation == null) variation = '';
+
     for (difficulty in difficultyList)
     {
+      if (variation != '') difficulty = '${difficulty}-${variation}';
+
       var score:Null<SaveScoreData> = getSongScore(songId, difficulty);
       if (score != null)
       {

--- a/source/funkin/save/Save.hx
+++ b/source/funkin/save/Save.hx
@@ -543,22 +543,34 @@ class Save
    *
    * @param songId The ID of the song.
    * @param difficultyId The difficulty to check.
+   * @param variation The variation to check. Defaults to empty string. Appended to difficulty with `-`, e.g. `easy-pico`.
    * @return A data structure containing score, judgement counts, and accuracy. Returns `null` if no score is saved.
    */
-  public function getSongScore(songId:String, difficultyId:String = 'normal'):Null<SaveScoreData>
+  public function getSongScore(songId:String, difficultyId:String = 'normal', ?variation:String):Null<SaveScoreData>
   {
     var song = data.scores.songs.get(songId);
+    trace('Getting song score for $songId $difficultyId $variation');
     if (song == null)
     {
+      trace('Could not find song data for $songId $difficultyId $variation');
       song = [];
       data.scores.songs.set(songId, song);
     }
+
+    // 'default' variations are left with no suffix ('easy', 'normal', 'hard'),
+    // along with 'erect' variations ('erect', 'nightmare')
+    // otherwise, we want to add a suffix of our current variation to get the save data.
+    if (variation != null && variation != '' && variation != 'default' && variation != 'erect')
+    {
+      difficultyId = '${difficultyId}-${variation}';
+    }
+
     return song.get(difficultyId);
   }
 
-  public function getSongRank(songId:String, difficultyId:String = 'normal'):Null<ScoringRank>
+  public function getSongRank(songId:String, difficultyId:String = 'normal', ?variation:String):Null<ScoringRank>
   {
-    return Scoring.calculateRank(getSongScore(songId, difficultyId));
+    return Scoring.calculateRank(getSongScore(songId, difficultyId, variation));
   }
 
   /**

--- a/source/funkin/ui/freeplay/FreeplayState.hx
+++ b/source/funkin/ui/freeplay/FreeplayState.hx
@@ -270,6 +270,13 @@ class FreeplayState extends MusicBeatSubState
 
     fromResultsParams = params?.fromResults;
 
+    // bf songs have no suffix, but we need to initalize the difficulty
+    // in case we begin playing as pico
+    if (currentCharacterId != 'bf')
+    {
+      currentSuffixedDifficulty = Constants.DEFAULT_DIFFICULTY + '-$currentCharacterId';
+    }
+
     if (fromResultsParams?.playRankAnim == true)
     {
       prepForNewRank = true;
@@ -783,7 +790,7 @@ class FreeplayState extends MusicBeatSubState
     {
       tempSongs = tempSongs.filter(song -> {
         if (song == null) return true; // Random
-        return song.suffixedSongDifficulties.contains(currentSuffixedDifficulty);
+        return (song.suffixedSongDifficulties.contains(currentSuffixedDifficulty) || song.songCharacter == currentCharacterId);
       });
     }
 
@@ -1797,6 +1804,7 @@ class FreeplayState extends MusicBeatSubState
     currentSuffixedDifficulty = suffixedDiffIdsCurrent[currentDifficultyIndex];
 
     trace('Switching to difficulty: ${currentSuffixedDifficulty}');
+    trace(suffixedDiffIdsCurrent);
 
     var daSong:Null<FreeplaySongData> = grpCapsules.members[curSelected].songData;
     if (daSong != null)
@@ -2382,6 +2390,7 @@ class FreeplaySongData
     this.isFav = Save.instance.isSongFavorited(songId);
 
     this.currentCharacter = currentCharacter;
+
     if (displayedVariations != null) this.displayedVariations = displayedVariations;
 
     updateValues(displayedVariations);
@@ -2407,6 +2416,7 @@ class FreeplaySongData
 
   function updateValues(variations:Array<String>):Void
   {
+    trace('variations: ${variations}');
     this.songDifficulties = song.listDifficulties(null, variations, false, false);
     this.suffixedSongDifficulties = song.listSuffixedDifficulties(variations, false, false);
     if (!this.songDifficulties.contains(currentUnsuffixedDifficulty))

--- a/source/funkin/ui/freeplay/FreeplayState.hx
+++ b/source/funkin/ui/freeplay/FreeplayState.hx
@@ -59,49 +59,6 @@ import funkin.api.discord.DiscordClient;
 #end
 
 /**
- * Parameters used to initialize the FreeplayState.
- */
-typedef FreeplayStateParams =
-{
-  ?character:String,
-
-  ?fromCharSelect:Bool,
-
-  ?fromResults:FromResultsParams,
-};
-
-/**
- * A set of parameters for transitioning to the FreeplayState from the ResultsState.
- */
-typedef FromResultsParams =
-{
-  /**
-   * The previous rank the song hand, if any. Null if it had no score before.
-   */
-  var ?oldRank:ScoringRank;
-
-  /**
-   * Whether or not to play the rank animation on returning to freeplay.
-   */
-  var playRankAnim:Bool;
-
-  /**
-   * The new rank the song has.
-   */
-  var newRank:ScoringRank;
-
-  /**
-   * The song ID to play the animation on.
-   */
-  var songId:String;
-
-  /**
-   * The difficulty ID to play the animation on.
-   */
-  var difficultyId:String;
-};
-
-/**
  * The state for the freeplay menu, allowing the player to select any song to play.
  */
 @:nullSafety
@@ -147,37 +104,17 @@ class FreeplayState extends MusicBeatSubState
 
   var songs:Array<Null<FreeplaySongData>> = [];
 
-  // List of available difficulties for the current song, without `-variation` at the end (no duplicates or nulls).
-  var diffIdsCurrent:Array<String> = [];
-  // List of available difficulties for the total song list, without `-variation` at the end (no duplicates or nulls).
-  var diffIdsTotal:Array<String> = [];
-  // List of available difficulties for the current song, with `-variation` at the end (no duplicates or nulls).
-  var suffixedDiffIdsCurrent:Array<String> = [];
-  // List of available difficulties for the total song list, with `-variation` at the end (no duplicates or nulls).
-  var suffixedDiffIdsTotal:Array<String> = [];
-
   var curSelected:Int = 0;
-  var currentSuffixedDifficulty:String = Constants.DEFAULT_DIFFICULTY;
-  var currentUnsuffixedDifficulty(get, never):String;
 
-  function get_currentUnsuffixedDifficulty():String
-  {
-    if (Constants.DEFAULT_DIFFICULTY_LIST_FULL.contains(currentSuffixedDifficulty)) return currentSuffixedDifficulty;
+  /**
+   * Currently selected difficulty, in string form.
+   */
+  var currentDifficulty:String = Constants.DEFAULT_DIFFICULTY;
 
-    // Else, we need to strip the suffix.
-    return currentSuffixedDifficulty.substring(0, currentSuffixedDifficulty.lastIndexOf('-'));
-  }
-
-  var currentVariation(get, never):String;
-
-  function get_currentVariation():String
-  {
-    if (Constants.DEFAULT_DIFFICULTY_LIST.contains(currentSuffixedDifficulty)) return Constants.DEFAULT_VARIATION;
-    if (Constants.DEFAULT_DIFFICULTY_LIST_ERECT.contains(currentSuffixedDifficulty)) return 'erect';
-
-    // Else, we need to isolate the suffix.
-    return currentSuffixedDifficulty.substring(currentSuffixedDifficulty.lastIndexOf('-') + 1, currentSuffixedDifficulty.length);
-  }
+  /**
+   *  Current variation: default, erect, pico, bf, etc.
+   */
+  var currentVariation:String = Constants.DEFAULT_VARIATION;
 
   public var fp:FreeplayScore;
 
@@ -234,6 +171,11 @@ class FreeplayState extends MusicBeatSubState
    */
   public static var rememberedCharacterId:String = Constants.DEFAULT_CHARACTER;
 
+  /**
+   * The remembered variation we were on when this menu was last accessed.
+   */
+  public static var rememberedVariation:String = Constants.DEFAULT_VARIATION;
+
   var funnyCam:FunkinCamera;
   var rankCamera:FunkinCamera;
   var rankBg:FunkinSprite;
@@ -241,53 +183,43 @@ class FreeplayState extends MusicBeatSubState
 
   var backingCard:Null<BackingCard> = null;
 
+  /**
+   * The backing card that has the toned dots, right now we just use that one dad graphic dave cooked up
+   */
   public var bgDad:FlxSprite;
 
+  public var angleMaskShader:AngleMask = new AngleMask();
+
+  var fadeShader:BlueFade = new BlueFade();
+
   var fromResultsParams:Null<FromResultsParams> = null;
-
   var prepForNewRank:Bool = false;
-
   var styleData:Null<FreeplayStyle> = null;
-
-  var fromCharSelect:Null<Bool> = null;
+  var fromCharSelect:Bool = false;
 
   public function new(?params:FreeplayStateParams, ?stickers:StickerSubState)
   {
     currentCharacterId = params?.character ?? rememberedCharacterId;
     styleData = FreeplayStyleRegistry.instance.fetchEntry(currentCharacterId);
+
     var fetchPlayableCharacter = function():PlayableCharacter {
       var targetCharId = params?.character ?? rememberedCharacterId;
       var result = PlayerRegistry.instance.fetchEntry(targetCharId);
       if (result == null) throw 'No valid playable character with id ${targetCharId}';
       return result;
     };
-    currentCharacter = fetchPlayableCharacter();
 
+    currentCharacter = fetchPlayableCharacter();
+    currentVariation = rememberedVariation;
     styleData = FreeplayStyleRegistry.instance.fetchEntry(currentCharacter.getFreeplayStyleID());
     rememberedCharacterId = currentCharacter?.id ?? Constants.DEFAULT_CHARACTER;
-
-    fromCharSelect = params?.fromCharSelect;
-
+    fromCharSelect = params?.fromCharSelect ?? false;
     fromResultsParams = params?.fromResults;
-
-    // bf songs have no suffix, but we need to initalize the difficulty
-    // in case we begin playing as pico
-    if (currentCharacterId != 'bf')
-    {
-      currentSuffixedDifficulty = Constants.DEFAULT_DIFFICULTY + '-$currentCharacterId';
-    }
-
-    if (fromResultsParams?.playRankAnim == true)
-    {
-      prepForNewRank = true;
-    }
+    prepForNewRank = fromResultsParams?.playRankAnim ?? false;
 
     super(FlxColor.TRANSPARENT);
 
-    if (stickers?.members != null)
-    {
-      stickerSubState = stickers;
-    }
+    if (stickers?.members != null) stickerSubState = stickers;
 
     switch (currentCharacterId)
     {
@@ -322,16 +254,11 @@ class FreeplayState extends MusicBeatSubState
     bgDad = new FlxSprite(backingCard.pinkBack.width * 0.74, 0).loadGraphic(styleData == null ? 'freeplay/freeplayBGdad' : styleData.getBgAssetGraphic());
   }
 
-  var fadeShader:BlueFade = new BlueFade();
-
-  public var angleMaskShader:AngleMask = new AngleMask();
-
   override function create():Void
   {
     super.create();
 
     FlxG.state.persistentUpdate = false;
-
     FlxTransitionableState.skipNextTransIn = true;
 
     var fadeShaderFilter:ShaderFilter = new ShaderFilter(fadeShader);
@@ -384,23 +311,7 @@ class FreeplayState extends MusicBeatSubState
           continue;
         }
 
-        // Only display songs which actually have available difficulties for the current character.
-        var displayedVariations = song.getVariationsByCharacter(currentCharacter);
-        trace('Displayed Variations (${songId}): $displayedVariations');
-        var availableDifficultiesForSong:Array<String> = song.listSuffixedDifficulties(displayedVariations, false, false);
-        var unsuffixedDifficulties = song.listDifficulties(displayedVariations, false, false);
-        trace('Available Difficulties: $availableDifficultiesForSong');
-        if (availableDifficultiesForSong.length == 0) continue;
-
-        songs.push(new FreeplaySongData(levelId, songId, song, currentCharacter, displayedVariations));
-        for (difficulty in unsuffixedDifficulties)
-        {
-          diffIdsTotal.pushUnique(difficulty);
-        }
-        for (difficulty in availableDifficultiesForSong)
-        {
-          suffixedDiffIdsTotal.pushUnique(difficulty);
-        }
+        songs.push(new FreeplaySongData(song, level));
       }
     }
 
@@ -493,21 +404,12 @@ class FreeplayState extends MusicBeatSubState
         wait: 0.1
       });
 
-    for (diffId in suffixedDiffIdsTotal)
+    for (diffId in Constants.DEFAULT_DIFFICULTY_LIST_FULL)
     {
       var diffSprite:DifficultySprite = new DifficultySprite(diffId);
       diffSprite.difficultyId = diffId;
+      diffSprite.visible = diffId == Constants.DEFAULT_DIFFICULTY;
       grpDifficulties.add(diffSprite);
-    }
-
-    grpDifficulties.group.forEach(function(spr) {
-      spr.visible = false;
-    });
-
-    for (diffSprite in grpDifficulties.group.members)
-    {
-      if (diffSprite == null) continue;
-      if (diffSprite.difficultyId == currentSuffixedDifficulty) diffSprite.visible = true;
     }
 
     albumRoll.albumId = null;
@@ -516,7 +418,7 @@ class FreeplayState extends MusicBeatSubState
     var overhangStuff:FlxSprite = new FlxSprite().makeGraphic(FlxG.width, 164, FlxColor.BLACK);
     overhangStuff.y -= overhangStuff.height;
 
-    if (fromCharSelect == true)
+    if (fromCharSelect)
     {
       blackOverlayBullshitLOLXD.x = 387.76;
       overhangStuff.y = -100;
@@ -602,6 +504,7 @@ class FreeplayState extends MusicBeatSubState
         wait: 0.1
       });
 
+    // Reminder, this is a callback function being set, rather than these being called here in create()
     letterSort.changeSelectionCallback = (str) -> {
       switch (str)
       {
@@ -650,7 +553,7 @@ class FreeplayState extends MusicBeatSubState
     add(fnfFreeplay);
     add(ostName);
 
-    if (PlayerRegistry.instance.hasNewCharacter() == true)
+    if (PlayerRegistry.instance.hasNewCharacter())
     {
       add(charSelectHint);
     }
@@ -663,10 +566,10 @@ class FreeplayState extends MusicBeatSubState
       // when boyfriend hits dat shiii
 
       albumRoll.playIntro();
-      var daSong = grpCapsules.members[curSelected].songData;
-      albumRoll.albumId = daSong?.albumId;
+      var daSong = grpCapsules.members[curSelected].freeplayData;
+      albumRoll.albumId = daSong?.data.getAlbumId(currentDifficulty, currentVariation);
 
-      if (fromCharSelect == null)
+      if (!fromCharSelect)
       {
         // render optimisation
         if (_parentState != null) _parentState.persistentDraw = false;
@@ -735,6 +638,7 @@ class FreeplayState extends MusicBeatSubState
       onDJIntroDone();
     }
 
+    // Generates song list with the starter params (who our current character is, last remembered difficulty, etc.)
     generateSongList(null, false);
 
     // dedicated camera for the state so we don't need to fuk around with camera scrolls from the mainmenu / elsewhere
@@ -762,7 +666,7 @@ class FreeplayState extends MusicBeatSubState
       rankCamera.fade(0xFF000000, 0, false, null, true);
     }
 
-    if (fromCharSelect == true)
+    if (fromCharSelect)
     {
       enterFromCharSel();
       onDJIntroDone();
@@ -773,7 +677,8 @@ class FreeplayState extends MusicBeatSubState
   var currentFilteredSongs:Array<Null<FreeplaySongData>> = [];
 
   /**
-   * Given the current filter, rebuild the current song list.
+   * Given the current filter, rebuild the current song list and display it.
+   * Automatically takes into account currentDifficulty, character, and variation
    *
    * @param filterStuff A filter to apply to the song list (regex, startswith, all, favorite)
    * @param force Whether the capsules should "jump" back in or not using their animation
@@ -785,27 +690,18 @@ class FreeplayState extends MusicBeatSubState
 
     if (filterStuff != null) tempSongs = sortSongs(tempSongs, filterStuff);
 
-    // Filter further by current selected difficulty.
-    if (currentSuffixedDifficulty != null)
-    {
-      tempSongs = tempSongs.filter(song -> {
-        if (song == null) return true; // Random
+    tempSongs = tempSongs.filter(song -> {
+      if (song == null) return true; // Random
 
-        // Check for character-specific difficulty first
-        var characterSuffixedDifficulty = '${currentUnsuffixedDifficulty}-${currentCharacterId}';
-        if (song.suffixedSongDifficulties.contains(characterSuffixedDifficulty))
-        {
-          return true;
-        }
+      // Available variations for current character. We get this since bf is usually `default` variation, and `pico` is `pico`
+      // but sometimes pico can be the default variation (weekend 1 songs), and bf can be `bf` variation (darnell)
+      var characterVariations:Array<String> = song.data.getVariationsByCharacter(currentCharacter);
 
-        // Include songs that match the current suffixed difficulty (`normal-pico`)
-        // or the current unsuffixed difficulty, `normal`
-        // or songs specifically for the current character `normal` w/ songCharacter == `pico`
-        return (song.suffixedSongDifficulties.contains(currentSuffixedDifficulty)
-          || song.songDifficulties.contains(currentUnsuffixedDifficulty)
-          || song.songCharacter == currentCharacterId);
-      });
-    }
+      // Gets all available difficulties for our character, via our available variations
+      var difficultiesAvailable:Array<String> = song.data.listDifficulties(null, characterVariations);
+
+      return difficultiesAvailable.contains(currentDifficulty);
+    });
 
     if (onlyIfChanged)
     {
@@ -814,28 +710,20 @@ class FreeplayState extends MusicBeatSubState
     }
 
     // Only now do we know that the filter is actually changing.
-
-    // If curSelected is 0, the result will be null and fall back to the rememberedSongId.
-    rememberedSongId = grpCapsules.members[curSelected]?.songData?.songId ?? rememberedSongId;
-
-    for (cap in grpCapsules.members)
-    {
-      cap.songText.resetText();
-      cap.kill();
-    }
-
     currentFilter = filterStuff;
 
     currentFilteredSongs = tempSongs;
     curSelected = 0;
 
-    var hsvShader:HSVShader = new HSVShader();
+    // If curSelected is 0, the result will be null and fall back to the rememberedSongId.
+    // We set this so if we change the filter, we'd remain on the same song if it's still in the list.
+    rememberedSongId = grpCapsules.members[curSelected]?.freeplayData?.data.id ?? rememberedSongId;
 
+    grpCapsules.killMembers();
+
+    // Initialize the random capsule, with empty/blank info (which we display once bf/pico does his hand)
     var randomCapsule:SongMenuItem = grpCapsules.recycle(SongMenuItem);
     randomCapsule.init(FlxG.width, 0, null, styleData);
-    randomCapsule.onConfirm = function() {
-      capsuleOnConfirmRandom(randomCapsule);
-    };
     randomCapsule.y = randomCapsule.intendedY(0) + 10;
     randomCapsule.targetPos.x = randomCapsule.x;
     randomCapsule.alpha = 0;
@@ -844,14 +732,15 @@ class FreeplayState extends MusicBeatSubState
     randomCapsule.favIconBlurred.visible = false;
     randomCapsule.ranking.visible = false;
     randomCapsule.blurredRanking.visible = false;
-    if (fromCharSelect == false)
-    {
-      randomCapsule.initJumpIn(0, force);
-    }
+    randomCapsule.onConfirm = function() {
+      capsuleOnConfirmRandom(randomCapsule);
+    };
+
+    if (fromCharSelect) randomCapsule.forcePosition();
     else
-    {
-      randomCapsule.forcePosition();
-    }
+      randomCapsule.initJumpIn(0, force);
+
+    var hsvShader:HSVShader = new HSVShader();
     randomCapsule.hsvShader = hsvShader;
     grpCapsules.add(randomCapsule);
 
@@ -870,13 +759,8 @@ class FreeplayState extends MusicBeatSubState
       funnyMenu.targetPos.x = funnyMenu.x;
       funnyMenu.ID = i;
       funnyMenu.capsule.alpha = 0.5;
-      funnyMenu.songText.visible = false;
-      funnyMenu.favIcon.visible = tempSong.isFav;
-      funnyMenu.favIconBlurred.visible = tempSong.isFav;
       funnyMenu.hsvShader = hsvShader;
-
       funnyMenu.newText.animation.curAnim.curFrame = 45 - ((i * 4) % 45);
-      funnyMenu.checkClip();
       funnyMenu.forcePosition();
 
       grpCapsules.add(funnyMenu);
@@ -885,9 +769,8 @@ class FreeplayState extends MusicBeatSubState
     FlxG.console.registerFunction('changeSelection', changeSelection);
 
     rememberSelection();
-
     changeSelection();
-    changeDiff(0, true);
+    refreshCapsuleDisplays();
   }
 
   /**
@@ -899,7 +782,7 @@ class FreeplayState extends MusicBeatSubState
   public function sortSongs(songsToFilter:Array<Null<FreeplaySongData>>, songFilter:SongFilter):Array<Null<FreeplaySongData>>
   {
     var filterAlphabetically = function(a:Null<FreeplaySongData>, b:Null<FreeplaySongData>):Int {
-      return SortUtil.alphabetically(a?.songName ?? '', b?.songName ?? '');
+      return SortUtil.alphabetically(a?.data.songName ?? '', b?.data.songName ?? '');
     };
 
     switch (songFilter.filterType)
@@ -911,9 +794,9 @@ class FreeplayState extends MusicBeatSubState
         // if filterData looks like "A-C", the regex should look something like this: ^[A-C].*
         // to get every song that starts between A and C
         var filterRegexp:EReg = new EReg('^[' + songFilter.filterData + '].*', 'i');
-        songsToFilter = songsToFilter.filter(str -> {
-          if (str == null) return true; // Random
-          return filterRegexp.match(str.songName);
+        songsToFilter = songsToFilter.filter(filteredSong -> {
+          if (filteredSong == null) return true; // Random
+          return filterRegexp.match(filteredSong.data.songName);
         });
 
         songsToFilter.sort(filterAlphabetically);
@@ -921,16 +804,16 @@ class FreeplayState extends MusicBeatSubState
       case STARTSWITH:
         // extra note: this is essentially a "search"
 
-        songsToFilter = songsToFilter.filter(str -> {
-          if (str == null) return true; // Random
-          return str.songName.toLowerCase().startsWith(songFilter.filterData ?? '');
+        songsToFilter = songsToFilter.filter(filteredSong -> {
+          if (filteredSong == null) return true; // Random
+          return filteredSong.data.songName.toLowerCase().startsWith(songFilter.filterData ?? '');
         });
       case ALL:
         // no filter!
       case FAVORITE:
-        songsToFilter = songsToFilter.filter(str -> {
-          if (str == null) return true; // Random
-          return str.isFav;
+        songsToFilter = songsToFilter.filter(filteredSong -> {
+          if (filteredSong == null) return true; // Random
+          return filteredSong.isFav;
         });
 
         songsToFilter.sort(filterAlphabetically);
@@ -1298,7 +1181,7 @@ class FreeplayState extends MusicBeatSubState
       }
     }
     fadeShader.fade(1.0, 0.0, 0.8, {ease: FlxEase.quadIn});
-    FlxG.sound.music.fadeOut(0.9, 0);
+    FlxG.sound.music?.fadeOut(0.9, 0);
     new FlxTimer().start(0.9, _ -> {
       FlxG.switchState(new funkin.ui.charSelect.CharSelectSubState());
     });
@@ -1461,7 +1344,7 @@ class FreeplayState extends MusicBeatSubState
 
     if (controls.FREEPLAY_FAVORITE && !busy)
     {
-      var targetSong = grpCapsules.members[curSelected]?.songData;
+      var targetSong = grpCapsules.members[curSelected]?.freeplayData;
       if (targetSong != null)
       {
         var realShit:Int = curSelected;
@@ -1504,7 +1387,6 @@ class FreeplayState extends MusicBeatSubState
           busy = true;
           grpCapsules.members[realShit].doLerp = false;
           FlxTween.tween(grpCapsules.members[realShit], {y: grpCapsules.members[realShit].y + 5}, 0.1, {ease: FlxEase.expoOut});
-
           FlxTween.tween(grpCapsules.members[realShit], {y: grpCapsules.members[realShit].y - 5}, 0.1,
             {
               ease: FlxEase.expoIn,
@@ -1792,74 +1674,72 @@ class FreeplayState extends MusicBeatSubState
   public override function destroy():Void
   {
     super.destroy();
-    var daSong:Null<FreeplaySongData> = currentFilteredSongs[curSelected];
-    if (daSong != null)
-    {
-      clearDaCache(daSong.songName);
-    }
-    // remove and destroy freeplay camera
     FlxG.cameras.remove(funnyCam);
   }
 
+  /**
+   * changeDiff is the root of both difficulty and variation changes/management.
+   * It will check the difficulty of the current variation, all available variations, and all available difficulties per variation.
+   * It's generally recommended that after calling this you re-sort the song list, however usually it's already on the way to being sorted.
+   * @param change
+   * @param force
+   */
   function changeDiff(change:Int = 0, force:Bool = false):Void
   {
     touchTimer = 0;
 
-    var currentDifficultyIndex:Int = suffixedDiffIdsCurrent.indexOf(currentSuffixedDifficulty);
+    // Available variations for current character. We get this since bf is usually `default` variation, and `pico` is `pico`
+    // but sometimes pico can be the default variation (weekend 1 songs), and bf can be `bf` variation (darnell)
+    var characterVariations:Array<String> = grpCapsules.members[curSelected].freeplayData?.data.getVariationsByCharacter(currentCharacter) ?? Constants.DEFAULT_VARIATION_LIST;
 
-    if (currentDifficultyIndex == -1) currentDifficultyIndex = suffixedDiffIdsCurrent.indexOf(Constants.DEFAULT_DIFFICULTY);
+    // Gets all available difficulties for our character, via our available variations
+    var difficultiesAvailable:Array<String> = grpCapsules.members[curSelected].freeplayData?.data.listDifficulties(null,
+      characterVariations) ?? Constants.DEFAULT_DIFFICULTY_LIST;
+
+    var currentDifficultyIndex:Int = difficultiesAvailable.indexOf(currentDifficulty);
+
+    if (currentDifficultyIndex == -1) currentDifficultyIndex = difficultiesAvailable.indexOf(Constants.DEFAULT_DIFFICULTY);
 
     currentDifficultyIndex += change;
 
-    if (currentDifficultyIndex < 0) currentDifficultyIndex = suffixedDiffIdsCurrent.length - 1;
-    if (currentDifficultyIndex >= suffixedDiffIdsCurrent.length) currentDifficultyIndex = 0;
+    if (currentDifficultyIndex < 0) currentDifficultyIndex = Std.int(difficultiesAvailable.length - 1);
+    if (currentDifficultyIndex >= difficultiesAvailable.length) currentDifficultyIndex = 0;
 
-    var newSuffixedDifficulty = suffixedDiffIdsCurrent[currentDifficultyIndex];
-
-    // Always try to use the character-specific difficulty
-    var characterSuffixedDifficulty = '${newSuffixedDifficulty}-${currentCharacterId}';
-    if (suffixedDiffIdsCurrent.contains(characterSuffixedDifficulty))
+    // Update the current difficulty
+    currentDifficulty = difficultiesAvailable[currentDifficultyIndex];
+    for (variation in characterVariations)
     {
-      newSuffixedDifficulty = characterSuffixedDifficulty;
+      if (grpCapsules.members[curSelected].freeplayData?.data.hasDifficulty(currentDifficulty, variation) ?? false)
+      {
+        currentVariation = variation;
+        rememberedVariation = variation;
+        break;
+      }
     }
 
-    currentSuffixedDifficulty = newSuffixedDifficulty;
+    trace('CURRENT VARIATION OF SONG: ${currentVariation}');
 
-    trace('Switching to difficulty: ${currentSuffixedDifficulty}');
-    trace(suffixedDiffIdsCurrent);
-
-    var daSong:Null<FreeplaySongData> = grpCapsules.members[curSelected].songData;
+    var daSong:Null<FreeplaySongData> = grpCapsules.members[curSelected].freeplayData;
     if (daSong != null)
     {
-      var targetSong:Null<Song> = SongRegistry.instance.fetchEntry(daSong.songId);
+      var targetSong:Null<Song> = SongRegistry.instance.fetchEntry(daSong.data.id);
       if (targetSong == null)
       {
-        FlxG.log.warn('WARN: could not find song with id (${daSong.songId})');
+        FlxG.log.warn('WARN: could not find song with id (${daSong.data.id})');
         return;
       }
 
-      var suffixedDifficulty = suffixedDiffIdsCurrent[currentDifficultyIndex];
-      var unsuffixedDifficulty = currentUnsuffixedDifficulty;
-
-      // Check for character-specific difficulty
-      var characterSuffixedDifficulty = '${unsuffixedDifficulty}-${currentCharacterId}';
-      if (daSong.suffixedSongDifficulties.contains(characterSuffixedDifficulty))
-      {
-        suffixedDifficulty = characterSuffixedDifficulty;
-      }
-
-      var songScore:Null<SaveScoreData> = Save.instance.getSongScore(daSong.songId, suffixedDifficulty);
-      trace(songScore);
+      var songScore:Null<SaveScoreData> = Save.instance.getSongScore(daSong.data.id, currentDifficulty);
       intendedScore = songScore?.score ?? 0;
       intendedCompletion = songScore == null ? 0.0 : ((songScore.tallies.sick + songScore.tallies.good) / songScore.tallies.totalNotes);
-      rememberedDifficulty = suffixedDifficulty;
-      currentSuffixedDifficulty = suffixedDifficulty;
+      rememberedDifficulty = currentDifficulty;
+      grpCapsules.members[curSelected].refreshDisplay();
     }
     else
     {
       intendedScore = 0;
       intendedCompletion = 0.0;
-      rememberedDifficulty = currentSuffixedDifficulty;
+      rememberedDifficulty = currentDifficulty;
     }
 
     if (intendedCompletion == Math.POSITIVE_INFINITY || intendedCompletion == Math.NEGATIVE_INFINITY || Math.isNaN(intendedCompletion))
@@ -1867,15 +1747,15 @@ class FreeplayState extends MusicBeatSubState
       intendedCompletion = 0;
     }
 
-    grpDifficulties.group.forEach(function(diffSprite) {
-      diffSprite.visible = false;
-    });
-
     for (diffSprite in grpDifficulties.group.members)
     {
       if (diffSprite == null) continue;
-      if (diffSprite.difficultyId == currentSuffixedDifficulty)
+      diffSprite.visible = false;
+
+      if (diffSprite.difficultyId == currentDifficulty)
       {
+        diffSprite.visible = true;
+
         if (change != 0)
         {
           diffSprite.visible = true;
@@ -1886,10 +1766,6 @@ class FreeplayState extends MusicBeatSubState
             diffSprite.updateHitbox();
           });
         }
-        else
-        {
-          diffSprite.visible = true;
-        }
       }
     }
 
@@ -1899,17 +1775,11 @@ class FreeplayState extends MusicBeatSubState
       for (songCapsule in grpCapsules.members)
       {
         if (songCapsule == null) continue;
-        if (songCapsule.songData != null)
+
+        if (songCapsule.freeplayData != null)
         {
-          songCapsule.songData.currentVariation = currentVariation;
-          songCapsule.songData.currentUnsuffixedDifficulty = currentUnsuffixedDifficulty;
-          songCapsule.songData.currentSuffixedDifficulty = currentSuffixedDifficulty;
-          songCapsule.init(null, null, songCapsule.songData);
+          songCapsule.init(null, null, songCapsule.freeplayData);
           songCapsule.checkClip();
-        }
-        else
-        {
-          songCapsule.init(null, null, null);
         }
       }
 
@@ -1918,7 +1788,7 @@ class FreeplayState extends MusicBeatSubState
     }
 
     // Set the album graphic and play the animation if relevant.
-    var newAlbumId:Null<String> = daSong?.albumId;
+    var newAlbumId:Null<String> = daSong?.data.getAlbumId(currentDifficulty, currentVariation);
     if (albumRoll.albumId != newAlbumId)
     {
       albumRoll.albumId = newAlbumId;
@@ -1926,21 +1796,7 @@ class FreeplayState extends MusicBeatSubState
     }
 
     // Set difficulty star count.
-    albumRoll.setDifficultyStars(daSong?.difficultyRating);
-  }
-
-  // Clears the cache of songs to free up memory, they'll have to be loaded in later tho
-  function clearDaCache(actualSongTho:String):Void
-  {
-    for (song in songs)
-    {
-      if (song == null) continue;
-      if (song.songName != actualSongTho)
-      {
-        trace('trying to remove: ' + song.songName);
-        // openfl.Assets.cache.clear(Paths.inst(song.songName));
-      }
-    }
+    albumRoll.setDifficultyStars(daSong?.data.getDifficulty(currentDifficulty, currentVariation)?.difficultyRating ?? 0);
   }
 
   function capsuleOnConfirmRandom(randomCapsule:SongMenuItem):Void
@@ -1952,11 +1808,11 @@ class FreeplayState extends MusicBeatSubState
 
     var availableSongCapsules:Array<SongMenuItem> = grpCapsules.members.filter(function(cap:SongMenuItem) {
       // Dead capsules are ones which were removed from the list when changing filters.
-      return cap.alive && cap.songData != null;
+      return cap.alive && cap.freeplayData != null;
     });
 
     trace('Available songs: ${availableSongCapsules.map(function(cap) {
-      return cap?.songData?.songName;
+      return cap?.freeplayData?.data.songName;
     })}');
 
     if (availableSongCapsules.length == 0)
@@ -1983,7 +1839,7 @@ class FreeplayState extends MusicBeatSubState
    */
   function capsuleOnOpenDefault(cap:SongMenuItem):Void
   {
-    var targetSongId:String = cap?.songData?.songId ?? 'unknown';
+    var targetSongId:String = cap?.freeplayData?.data.id ?? 'unknown';
     var targetSongNullable:Null<Song> = SongRegistry.instance.fetchEntry(targetSongId);
     if (targetSongNullable == null)
     {
@@ -1991,10 +1847,10 @@ class FreeplayState extends MusicBeatSubState
       return;
     }
     var targetSong:Song = targetSongNullable;
-    var targetDifficultyId:String = currentUnsuffixedDifficulty;
+    var targetDifficultyId:String = currentDifficulty;
     var targetVariation:Null<String> = currentVariation;
     trace('target song: ${targetSongId} (${targetVariation})');
-    var targetLevelId:Null<String> = cap?.songData?.levelId;
+    var targetLevelId:Null<String> = cap?.freeplayData?.levelId;
     PlayStatePlaylist.campaignId = targetLevelId ?? null;
 
     var targetDifficulty:Null<SongDifficulty> = targetSong.getDifficulty(targetDifficultyId, targetVariation);
@@ -2065,7 +1921,7 @@ class FreeplayState extends MusicBeatSubState
 
     PlayStatePlaylist.isStoryMode = false;
 
-    var targetSongId:String = cap?.songData?.songId ?? 'unknown';
+    var targetSongId:String = cap?.freeplayData?.data.id ?? 'unknown';
     var targetSongNullable:Null<Song> = SongRegistry.instance.fetchEntry(targetSongId);
     if (targetSongNullable == null)
     {
@@ -2073,21 +1929,20 @@ class FreeplayState extends MusicBeatSubState
       return;
     }
     var targetSong:Song = targetSongNullable;
-    var targetDifficultyId:String = currentUnsuffixedDifficulty;
     var targetVariation:Null<String> = currentVariation;
-    var targetLevelId:Null<String> = cap?.songData?.levelId;
+    var targetLevelId:Null<String> = cap?.freeplayData?.levelId;
     PlayStatePlaylist.campaignId = targetLevelId ?? null;
 
-    var targetDifficulty:Null<SongDifficulty> = targetSong.getDifficulty(targetDifficultyId, targetVariation);
+    var targetDifficulty:Null<SongDifficulty> = targetSong.getDifficulty(currentDifficulty, currentVariation);
     if (targetDifficulty == null)
     {
-      FlxG.log.warn('WARN: could not find difficulty with id (${targetDifficultyId})');
+      FlxG.log.warn('WARN: could not find difficulty with id (${currentDifficulty})');
       return;
     }
 
     if (targetInstId == null)
     {
-      var baseInstrumentalId:String = targetSong?.getBaseInstrumentalId(targetDifficultyId, targetDifficulty.variation ?? Constants.DEFAULT_VARIATION) ?? '';
+      var baseInstrumentalId:String = targetSong?.getBaseInstrumentalId(currentDifficulty, targetDifficulty.variation ?? Constants.DEFAULT_VARIATION) ?? '';
       targetInstId = baseInstrumentalId;
     }
 
@@ -2103,12 +1958,12 @@ class FreeplayState extends MusicBeatSubState
     new FlxTimer().start(styleData?.getStartDelay(), function(tmr:FlxTimer) {
       FunkinSound.emptyPartialQueue();
 
-      Paths.setCurrentLevel(cap?.songData?.levelId);
+      Paths.setCurrentLevel(cap?.freeplayData?.levelId);
       LoadingState.loadPlayState(
         {
           targetSong: targetSong,
-          targetDifficulty: targetDifficultyId,
-          targetVariation: targetVariation,
+          targetDifficulty: currentDifficulty,
+          targetVariation: currentVariation,
           targetInstrumental: targetInstId,
           practiceMode: false,
           minimalMode: false,
@@ -2126,13 +1981,20 @@ class FreeplayState extends MusicBeatSubState
     });
   }
 
+  function refreshCapsuleDisplays():Void
+  {
+    grpCapsules.forEachAlive((cap:SongMenuItem) -> {
+      cap.refreshDisplay();
+    });
+  }
+
   function rememberSelection():Void
   {
     if (rememberedSongId != null)
     {
       curSelected = currentFilteredSongs.findIndex(function(song) {
         if (song == null) return false;
-        return song.songId == rememberedSongId;
+        return song.data.id == rememberedSongId;
       });
 
       if (curSelected == -1) curSelected = 0;
@@ -2140,7 +2002,12 @@ class FreeplayState extends MusicBeatSubState
 
     if (rememberedDifficulty != null)
     {
-      currentSuffixedDifficulty = rememberedDifficulty;
+      currentDifficulty = rememberedDifficulty;
+    }
+
+    if (rememberedVariation != null)
+    {
+      currentVariation = rememberedVariation;
     }
   }
 
@@ -2156,22 +2023,19 @@ class FreeplayState extends MusicBeatSubState
     if (curSelected >= grpCapsules.countLiving()) curSelected = 0;
 
     var daSongCapsule:SongMenuItem = grpCapsules.members[curSelected];
-    if (daSongCapsule.songData != null)
+    if (daSongCapsule.freeplayData != null)
     {
-      var songScore:Null<SaveScoreData> = Save.instance.getSongScore(daSongCapsule.songData.songId, currentSuffixedDifficulty);
+      var songScore:Null<SaveScoreData> = Save.instance.getSongScore(daSongCapsule.freeplayData.data.id, currentDifficulty);
       intendedScore = songScore?.score ?? 0;
       intendedCompletion = songScore == null ? 0.0 : ((songScore.tallies.sick + songScore.tallies.good) / songScore.tallies.totalNotes);
-      diffIdsCurrent = daSongCapsule.songData.songDifficulties;
-      suffixedDiffIdsCurrent = daSongCapsule.songData.suffixedSongDifficulties;
-      rememberedSongId = daSongCapsule.songData.songId;
+      rememberedSongId = daSongCapsule.freeplayData.data.id;
       changeDiff();
+      daSongCapsule.refreshDisplay();
     }
     else
     {
       intendedScore = 0;
       intendedCompletion = 0.0;
-      diffIdsCurrent = diffIdsTotal;
-      suffixedDiffIdsCurrent = suffixedDiffIdsTotal;
       rememberedSongId = null;
       rememberedDifficulty = Constants.DEFAULT_DIFFICULTY;
       albumRoll.albumId = null;
@@ -2199,7 +2063,6 @@ class FreeplayState extends MusicBeatSubState
   public function playCurSongPreview(?daSongCapsule:SongMenuItem):Void
   {
     if (daSongCapsule == null) daSongCapsule = grpCapsules.members[curSelected];
-
     if (curSelected == 0)
     {
       FunkinSound.playMusic('freeplayRandom',
@@ -2212,43 +2075,25 @@ class FreeplayState extends MusicBeatSubState
     }
     else
     {
-      var previewSongId:Null<String> = daSongCapsule?.songData?.songId;
-      if (previewSongId == null) return;
-
-      var previewSong:Null<Song> = SongRegistry.instance.fetchEntry(previewSongId);
+      var previewSong:Null<Song> = daSongCapsule?.freeplayData?.data;
       if (previewSong == null) return;
 
-      var targetDifficultyId:String = currentUnsuffixedDifficulty;
-      var targetVariation:Null<String> = currentVariation;
-
       // Check if character-specific difficulty exists
-      var characterSuffixedDifficulty:String = '${targetDifficultyId}-${currentCharacterId}';
-      var suffixedSongDifficulties:Array<String> = daSongCapsule.songData?.suffixedSongDifficulties ?? Constants.DEFAULT_DIFFICULTY_LIST;
-      if (suffixedSongDifficulties != null && suffixedSongDifficulties.contains(characterSuffixedDifficulty))
-      {
-        targetDifficultyId = characterSuffixedDifficulty;
-      }
+      var songDifficulty:Null<SongDifficulty> = previewSong.getDifficulty(currentDifficulty, currentVariation);
 
-      var songDifficulty:Null<SongDifficulty> = previewSong.getDifficulty(targetDifficultyId, targetVariation ?? Constants.DEFAULT_VARIATION);
-
-      var baseInstrumentalId:String = previewSong.getBaseInstrumentalId(targetDifficultyId, songDifficulty?.variation ?? Constants.DEFAULT_VARIATION) ?? '';
-      var altInstrumentalIds:Array<String> = previewSong.listAltInstrumentalIds(targetDifficultyId,
+      var baseInstrumentalId:String = previewSong.getBaseInstrumentalId(currentDifficulty, songDifficulty?.variation ?? Constants.DEFAULT_VARIATION) ?? '';
+      var altInstrumentalIds:Array<String> = previewSong.listAltInstrumentalIds(currentDifficulty,
         songDifficulty?.variation ?? Constants.DEFAULT_VARIATION) ?? [];
-
       var instSuffix:String = baseInstrumentalId;
-
       #if FEATURE_DEBUG_FUNCTIONS
       if (altInstrumentalIds.length > 0 && FlxG.keys.pressed.CONTROL)
       {
         instSuffix = altInstrumentalIds[0];
       }
       #end
-
       instSuffix = (instSuffix != '') ? '-$instSuffix' : '';
-
-      trace('Attempting to play partial preview: ${previewSongId}:${instSuffix}');
-
-      FunkinSound.playMusic(previewSongId,
+      trace('Attempting to play partial preview: ${previewSong.id}:${instSuffix}');
+      FunkinSound.playMusic(previewSong.id,
         {
           startingVolume: 0.0,
           overrideExisting: true,
@@ -2266,7 +2111,6 @@ class FreeplayState extends MusicBeatSubState
             FlxG.sound.music.fadeIn(2, 0, 0.4);
           }
         });
-
       if (songDifficulty != null)
       {
         Conductor.instance.mapTimeChanges(songDifficulty.timeChanges);
@@ -2383,57 +2227,66 @@ enum abstract FilterType(String)
 class FreeplaySongData
 {
   /**
+   * We used to have a billion fields, but this SongMetadata variable should be all we need
+   * to be able to get most information about an available song.
+   * For example, you can get the artist via `data.songArtist`
+   *
+   * You can usually get various other particulars of a specific difficulty/variation by
+   * using data.getDifficulty(), and inputting specifics on your difficulty, variations, etc.
+   * See the getters here for songCharacter, fullSongName, and songStartingBpm for examples.
+   *
+   * @see Song
+   */
+  public var data:Song;
+
+  /**
+   * The level id of the song, useful for sorting from week1 -> week 7 + weekend1
+   * and for properly loading PlayStatePlaylist for preloading on web
+   */
+  public var levelId(get, never):Null<String>;
+
+  function get_levelId():Null<String>
+  {
+    return _levelId;
+  }
+
+  var _levelId:String;
+
+  /**
    * Whether or not the song has been favorited.
    */
   public var isFav:Bool = false;
 
+  /**
+   * Whether the player has seen/played this song before within freeplay
+   */
   public var isNew:Bool = false;
 
-  var song:Song;
+  /**
+   * The default opponent for the song.
+   * Does the getter stuff for you depending on your current (or rather, rememberd) variation and difficulty.
+   */
+  public var songCharacter(get, never):String;
 
-  public var levelId(default, null):String = '';
-  public var songId(default, null):String = '';
+  /**
+   * The full song name, dynamically generated depending on your current (or rather, rememberd) variation and difficulty.
+   */
+  public var fullSongName(get, never):String;
 
-  public var songDifficulties(default, null):Array<String> = [];
-  public var suffixedSongDifficulties(default, null):Array<String> = [];
+  /**
+   * The starting BPM of the song, dynamically generated depending on your current (or rather, rememberd) variation and difficulty.
+   */
+  public var songStartingBpm(get, never):Float;
 
-  public var songName(default, null):String = '';
-  public var songCharacter(default, null):String = '';
-  public var songStartingBpm(default, null):Float = 0;
-  public var difficultyRating(default, null):Int = 0;
-  public var albumId(default, null):Null<String> = null;
+  public var difficultyRating(get, never):Int;
 
-  public var currentCharacter:PlayableCharacter;
-  public var currentVariation:String = Constants.DEFAULT_VARIATION;
-  public var currentSuffixedDifficulty(default, set):String = Constants.DEFAULT_DIFFICULTY;
-  public var currentUnsuffixedDifficulty:String = Constants.DEFAULT_DIFFICULTY;
+  public var scoringRank(get, never):Null<ScoringRank>;
 
-  public var scoringRank:Null<ScoringRank> = null;
-
-  var displayedVariations:Array<String> = [Constants.DEFAULT_VARIATION];
-
-  function set_currentSuffixedDifficulty(value:String):String
+  public function new(data:Song, levelData:Level)
   {
-    if (currentSuffixedDifficulty == value) return value;
-
-    currentSuffixedDifficulty = value;
-    updateValues(displayedVariations);
-    return value;
-  }
-
-  public function new(levelId:String, songId:String, song:Song, currentCharacter:PlayableCharacter, ?displayedVariations:Array<String>)
-  {
-    this.levelId = levelId;
-    this.songId = songId;
-    this.song = song;
-
-    this.isFav = Save.instance.isSongFavorited(songId);
-
-    this.currentCharacter = currentCharacter;
-
-    if (displayedVariations != null) this.displayedVariations = displayedVariations;
-
-    updateValues(displayedVariations);
+    this.data = data;
+    _levelId = levelData.id;
+    this.isFav = Save.instance.isSongFavorited(data.songName);
   }
 
   /**
@@ -2445,71 +2298,95 @@ class FreeplaySongData
     isFav = !isFav;
     if (isFav)
     {
-      Save.instance.favoriteSong(this.songId);
+      Save.instance.favoriteSong(data.songName);
     }
     else
     {
-      Save.instance.unfavoriteSong(this.songId);
+      Save.instance.unfavoriteSong(data.songName);
     }
     return isFav;
   }
 
   function updateValues(variations:Array<String>):Void
   {
-    trace('variations: ${variations}');
-    this.songDifficulties = song.listDifficulties(null, variations, false, false);
-    this.suffixedSongDifficulties = song.listSuffixedDifficulties(variations, false, false);
+    // this.isNew = song.isSongNew(suffixedDifficulty);
+  }
 
-    // Add character-specific difficulties
-    for (difficulty in this.songDifficulties)
-    {
-      var characterDifficulty = '${difficulty}-${currentCharacter.id}';
-      if (!this.suffixedSongDifficulties.contains(characterDifficulty))
-      {
-        this.suffixedSongDifficulties.push(characterDifficulty);
-      }
-    }
+  function get_songCharacter():String
+  {
+    var variations:Array<String> = data.getVariationsByCharacterId(FreeplayState.rememberedCharacterId);
+    return data.getDifficulty(FreeplayState.rememberedDifficulty, null, variations)?.characters.opponent ?? '';
+  }
 
-    // Prioritize character-specific difficulty
-    var characterSuffixedDifficulty = '${currentUnsuffixedDifficulty}-${currentCharacter.id}';
-    if (this.suffixedSongDifficulties.contains(characterSuffixedDifficulty))
-    {
-      currentSuffixedDifficulty = characterSuffixedDifficulty;
-    }
-    else if (!this.songDifficulties.contains(currentUnsuffixedDifficulty)
-      && !this.suffixedSongDifficulties.contains(currentSuffixedDifficulty))
-    {
-      currentSuffixedDifficulty = Constants.DEFAULT_DIFFICULTY;
-      // This method gets called again by the setter-method
-      // or the difficulty didn't change, so there's no need to continue.
-      return;
-    }
+  function get_fullSongName():String
+  {
+    var variations:Array<String> = data.getVariationsByCharacterId(FreeplayState.rememberedCharacterId);
 
-    var targetVariation:Null<String> = currentVariation;
+    return data.getDifficulty(FreeplayState.rememberedDifficulty, null, variations)?.songName ?? data.songName;
+  }
 
-    var songDifficulty:SongDifficulty = song.getDifficulty(currentUnsuffixedDifficulty, targetVariation);
-    if (songDifficulty == null) return;
-    this.songStartingBpm = songDifficulty.getStartingBPM();
-    this.songName = songDifficulty.songName;
-    this.songCharacter = songDifficulty.characters.opponent;
-    this.difficultyRating = songDifficulty.difficultyRating;
-    if (songDifficulty.album == null)
-    {
-      FlxG.log.warn('No album for: ${songDifficulty.songName}');
-      this.albumId = Constants.DEFAULT_ALBUM_ID;
-    }
-    else
-    {
-      this.albumId = songDifficulty.album;
-    }
+  function get_songStartingBpm():Float
+  {
+    var variations:Array<String> = data.getVariationsByCharacterId(FreeplayState.rememberedCharacterId);
 
-    var suffixedDifficulty = currentSuffixedDifficulty;
+    return data.getDifficulty(FreeplayState.rememberedDifficulty, null, variations)?.getStartingBPM() ?? 0;
+  }
 
-    this.scoringRank = Save.instance.getSongRank(songId, suffixedDifficulty);
+  function get_difficultyRating():Int
+  {
+    var variations:Array<String> = data.getVariationsByCharacterId(FreeplayState.rememberedCharacterId);
+    return data.getDifficulty(FreeplayState.rememberedDifficulty, null, variations)?.difficultyRating ?? 0;
+  }
 
-    this.isNew = song.isSongNew(suffixedDifficulty);
+  function get_scoringRank():Null<ScoringRank>
+  {
+    // TODO: Properly get/migrate the save data from the suffixed difficulty version to our new unsuffixed version
+    return Save.instance.getSongRank(data.songName, FreeplayState.rememberedDifficulty);
   }
 }
+
+/**
+ * Parameters used to initialize the FreeplayState.
+ */
+typedef FreeplayStateParams =
+{
+  ?character:String,
+
+  ?fromCharSelect:Bool,
+
+  ?fromResults:FromResultsParams,
+};
+
+/**
+ * A set of parameters for transitioning to the FreeplayState from the ResultsState.
+ */
+typedef FromResultsParams =
+{
+  /**
+   * The previous rank the song hand, if any. Null if it had no score before.
+   */
+  var ?oldRank:ScoringRank;
+
+  /**
+   * Whether or not to play the rank animation on returning to freeplay.
+   */
+  var playRankAnim:Bool;
+
+  /**
+   * The new rank the song has.
+   */
+  var newRank:ScoringRank;
+
+  /**
+   * The song ID to play the animation on.
+   */
+  var songId:String;
+
+  /**
+   * The difficulty ID to play the animation on.
+   */
+  var difficultyId:String;
+};
 
 /**
  * The map storing information about the exit movers.

--- a/source/funkin/ui/freeplay/SongMenuItem.hx
+++ b/source/funkin/ui/freeplay/SongMenuItem.hx
@@ -36,7 +36,7 @@ class SongMenuItem extends FlxSpriteGroup
    * Modify this by calling `init()`
    * If `null`, assume this SongMenuItem is for the "Random Song" option.
    */
-  public var songData(default, null):Null<FreeplaySongData> = null;
+  public var freeplayData(default, null):Null<FreeplaySongData> = null;
 
   public var selected(default, set):Bool;
 
@@ -422,6 +422,34 @@ class SongMenuItem extends FlxSpriteGroup
     return evilTrail.color;
   }
 
+  public function refreshDisplay():Void
+  {
+    if (freeplayData == null)
+    {
+      songText.text = 'Random';
+      pixelIcon.visible = false;
+      ranking.visible = false;
+      blurredRanking.visible = false;
+      favIcon.visible = false;
+      favIconBlurred.visible = false;
+      newText.visible = false;
+    }
+    else
+    {
+      songText.text = freeplayData.fullSongName;
+      if (freeplayData.songCharacter != null) pixelIcon.setCharacter(freeplayData.songCharacter);
+      pixelIcon.visible = true;
+      updateBPM(Std.int(freeplayData.songStartingBpm) ?? 0);
+      updateDifficultyRating(freeplayData.difficultyRating ?? 0);
+      updateScoringRank(freeplayData.scoringRank);
+      newText.visible = freeplayData.isNew;
+      favIcon.visible = freeplayData.isFav;
+      favIconBlurred.visible = freeplayData.isFav;
+      checkClip();
+    }
+    updateSelected();
+  }
+
   function updateDifficultyRating(newRating:Int):Void
   {
     var ratingPadded:String = newRating < 10 ? '0$newRating' : '$newRating';
@@ -500,11 +528,11 @@ class SongMenuItem extends FlxSpriteGroup
     updateSelected();
   }
 
-  public function init(?x:Float, ?y:Float, songData:Null<FreeplaySongData>, ?styleData:FreeplayStyle = null):Void
+  public function init(?x:Float, ?y:Float, freeplayData:Null<FreeplaySongData>, ?styleData:FreeplayStyle = null):Void
   {
     if (x != null) this.x = x;
     if (y != null) this.y = y;
-    this.songData = songData;
+    this.freeplayData = freeplayData;
 
     // im so mad i have to do this but im pretty sure with the capsules recycling i cant call the new function properly :/
     // if thats possible someone Please change the new function to be something like
@@ -517,21 +545,13 @@ class SongMenuItem extends FlxSpriteGroup
       songText.applyStyle(styleData);
     }
 
-    // Update capsule text.
-    songText.text = songData?.songName ?? 'Random';
-    // Update capsule character.
-    if (songData?.songCharacter != null) pixelIcon.setCharacter(songData.songCharacter);
-    updateBPM(Std.int(songData?.songStartingBpm) ?? 0);
-    updateDifficultyRating(songData?.difficultyRating ?? 0);
-    updateScoringRank(songData?.scoringRank);
-    newText.visible = songData?.isNew;
+    updateScoringRank(freeplayData?.scoringRank);
     favIcon.animation.curAnim.curFrame = favIcon.animation.curAnim.numFrames - 1;
     favIconBlurred.animation.curAnim.curFrame = favIconBlurred.animation.curAnim.numFrames - 1;
 
-    // Update opacity, offsets, etc.
-    updateSelected();
+    refreshDisplay();
 
-    checkWeek(songData?.songId);
+    checkWeek(freeplayData?.data.id);
   }
 
   var frameInTicker:Float = 0;


### PR DESCRIPTION
Freeplay would default it's difficulty string to `normal` but pico variations are `normal-pico`, so it wouldn't show you any Pico remix songs until you went to Random and changed difficulties.

This just initializes the suffixed difficulty string with `-pico` (or any other non-bf character id) when we load up Freeplay, so the initial generateSongs() filters correctly