### PR TITLE
Freeplay DJ bops to BPM

### DIFF
--- a/source/funkin/data/freeplay/player/PlayerData.hx
+++ b/source/funkin/data/freeplay/player/PlayerData.hx
@@ -104,6 +104,10 @@ class PlayerFreeplayDJData
   var animations:Array<AnimationData>;
 
   @:optional
+  @default(true)
+  var idleOnBeat:Bool;
+
+  @:optional
   @:default("BOYFRIEND")
   var text1:String;
 
@@ -152,6 +156,11 @@ class PlayerFreeplayDJData
   public function getAtlasPath():String
   {
     return Paths.animateAtlas(assetPath);
+  }
+
+  public function shouldIdleOnBeat():Bool
+  {
+    return idleOnBeat;
   }
 
   public function getFreeplayDJText(index:Int):String

--- a/source/funkin/ui/freeplay/FreeplayDJ.hx
+++ b/source/funkin/ui/freeplay/FreeplayDJ.hx
@@ -94,7 +94,7 @@ class FreeplayDJ extends FlxAtlasSprite
         var animPrefix = playableCharData.getAnimationPrefix('idle');
         if (getCurrentAnimation() != animPrefix)
         {
-          playFlashAnimation(animPrefix, true, false, true);
+          playFlashAnimation(animPrefix, true, false, !playableCharData.shouldIdleOnBeat());
         }
         timeIdling += elapsed;
       case NewUnlock:
@@ -263,6 +263,24 @@ class FreeplayDJ extends FlxAtlasSprite
     {
       trace('Finished ${name}');
     }
+  }
+
+  var beatFreq:Int = 1;
+  var beatFreqList:Array<Int> = [1, 2, 4, 8];
+
+  /**
+   * Called on each beat in freeplay state.
+   */
+  public function beatHit():Void
+  {
+    if (!playableCharData.shouldIdleOnBeat()) return;
+    if (currentState != Idle) return;
+
+    beatFreq = beatFreqList[Math.floor(Conductor.instance.bpm / 140)];
+    if (Conductor.instance.currentBeat % beatFreq != 0) return;
+
+    var animPrefix = playableCharData.getAnimationPrefix('idle');
+    playFlashAnimation(animPrefix, true);
   }
 
   public function resetAFKTimer():Void

--- a/source/funkin/ui/freeplay/FreeplayState.hx
+++ b/source/funkin/ui/freeplay/FreeplayState.hx
@@ -17,6 +17,7 @@ import flixel.util.FlxColor;
 import flixel.util.FlxTimer;
 import funkin.audio.FunkinSound;
 import funkin.data.freeplay.player.PlayerRegistry;
+import funkin.data.song.SongData.SongMusicData;
 import funkin.data.song.SongRegistry;
 import funkin.data.story.level.LevelRegistry;
 import funkin.effects.IntervalShake;
@@ -1293,6 +1294,8 @@ class FreeplayState extends MusicBeatSubState
   {
     super.update(elapsed);
 
+    Conductor.instance.update();
+
     if (charSelectHint != null)
     {
       hintTimer += elapsed * 2;
@@ -1664,6 +1667,7 @@ class FreeplayState extends MusicBeatSubState
 
   override function beatHit():Bool
   {
+    dj?.beatHit();
     backingCard?.beatHit();
 
     return super.beatHit();
@@ -2119,6 +2123,13 @@ class FreeplayState extends MusicBeatSubState
           restartTrack: false
         });
       FlxG.sound.music.fadeIn(2, 0, 0.8);
+
+      var freeplayRandomData:Null<SongMusicData> = SongRegistry.instance.parseMusicData('freeplayRandom');
+      if (freeplayRandomData != null)
+      {
+        Conductor.instance.mapTimeChanges(freeplayRandomData.timeChanges);
+        Conductor.instance.update();
+      }
     }
     else
     {
@@ -2161,7 +2172,7 @@ class FreeplayState extends MusicBeatSubState
       if (songDifficulty != null)
       {
         Conductor.instance.mapTimeChanges(songDifficulty.timeChanges);
-        Conductor.instance.update(FlxG.sound?.music?.time ?? 0.0);
+        Conductor.instance.update();
       }
     }
   }


### PR DESCRIPTION
Implements #2760 

The Freeplay DJ idle animation just looped before, now it plays with the bpm of whatever song is selected.
Also the `backingCard` had stuff to do on beatHit but the Conductor wasn't being updated so that works as well now.

Before:

https://github.com/user-attachments/assets/8808701b-cc0e-4158-96fb-de3bd83b9d94

After:

https://github.com/user-attachments/assets/86af3dee-f898-4d84-8293-32977523b4b8
