### PR TITLE
[Feature] Camera bop event offset

### DIFF
--- a/source/funkin/play/PlayState.hx
+++ b/source/funkin/play/PlayState.hx
@@ -1786,7 +1786,7 @@ class PlayState extends MusicBeatSubState
     if (Preferences.zoomCamera
       && FlxG.camera.zoom < (1.35 * FlxCamera.defaultZoom)
       && cameraZoomRate > 0
-      && Conductor.instance.currentBeat + cameraZoomRateOffset % cameraZoomRate == 0)
+      && (Conductor.instance.currentBeat + cameraZoomRateOffset) % cameraZoomRate == 0)
     {
       // Set zoom multiplier for camera bop.
       cameraBopMultiplier = cameraBopIntensity;

--- a/source/funkin/play/PlayState.hx
+++ b/source/funkin/play/PlayState.hx
@@ -321,6 +321,13 @@ class PlayState extends MusicBeatSubState
   public var cameraZoomRate:Int = Constants.DEFAULT_ZOOM_RATE;
 
   /**
+   * How many beats (quarter notes) the zoom rate is offset.
+   * For if you want the zoom to happen off-beat.
+   * @default Zero beats (on-beat).
+   */
+  public var cameraZoomRateOffset:Int = Constants.DEFAULT_ZOOM_OFFSET;
+
+  /**
    * Whether the game is currently in the countdown before the song resumes.
    */
   public var isInCountdown:Bool = false;
@@ -1779,7 +1786,7 @@ class PlayState extends MusicBeatSubState
     if (Preferences.zoomCamera
       && FlxG.camera.zoom < (1.35 * FlxCamera.defaultZoom)
       && cameraZoomRate > 0
-      && Conductor.instance.currentBeat % cameraZoomRate == 0)
+      && Conductor.instance.currentBeat + cameraZoomRateOffset % cameraZoomRate == 0)
     {
       // Set zoom multiplier for camera bop.
       cameraBopMultiplier = cameraBopIntensity;

--- a/source/funkin/play/event/SetCameraBopSongEvent.hx
+++ b/source/funkin/play/event/SetCameraBopSongEvent.hx
@@ -42,12 +42,15 @@ class SetCameraBopSongEvent extends SongEvent
 
     var rate:Null<Int> = data.getInt('rate');
     if (rate == null) rate = Constants.DEFAULT_ZOOM_RATE;
+    var offset:Null<Int> = data.getInt('offset');
+    if (rate == null) offset = Constants.DEFAULT_ZOOM_OFFSET;
     var intensity:Null<Float> = data.getFloat('intensity');
     if (intensity == null) intensity = 1.0;
 
     PlayState.instance.cameraBopIntensity = (Constants.DEFAULT_BOP_INTENSITY - 1.0) * intensity + 1.0;
     PlayState.instance.hudCameraZoomIntensity = (Constants.DEFAULT_BOP_INTENSITY - 1.0) * intensity * 2.0;
     PlayState.instance.cameraZoomRate = rate;
+    PlayState.instance.cameraZoomRateOffset = offset;
     trace('Set camera zoom rate to ${PlayState.instance.cameraZoomRate}');
   }
 
@@ -77,6 +80,14 @@ class SetCameraBopSongEvent extends SongEvent
         type: SongEventFieldType.FLOAT,
         units: 'x'
       },
+      {
+        name: 'offset',
+        title: 'Offset',
+        defaultValue: 0,
+        step: 1,
+        type: SongEventFieldType.INTEGER,
+        units: 'beats'
+      }
       {
         name: 'rate',
         title: 'Rate',

--- a/source/funkin/play/event/SetCameraBopSongEvent.hx
+++ b/source/funkin/play/event/SetCameraBopSongEvent.hx
@@ -87,7 +87,7 @@ class SetCameraBopSongEvent extends SongEvent
         step: 1,
         type: SongEventFieldType.INTEGER,
         units: 'beats'
-      }
+      },
       {
         name: 'rate',
         title: 'Rate',

--- a/source/funkin/util/Constants.hx
+++ b/source/funkin/util/Constants.hx
@@ -238,6 +238,11 @@ class Constants
   public static final DEFAULT_ZOOM_RATE:Int = 4;
 
   /**
+   * The default offset of camera zooms (in beats).
+   */
+  public static final DEFAULT_ZOOM_OFFSET:Int = 0;
+
+  /**
    * The default BPM for charts, so things don't break if none is specified.
    */
   public static final DEFAULT_BPM:Float = 100.0;


### PR DESCRIPTION
Adds an offset option to the camera bop event, useful for if you want the camera bopping to occur off-beat.