### PR TITLE
[ENHANCEMENT] Add Script Events for losing/gaining focus

### DIFF
--- a/source/funkin/modding/IScriptedClass.hx
+++ b/source/funkin/modding/IScriptedClass.hx
@@ -14,6 +14,7 @@ interface IScriptedClass
   public function onCreate(event:ScriptEvent):Void;
   public function onDestroy(event:ScriptEvent):Void;
   public function onUpdate(event:UpdateScriptEvent):Void;
+
   public function onFocusLost(event:FocusScriptEvent):Void;
   public function onFocusGained(event:FocusScriptEvent):Void;
 }

--- a/source/funkin/modding/IScriptedClass.hx
+++ b/source/funkin/modding/IScriptedClass.hx
@@ -14,6 +14,8 @@ interface IScriptedClass
   public function onCreate(event:ScriptEvent):Void;
   public function onDestroy(event:ScriptEvent):Void;
   public function onUpdate(event:UpdateScriptEvent):Void;
+  public function onFocusLost(event:FocusScriptEvent):Void;
+  public function onFocusGained(event:FocusScriptEvent):Void;
 }
 
 /**

--- a/source/funkin/modding/IScriptedClass.hx
+++ b/source/funkin/modding/IScriptedClass.hx
@@ -14,9 +14,6 @@ interface IScriptedClass
   public function onCreate(event:ScriptEvent):Void;
   public function onDestroy(event:ScriptEvent):Void;
   public function onUpdate(event:UpdateScriptEvent):Void;
-
-  public function onFocusLost(event:FocusScriptEvent):Void;
-  public function onFocusGained(event:FocusScriptEvent):Void;
 }
 
 /**
@@ -40,6 +37,15 @@ interface IStateChangingScriptedClass extends IScriptedClass
   public function onSubStateOpenEnd(event:SubStateScriptEvent):Void;
   public function onSubStateCloseBegin(event:SubStateScriptEvent):Void;
   public function onSubStateCloseEnd(event:SubStateScriptEvent):Void;
+}
+
+/**
+ * Defines a set of callbacks available to scripted classes which involve focus loss/gain.
+ */
+interface IFocusScriptedClass extends IScriptedClass
+{
+  public function onFocusLost(event:FocusScriptEvent):Void;
+  public function onFocusGained(event:FocusScriptEvent):Void;
 }
 
 /**

--- a/source/funkin/modding/IScriptedClass.hx
+++ b/source/funkin/modding/IScriptedClass.hx
@@ -37,13 +37,7 @@ interface IStateChangingScriptedClass extends IScriptedClass
   public function onSubStateOpenEnd(event:SubStateScriptEvent):Void;
   public function onSubStateCloseBegin(event:SubStateScriptEvent):Void;
   public function onSubStateCloseEnd(event:SubStateScriptEvent):Void;
-}
 
-/**
- * Defines a set of callbacks available to scripted classes which involve focus loss/gain.
- */
-interface IFocusScriptedClass extends IScriptedClass
-{
   public function onFocusLost(event:FocusScriptEvent):Void;
   public function onFocusGained(event:FocusScriptEvent):Void;
 }

--- a/source/funkin/modding/events/ScriptEvent.hx
+++ b/source/funkin/modding/events/ScriptEvent.hx
@@ -441,9 +441,9 @@ class StateChangeScriptEvent extends ScriptEvent
  */
 class FocusScriptEvent extends ScriptEvent
 {
-  public function new(type:ScriptEventType, cancelable:Bool = false):Void
+  public function new(type:ScriptEventType):Void
   {
-    super(type, cancelable);
+    super(type, false);
   }
 
   public override function toString():String

--- a/source/funkin/modding/events/ScriptEvent.hx
+++ b/source/funkin/modding/events/ScriptEvent.hx
@@ -437,6 +437,22 @@ class StateChangeScriptEvent extends ScriptEvent
 }
 
 /**
+ * An event that is fired when the game loses or gains focus.
+ */
+class FocusScriptEvent extends ScriptEvent
+{
+  public function new(type:ScriptEventType, cancelable:Bool = false):Void
+  {
+    super(type, cancelable);
+  }
+
+  public override function toString():String
+  {
+    return 'FocusScriptEvent(type=' + type + ')';
+  }
+}
+
+/**
  * An event that is fired when moving out of or into an FlxSubState.
  */
 class SubStateScriptEvent extends ScriptEvent

