### PR TITLE
[FIX] Cap Score Displays to their biggest possible values

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "assets"]
 	path = assets
-	url = https://github.com/FunkinCrew/Funkin-assets-secret
+	url = https://github.com/FunkinCrew/Funkin.assets
 [submodule "art"]
 	path = art
-	url = https://github.com/FunkinCrew/Funkin-art-secret
+	url = https://github.com/FunkinCrew/Funkin.art

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,18 +4,18 @@ All notable changes will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.6.2] - 2024-03-31
+## [0.6.2] - 2025-03-31
 ### Added
 - 0.6 credits list updated
 ### Fixed
 - Additional shader fix for Stress Pico crashing at the end (was the same issue as Senpai Pico shader error, just in a different shaderfile)
 
-## [0.6.1] - 2024-03-31
+## [0.6.1] - 2025-03-31
 ### Fixed
 - Hopefully Senpai Pico/Erect mix shader isn't brokey
 - NG API encryption key was added proper, so medals + leaderboards posting should work
 
-## [0.6.0] - 2024-03-31
+## [0.6.0] - 2025-03-31
 The Pit Stop 2 update!
 ### Added
 - Added six (!) new playable songs! Check them out in the Freeplay menu for their respective characters.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,20 +4,34 @@ All notable changes will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+
 ## [0.6.2] - 2025-03-31
+
 ### Added
-- 0.6 credits list updated
+
+- Updated the 0.6 credits list
+
 ### Fixed
-- Additional shader fix for Stress Pico crashing at the end (was the same issue as Senpai Pico shader error, just in a different shaderfile)
+
+- Additional shader fix for Stress (Pico Mix) crashing at the end (was the same issue as Senpai Pico shader error, just in a different shaderfile)
+
+
 
 ## [0.6.1] - 2025-03-31
+
 ### Fixed
+
 - Hopefully Senpai Pico/Erect mix shader isn't brokey
 - NG API encryption key was added proper, so medals + leaderboards posting should work
 
+
+
 ## [0.6.0] - 2025-03-31
 The Pit Stop 2 update!
+
 ### Added
+
 - Added six (!) new playable songs! Check them out in the Freeplay menu for their respective characters.
   - Cocoa (Pico Mix)
   - Senpai (Pico Mix)
@@ -38,7 +52,6 @@ The Pit Stop 2 update!
   - The new sticker system isn't fully available to mods yet, but we're working on it!
 - New option in the Preferences menu: Strumline Backgrounds!
 - Options in the Preferences menu now display an on-screen description when selected.
