### PR TITLE
[BUGFIX] Fix Input Offset interactions with Input Window (+ sustains)

### DIFF
--- a/source/funkin/play/notes/Strumline.hx
+++ b/source/funkin/play/notes/Strumline.hx
@@ -614,7 +614,8 @@ class Strumline extends FlxSpriteGroup
       }
 
       final magicNumberIGuess:Float = 8;
-      var renderWindowEnd:Float = holdNote.strumTime + holdNote.fullSustainLength + Constants.HIT_WINDOW_MS + (renderDistanceMs / magicNumberIGuess);
+      var renderWindowEnd:Float = holdNote.strumTime - conductorInUse.globalOffset + holdNote.fullSustainLength + Constants.HIT_WINDOW_MS
+        + (renderDistanceMs / magicNumberIGuess);
 
       if (holdNote.missedNote && conductorInUse.songPosition >= renderWindowEnd)
       {
@@ -698,7 +699,7 @@ class Strumline extends FlxSpriteGroup
         holdConfirm(holdNote.noteDirection);
         holdNote.visible = true;
 
-        holdNote.sustainLength = (holdNote.strumTime + holdNote.fullSustainLength) - conductorInUse.songPosition;
+        holdNote.sustainLength = (holdNote.strumTime + holdNote.fullSustainLength) - conductorInUse.songPosition + conductorInUse.globalOffset;
 
         if (holdNote.sustainLength <= 10)
         {
@@ -932,7 +933,8 @@ class Strumline extends FlxSpriteGroup
       note.holdNoteSprite.hitNote = true;
       note.holdNoteSprite.missedNote = false;
 
-      note.holdNoteSprite.sustainLength = (note.holdNoteSprite.strumTime + note.holdNoteSprite.fullSustainLength) - conductorInUse.songPosition;
+      note.holdNoteSprite.sustainLength = (note.holdNoteSprite.strumTime + note.holdNoteSprite.fullSustainLength)
+        - (conductorInUse.songPosition - conductorInUse.globalOffset);
     }
 
     #if FEATURE_GHOST_TAPPING


### PR DESCRIPTION
Very odd that this was already done on the opponent's side, but not the Player's.

<!-- Please check for duplicates or similar PRs before submitting this PR. -->
## Does this PR close any issues? If so, link them below.
https://github.com/FunkinCrew/Funkin/issues/3692, https://github.com/FunkinCrew/Funkin/issues/2382

## Briefly describe the issue(s) fixed.
Input Windows would not be offset by Input Offset, only Note Judgement would be. This pull request fixes that.

## Include any relevant screenshots or videos.
BEFORE: 

https://github.com/user-attachments/assets/0b646dc7-d023-4c25-b1c7-cbd233acb484


AFTER:

https://github.com/user-attachments/assets/8536df28-cfc1-4b3a-ba33-a4e816dcae5e

(Recorded on 200ms Input Offset)
~~(side note: can someone make events responsive to your offset ?? the hey animations are playing too early)~~ _ignore, use visual offset on negative side to achieve effect_