### PR TITLE
[BUGFIX] Fix the `RangeError` bug by bumping the funkVis commit

### DIFF
--- a/hmm.json
+++ b/hmm.json
@@ -44,7 +44,7 @@
       "name": "funkin.vis",
       "type": "git",
       "dir": null,
-      "ref": "22b1ce089dd924f15cdc4632397ef3504d464e90",
+      "ref": "1966f8fbbbc509ed90d4b520f3c49c084fc92fd6",
       "url": "https://github.com/FunkinCrew/funkVis"
     },
     {


### PR DESCRIPTION
Fixes #3499 by bumping the commit to [this newer one](https://github.com/FunkinCrew/funkVis/commit/1966f8fbbbc509ed90d4b520f3c49c084fc92fd6).