-- Added a little easter egg to Pico's Good Results Screen animation.
 - The HOME and END keys now jump to the top and bottom of the Freeplay song list, respectively. ([bb974c2](https://github.com/FunkinCrew/Funkin/commit/bb974c264270d10ff503784063e5d77bb352b3f7)) - by @AbnormalPoof in [#4103](https://github.com/FunkinCrew/Funkin/pull/4103)
 - Added an option to launch the game in fullscreen. ([ee53ccd](https://github.com/FunkinCrew/Funkin/commit/ee53ccd32721e0790adfe82c60d4aca419db0a7f)) - by @AbnormalPoof in [#3738](https://github.com/FunkinCrew/Funkin/pull/3738)
 - Added descriptions for each item in the Preferences menu. ([a17b0e8](https://github.com/FunkinCrew/Funkin/commit/a17b0e8b3cc1d56fcdc0b51eaca9fd57cdb5bce0)) - by @anysad in [#3872](https://github.com/FunkinCrew/Funkin/pull/3872)
@@ -52,42 +65,31 @@ The Pit Stop 2 update!
 - Added `DEBUG_BUILD` value to `Constants` to indicate whether a build has debug functions enabled. ([ad45b72](https://github.com/FunkinCrew/Funkin/commit/ad45b72b1ae8eb73a12dc51bcb59f66cc55e7bbd)) - by @AbnormalPoof in [#3853](https://github.com/FunkinCrew/Funkin/pull/3853)
 
 ### Changed
+
 - Switched from hxCodec to hxvlc for video playback. This may break a mod or two.
   - Check the [Funkin Modding Docs](https://funkincrew.github.io/funkin-modding-docs/09-migration/09-02-0.5.0-to-0.6.0.html) for more info on how to update your mods.
 - Polymod should now ignore `.git` files when loading mods.
-- Lots of improvements to issue and pull request organization. - by @Hundrec and @AbnormalPoof
+- Lots of improvements to GitHub issue and pull request organization. - by @Hundrec and @AbnormalPoof
 - Overhauled the Changelog to improve readability and properly credit contributors. ([4383fcf](https://github.com/FunkinCrew/Funkin/commit/4383fcf32c280a1c0ee7b9c80d255611d497cabc)) - by @Hundrec in [#4296](https://github.com/FunkinCrew/Funkin/pull/4296) and [#4298](https://github.com/FunkinCrew/Funkin/pull/4298)
 - Made various improvements to the screenshot function. ([9ce7bbc](https://github.com/FunkinCrew/Funkin/commit/9ce7bbcfbb8f30ae120c876194f89bc4c787f585)) - by @Lasercar in [#4082](https://github.com/FunkinCrew/Funkin/pull/4082)
 - Accept keybinds (Z and Space by default) can now be used to exit the Results screen. ([edb270d](https://github.com/FunkinCrew/Funkin/commit/edb270d15e41784dccbf75639ac731840e80fe23)) - by @JVNpixels in [#3799](https://github.com/FunkinCrew/Funkin/pull/3799)
 - Reordered UI keybinds in the controls menu for consistency. ([a01bcc3](https://github.com/FunkinCrew/Funkin/commit/a01bcc3da836ec52851ca9de13ef459daf61269a)) - by @lemz1 in [#3027](https://github.com/FunkinCrew/Funkin/pull/3027)
 - New save files now have default Freeplay controls for gamepads. ([2b7f62e](https://github.com/FunkinCrew/Funkin/commit/2b7f62edd33de5527e259d9e5643f926d35da734)) - by @MrMadera in [#3934](https://github.com/FunkinCrew/Funkin/pull/3934)
-- Renamed “Auto Pause” preference to “Pause on Unfocus” for clarity. ([49a21c1](https://github.com/FunkinCrew/Funkin/commit/49a21c198236fbecbe5902bb106f78939cc6442a)) - by @JackXson-Real in [#4346](https://github.com/FunkinCrew/Funkin/pull/4346)
 - Made scrolling smoother in the Chart Editor. ([20d9016](https://github.com/FunkinCrew/Funkin/commit/20d90169845f1e50f849e39f4c5f818359756c78)) - by @ninjamuffin99 in [#3768](https://github.com/FunkinCrew/Funkin/pull/3768)
-- The Chart Editor now clears the undo/redo history after loading a new song. ([c7bdc1a](https://github.com/FunkinCrew/Funkin/commit/c7bdc1abe265678468920ca3cc3d7eface5d6925)) - by @Lasercar in [#4308](https://github.com/FunkinCrew/Funkin/pull/4308)
 - Mods with missing dependencies are now skipped instead of preventing all mods from loading. ([1c2fb43](https://github.com/FunkinCrew/Funkin/commit/1c2fb43ae16cf40be5ef94c40b047e8e772b1211)) - by @AbnormalPoof in [#3993](https://github.com/FunkinCrew/Funkin/pull/3993)
 - Slightly improved flexibility for modding note hit animations. ([3aad825](https://github.com/FunkinCrew/Funkin/commit/3aad825f865c4ed87016983d44121e2c1610d332)) - by @TechnikTil in [#3936](https://github.com/FunkinCrew/Funkin/pull/3936)
 - Introduced several QoL modding changes. ([785c4be](https://github.com/FunkinCrew/Funkin/commit/785c4be88b52dc1b5899013822fc004ba7d9894d)) - by @Kade-github in [#4009](https://github.com/FunkinCrew/Funkin/pull/4009)
 - Lots of smaller bug fixes.
 
-## New Contributors for 0.6.0
+### Fixed
 
-* @PatoFlamejanteTV made their first contribution in [#3843](https://github.com/FunkinCrew/Funkin/pull/3843)
-* @sphis-Sinco made their first contribution in [#3881](https://github.com/FunkinCrew/Funkin/pull/3881)
-* @MrMadera made their first contribution in [#3934](https://github.com/FunkinCrew/Funkin/pull/3934)
-* @Lasercar made their first contribution in [#4100](https://github.com/FunkinCrew/Funkin/pull/4065)
-* @MidyGamy made their first contribution in [#4068](https://github.com/FunkinCrew/Funkin/pull/4068)
-* @MrScottyPieey made their first contribution in [#4085](https://github.com/FunkinCrew/Funkin/pull/4085)
-* @JackXson-Real made their first contribution in [#4346](https://github.com/FunkinCrew/Funkin/pull/4346)
-
-# Fixed
 - Fixed a bug where the song would restart from the beginning instead of moving to the Results screen. ([3667c51](https://github.com/FunkinCrew/Funkin/commit/3667c51c1efe14cfe7c810e2f35991f08f50781a)) - by @KoloInDaCrib in [#4309](https://github.com/FunkinCrew/Funkin/pull/4309) and @Lasercar in [#4330](https://github.com/FunkinCrew/Funkin/pull/4330)
 - Reduced stuttering when resyncing instrumental and voices tracks. ([22d41d2](https://github.com/FunkinCrew/Funkin/commit/22d41d21b88acb7422a0afcda8414682710bd2ed)) - by @TechnikTil in [#3955](https://github.com/FunkinCrew/Funkin/pull/3955)
 - Songs with only instrumental tracks no longer stutter. ([dfe02ec](https://github.com/FunkinCrew/Funkin/commit/dfe02ec668b61d6308f459c978d12a7487f9dc28)) - by @KoloInDaCrib in [#3861](https://github.com/FunkinCrew/Funkin/pull/3861)
-- The mouse cursor is no longer visible outside of debug editors. ([1c12b84](https://github.com/FunkinCrew/Funkin/commit/1c12b8467eca350eb28138473360d5358fa620e2)) - by @sphis-Sinco in [#3881](https://github.com/FunkinCrew/Funkin/pull/3881)
+- The debug mouse cursor no longer flickers before the Title Screen loads. ([1c12b84](https://github.com/FunkinCrew/Funkin/commit/1c12b8467eca350eb28138473360d5358fa620e2)) - by @sphis-Sinco in [#3881](https://github.com/FunkinCrew/Funkin/pull/3881)
 - Unbound keys now display as [N/A] instead of crashing the game. ([94e5d3c](https://github.com/FunkinCrew/Funkin/commit/94e5d3ca258cbaa5d9ab6f0cb26feda83b3433a2)) - by @NotHyper-474 in [#4355](https://github.com/FunkinCrew/Funkin/pull/4355)
 - Songs can no longer be spam-selected after selecting an instrumental in Freeplay. ([0e0c4ae](https://github.com/FunkinCrew/Funkin/commit/0e0c4aeb7745cfb9479685ccbb635cf3743cddbb)) - by @AbnormalPoof in [#3866](https://github.com/FunkinCrew/Funkin/pull/3866)
 - The Random capsule can now switch to Erect/Nightmare difficulties in Freeplay. ([6f32747](https://github.com/FunkinCrew/Funkin/commit/6f327474f30374f50774f432ea3ccb6d02579445)) - by @KoloInDaCrib in [#3838](https://github.com/FunkinCrew/Funkin/pull/3838)
-- The millions place digit of the Freeplay score now updates properly. ([3719ca6](https://github.com/FunkinCrew/Funkin/commit/3719ca6ce7a170c3c890cdb2aeea3e4534b91736)) - by @Lasercar in [#4065](https://github.com/FunkinCrew/Funkin/pull/4065)
 - Fixed a rare bug where a song would not register as beaten. ([a3e2373](https://github.com/FunkinCrew/Funkin/commit/a3e23733db104b1ef00cfcff17db3a5d032a4d67)) - by @AbnormalPoof in [#3820](https://github.com/FunkinCrew/Funkin/pull/3820)
 - The difficulty graphic on the Results screen no longer cuts off incorrectly. ([b13bf05](https://github.com/FunkinCrew/Funkin/commit/b13bf05d16ff2977309e0c7ba3f049c0134e8902)) - by @AbnormalPoof in [#4161](https://github.com/FunkinCrew/Funkin/pull/4161)
 - Four-digit long Total Notes values in the Results screen no longer overflow to the right. ([2be4c0c](https://github.com/FunkinCrew/Funkin/commit/2be4c0c7196e018a43f9697f015179f3efc3fcdb)) - by @Hundrec in [#4356](https://github.com/FunkinCrew/Funkin/pull/4356)
@@ -98,6 +100,16 @@ The Pit Stop 2 update!
 - Blacklisted an additional class for security. ([3492d41](https://github.com/FunkinCrew/Funkin/commit/3492d412c65c7f3fd61e6fc6c9410d8467122ab0)) - by @AbnormalPoof in [#4074](https://github.com/FunkinCrew/Funkin/pull/4074)
 - Removed an unused class from Polymod blacklist. ([06c12e3](https://github.com/FunkinCrew/Funkin/commit/06c12e36c6bd6df4e2be32a3bec540172e79e162)) - by @AbnormalPoof in [#3729](https://github.com/FunkinCrew/Funkin/pull/3729)
 - Many additional small bug fixes.
+
+## New Contributors for 0.6.0
+
+* @PatoFlamejanteTV made their first contribution in [#3843](https://github.com/FunkinCrew/Funkin/pull/3843)
+* @sphis-Sinco made their first contribution in [#3881](https://github.com/FunkinCrew/Funkin/pull/3881)
+* @MrMadera made their first contribution in [#3934](https://github.com/FunkinCrew/Funkin/pull/3934)
+* @MidyGamy made their first contribution in [#4068](https://github.com/FunkinCrew/Funkin/pull/4068)
+* @Lasercar made their first contribution in [#4082](https://github.com/FunkinCrew/Funkin/pull/4082)
+* @MrScottyPieey made their first contribution in [#4085](https://github.com/FunkinCrew/Funkin/pull/4085)
+
 
 
 ## [0.5.3] - 2024-10-18

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,8 @@ The Pit Stop 2 update!
 - Switched from hxCodec to hxvlc for video playback. This may break a mod or two.
   - Check the [Funkin Modding Docs](https://funkincrew.github.io/funkin-modding-docs/09-migration/09-02-0.5.0-to-0.6.0.html) for more info on how to update your mods.
 - Polymod should now ignore `.git` files when loading mods.
+- The pause menu can now be opened and closed rapidly.
+- Adjusted difficulty ratings and scroll speeds for many songs.
 - Lots of improvements to GitHub issue and pull request organization. - by @Hundrec and @AbnormalPoof
 - Overhauled the Changelog to improve readability and properly credit contributors. ([4383fcf](https://github.com/FunkinCrew/Funkin/commit/4383fcf32c280a1c0ee7b9c80d255611d497cabc)) - by @Hundrec in [#4296](https://github.com/FunkinCrew/Funkin/pull/4296) and [#4298](https://github.com/FunkinCrew/Funkin/pull/4298)
 - Made various improvements to the screenshot function. ([9ce7bbc](https://github.com/FunkinCrew/Funkin/commit/9ce7bbcfbb8f30ae120c876194f89bc4c787f585)) - by @Lasercar in [#4082](https://github.com/FunkinCrew/Funkin/pull/4082)
@@ -79,10 +81,15 @@ The Pit Stop 2 update!
 - Mods with missing dependencies are now skipped instead of preventing all mods from loading. ([1c2fb43](https://github.com/FunkinCrew/Funkin/commit/1c2fb43ae16cf40be5ef94c40b047e8e772b1211)) - by @AbnormalPoof in [#3993](https://github.com/FunkinCrew/Funkin/pull/3993)
 - Slightly improved flexibility for modding note hit animations. ([3aad825](https://github.com/FunkinCrew/Funkin/commit/3aad825f865c4ed87016983d44121e2c1610d332)) - by @TechnikTil in [#3936](https://github.com/FunkinCrew/Funkin/pull/3936)
 - Introduced several QoL modding changes. ([785c4be](https://github.com/FunkinCrew/Funkin/commit/785c4be88b52dc1b5899013822fc004ba7d9894d)) - by @Kade-github in [#4009](https://github.com/FunkinCrew/Funkin/pull/4009)
-- Lots of smaller bug fixes.
+- Lots of smaller changes.
 
 ### Fixed
 
+- Shaders no longer create thin seams within atlas sprites.
+- Completing a song in Practice Mode no longer plays a new rank animation in the Freeplay menu.
+- Fixed lots of charting issues across many songs.
+- The Chart Editor grid now properly adjusts to the new BPM after switching variations.
+- Fixed a few crashes in the Stage Editor.
 - Fixed a bug where the song would restart from the beginning instead of moving to the Results screen. ([3667c51](https://github.com/FunkinCrew/Funkin/commit/3667c51c1efe14cfe7c810e2f35991f08f50781a)) - by @KoloInDaCrib in [#4309](https://github.com/FunkinCrew/Funkin/pull/4309) and @Lasercar in [#4330](https://github.com/FunkinCrew/Funkin/pull/4330)
 - Reduced stuttering when resyncing instrumental and voices tracks. ([22d41d2](https://github.com/FunkinCrew/Funkin/commit/22d41d21b88acb7422a0afcda8414682710bd2ed)) - by @TechnikTil in [#3955](https://github.com/FunkinCrew/Funkin/pull/3955)
 - Songs with only instrumental tracks no longer stutter. ([dfe02ec](https://github.com/FunkinCrew/Funkin/commit/dfe02ec668b61d6308f459c978d12a7487f9dc28)) - by @KoloInDaCrib in [#3861](https://github.com/FunkinCrew/Funkin/pull/3861)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,7 +61,7 @@ The Pit Stop 2 update!
 - Added offsets support for album titles. ([69d8570](https://github.com/FunkinCrew/Funkin/commit/69d8570a9eb06011ed6dd95fcbef83d90f7f8684)) - by @AbnormalPoof in [#3618](https://github.com/FunkinCrew/Funkin/pull/3618)
 - Added three new properties to stage data: `angle`, `scroll`, and `alpha`. ([ff56b19](https://github.com/FunkinCrew/Funkin/commit/ff56b1948aef42bbb6bb4ede4f9b2012d49ab044)) - by @AbnormalPoof in [#3720](https://github.com/FunkinCrew/Funkin/pull/3720)
 - Added script events for losing/gaining focus. ([4b127b6](https://github.com/FunkinCrew/Funkin/commit/4b127b64130f6f753d0574ec66a1672322e4bd13)) - by @AbnormalPoof in [#3721](https://github.com/FunkinCrew/Funkin/pull/3721)
-- Added 10 new functions to `ReflectUtil`.([6216655](https://github.com/FunkinCrew/Funkin/commit/62166554e7a176245d1a63bd15122033044c4e40)) - by @AbnormalPoof in [#3622](https://github.com/FunkinCrew/Funkin/pull/3622), [#3809](https://github.com/FunkinCrew/Funkin/pull/3809), and [#4019](https://github.com/FunkinCrew/Funkin/pull/4019)
+- Added 10 new functions to `ReflectUtil`. ([6216655](https://github.com/FunkinCrew/Funkin/commit/62166554e7a176245d1a63bd15122033044c4e40)) - by @AbnormalPoof in [#3622](https://github.com/FunkinCrew/Funkin/pull/3622), [#3809](https://github.com/FunkinCrew/Funkin/pull/3809), and [#4019](https://github.com/FunkinCrew/Funkin/pull/4019)
 - Added `DEBUG_BUILD` value to `Constants` to indicate whether a build has debug functions enabled. ([ad45b72](https://github.com/FunkinCrew/Funkin/commit/ad45b72b1ae8eb73a12dc51bcb59f66cc55e7bbd)) - by @AbnormalPoof in [#3853](https://github.com/FunkinCrew/Funkin/pull/3853)
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,10 +51,11 @@ The Pit Stop 2 update!
   - Added new stickers which appear when exiting Pico songs!
   - The new sticker system isn't fully available to mods yet, but we're working on it!
 - New option in the Preferences menu: Strumline Backgrounds!
-- Options in the Preferences menu now display an on-screen description when selected.
+- New song event type in the Chart Editor: Set Health Icon!
+  - This event is now used in Stress (Pico Mix).
 - The HOME and END keys now jump to the top and bottom of the Freeplay song list, respectively. ([bb974c2](https://github.com/FunkinCrew/Funkin/commit/bb974c264270d10ff503784063e5d77bb352b3f7)) - by @AbnormalPoof in [#4103](https://github.com/FunkinCrew/Funkin/pull/4103)
 - Added an option to launch the game in fullscreen. ([ee53ccd](https://github.com/FunkinCrew/Funkin/commit/ee53ccd32721e0790adfe82c60d4aca419db0a7f)) - by @AbnormalPoof in [#3738](https://github.com/FunkinCrew/Funkin/pull/3738)
-- Added descriptions for each item in the Preferences menu. ([a17b0e8](https://github.com/FunkinCrew/Funkin/commit/a17b0e8b3cc1d56fcdc0b51eaca9fd57cdb5bce0)) - by @anysad in [#3872](https://github.com/FunkinCrew/Funkin/pull/3872)
+- Added on-screen descriptions for each item in the Preferences menu. ([a17b0e8](https://github.com/FunkinCrew/Funkin/commit/a17b0e8b3cc1d56fcdc0b51eaca9fd57cdb5bce0)) - by @anysad in [#3872](https://github.com/FunkinCrew/Funkin/pull/3872)
 - Added precise scrolling in the Chart Editor using Ctrl-Mouse Wheel. ([0d8e4a5](https://github.com/FunkinCrew/Funkin/commit/0d8e4a53305d6d069454812766300122f3581e31)) - by @ninjamuffin99 in [#3806](https://github.com/FunkinCrew/Funkin/pull/3806)
 - Added a “None” option to the character selector in the Chart Editor. ([d9637d3](https://github.com/FunkinCrew/Funkin/commit/d9637d3a19466b9fc68a102676c46a74ef504909)) - by @Lasercar in [#4279](https://github.com/FunkinCrew/Funkin/pull/4279)
 - Added the ability to flip the character in the Animation Editor. ([de02137](https://github.com/FunkinCrew/Funkin/commit/de02137d7c7d1779e85aeda34743f506a5b9cc27)) - by @AbnormalPoof in [#3028](https://github.com/FunkinCrew/Funkin/pull/3028)
@@ -71,6 +72,8 @@ The Pit Stop 2 update!
 - Polymod should now ignore `.git` files when loading mods.
 - The pause menu can now be opened and closed rapidly.
 - Adjusted difficulty ratings and scroll speeds for many songs.
+- Chart Editor event fields now allow for values to be as specific as desired.
+  - For example, the Zoom Camera event can now be set to 0.9857.
 - Lots of improvements to GitHub issue and pull request organization. - by @Hundrec and @AbnormalPoof
 - Overhauled the Changelog to improve readability and properly credit contributors. ([4383fcf](https://github.com/FunkinCrew/Funkin/commit/4383fcf32c280a1c0ee7b9c80d255611d497cabc)) - by @Hundrec in [#4296](https://github.com/FunkinCrew/Funkin/pull/4296) and [#4298](https://github.com/FunkinCrew/Funkin/pull/4298)
 - Made various improvements to the screenshot function. ([9ce7bbc](https://github.com/FunkinCrew/Funkin/commit/9ce7bbcfbb8f30ae120c876194f89bc4c787f585)) - by @Lasercar in [#4082](https://github.com/FunkinCrew/Funkin/pull/4082)

--- a/docs/COMPILING_MAC.md
+++ b/docs/COMPILING_MAC.md
@@ -1,0 +1,10 @@
+# Mac Compiling Guide + Considerations
+
+There's a few extra considerations when compiling FNF for Mac that *we* have to handle when creating a wider release.
+- [Creating a Universal Binary](#creating-a-universal-binary)
+- Code-signing
+- Notarizing
+
+## Creating a Universal Binary
+
+Run the `art/macos-universal.sh` script, which automatically compiles release versions of both arm64 and x86 of Funkin. You can also see there for reference of how it's done.

--- a/source/funkin/api/newgrounds/Events.hx
+++ b/source/funkin/api/newgrounds/Events.hx
@@ -17,13 +17,16 @@ class Events
   public static function logEvent(eventName:String):Void
   {
     #if (FEATURE_NEWGROUNDS && FEATURE_NEWGROUNDS_EVENTS)
-    var eventHandler = NG.core.calls.event;
-
-    if (eventHandler != null)
+    if (NewgroundsClient.instance.isLoggedIn())
     {
-      var sanitizedEventName = EVENT_NAME_REGEX.replace(eventName, '');
-      var outcomeHandler = onEventLogged.bind(sanitizedEventName, _);
-      eventHandler.logEvent(sanitizedEventName).addOutcomeHandler(outcomeHandler).send();
+      var eventHandler = NG.core.calls.event;
+
+      if (eventHandler != null)
+      {
+        var sanitizedEventName = EVENT_NAME_REGEX.replace(eventName, '');
+        var outcomeHandler = onEventLogged.bind(sanitizedEventName, _);
+        eventHandler.logEvent(sanitizedEventName).addOutcomeHandler(outcomeHandler).send();
+      }
     }
     #end
   }

--- a/source/funkin/api/newgrounds/Events.hx
+++ b/source/funkin/api/newgrounds/Events.hx
@@ -8,6 +8,7 @@ import io.newgrounds.objects.events.Result;
 /**
  * Use Newgrounds to perform basic telemetry. Ignore if not logged in to Newgrounds.
  */
+@:nullSafety
 class Events
 {
   // Only allow letters, numbers, spaces, dashes, and underscores.
@@ -16,16 +17,13 @@ class Events
   public static function logEvent(eventName:String):Void
   {
     #if (FEATURE_NEWGROUNDS && FEATURE_NEWGROUNDS_EVENTS)
-    if (NewgroundsClient.instance.isLoggedIn())
-    {
-      var eventHandler = NG.core.calls.event;
+    var eventHandler = NG.core.calls.event;
 
-      if (eventHandler != null)
-      {
-        var sanitizedEventName = EVENT_NAME_REGEX.replace(eventName, '');
-        var outcomeHandler = onEventLogged.bind(sanitizedEventName, _);
-        eventHandler.logEvent(sanitizedEventName).addOutcomeHandler(outcomeHandler).send();
-      }
+    if (eventHandler != null)
+    {
+      var sanitizedEventName = EVENT_NAME_REGEX.replace(eventName, '');
+      var outcomeHandler = onEventLogged.bind(sanitizedEventName, _);
+      eventHandler.logEvent(sanitizedEventName).addOutcomeHandler(outcomeHandler).send();
     }
     #end
   }

--- a/source/funkin/api/newgrounds/Leaderboards.hx
+++ b/source/funkin/api/newgrounds/Leaderboards.hx
@@ -4,29 +4,33 @@ package funkin.api.newgrounds;
 import io.newgrounds.Call.CallError;
 import io.newgrounds.objects.ScoreBoard as LeaderboardData;
 import io.newgrounds.objects.events.Outcome;
+import io.newgrounds.utils.ScoreBoardList;
 
 class Leaderboards
 {
   public static function listLeaderboardData():Map<Leaderboard, LeaderboardData>
   {
-    if (NewgroundsClient.instance.leaderboards == null)
+    var leaderboardList:Null<ScoreBoardList> = NewgroundsClient.instance.leaderboards;
+    if (leaderboardList == null)
     {
       trace('[NEWGROUNDS] Not logged in, cannot fetch medal data!');
       return [];
     }
-
-    var result:Map<Leaderboard, LeaderboardData> = [];
-
-    for (leaderboardId in NewgroundsClient.instance.leaderboards.keys())
+    else
     {
-      var leaderboardData = NewgroundsClient.instance.leaderboards.get(leaderboardId);
-      if (leaderboardData == null) continue;
+      var result:Map<Leaderboard, LeaderboardData> = [];
 
-      // A little hacky, but it works.
-      result.set(cast leaderboardId, leaderboardData);
+      for (leaderboardId in leaderboardList.keys())
+      {
+        var leaderboardData = leaderboardList.get(leaderboardId);
+        if (leaderboardData == null) continue;
+
+        // A little hacky, but it works.
+        result.set(cast leaderboardId, leaderboardData);
+      }
+
+      return result;
     }
-
-    return result;
   }
 
   /**
@@ -42,7 +46,10 @@ class Leaderboards
 
     if (NewgroundsClient.instance.isLoggedIn())
     {
-      var leaderboardData = NewgroundsClient.instance.leaderboards.get(leaderboard.getId());
+      var leaderboardList = NewgroundsClient.instance.leaderboards;
+      if (leaderboardList == null) return;
+
+      var leaderboardData:Null<LeaderboardData> = leaderboardList.get(leaderboard.getId());
       if (leaderboardData != null)
       {
         leaderboardData.postScore(score, function(outcome:Outcome<CallError>):Void {

--- a/source/funkin/api/newgrounds/Medals.hx
+++ b/source/funkin/api/newgrounds/Medals.hx
@@ -5,54 +5,55 @@ import io.newgrounds.objects.Medal as MedalData;
 import funkin.util.plugins.NewgroundsMedalPlugin;
 import flixel.graphics.FlxGraphic;
 import openfl.display.BitmapData;
+import io.newgrounds.utils.MedalList;
 import haxe.Json;
 
 class Medals
 {
-  public static var medalJSON:Array<MedalJSON>;
+  public static var medalJSON:Array<MedalJSON> = [];
 
   public static function listMedalData():Map<Medal, MedalData>
   {
-    if (NewgroundsClient.instance.medals == null)
+    var medalList = NewgroundsClient.instance.medals;
+
+    if (medalList == null)
     {
       trace('[NEWGROUNDS] Not logged in, cannot fetch medal data!');
       return [];
     }
-
-    var result:Map<Medal, MedalData> = [];
-
-    for (medalId in NewgroundsClient.instance.medals.keys())
+    else
     {
-      var medalData = NewgroundsClient.instance.medals.get(medalId);
-      if (medalData == null) continue;
+      // TODO: Why do I have to do this, @:nullSafety is fucked up
+      var result:Map<Medal, MedalData> = [];
 
-      // A little hacky, but it works.
-      result.set(cast medalId, medalData);
+      for (medalId in medalList.keys())
+      {
+        var medalData = medalList.get(medalId);
+        if (medalData == null) continue;
+
+        // A little hacky, but it works.
+        result.set(cast medalId, medalData);
+      }
+
+      return result;
     }
-
-    return result;
-  }
-
-  static function isValid(medalData:MedalData):Bool
-  {
-    // IDK why medalData can exist but _data can be null...
-    // TODO: Move checks to the NG library.
-    @:privateAccess
-    return (medalData != null && medalData._data != null);
   }
 
   public static function award(medal:Medal):Void
   {
     if (NewgroundsClient.instance.isLoggedIn())
     {
-      var medalData = NewgroundsClient.instance.medals.get(medal.getId());
-      if (!isValid(medalData))
+      var medalList = NewgroundsClient.instance.medals;
+      if (medalList == null) return;
+
+      var medalData:Null<MedalData> = medalList.get(medal.getId());
+      @:privateAccess
+      if (medalData == null || medalData._data == null)
       {
         trace('[NEWGROUNDS] Could not retrieve data for medal: ${medal}');
         return;
       }
-
-      if (!medalData.unlocked)
+      else if (!medalData.unlocked)
       {
         trace('[NEWGROUNDS] Awarding medal (${medal}).');
         medalData.sendUnlock();
@@ -70,8 +71,6 @@ class Medals
         // We have to use a medal image from the game files. We use a Base64 encoded image that NG spits out.
         // TODO: Wait, don't they give us the medal icon?
 
-        var g:FlxGraphic = null;
-
         var localMedalData:Null<MedalJSON> = medalJSON.filter(function(jsonMedal) {
           #if FEATURE_NEWGROUNDS_TESTING_MEDALS
           return medal == jsonMedal.idTest;
@@ -86,10 +85,14 @@ class Medals
         // Lime/OpenFL parses it without the included prefix stuff, so we remove it.
         str = str.replace("data:image/png;base64,", "").trim();
         var bitmapData = BitmapData.fromBase64(str, "image/png");
-        if (str != null) g = FlxGraphic.fromBitmapData(bitmapData);
-        g.persist = true;
+        var medalGraphic:Null<FlxGraphic> = null;
+        if (str != null)
+        {
+          medalGraphic = FlxGraphic.fromBitmapData(bitmapData);
+          medalGraphic.persist = true;
+        }
 
-        NewgroundsMedalPlugin.play(medalData.value, medalData.name, g);
+        NewgroundsMedalPlugin.play(medalData.value, medalData.name, medalGraphic);
         #end
       }
       else
@@ -119,7 +122,7 @@ class Medals
       trace('[NEWGROUNDS] Failed to parse local medal data!');
       for (error in parser.errors)
         funkin.data.DataError.printError(error);
-      medalJSON = null;
+      medalJSON = [];
     }
     else
     {

--- a/source/funkin/graphics/adobeanimate/FlxAtlasSprite.hx
+++ b/source/funkin/graphics/adobeanimate/FlxAtlasSprite.hx
@@ -35,6 +35,11 @@ class FlxAtlasSprite extends FlxAnimate
    */
   public var onAnimationComplete:FlxTypedSignal<String->Void> = new FlxTypedSignal();
 
+  /**
+   * Signal dispatched when a looping animation finishes playing.
+   */
+  public var onAnimationLoop:FlxTypedSignal<String->Void> = new FlxTypedSignal();
+
   var currentAnimation:String;
 
   var canPlayOtherAnims:Bool = true;
@@ -307,7 +312,7 @@ class FlxAtlasSprite extends FlxAnimate
         {
           anim.curFrame = (fr != null) ? fr.index : 0;
           anim.resume();
-          // _onAnimationComplete not called since this is a loop.
+          _onAnimationLoop();
         }
         else if (fr != null && anim.curFrame != anim.length - 1)
         {
@@ -328,6 +333,18 @@ class FlxAtlasSprite extends FlxAnimate
     else
     {
       onAnimationComplete.dispatch('');
+    }
+  }
+
+  function _onAnimationLoop():Void
+  {
+    if (currentAnimation != null)
+    {
+      onAnimationLoop.dispatch(currentAnimation);
+    }
+    else
+    {
+      onAnimationLoop.dispatch('');
     }
   }
 

--- a/source/funkin/modding/module/Module.hx
+++ b/source/funkin/modding/module/Module.hx
@@ -57,6 +57,9 @@ class Module implements IPlayStateScriptedClass implements IStateChangingScripte
 
   // TODO: Half of these aren't actually being called!!!!!!!
 
+  /**
+   * Called when ANY script event is dispatched.
+   */
   public function onScriptEvent(event:ScriptEvent) {}
 
   /**
@@ -71,55 +74,138 @@ class Module implements IPlayStateScriptedClass implements IStateChangingScripte
    */
   public function onDestroy(event:ScriptEvent) {}
 
+  /**
+   * Called every frame.
+   */
   public function onUpdate(event:UpdateScriptEvent) {}
 
+  /**
+   * Called when the game is paused.
+   */
   public function onPause(event:PauseScriptEvent) {}
 
+  /**
+   * Called when the game is resumed.
+   */
   public function onResume(event:ScriptEvent) {}
 
+  /**
+   * Called when the song begins.
+   */
   public function onSongStart(event:ScriptEvent) {}
 
+  /**
+   * Called when the song ends.
+   */
   public function onSongEnd(event:ScriptEvent) {}
 
+  /**
+   * Called when the player dies.
+   */
   public function onGameOver(event:ScriptEvent) {}
 
+  /**
+   * Called when a note on the strumline has been rendered and is now onscreen.
+   * This gets dispatched for both the player and opponent strumlines.
+   */
   public function onNoteIncoming(event:NoteScriptEvent) {}
 
+  /**
+   * Called when a note has been hit.
+   * This gets dispatched for both the player and opponent strumlines.
+   */
   public function onNoteHit(event:HitNoteScriptEvent) {}
 
+  /**
+   * Called when a note has been missed.
+   * This gets dispatched for both the player and opponent strumlines.
+   */
   public function onNoteMiss(event:NoteScriptEvent) {}
 
+  /**
+   * Called when the player presses a key without any notes present.
+   */
   public function onNoteGhostMiss(event:GhostMissNoteScriptEvent) {}
 
+  /**
+   * Called when a step is hit in the song.
+   */
   public function onStepHit(event:SongTimeScriptEvent) {}
 
+  /**
+   * Called when a beat is hit in the song.
+   */
   public function onBeatHit(event:SongTimeScriptEvent) {}
 
+  /**
+   * Called when a song event is triggered.
+   */
   public function onSongEvent(event:SongEventScriptEvent) {}
 
+  /**
+   * Called when the countdown begins.
+   */
   public function onCountdownStart(event:CountdownScriptEvent) {}
 
+  /**
+   * Called for every step in the countdown.
+   */
   public function onCountdownStep(event:CountdownScriptEvent) {}
 
+  /**
+   * Called when the countdown ends, but BEFORE the song starts.
+   */
   public function onCountdownEnd(event:CountdownScriptEvent) {}
 
+  /**
+   * Called when the song's chart has been parsed and loaded.
+   */
   public function onSongLoaded(event:SongLoadScriptEvent) {}
 
+  /**
+   * Called when the game is about to switch to a new state.
+   */
   public function onStateChangeBegin(event:StateChangeScriptEvent) {}
 
+  /**
+   * Called after the game has switched to a new state.
+   */
   public function onStateChangeEnd(event:StateChangeScriptEvent) {}
 
+  /**
+   * Called when the game regains focus.
+   * This does not get called if "Auto Pause" is disabled.
+   */
   public function onFocusGained(event:FocusScriptEvent) {}
 
+  /**
+   * Called when the game loses focus.
+   * This does not get called if "Auto Pause" is disabled.
+   */
   public function onFocusLost(event:FocusScriptEvent) {}
 
+  /**
+   * Called when the game is about to open a substate.
+   */
   public function onSubStateOpenBegin(event:SubStateScriptEvent) {}
 
+  /**
+   * Called when a substate has been opened.
+   */
   public function onSubStateOpenEnd(event:SubStateScriptEvent) {}
 
+  /**
+   * Called when the game is about to close a substate.
+   */
   public function onSubStateCloseBegin(event:SubStateScriptEvent) {}
 
+  /**
+   * Called when a substate has been closed.
+   */
   public function onSubStateCloseEnd(event:SubStateScriptEvent) {}
 
+  /**
+   * Called when the song has been restarted.
+   */
   public function onSongRetry(event:SongRetryEvent) {}
 }

--- a/source/funkin/play/PlayState.hx
+++ b/source/funkin/play/PlayState.hx
@@ -3017,7 +3017,7 @@ class PlayState extends MusicBeatSubState
             }
         });
 
-      // Award various medals based on variation, difficulty, and scoring rank.
+      // Award various medals based on variation, difficulty, song ID, and scoring rank.
       if (scoreRank == ScoringRank.SHIT) Medals.award(LossRating);
       if (scoreRank >= ScoringRank.PERFECT && currentDifficulty == 'hard') Medals.award(PerfectRatingHard);
       if (scoreRank == ScoringRank.PERFECT_GOLD && currentDifficulty == 'hard') Medals.award(GoldPerfectRatingHard);
@@ -3062,19 +3062,18 @@ class PlayState extends MusicBeatSubState
                 },
             };
 
-          if (currentSong.validScore
-            && Save.instance.isLevelHighScore(PlayStatePlaylist.campaignId, PlayStatePlaylist.campaignDifficulty, data))
+          #if FEATURE_NEWGROUNDS
+          // Award a medal for beating a Story level.
+          Medals.awardStoryLevel(PlayStatePlaylist.campaignId);
+
+          // Submit the score for the Story level to Newgrounds.
+          Leaderboards.submitLevelScore(PlayStatePlaylist.campaignId, PlayStatePlaylist.campaignDifficulty, PlayStatePlaylist.campaignScore);
+
+          Events.logCompleteLevel(PlayStatePlaylist.campaignId);
+          #end
+
+          if (Save.instance.isLevelHighScore(PlayStatePlaylist.campaignId, PlayStatePlaylist.campaignDifficulty, data))
           {
-            #if FEATURE_NEWGROUNDS
-            // Award a medal for beating a Story level.
-            Medals.awardStoryLevel(PlayStatePlaylist.campaignId);
-
-            // Submit the score for the Story level to Newgrounds.
-            Leaderboards.submitLevelScore(PlayStatePlaylist.campaignId, PlayStatePlaylist.campaignDifficulty, PlayStatePlaylist.campaignScore);
-
-            Events.logCompleteLevel(PlayStatePlaylist.campaignId);
-            #end
-
             Save.instance.setLevelScore(PlayStatePlaylist.campaignId, PlayStatePlaylist.campaignDifficulty, data);
             isNewHighscore = true;
           }

--- a/source/funkin/play/PlayState.hx
+++ b/source/funkin/play/PlayState.hx
@@ -2975,6 +2975,10 @@ class PlayState extends MusicBeatSubState
       // adds current song data into the tallies for the level (story levels)
       Highscore.talliesLevel = Highscore.combineTallies(Highscore.tallies, Highscore.talliesLevel);
 
+      #if FEATURE_NEWGROUNDS
+      Leaderboards.submitSongScore(currentSong.id, suffixedDifficulty, data);
+      #end
+
       if (!isPracticeMode && !isBotPlayMode)
       {
         #if FEATURE_NEWGROUNDS

--- a/source/funkin/play/PlayState.hx
+++ b/source/funkin/play/PlayState.hx
@@ -2976,7 +2976,7 @@ class PlayState extends MusicBeatSubState
       Highscore.talliesLevel = Highscore.combineTallies(Highscore.tallies, Highscore.talliesLevel);
 
       #if FEATURE_NEWGROUNDS
-      Leaderboards.submitSongScore(currentSong.id, suffixedDifficulty, data);
+      Leaderboards.submitSongScore(currentSong.id, suffixedDifficulty, data.score);
       #end
 
       if (!isPracticeMode && !isBotPlayMode)

--- a/source/funkin/play/ResultScore.hx
+++ b/source/funkin/play/ResultScore.hx
@@ -19,6 +19,8 @@ class ResultScore extends FlxTypedSpriteGroup<ScoreNum>
     var dumbNumb = Std.parseInt(Std.string(val));
     var prevNum:ScoreNum;
 
+    dumbNumb = Std.int(Math.min(dumbNumb, Math.pow(10, group.members.length) - 1));
+
     while (dumbNumb > 0)
     {
       scoreStart += 1;

--- a/source/funkin/play/ResultState.hx
+++ b/source/funkin/play/ResultState.hx
@@ -698,33 +698,6 @@ class ResultState extends MusicBeatSubState
 
   override function update(elapsed:Float):Void
   {
-    // if(FlxG.keys.justPressed.R){
-    //   FlxG.switchState(() -> new funkin.play.ResultState(
-    //   {
-    //     storyMode: false,
-    //     title: "Cum Song Erect by Kawai Sprite",
-    //     songId: "cum",
-    //     difficultyId: "nightmare",
-    //     isNewHighscore: true,
-    //     scoreData:
-    //       {
-    //         score: 1_234_567,
-    //         tallies:
-    //           {
-    //             sick: 200,
-    //             good: 0,
-    //             bad: 0,
-    //             shit: 0,
-    //             missed: 0,
-    //             combo: 0,
-    //             maxCombo: 69,
-    //             totalNotesHit: 200,
-    //             totalNotes: 200 // 0,
-    //           }
-    //       },
-    //   }));
-    // }
-
     // maskShaderSongName.swagSprX = songName.x;
     maskShaderDifficulty.swagSprX = difficulty.x;
 

--- a/source/funkin/play/ResultState.hx
+++ b/source/funkin/play/ResultState.hx
@@ -502,8 +502,9 @@ class ResultState extends MusicBeatSubState
           clearPercentCounter.curNumber = clearPercentTarget;
 
           #if FEATURE_NEWGROUNDS
+          var isScoreValid = !(params?.isPracticeMode ?? false) && !(params?.isBotPlayMode ?? false);
           // This is the easiest spot to do the medal calculation lol.
-          if (clearPercentTarget == 69) Medals.award(Nice);
+          if (isScoreValid && clearPercentTarget == 69) Medals.award(Nice);
           #end
 
           clearPercentCounter.flash(true);

--- a/source/funkin/play/character/CharacterData.hx
+++ b/source/funkin/play/character/CharacterData.hx
@@ -296,7 +296,7 @@ class CharacterDataParser
         charPath += "monsterpixel";
       case "mom" | "mom-car":
         charPath += "mommypixel";
-      case "pico-blazin" | "pico-playable" | "pico-speaker":
+      case "pico-blazin" | "pico-playable" | "pico-speaker" | "pico-pixel" | "pico-holding-nene":
         charPath += "picopixel";
       case "gf-christmas" | "gf-car" | "gf-pixel" | "gf-tankmen" | "gf-dark":
         charPath += "gfpixel";
@@ -308,7 +308,7 @@ class CharacterDataParser
         charPath += "senpaipixel";
       case "spooky-dark":
         charPath += "spookypixel";
-      case "tankman-atlas":
+      case "tankman-atlas" | "tankman-bloody":
         charPath += "tankmanpixel";
       case "pico-christmas" | "pico-dark":
         charPath += "picopixel";

--- a/source/funkin/save/Save.hx
+++ b/source/funkin/save/Save.hx
@@ -983,6 +983,7 @@ class Save
    * If you set slot to `2`, it will load an independent save file from slot 2.
    * @param slot
    */
+  @:haxe.warning("-WDeprecated")
   static function loadFromSlot(slot:Int):Save
   {
     trace('[SAVE] Loading save from slot $slot...');

--- a/source/funkin/save/Save.hx
+++ b/source/funkin/save/Save.hx
@@ -730,10 +730,6 @@ class Save
       // Directly set the highscore.
       setSongScore(songId, difficultyId, newScoreData);
 
-      #if FEATURE_NEWGROUNDS
-      Leaderboards.submitSongScore(songId, difficultyId, newScoreData.score);
-      #end
-
       return;
     }
 

--- a/source/funkin/ui/PixelatedIcon.hx
+++ b/source/funkin/ui/PixelatedIcon.hx
@@ -28,7 +28,7 @@ class PixelatedIcon extends FlxFilteredSprite
         charPath += "monsterpixel";
       case "mom" | "mom-car":
         charPath += "mommypixel";
-      case "pico-blazin" | "pico-playable" | "pico-speaker":
+      case "pico-blazin" | "pico-playable" | "pico-speaker" | "pico-pixel" | "pico-holding-nene":
         charPath += "picopixel";
       case "gf-christmas" | "gf-car" | "gf-pixel" | "gf-tankmen":
         charPath += "gfpixel";

--- a/source/funkin/ui/charSelect/CharSelectGF.hx
+++ b/source/funkin/ui/charSelect/CharSelectGF.hx
@@ -54,20 +54,6 @@ class CharSelectGF extends FlxAtlasSprite implements IBPMSyncedScriptedClass
         doFade(animInInfo);
       default:
     }
-
-    #if FEATURE_DEBUG_FUNCTIONS
-    if (FlxG.keys.justPressed.J)
-    {
-      alpha = 1;
-      x = y = 0;
-      fadingStatus = FADE_OUT;
-    }
-    if (FlxG.keys.justPressed.K)
-    {
-      alpha = 0;
-      fadingStatus = FADE_IN;
-    }
-    #end
   }
 
   public function onStepHit(event:SongTimeScriptEvent):Void {}

--- a/source/funkin/ui/charSelect/CharSelectSubState.hx
+++ b/source/funkin/ui/charSelect/CharSelectSubState.hx
@@ -425,6 +425,7 @@ class CharSelectSubState extends MusicBeatSubState
     else
     {
       #if FEATURE_NEWGROUNDS
+      // Make the character unlock medal retroactive.
       if (availableChars.size() > 1) Medals.award(CharSelect);
       #end
 
@@ -570,6 +571,7 @@ class CharSelectSubState extends MusicBeatSubState
         });
 
         #if FEATURE_NEWGROUNDS
+        // Grant the medal when the player unlocks a character.
         Medals.award(CharSelect);
         #end
 

--- a/source/funkin/ui/debug/results/ResultsDebugSubState.hx
+++ b/source/funkin/ui/debug/results/ResultsDebugSubState.hx
@@ -126,6 +126,8 @@ class ResultsDebugSubState extends MusicBeatSubState
         characterId: "bf",
         difficultyId: "nightmare",
         isNewHighscore: true,
+        isPracticeMode: true, // Invalidates achievements/scores.
+        isBotPlayMode: true, // Invalidates achievements/scores.
         scoreData:
           {
             score: 1_234_567,

--- a/source/funkin/ui/freeplay/FreeplayDJ.hx
+++ b/source/funkin/ui/freeplay/FreeplayDJ.hx
@@ -183,36 +183,6 @@ class FreeplayDJ extends FlxAtlasSprite
       default:
         // I shit myself.
     }
-
-    #if FEATURE_DEBUG_FUNCTIONS
-    if (FlxG.keys.pressed.CONTROL)
-    {
-      if (FlxG.keys.justPressed.LEFT)
-      {
-        this.offsetX -= FlxG.keys.pressed.ALT ? 0.1 : (FlxG.keys.pressed.SHIFT ? 10.0 : 1.0);
-      }
-
-      if (FlxG.keys.justPressed.RIGHT)
-      {
-        this.offsetX += FlxG.keys.pressed.ALT ? 0.1 : (FlxG.keys.pressed.SHIFT ? 10.0 : 1.0);
-      }
-
-      if (FlxG.keys.justPressed.UP)
-      {
-        this.offsetY -= FlxG.keys.pressed.ALT ? 0.1 : (FlxG.keys.pressed.SHIFT ? 10.0 : 1.0);
-      }
-
-      if (FlxG.keys.justPressed.DOWN)
-      {
-        this.offsetY += FlxG.keys.pressed.ALT ? 0.1 : (FlxG.keys.pressed.SHIFT ? 10.0 : 1.0);
-      }
-
-      if (FlxG.keys.justPressed.C)
-      {
-        currentState = (currentState == Idle ? Cartoon : Idle);
-      }
-    }
-    #end
   }
 
   function onFinishAnim(name:String):Void

--- a/source/funkin/ui/freeplay/FreeplayDJ.hx
+++ b/source/funkin/ui/freeplay/FreeplayDJ.hx
@@ -58,6 +58,7 @@ class FreeplayDJ extends FlxAtlasSprite
     FlxG.console.registerObject("dj", this);
 
     onAnimationComplete.add(onFinishAnim);
+    onAnimationLoop.add(onFinishAnim);
 
     FlxG.console.registerFunction("freeplayCartoon", function() {
       currentState = Cartoon;

--- a/source/funkin/ui/freeplay/FreeplayScore.hx
+++ b/source/funkin/ui/freeplay/FreeplayScore.hx
@@ -14,6 +14,8 @@ class FreeplayScore extends FlxTypedSpriteGroup<ScoreNum>
     var dumbNumb = Std.parseInt(Std.string(val));
     var prevNum:ScoreNum;
 
+    dumbNumb = Std.int(Math.min(dumbNumb, Math.pow(10, group.members.length) - 1));
+
     while (dumbNumb > 0)
     {
       group.members[loopNum].digit = dumbNumb % 10;

--- a/source/funkin/ui/freeplay/FreeplayState.hx
+++ b/source/funkin/ui/freeplay/FreeplayState.hx
@@ -1300,16 +1300,6 @@ class FreeplayState extends MusicBeatSubState
           difficultyId: "hard"
         }, grpCapsules.members[curSelected]);
     }
-
-    // if (FlxG.keys.justPressed.H)
-    // {
-    //   rankDisplayNew(fromResultsParams);
-    // }
-
-    // if (FlxG.keys.justPressed.G)
-    // {
-    //   rankAnimSlam(fromResultsParams);
-    // }
     #end // ^<-- FEATURE_DEBUG_FUNCTIONS
 
     if (controls.FREEPLAY_CHAR_SELECT && !busy)

--- a/source/funkin/ui/options/PreferencesMenu.hx
+++ b/source/funkin/ui/options/PreferencesMenu.hx
@@ -112,7 +112,7 @@ class PreferencesMenu extends Page<OptionsState.OptionsMenuPageName>
     createPrefItemCheckbox('Debug Display', 'If enabled, FPS and other debug stats will be displayed.', function(value:Bool):Void {
       Preferences.debugDisplay = value;
     }, Preferences.debugDisplay);
-    createPrefItemCheckbox('Auto Pause', 'If enabled, game automatically pauses when it loses focus.', function(value:Bool):Void {
+    createPrefItemCheckbox('Pause on Unfocus', 'If enabled, game automatically pauses when it loses focus.', function(value:Bool):Void {
       Preferences.autoPause = value;
     }, Preferences.autoPause);
     createPrefItemCheckbox('Launch in Fullscreen', 'Automatically launch the game in fullscreen on startup', function(value:Bool):Void {

--- a/source/funkin/ui/title/TitleState.hx
+++ b/source/funkin/ui/title/TitleState.hx
@@ -264,9 +264,6 @@ class TitleState extends MusicBeatState
     if (gamepad != null)
     {
       if (gamepad.justPressed.START) pressedEnter = true;
-      #if switch
-      if (gamepad.justPressed.B) pressedEnter = true;
-      #end
     }
 
     // If you spam Enter, we should skip the transition.

--- a/source/funkin/ui/transition/LoadingState.hx
+++ b/source/funkin/ui/transition/LoadingState.hx
@@ -171,10 +171,6 @@ class LoadingState extends MusicBeatSubState
       }
       FlxG.watch.addQuick('percentage?', callbacks.numRemaining / callbacks.length);
     }
-
-    #if FEATURE_DEBUG_FUNCTIONS
-    if (FlxG.keys.justPressed.SPACE) trace('fired: ' + callbacks.getFired() + ' unfired:' + callbacks.getUnfired());
-    #end
   }
 
   function onLoad():Void

--- a/source/funkin/ui/transition/StickerSubState.hx
+++ b/source/funkin/ui/transition/StickerSubState.hx
@@ -301,11 +301,6 @@ class StickerSubState extends MusicBeatSubState
   override public function update(elapsed:Float):Void
   {
     super.update(elapsed);
-
-    // if (FlxG.keys.justPressed.ANY)
-    // {
-    //   regenStickers();
-    // }
   }
 
   var switchingState:Bool = false;


### PR DESCRIPTION
## Does this PR close any issues? If so, link them below.
[3631](https://github.com/FunkinCrew/Funkin/issues/3631)
## Briefly describe the issue(s) fixed.
No, this does not cap the score itself as well. Just wanted to clarify that.
Caps the score displays in `ResultState` and `FreeplayState` to their maximum possible value. Adding more numbers instead would just make it look ugly and yucky :[

(this is not as massive of a change as it shows lol it makes it look like the automatically made spaces from vscode settings are one of the changes lol)