### PR TITLE
[feature/automatic-offset-flipping] Attribute Is Facing Right

### DIFF
--- a/source/funkin/data/character/CharacterData.hx
+++ b/source/funkin/data/character/CharacterData.hx
@@ -125,6 +125,13 @@ typedef CharacterData =
   var flipSingAnimations:Bool;
 
   /**
+   * Whether the character's animations are looking to the right or left.
+   */
+  @:optional
+  @:default(true)
+  var isFacingRight:Bool;
+
+  /**
    * The amount to offset the camera by while focusing on this character.
    * Default value focuses on the character directly.
    * @default `[0, 0]`

--- a/source/funkin/data/character/CharacterRegistry.hx
+++ b/source/funkin/data/character/CharacterRegistry.hx
@@ -443,13 +443,13 @@ class CharacterRegistry
     }
 
     // If `flipXOffsets` is enabled, we need to account for the default value of `flipX`.
-    if (result.flipX && result.flipXOffsets)
-    {
-      for (anim in result.animations)
-      {
-        anim.offsets[0] *= -1;
-      }
-    }
+    // if (result.flipX && result.flipXOffsets)
+    // {
+    //   for (anim in result.animations)
+    //   {
+    //     anim.offsets[0] *= -1;
+    //   }
+    // }
 
     return result;
   }

--- a/source/funkin/play/character/BaseCharacter.hx
+++ b/source/funkin/play/character/BaseCharacter.hx
@@ -46,6 +46,11 @@ class BaseCharacter extends Bopper
   public var flipSingAnimations:Bool = false;
 
   /**
+   * Whether the character's animations are looking to the right or left.
+   */
+  public var isFacingRight:Bool = false;
+
+  /**
    * Set to true when the character being used in a special way.
    * This includes the Chart Editor and the Animation Editor.
    *
@@ -177,6 +182,7 @@ class BaseCharacter extends Bopper
       this.flipX = _data.flipX;
       this.flipXOffsets = _data.flipXOffsets;
       this.flipSingAnimations = _data.flipSingAnimations;
+      this.isFacingRight = _data.isFacingRight;
     }
 
     shouldBop = false;
@@ -639,7 +645,7 @@ class BaseCharacter extends Bopper
    */
   public function playSingAnimation(dir:NoteDirection, miss:Bool = false, ?suffix:String = ''):Void
   {
-    if (flipX && flipSingAnimations)
+    if (flipSingAnimations && ((!isFacingRight && flipX == _data.flipX) || (isFacingRight && flipX != _data.flipX)))
     {
       switch (dir)
       {
@@ -662,6 +668,12 @@ class BaseCharacter extends Bopper
   public override function playAnimation(name:String, restart:Bool = false, ignoreOther:Bool = false, reversed:Bool = false):Void
   {
     super.playAnimation(name, restart, ignoreOther, reversed);
+  }
+
+  override function shouldFlip(xAxis:Bool):Bool
+  {
+    return xAxis ? (flipXOffsets
+      && ((!isFacingRight && flipX == _data.flipX) || (isFacingRight && flipX != _data.flipX))) : (flipYOffsets && flipY);
   }
 }
 

--- a/source/funkin/play/stage/Bopper.hx
+++ b/source/funkin/play/stage/Bopper.hx
@@ -368,18 +368,23 @@ class Bopper extends StageProp implements IPlayStateScriptedClass
     var output:FlxPoint = super.getScreenPosition(result, camera);
 
     output.x -= (animOffsets[0] - globalOffsets[0]) * this.scale.x;
-    if (flipXOffsets && flipX)
+    if (shouldFlip(true))
     {
       output.x += (animOffsets[0] * 2 + (width - frameWidth)) * this.scale.x;
     }
 
     output.y -= (animOffsets[1] - globalOffsets[1]) * this.scale.y;
-    if (flipYOffsets && flipY)
+    if (shouldFlip(false))
     {
       output.y += (animOffsets[1] * 2 + (height - frameHeight)) * this.scale.y;
     }
 
     return output;
+  }
+
+  function shouldFlip(xAxis:Bool):Bool
+  {
+    return xAxis ? (flipXOffsets && flipX) : (flipYOffsets && flipY);
   }
 
   public function onPause(event:PauseScriptEvent) {}


### PR DESCRIPTION
- #3539 Automatic character offset flipping isn't 100% working yet

## FIXES / CHANGES
- Adds `isFacingRight` attribute to character data
- Reverts tankman.json

By using `isFacingRight`, we can fix the problem of wrong animations and broken offsets

Default is `true`

if a character seems to have broken offsets, set `isFacingRight` to false, and see if that fixes it.