### PR TITLE
Fix rendering for devices which has higher DPI

### DIFF
--- a/project.hxp
+++ b/project.hxp
@@ -330,6 +330,7 @@ class Project extends HXProject {
 
 		this.window.hardware = true;
 		this.window.vsync = false;
+		this.window.allowHighDPI = true;
 
 		if (isWeb()) {
 			this.window.resizable = true;


### PR DESCRIPTION
<!-- Please check for duplicates or similar PRs before submitting this PR. -->
## Does this PR close any issues? If so, link them below.

## Briefly describe the issue(s) fixed.
This fixed the game looking low res for certain devices, that has a higher dpi monitor.
This might not fix windows, since windows requires `SetProcessDPIAware()` to be called.
And i don't use windows so i cant test if it fixes it for windows

## Include any relevant screenshots or videos.
Before:
![image](https://github.com/user-attachments/assets/aeefe73e-dd61-4fb2-9a45-855c54f0c873)

after:
![image](https://github.com/user-attachments/assets/306c8ade-4462-451d-8490-aec996b0d187)

Despite the images showing the openfl sprites, it applies to flixel too