--- a/source/funkin/modding/events/ScriptEventDispatcher.hx
+++ b/source/funkin/modding/events/ScriptEventDispatcher.hx
@@ -37,12 +37,6 @@ class ScriptEventDispatcher
       case UPDATE:
         target.onUpdate(cast event);
         return;
-      case FOCUS_LOST:
-        target.onFocusLost(cast event);
-        return;
-      case FOCUS_GAINED:
-        target.onFocusGained(cast event);
-        return;
       default: // Continue;
     }
 
@@ -110,6 +104,21 @@ class ScriptEventDispatcher
           return;
         case SONG_STEP_HIT:
           t.onStepHit(cast event);
+          return;
+        default: // Continue;
+      }
+    }
+
+    if (Std.isOfType(target, IFocusScriptedClass))
+    {
+      var t = cast(target, IFocusScriptedClass);
+      switch (event.type)
+      {
+        case FOCUS_LOST:
+          t.onFocusLost(cast event);
+          return;
+        case FOCUS_GAINED:
+          t.onFocusGained(cast event);
           return;
         default: // Continue;
       }

--- a/source/funkin/modding/events/ScriptEventDispatcher.hx
+++ b/source/funkin/modding/events/ScriptEventDispatcher.hx
@@ -109,21 +109,6 @@ class ScriptEventDispatcher
       }
     }
 
-    if (Std.isOfType(target, IFocusScriptedClass))
-    {
-      var t = cast(target, IFocusScriptedClass);
-      switch (event.type)
-      {
-        case FOCUS_LOST:
-          t.onFocusLost(cast event);
-          return;
-        case FOCUS_GAINED:
-          t.onFocusGained(cast event);
-          return;
-        default: // Continue;
-      }
-    }
-
     if (Std.isOfType(target, IPlayStateScriptedClass))
     {
       var t:IPlayStateScriptedClass = cast(target, IPlayStateScriptedClass);
@@ -191,6 +176,12 @@ class ScriptEventDispatcher
           return;
         case SUBSTATE_CLOSE_END:
           t.onSubStateCloseEnd(cast event);
+          return;
+        case FOCUS_LOST:
+          t.onFocusLost(cast event);
+          return;
+        case FOCUS_GAINED:
+          t.onFocusGained(cast event);
           return;
         default: // Continue;
       }

--- a/source/funkin/modding/events/ScriptEventDispatcher.hx
+++ b/source/funkin/modding/events/ScriptEventDispatcher.hx
@@ -37,6 +37,12 @@ class ScriptEventDispatcher
       case UPDATE:
         target.onUpdate(cast event);
         return;
+      case FOCUS_LOST:
+        target.onFocusLost(cast event);
+        return;
+      case FOCUS_GAINED:
+        target.onFocusGained(cast event);
+        return;
       default: // Continue;
     }
 

--- a/source/funkin/modding/events/ScriptEventType.hx
+++ b/source/funkin/modding/events/ScriptEventType.hx
@@ -224,18 +224,18 @@ enum abstract ScriptEventType(String) from String to String
   var SUBSTATE_CLOSE_END = 'SUBSTATE_CLOSE_END';
 
   /**
-   * Called when the game loses focus.
-   *
-   * This event is not cancelable.
-   */
-  var FOCUS_LOST = 'FOCUS_LOST';
-
-  /**
    * Called when the game regains focus.
    *
    * This event is not cancelable.
    */
   var FOCUS_GAINED = 'FOCUS_GAINED';
