### PR TITLE
Center Box Text in Preloader

### DIFF
--- a/source/funkin/ui/transition/preload/FunkinPreloader.hx
+++ b/source/funkin/ui/transition/preload/FunkinPreloader.hx
@@ -250,18 +250,18 @@ class FunkinPreloader extends FlxBasePreloader
     dspText.selectable = false;
     dspText.textColor = 0x000000;
     dspText.width = this._width;
-    dspText.height = 20;
+    dspText.height = 30;
     dspText.text = 'DSP';
     dspText.x = 10;
-    dspText.y = -5;
+    dspText.y = -7;
     box.addChild(dspText);
 
     fnfText.selectable = false;
     fnfText.textColor = 0x000000;
     fnfText.width = this._width;
-    fnfText.height = 20;
-    fnfText.x = 75;
-    fnfText.y = -5;
+    fnfText.height = 30;
+    fnfText.x = 78;
+    fnfText.y = -7;
     fnfText.text = 'FNF';
     box.addChild(fnfText);
 

--- a/source/funkin/util/WindowUtil.hx
+++ b/source/funkin/util/WindowUtil.hx
@@ -105,11 +105,13 @@ class WindowUtil
         // FlxG.stage.focus is set to null by the debug console stuff,
         // so when that's in focus, we don't want to toggle fullscreen using F
         // (annoying when tying "FlxG" in console... lol)
+        #if FLX_DEBUG
         @:privateAccess
         if (FlxG.game.debugger.visible)
         {
           return;
         }
+        #end
 
         if (e.keyCode == key)
         {


### PR DESCRIPTION
Just a simple quick and dirty fix to center the "DSP" and "FNF" text in the preloader cuz it bugged me a little...

![image](https://github.com/user-attachments/assets/97fe4596-85e9-496d-8ca3-0df14bcff24c)
