### PR TITLE
Replace deprecated FlxG.mouse.screenX/Y in MouseUtil

### DIFF
--- a/source/funkin/util/MouseUtil.hx
+++ b/source/funkin/util/MouseUtil.hx
@@ -28,13 +28,13 @@ class MouseUtil
     if (jusPres)
     {
       oldCamPos.set(target.x, target.y);
-      oldMousePos.set(FlxG.mouse.screenX, FlxG.mouse.screenY);
+      oldMousePos.set(FlxG.mouse.viewX, FlxG.mouse.viewY);
     }
 
     if (pressed)
     {
-      target.x = oldCamPos.x - (FlxG.mouse.screenX - oldMousePos.x);
-      target.y = oldCamPos.y - (FlxG.mouse.screenY - oldMousePos.y);
+      target.x = oldCamPos.x - (FlxG.mouse.viewX - oldMousePos.x);
+      target.y = oldCamPos.y - (FlxG.mouse.viewY - oldMousePos.y);
     }
   }
 


### PR DESCRIPTION
<!-- Please check for duplicates or similar PRs before submitting this PR. -->
## Does this PR close any issues? If so, link them below.
Fixes #3690
## Briefly describe the issue(s) fixed.
Should fix the Character Editor's camera panning