### PR TITLE
Revert "[BUGFIX] Reset CWD before Preloader"

### DIFF
--- a/source/funkin/ui/transition/preload/FunkinPreloader.hx
+++ b/source/funkin/ui/transition/preload/FunkinPreloader.hx
@@ -136,8 +136,6 @@ class FunkinPreloader extends FlxBasePreloader
     // We can't even call trace() yet, until Flixel loads.
     trace('Initializing custom preloader...');
 
-    funkin.util.CLIUtil.resetWorkingDir();
-
     this.siteLockTitleText = Constants.SITE_LOCK_TITLE;
     this.siteLockBodyText = Constants.SITE_LOCK_DESC;
   }


### PR DESCRIPTION
Reverts FunkinCrew/Funkin#2629 as it's not needed anymore due to Lime having patched [this bug internally](https://github.com/openfl/lime/blob/9f369b7637f6f682ffbfb1257ac37435f6dcb820/CHANGELOG.md?plain=1#L73) since 8.1.0