### PR TITLE
[FIX] Remove Flicker When Accepting FPS Setting

### DIFF
--- a/source/funkin/ui/options/items/EnumPreferenceItem.hx
+++ b/source/funkin/ui/options/items/EnumPreferenceItem.hx
@@ -46,6 +46,8 @@ class EnumPreferenceItem extends TextMenuItem
     }
 
     lefthandText = new AtlasText(15, y, formatted(defaultValue), AtlasFont.DEFAULT);
+
+    this.fireInstantly = true;
   }
 
   override function update(elapsed:Float):Void

--- a/source/funkin/ui/options/items/NumberPreferenceItem.hx
+++ b/source/funkin/ui/options/items/NumberPreferenceItem.hx
@@ -58,6 +58,8 @@ class NumberPreferenceItem extends TextMenuItem
     this.precision = precision;
     this.onChangeCallback = callback;
     this.valueFormatter = valueFormatter;
+
+    this.fireInstantly = true;
   }
 
   override function update(elapsed:Float):Void


### PR DESCRIPTION
## FIXES
fixes #3624

## CHANGES
this pr sets `fireInstantly` to true for Enum and Number preference items.
this fixes the issue with the flicker.