### PR TITLE
Fix the character select cursor lerp for lower framerates

### DIFF
--- a/source/funkin/ui/charSelect/CharSelectSubState.hx
+++ b/source/funkin/ui/charSelect/CharSelectSubState.hx
@@ -885,8 +885,8 @@ class CharSelectSubState extends MusicBeatSubState
     cursorLocIntended.x += cursorOffsetX;
     cursorLocIntended.y += cursorOffsetY;
 
-    cursor.x = MathUtil.coolLerp(cursor.x, cursorLocIntended.x, lerpAmnt);
-    cursor.y = MathUtil.coolLerp(cursor.y, cursorLocIntended.y, lerpAmnt);
+    cursor.x = MathUtil.smoothLerp(cursor.x, cursorLocIntended.x, elapsed, 0.1);
+    cursor.y = MathUtil.smoothLerp(cursor.y, cursorLocIntended.y, elapsed, 0.1);
 
     cursorBlue.x = MathUtil.coolLerp(cursorBlue.x, cursor.x, lerpAmnt * 0.4);
     cursorBlue.y = MathUtil.coolLerp(cursorBlue.y, cursor.y, lerpAmnt * 0.4);


### PR DESCRIPTION
fixes #3505 

Updating the main cursor to use the `smoothLerp()` instead of `coolLerp()` seems to fix it, as the rest of the squares lerp towards the main yellow cursor.

I believe this bug is caused from the lerp overshooting and needing to recorrect itself using the old lerp method