### PR TITLE
Fixed Conflict With Modded StrumlineNote Sprite Looping Animation

### DIFF
--- a/source/funkin/graphics/FunkinSprite.hx
+++ b/source/funkin/graphics/FunkinSprite.hx
@@ -239,6 +239,18 @@ class FunkinSprite extends FlxSprite
   }
 
   /**
+   * @param id The animation ID to check.
+   * @return Whether the animation is dynamic (has multiple frames). `false` for static, one-frame animations.
+   */
+  public function isAnimationDynamic(id:String):Bool
+  {
+    if (this.animation == null) return false;
+    var animData = this.animation.getByName(id);
+    if (animData == null) return false;
+    return animData.numFrames > 1;
+  }
+
+  /**
    * Acts similarly to `makeGraphic`, but with improved memory usage,
    * at the expense of not being able to paint onto the resulting sprite.
    *

--- a/source/funkin/play/notes/StrumlineNote.hx
+++ b/source/funkin/play/notes/StrumlineNote.hx
@@ -24,6 +24,12 @@ class StrumlineNote extends FlxSprite
     return this.direction;
   }
 
+  /**
+   * Set this flag to `true` to disable performance optimizations that cause
+   * the Strumline note sprite to ignore `velocity` and `acceleration`.
+   */
+  public var forceActive:Bool = false;
+
   public function new(noteStyle:NoteStyle, isPlayer:Bool, direction:NoteDirection)
   {
     super(0, 0);
@@ -103,19 +109,19 @@ class StrumlineNote extends FlxSprite
 
   public function playStatic():Void
   {
-    this.active = true;
+    this.active = (forceActive || isAnimationDynamic('static'));
     this.playAnimation('static', true);
   }
 
   public function playPress():Void
   {
-    this.active = true;
+    this.active = (forceActive || isAnimationDynamic('press'));
     this.playAnimation('press', true);
   }
 
   public function playConfirm():Void
   {
-    this.active = true;
+    this.active = (forceActive || isAnimationDynamic('confirm'));
     this.playAnimation('confirm', true);
   }
 

--- a/source/funkin/play/notes/StrumlineNote.hx
+++ b/source/funkin/play/notes/StrumlineNote.hx
@@ -103,7 +103,7 @@ class StrumlineNote extends FlxSprite
 
   public function playStatic():Void
   {
-    this.active = false;
+    this.active = true;
     this.playAnimation('static', true);
   }
 

--- a/source/funkin/play/notes/StrumlineNote.hx
+++ b/source/funkin/play/notes/StrumlineNote.hx
@@ -2,21 +2,23 @@ package funkin.play.notes;
 
 import funkin.play.notes.notestyle.NoteStyle;
 import flixel.graphics.frames.FlxAtlasFrames;
-import flixel.FlxSprite;
+import funkin.graphics.FunkinSprite;
 import funkin.play.notes.NoteSprite;
 
 /**
  * The actual receptor that you see on screen.
  */
-class StrumlineNote extends FlxSprite
+class StrumlineNote extends FunkinSprite
 {
+  /**
+   * Whether this strumline note is on the player's side or the opponent's side.
+   */
   public var isPlayer(default, null):Bool;
 
+  /**
+   * The direction which this strumline note is facing.
+   */
   public var direction(default, set):NoteDirection;
-
-  var confirmHoldTimer:Float = -1;
-
-  static final CONFIRM_HOLD_TIME:Float = 0.1;
 
   function set_direction(value:NoteDirection):NoteDirection
   {
@@ -29,6 +31,16 @@ class StrumlineNote extends FlxSprite
    * the Strumline note sprite to ignore `velocity` and `acceleration`.
    */
   public var forceActive:Bool = false;
+
+  /**
+   * How long to continue the hold note animation after a note is pressed.
+   */
+  static final CONFIRM_HOLD_TIME:Float = 0.1;
+
+  /**
+   * How long the hold note animation has been playing after a note is pressed.
+   */
+  var confirmHoldTimer:Float = -1;
 
   public function new(noteStyle:NoteStyle, isPlayer:Bool, direction:NoteDirection)
   {
@@ -47,7 +59,10 @@ class StrumlineNote extends FlxSprite
     this.active = true;
   }
 
-  function onAnimationFrame(name:String, frameNumber:Int, frameIndex:Int):Void {}
+  function onAnimationFrame(name:String, frameNumber:Int, frameIndex:Int):Void
+  {
+    // Do nothing.
+  }
 
   function onAnimationFinished(name:String):Void
   {


### PR DESCRIPTION
<!-- Please check for duplicates or similar PRs before submitting this PR. -->
## Does this PR close any issues? If so, link them below.
[#3571](https://github.com/FunkinCrew/Funkin/issues/3571)
## Briefly describe the issue(s) fixed.
The playStatic function on the StrumlineNote.hx file has this.active = false; which breaks modding compatibility for StrumlineNote sprites with looping animations. By setting this.active = true; it allows StrumlineNote sprites to loop an animation that is defined in the new notestyles folder.
## Include any relevant screenshots or videos.
Broken StrumlineNote Animations when playStatic() this.active = false;

https://github.com/user-attachments/assets/30ef10f1-f785-4af3-89d7-383f4285bef4

Working StrumlineNote Animations when setting playStatic() this.active = true;

https://github.com/user-attachments/assets/28ace392-e01f-4d5c-8ef5-ddf1fa00d005

Custom NoteStyle JSON file for reference:
![NoteStyle_JSON_Reference](https://github.com/user-attachments/assets/7429fb3f-231a-48f7-be66-26ceb341858d)