### PR TITLE
[BUGFIX] Don't restart the FreeplayState song preview when changing the difficulty within the same variation

### DIFF
--- a/source/funkin/ui/freeplay/FreeplayState.hx
+++ b/source/funkin/ui/freeplay/FreeplayState.hx
@@ -1689,6 +1689,7 @@ class FreeplayState extends MusicBeatSubState
   function changeDiff(change:Int = 0, force:Bool = false):Void
   {
     touchTimer = 0;
+    var previousVariation:String = currentVariation;
 
     // Available variations for current character. We get this since bf is usually `default` variation, and `pico` is `pico`
     // but sometimes pico can be the default variation (weekend 1 songs), and bf can be `bf` variation (darnell)
@@ -1784,7 +1785,7 @@ class FreeplayState extends MusicBeatSubState
       }
 
       // Reset the song preview in case we changed variations (normal->erect etc)
-      playCurSongPreview();
+      if (currentVariation != previousVariation) playCurSongPreview();
     }
 
     // Set the album graphic and play the animation if relevant.


### PR DESCRIPTION
## Does this PR close any issues? If so, link them below.
[3583](https://github.com/FunkinCrew/Funkin/issues/3583)

## Briefly describe the issue(s) fixed.
Modifies the `changeDiff` function inside `FreeplayState` to account for changing variations.

## Include any relevant screenshots or videos.
https://github.com/user-attachments/assets/04ccf4e5-ddea-4ed5-8857-00fd6e643e93