+
+  /**
+   * Called when the game loses focus.
+   *
+   * This event is not cancelable.
+   */
+  var FOCUS_LOST = 'FOCUS_LOST';
 
   /**
    * Called when the game starts a conversation.

--- a/source/funkin/modding/events/ScriptEventType.hx
+++ b/source/funkin/modding/events/ScriptEventType.hx
@@ -224,6 +224,20 @@ enum abstract ScriptEventType(String) from String to String
   var SUBSTATE_CLOSE_END = 'SUBSTATE_CLOSE_END';
 
   /**
+   * Called when the game loses focus.
+   *
+   * This event is not cancelable.
+   */
+  var FOCUS_LOST = 'FOCUS_LOST';
+
+  /**
+   * Called when the game regains focus.
+   *
+   * This event is not cancelable.
+   */
+  var FOCUS_GAINED = 'FOCUS_GAINED';
+
+  /**
    * Called when the game starts a conversation.
    *
    * This event is not cancelable.

--- a/source/funkin/modding/module/Module.hx
+++ b/source/funkin/modding/module/Module.hx
@@ -109,6 +109,10 @@ class Module implements IPlayStateScriptedClass implements IStateChangingScripte
 
   public function onStateChangeEnd(event:StateChangeScriptEvent) {}
 
+  public function onFocusGained(event:FocusScriptEvent) {}
+
+  public function onFocusLost(event:FocusScriptEvent) {}
+
   public function onSubStateOpenBegin(event:SubStateScriptEvent) {}
 
   public function onSubStateOpenEnd(event:SubStateScriptEvent) {}

--- a/source/funkin/ui/MusicBeatState.hx
+++ b/source/funkin/ui/MusicBeatState.hx
@@ -87,6 +87,20 @@ class MusicBeatState extends FlxTransitionableState implements IEventHandler
     dispatchEvent(new UpdateScriptEvent(elapsed));
   }
 
+  override function onFocus():Void
+  {
+    super.onFocus();
+
+    dispatchEvent(new FocusScriptEvent(FOCUS_GAINED));
+  }
+
+  override function onFocusLost():Void
+  {
+    super.onFocusLost();
+
+    dispatchEvent(new FocusScriptEvent(FOCUS_LOST));
+  }
+
   function createWatermarkText()
   {
     // Both have an xPos of 0, but a width equal to the full screen.

--- a/source/funkin/ui/MusicBeatSubState.hx
+++ b/source/funkin/ui/MusicBeatSubState.hx
@@ -89,6 +89,20 @@ class MusicBeatSubState extends FlxSubState implements IEventHandler
     dispatchEvent(new UpdateScriptEvent(elapsed));
   }
 
+  override function onFocus():Void
+  {
+    super.onFocus();
+
+    dispatchEvent(new FocusScriptEvent(FOCUS_GAINED));
+  }
+
+  override function onFocusLost():Void
+  {
+    super.onFocusLost();
+
+    dispatchEvent(new FocusScriptEvent(FOCUS_LOST));
+  }
+
   public function initConsoleHelpers():Void {}
 
   function reloadAssets()


### PR DESCRIPTION
This PR adds callbacks to Modules for when the game loses/gains focus. Mods can use these callbacks like so:
```haxe
import funkin.modding.module.Module;

/**
 * A test of the focus events.
 *
 * Delete this later.
 */
class FocusTest extends Module {
  public function new() {
    super('FocusTest');
  }

  function onFocusLost(event) {
    trace("LOST FOCUS!");
  }

  function onFocusGained(event) {
    trace("FOCUS GAINED!");
  }
}
```

### Issues
- The game fires the `FOCUS_LOST` event when the game is closed/exited, though I'm pretty sure this is a Flixel bug since the events ride off of Flixel's existing `onFocus()` and `onFocusLost()` functions. (You're closing the game anyway though, so it's not much of an issue.)

### Notes
- Should `onFocusGained()` be `onFocus()` instead? I'm not really sure.