### PR TITLE
[BUGFIX] Fix the Save File being overriden in certain occassions, such as downgrading to versions between 0.5.2 and 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,40 +5,45 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [0.5.2] - 2024-10-11
+### Added
+- Added InverseDotsShader that emulates flash selections ([097dbf5](https://github.com/FunkinCrew/Funkin/commit/097dbf5bb4346d431d8ca9f0ec4bc5b5e6f4523f)) - by @ninjamuffin99
+- Added a new reworked Stage Editor ([27a0b44](https://github.com/FunkinCrew/Funkin/pull/3482/commits/27a0b4426f86f04362f97e16e2eff580c9402f34)) - by @JustKolosaki 
+- Added the `color` attribute to stage prop JSON data to allow them to be tinted without code. ([27a0b44](https://github.com/FunkinCrew/Funkin/pull/3482/commits/27a0b4426f86f04362f97e16e2eff580c9402f34)) - by @JustKolosaki 
+- Added the `angle` attribute to stage prop JSON data to allow them to be rotated without code. ([27a0b44](https://github.com/FunkinCrew/Funkin/pull/3482/commits/27a0b4426f86f04362f97e16e2eff580c9402f34)) - by @JustKolosaki 
+- Added the `blend` attribute to the stage prop JSON data to allow blend modes to be applied without code. ([27a0b44](https://github.com/FunkinCrew/Funkin/pull/3482/commits/27a0b4426f86f04362f97e16e2eff580c9402f34)) - by @JustKolosaki 
 
 ### Changed
 - (docs) Delete Modding.md since we have a separate modding documentation ([a42240e](https://github.com/FunkinCrew/Funkin/commit/a42240e6a595d33034f2c887bf38a350d1fa0f15)) - by @AbnormalPoof in [#3651](https://github.com/FunkinCrew/Funkin/pull/3651)
 - (docs) Create a git cliff template for easier changelog stuff ([91b4544](https://github.com/FunkinCrew/Funkin/commit/91b4544f7ebc51485e3e28c3d716ba6ee69ad885)) - by @ninjamuffin99 in [#3652](https://github.com/FunkinCrew/Funkin/pull/3652)
-- Added InverseDotsShader that emulates flash selections ([097dbf5](https://github.com/FunkinCrew/Funkin/commit/097dbf5bb4346d431d8ca9f0ec4bc5b5e6f4523f)) - by @ninjamuffin99
 - (docs) Add additional `variation` input parameter to `Save.hasBeatenSong()` to allow usage of the function by inputting a variation id ([4fa9a0d](https://github.com/FunkinCrew/Funkin/commit/4fa9a0daaa67e0977460b147bd1f74a118e3e2a5)) - by @ninjamuffin99
 - (docs) Added modding docs link in readme ([4b54118](https://github.com/FunkinCrew/Funkin/commit/4b54118731e26118111e06558ae4853c577fe4bb)) - by @Cartridge-Man
-- Fix some misspellings and grammar in code documentation ([2175bea](https://github.com/FunkinCrew/Funkin/commit/2175beaa651e009332202985be4b7eb4ed36e5a4)) - by @Hundrec
+- (docs) Fix some misspellings and grammar in code documentation ([2175bea](https://github.com/FunkinCrew/Funkin/commit/2175beaa651e009332202985be4b7eb4ed36e5a4)) - by @Hundrec
 - (docs) Improvements to Github Issues templates ([399869c](https://github.com/FunkinCrew/Funkin/commit/399869cdccc9c5ac27cecfbcdc33c3d7eb4b348c)) - by @Hundrec in [#3458](https://github.com/FunkinCrew/Funkin/pull/3458)
 - Fix some misspellings and grammar in code documentation ([6df80ba](https://github.com/FunkinCrew/Funkin/commit/6df80ba69d0e24269f40471f83462cab7d5e13cf)) - by @Hundrec in [#3477](https://github.com/FunkinCrew/Funkin/pull/3477)
 - (docs) Improvements to Github Issues templates ([67f7b63](https://github.com/FunkinCrew/Funkin/commit/67f7b638fb76840b868cbfa70a1c6063577984c5)) - by @Hundrec
 
 ### Fixed
+- Fix the user song offsets being applied incorrectly, causing stuttering or skipping ([410cfe9](https://github.com/FunkinCrew/Funkin/commit/410cfe972d6df9de4d4d128375cf8380c4f06d92)) - by @JustKolosaki
+- Fixed issues with variation / difficulty loading for Freeplay Menu which caused some songs to disappear ([c0314c8](https://github.com/FunkinCrew/Funkin/commit/c0314c85ecd5116641aff3de8e9153f7fe48e79c)) - by @ninjamuffin99
+- Picos songs now display properly on the Freeplay Menu ([1d2bd61](https://github.com/FunkinCrew/Funkin/commit/1d2bd61119e5f418df7f11d7ef2a0fdedee17d3d)) - by @ninjamuffin99
+- Exiting the chart editor doesn't crash the game anymore ([f52472a](https://github.com/FunkinCrew/Funkin/commit/f52472a4767388b22cfbab0f5f7860f6e6762856)) - by @EliteMasterEric and @ianharrigan
 - Disable flickering when changing FPS in the options menu ([b2647fe](https://github.com/FunkinCrew/Funkin/commit/b2647fe09f5281ce7074b26d47bc1524764168ee)) - by @lemz1 in [#3629](https://github.com/FunkinCrew/Funkin/pull/3629)
 - Anti alias / smooth the volume sound tray ([e66290c](https://github.com/FunkinCrew/Funkin/commit/e66290c55f7141402223644f06ec8a69edeee089)) - by @Kn1ghtNight in [#2853](https://github.com/FunkinCrew/Funkin/pull/2853)
 - Don't restart the FreeplayState song preview when changing the difficulty within the same variation ([903b3fc](https://github.com/FunkinCrew/Funkin/commit/903b3fc59905a70802618a1cd67407722ea956ed)) - by @JustKolosaki in [#3587](https://github.com/FunkinCrew/Funkin/pull/3587)
-- Exiting the chart editor doesn't crash the game anymore ([f52472a](https://github.com/FunkinCrew/Funkin/commit/f52472a4767388b22cfbab0f5f7860f6e6762856)) - by @EliteMasterEric
 - Character Select cursor moves properly at lower framerates ([ab5bda3](https://github.com/FunkinCrew/Funkin/commit/ab5bda3ee573a6e03595ec6941e6de38df851889)) - by @ninjamuffin99 in [#3507](https://github.com/FunkinCrew/Funkin/pull/3507)
 - Stopped allowing F1 to create more than one help dialog window in the Charting Editor ([777978f](https://github.com/FunkinCrew/Funkin/commit/777978f5a544e1b7c89b47dcc365f734eb6d0df1)) - by @amyspark-ng
 - Main menu music doesn't cut out when switching states anymore. ([711e0a6](https://github.com/FunkinCrew/Funkin/commit/711e0a6b7547eb04113e9318dab900f01ad576a5)) - by @EliteMasterEric in [#3530](https://github.com/FunkinCrew/Funkin/pull/3530)
 - The dialog now shows up on the animation debugger view ([1fde59f](https://github.com/FunkinCrew/Funkin/commit/1fde59f999eac94eb10fc22094885de2f5310705)) - by @EliteMasterEric
 - Center preloader 'fnf' and 'dsp' text so it doesn't clip anymore ([165ad60](https://github.com/FunkinCrew/Funkin/commit/165ad6015539a295e9eefdaef291c312e9566b26)) - by @Burgerballs in [#3567](https://github.com/FunkinCrew/Funkin/pull/3567)
 - `Song.getFirstValidVariation()` now properly takes into account multiple variations/difficulty input ([d2e2987](https://github.com/FunkinCrew/Funkin/commit/d2e29879fe2acc6febfe0f335f655b741d630c34)) - by @ninjamuffin99 in [#3506](https://github.com/FunkinCrew/Funkin/pull/3506)
-- (freeplay) Proper variation / difficulty loading for Freeplay Menu ([c0314c8](https://github.com/FunkinCrew/Funkin/commit/c0314c85ecd5116641aff3de8e9153f7fe48e79c)) - by @ninjamuffin99
-- Picos songs properly load on freeplay ([1d2bd61](https://github.com/FunkinCrew/Funkin/commit/1d2bd61119e5f418df7f11d7ef2a0fdedee17d3d)) - by @ninjamuffin99
 - (debug) No more fullscreening when typing "F" in the flixel debugger console ([29b6763](https://github.com/FunkinCrew/Funkin/commit/29b6763290df05d42039806f3d142740568c80f0)) - by @ninjamuffin99
-- Fix the user song offsets being applied incorrectly ([410cfe9](https://github.com/FunkinCrew/Funkin/commit/410cfe972d6df9de4d4d128375cf8380c4f06d92)) - by @JustKolosaki
 - Fix crash in LatencyState when exiting / cleaning up state data ([39b1a42](https://github.com/FunkinCrew/Funkin/commit/39b1a42cfeafe2b7be8b66e2fe529e853d9ae197)) - by @lemz1
-- Add additional classes to Polymod Blacklist ([b0b73c8](https://github.com/FunkinCrew/Funkin/commit/b0b73c83994f33118c6a69550da9ec8ec1c07adc)) - by @EliteMasterEric
+- Add additional classes to Polymod blacklist for security ([b0b73c8](https://github.com/FunkinCrew/Funkin/commit/b0b73c83994f33118c6a69550da9ec8ec1c07adc)) - by @EliteMasterEric
 - Stop allowing inputs after selecting a character ([dbf66ac](https://github.com/FunkinCrew/Funkin/commit/dbf66ac250137262866d75f7c1387645b35d88d0)) - by @ACrazyTown
-- Fixed an issue where the player and girlfriend would disappear or overlap themselves in Character Select (community fix by gamerbross)
-- Fixed an issue where the game would show the wrong girlfriend in Character Select (community fix by gamerbross)
-- Fixed an issue where the cursor wouldn't update properly in Character Select (community fix by gamerbross)
-- Fixed an issue where the player would display double after entering character select or when spamming buttons (community fix by gamerbross)
+- Fixed an issue where the player and girlfriend would disappear or overlap themselves in Character Select (community fix by @gamerbross)
+- Fixed an issue where the game would show the wrong girlfriend in Character Select (community fix by @gamerbross)
+- Fixed an issue where the cursor wouldn't update properly in Character Select (community fix by @gamerbross)
+- Fixed an issue where the player would display double after entering character select or when spamming buttons (community fix by @gamerbross)
 
 ## New Contributors for 0.5.2
 * @Kn1ghtNight made their first contribution in [#2853](https://github.com/FunkinCrew/Funkin/pull/2853)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,45 +5,40 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [0.5.2] - 2024-10-11
-### Added
-- Added InverseDotsShader that emulates flash selections ([097dbf5](https://github.com/FunkinCrew/Funkin/commit/097dbf5bb4346d431d8ca9f0ec4bc5b5e6f4523f)) - by @ninjamuffin99
-- Added a new reworked Stage Editor ([27a0b44](https://github.com/FunkinCrew/Funkin/pull/3482/commits/27a0b4426f86f04362f97e16e2eff580c9402f34)) - by @JustKolosaki 
-- Added the `color` attribute to stage prop JSON data to allow them to be tinted without code. ([27a0b44](https://github.com/FunkinCrew/Funkin/pull/3482/commits/27a0b4426f86f04362f97e16e2eff580c9402f34)) - by @JustKolosaki 
-- Added the `angle` attribute to stage prop JSON data to allow them to be rotated without code. ([27a0b44](https://github.com/FunkinCrew/Funkin/pull/3482/commits/27a0b4426f86f04362f97e16e2eff580c9402f34)) - by @JustKolosaki 
-- Added the `blend` attribute to the stage prop JSON data to allow blend modes to be applied without code. ([27a0b44](https://github.com/FunkinCrew/Funkin/pull/3482/commits/27a0b4426f86f04362f97e16e2eff580c9402f34)) - by @JustKolosaki 
 
 ### Changed
 - (docs) Delete Modding.md since we have a separate modding documentation ([a42240e](https://github.com/FunkinCrew/Funkin/commit/a42240e6a595d33034f2c887bf38a350d1fa0f15)) - by @AbnormalPoof in [#3651](https://github.com/FunkinCrew/Funkin/pull/3651)
 - (docs) Create a git cliff template for easier changelog stuff ([91b4544](https://github.com/FunkinCrew/Funkin/commit/91b4544f7ebc51485e3e28c3d716ba6ee69ad885)) - by @ninjamuffin99 in [#3652](https://github.com/FunkinCrew/Funkin/pull/3652)
+- Added InverseDotsShader that emulates flash selections ([097dbf5](https://github.com/FunkinCrew/Funkin/commit/097dbf5bb4346d431d8ca9f0ec4bc5b5e6f4523f)) - by @ninjamuffin99
 - (docs) Add additional `variation` input parameter to `Save.hasBeatenSong()` to allow usage of the function by inputting a variation id ([4fa9a0d](https://github.com/FunkinCrew/Funkin/commit/4fa9a0daaa67e0977460b147bd1f74a118e3e2a5)) - by @ninjamuffin99
 - (docs) Added modding docs link in readme ([4b54118](https://github.com/FunkinCrew/Funkin/commit/4b54118731e26118111e06558ae4853c577fe4bb)) - by @Cartridge-Man
-- (docs) Fix some misspellings and grammar in code documentation ([2175bea](https://github.com/FunkinCrew/Funkin/commit/2175beaa651e009332202985be4b7eb4ed36e5a4)) - by @Hundrec
+- Fix some misspellings and grammar in code documentation ([2175bea](https://github.com/FunkinCrew/Funkin/commit/2175beaa651e009332202985be4b7eb4ed36e5a4)) - by @Hundrec
 - (docs) Improvements to Github Issues templates ([399869c](https://github.com/FunkinCrew/Funkin/commit/399869cdccc9c5ac27cecfbcdc33c3d7eb4b348c)) - by @Hundrec in [#3458](https://github.com/FunkinCrew/Funkin/pull/3458)
 - Fix some misspellings and grammar in code documentation ([6df80ba](https://github.com/FunkinCrew/Funkin/commit/6df80ba69d0e24269f40471f83462cab7d5e13cf)) - by @Hundrec in [#3477](https://github.com/FunkinCrew/Funkin/pull/3477)
 - (docs) Improvements to Github Issues templates ([67f7b63](https://github.com/FunkinCrew/Funkin/commit/67f7b638fb76840b868cbfa70a1c6063577984c5)) - by @Hundrec
 
 ### Fixed
-- Fix the user song offsets being applied incorrectly, causing stuttering or skipping ([410cfe9](https://github.com/FunkinCrew/Funkin/commit/410cfe972d6df9de4d4d128375cf8380c4f06d92)) - by @JustKolosaki
-- Fixed issues with variation / difficulty loading for Freeplay Menu which caused some songs to disappear ([c0314c8](https://github.com/FunkinCrew/Funkin/commit/c0314c85ecd5116641aff3de8e9153f7fe48e79c)) - by @ninjamuffin99
-- Picos songs now display properly on the Freeplay Menu ([1d2bd61](https://github.com/FunkinCrew/Funkin/commit/1d2bd61119e5f418df7f11d7ef2a0fdedee17d3d)) - by @ninjamuffin99
-- Exiting the chart editor doesn't crash the game anymore ([f52472a](https://github.com/FunkinCrew/Funkin/commit/f52472a4767388b22cfbab0f5f7860f6e6762856)) - by @EliteMasterEric and @ianharrigan
 - Disable flickering when changing FPS in the options menu ([b2647fe](https://github.com/FunkinCrew/Funkin/commit/b2647fe09f5281ce7074b26d47bc1524764168ee)) - by @lemz1 in [#3629](https://github.com/FunkinCrew/Funkin/pull/3629)
 - Anti alias / smooth the volume sound tray ([e66290c](https://github.com/FunkinCrew/Funkin/commit/e66290c55f7141402223644f06ec8a69edeee089)) - by @Kn1ghtNight in [#2853](https://github.com/FunkinCrew/Funkin/pull/2853)
 - Don't restart the FreeplayState song preview when changing the difficulty within the same variation ([903b3fc](https://github.com/FunkinCrew/Funkin/commit/903b3fc59905a70802618a1cd67407722ea956ed)) - by @JustKolosaki in [#3587](https://github.com/FunkinCrew/Funkin/pull/3587)
+- Exiting the chart editor doesn't crash the game anymore ([f52472a](https://github.com/FunkinCrew/Funkin/commit/f52472a4767388b22cfbab0f5f7860f6e6762856)) - by @EliteMasterEric
 - Character Select cursor moves properly at lower framerates ([ab5bda3](https://github.com/FunkinCrew/Funkin/commit/ab5bda3ee573a6e03595ec6941e6de38df851889)) - by @ninjamuffin99 in [#3507](https://github.com/FunkinCrew/Funkin/pull/3507)
 - Stopped allowing F1 to create more than one help dialog window in the Charting Editor ([777978f](https://github.com/FunkinCrew/Funkin/commit/777978f5a544e1b7c89b47dcc365f734eb6d0df1)) - by @amyspark-ng
 - Main menu music doesn't cut out when switching states anymore. ([711e0a6](https://github.com/FunkinCrew/Funkin/commit/711e0a6b7547eb04113e9318dab900f01ad576a5)) - by @EliteMasterEric in [#3530](https://github.com/FunkinCrew/Funkin/pull/3530)
 - The dialog now shows up on the animation debugger view ([1fde59f](https://github.com/FunkinCrew/Funkin/commit/1fde59f999eac94eb10fc22094885de2f5310705)) - by @EliteMasterEric
 - Center preloader 'fnf' and 'dsp' text so it doesn't clip anymore ([165ad60](https://github.com/FunkinCrew/Funkin/commit/165ad6015539a295e9eefdaef291c312e9566b26)) - by @Burgerballs in [#3567](https://github.com/FunkinCrew/Funkin/pull/3567)
 - `Song.getFirstValidVariation()` now properly takes into account multiple variations/difficulty input ([d2e2987](https://github.com/FunkinCrew/Funkin/commit/d2e29879fe2acc6febfe0f335f655b741d630c34)) - by @ninjamuffin99 in [#3506](https://github.com/FunkinCrew/Funkin/pull/3506)
+- (freeplay) Proper variation / difficulty loading for Freeplay Menu ([c0314c8](https://github.com/FunkinCrew/Funkin/commit/c0314c85ecd5116641aff3de8e9153f7fe48e79c)) - by @ninjamuffin99
+- Picos songs properly load on freeplay ([1d2bd61](https://github.com/FunkinCrew/Funkin/commit/1d2bd61119e5f418df7f11d7ef2a0fdedee17d3d)) - by @ninjamuffin99
 - (debug) No more fullscreening when typing "F" in the flixel debugger console ([29b6763](https://github.com/FunkinCrew/Funkin/commit/29b6763290df05d42039806f3d142740568c80f0)) - by @ninjamuffin99
+- Fix the user song offsets being applied incorrectly ([410cfe9](https://github.com/FunkinCrew/Funkin/commit/410cfe972d6df9de4d4d128375cf8380c4f06d92)) - by @JustKolosaki
 - Fix crash in LatencyState when exiting / cleaning up state data ([39b1a42](https://github.com/FunkinCrew/Funkin/commit/39b1a42cfeafe2b7be8b66e2fe529e853d9ae197)) - by @lemz1
-- Add additional classes to Polymod blacklist for security ([b0b73c8](https://github.com/FunkinCrew/Funkin/commit/b0b73c83994f33118c6a69550da9ec8ec1c07adc)) - by @EliteMasterEric
+- Add additional classes to Polymod Blacklist ([b0b73c8](https://github.com/FunkinCrew/Funkin/commit/b0b73c83994f33118c6a69550da9ec8ec1c07adc)) - by @EliteMasterEric
 - Stop allowing inputs after selecting a character ([dbf66ac](https://github.com/FunkinCrew/Funkin/commit/dbf66ac250137262866d75f7c1387645b35d88d0)) - by @ACrazyTown
-- Fixed an issue where the player and girlfriend would disappear or overlap themselves in Character Select (community fix by @gamerbross)
-- Fixed an issue where the game would show the wrong girlfriend in Character Select (community fix by @gamerbross)
-- Fixed an issue where the cursor wouldn't update properly in Character Select (community fix by @gamerbross)
-- Fixed an issue where the player would display double after entering character select or when spamming buttons (community fix by @gamerbross)
+- Fixed an issue where the player and girlfriend would disappear or overlap themselves in Character Select (community fix by gamerbross)
+- Fixed an issue where the game would show the wrong girlfriend in Character Select (community fix by gamerbross)
+- Fixed an issue where the cursor wouldn't update properly in Character Select (community fix by gamerbross)
+- Fixed an issue where the player would display double after entering character select or when spamming buttons (community fix by gamerbross)
 
 ## New Contributors for 0.5.2
 * @Kn1ghtNight made their first contribution in [#2853](https://github.com/FunkinCrew/Funkin/pull/2853)

--- a/source/funkin/save/Save.hx
+++ b/source/funkin/save/Save.hx
@@ -9,6 +9,8 @@ import funkin.save.migrator.RawSaveData_v1_0_0;
 import funkin.save.migrator.SaveDataMigrator;
 import funkin.save.migrator.SaveDataMigrator;
 import funkin.ui.debug.charting.ChartEditorState.ChartEditorLiveInputStyle;
+import funkin.ui.debug.charting.ChartEditorState.LiveInputStyle;
+import funkin.ui.debug.DebugMenuSubState.EditorTheme;
 import funkin.ui.debug.charting.ChartEditorState.ChartEditorTheme;
 import funkin.ui.debug.stageeditor.StageEditorState.StageEditorTheme;
 import funkin.util.SerializerUtil;
@@ -18,12 +20,13 @@ import thx.semver.Version;
 @:nullSafety
 class Save
 {
-  public static final SAVE_DATA_VERSION:thx.semver.Version = "2.0.4";
+  public static final SAVE_DATA_VERSION:thx.semver.Version = "2.0.5";
   public static final SAVE_DATA_VERSION_RULE:thx.semver.VersionRule = "2.0.x";
 
   // We load this version's saves from a new save path, to maintain SOME level of backwards compatibility.
   static final SAVE_PATH:String = 'FunkinCrew';
   static final SAVE_NAME:String = 'Funkin';
+  static final SCORE_BACKUP_NAME:String = "SaveBackup";
 
   static final SAVE_PATH_LEGACY:String = 'ninjamuffin99';
   static final SAVE_NAME_LEGACY:String = 'funkin';
@@ -138,8 +141,10 @@ class Save
           // Reasonable defaults.
           previousFiles: [],
           noteQuant: 3,
-          chartEditorLiveInputStyle: ChartEditorLiveInputStyle.None,
-          theme: ChartEditorTheme.Light,
+          // chartEditorLiveInputStyle: ChartEditorLiveInputStyle.None,
+          // theme: Light,
+          liveInputStyle: NONE,
+          editorTheme: LIGHT_THEME,
           playtestStartTime: false,
           downscroll: false,
           metronomeVolume: 1.0,
@@ -153,7 +158,8 @@ class Save
           previousFiles: [],
           moveStep: "1px",
           angleStep: 5,
-          theme: StageEditorTheme.Light
+          // theme: Light
+          editorTheme: LIGHT_THEME
         }
     };
   }
@@ -260,21 +266,34 @@ class Save
     return data.optionsChartEditor.noteQuant;
   }
 
-  public var chartEditorLiveInputStyle(get, set):ChartEditorLiveInputStyle;
+  public var chartEditorLiveInputStyle(get, set):LiveInputStyle;
 
-  function get_chartEditorLiveInputStyle():ChartEditorLiveInputStyle
+  function get_chartEditorLiveInputStyle():LiveInputStyle
   {
-    if (data.optionsChartEditor.chartEditorLiveInputStyle == null) data.optionsChartEditor.chartEditorLiveInputStyle = ChartEditorLiveInputStyle.None;
+    if (data.optionsChartEditor.liveInputStyle == null)
+    {
+      if (data.optionsChartEditor.chartEditorLiveInputStyle != null)
+      {
+        data.optionsChartEditor.liveInputStyle = switch (data.optionsChartEditor.chartEditorLiveInputStyle)
+        {
+          case NumberKeys: NUMBER_KEYS;
+          case WASDKeys: WASD_KEYS;
+          default: NONE;
+        }
+      }
 
-    return data.optionsChartEditor.chartEditorLiveInputStyle;
+      if (data.optionsChartEditor.liveInputStyle == null) data.optionsChartEditor.liveInputStyle = NONE;
+    }
+
+    return data.optionsChartEditor.liveInputStyle;
   }
 
-  function set_chartEditorLiveInputStyle(value:ChartEditorLiveInputStyle):ChartEditorLiveInputStyle
+  function set_chartEditorLiveInputStyle(value:LiveInputStyle):LiveInputStyle
   {
     // Set and apply.
-    data.optionsChartEditor.chartEditorLiveInputStyle = value;
+    data.optionsChartEditor.liveInputStyle = value;
     flush();
-    return data.optionsChartEditor.chartEditorLiveInputStyle;
+    return data.optionsChartEditor.liveInputStyle;
   }
 
   public var chartEditorDownscroll(get, set):Bool;
@@ -311,21 +330,29 @@ class Save
     return data.optionsChartEditor.playtestStartTime;
   }
 
-  public var chartEditorTheme(get, set):ChartEditorTheme;
+  public var chartEditorTheme(get, set):EditorTheme;
 
-  function get_chartEditorTheme():ChartEditorTheme
+  function get_chartEditorTheme():EditorTheme
   {
-    if (data.optionsChartEditor.theme == null) data.optionsChartEditor.theme = ChartEditorTheme.Light;
+    if (data.optionsChartEditor.editorTheme == null) // I hate having to do backwards compatibility.
+    {
+      if (data.optionsChartEditor.theme != null
+        && data.optionsChartEditor.theme == ChartEditorTheme.Light) data.optionsChartEditor.editorTheme = LIGHT_THEME;
+      else if (data.optionsChartEditor.theme != null
+        && data.optionsChartEditor.theme == ChartEditorTheme.Dark) data.optionsChartEditor.editorTheme = DARK_THEME;
+      else
+        data.optionsChartEditor.editorTheme = LIGHT_THEME;
+    }
 
-    return data.optionsChartEditor.theme;
+    return data.optionsChartEditor.editorTheme;
   }
 
-  function set_chartEditorTheme(value:ChartEditorTheme):ChartEditorTheme
+  function set_chartEditorTheme(value:EditorTheme):EditorTheme
   {
     // Set and apply.
-    data.optionsChartEditor.theme = value;
+    data.optionsChartEditor.editorTheme = value;
     flush();
-    return data.optionsChartEditor.theme;
+    return data.optionsChartEditor.editorTheme;
   }
 
   public var chartEditorMetronomeVolume(get, set):Float;
@@ -505,21 +532,29 @@ class Save
     return data.optionsStageEditor.angleStep;
   }
 
-  public var stageEditorTheme(get, set):StageEditorTheme;
+  public var stageEditorTheme(get, set):EditorTheme;
 
-  function get_stageEditorTheme():StageEditorTheme
+  function get_stageEditorTheme():EditorTheme
   {
-    if (data.optionsStageEditor.theme == null) data.optionsStageEditor.theme = StageEditorTheme.Light;
+    if (data.optionsStageEditor.editorTheme == null) // I hate having to do backwards compatibility.
+    {
+      if (data.optionsStageEditor.theme != null
+        && data.optionsStageEditor.theme == StageEditorTheme.Light) data.optionsStageEditor.editorTheme = LIGHT_THEME;
+      else if (data.optionsStageEditor.theme != null
+        && data.optionsStageEditor.theme == StageEditorTheme.Dark) data.optionsStageEditor.editorTheme = DARK_THEME;
+      else
+        data.optionsStageEditor.editorTheme = LIGHT_THEME;
+    }
 
-    return data.optionsStageEditor.theme;
+    return data.optionsStageEditor.editorTheme;
   }
 
-  function set_stageEditorTheme(value:StageEditorTheme):StageEditorTheme
+  function set_stageEditorTheme(value:EditorTheme):EditorTheme
   {
     // Set and apply.
-    data.optionsStageEditor.theme = value;
+    data.optionsStageEditor.editorTheme = value;
     flush();
-    return data.optionsStageEditor.theme;
+    return data.optionsStageEditor.editorTheme;
   }
 
   /**
@@ -953,6 +988,11 @@ class Save
   public function flush():Void
   {
     FlxG.save.flush();
+
+    var backupSaveFile = new FlxSave();
+    backupSaveFile.bind(SCORE_BACKUP_NAME, SAVE_PATH);
+    backupSaveFile.mergeData(FlxG.save.data, true);
+    backupSaveFile.flush();
   }
 
   /**
@@ -983,6 +1023,7 @@ class Save
       {
         trace('[SAVE] No legacy save data found.');
         var gameSave = new Save();
+        loadScoreBackups(gameSave);
         FlxG.save.mergeData(gameSave.data, true);
         return gameSave;
       }
@@ -995,6 +1036,17 @@ class Save
 
       return gameSave;
     }
+  }
+
+  static function loadScoreBackups(save:Save)
+  {
+    var backupsFile = new FlxSave();
+    backupsFile.bind(SCORE_BACKUP_NAME, SAVE_PATH);
+
+    if (backupsFile.isEmpty()) return; // damn it, nothing was saved. the save system has fallen
+
+    save.data = backupsFile.data;
+    save.flush();
   }
 
   public static function archiveBadSaveData(data:Dynamic):Int
@@ -1478,13 +1530,29 @@ typedef SaveDataChartEditorOptions =
    * Live input style in the Chart Editor.
    * @default `ChartEditorLiveInputStyle.None`
    */
+  @:optional
+  @:deprecated("Use liveInputStyle instead!")
   var ?chartEditorLiveInputStyle:ChartEditorLiveInputStyle;
+
+  /**
+   * Live input style in the Chart Editor.
+   * @default `NONE`
+   */
+  var ?liveInputStyle:LiveInputStyle;
 
   /**
    * Theme in the Chart Editor.
    * @default `ChartEditorTheme.Light`
    */
+  @:deprecated("Use editorTheme instead!")
+  @:optional
   var ?theme:ChartEditorTheme;
+
+  /**
+   * Theme in the Chart Editor.
+   * @default `LIGHT_THEME`
+   */
+  var ?editorTheme:EditorTheme;
 
   /**
    * Downscroll in the Chart Editor.
@@ -1574,5 +1642,13 @@ typedef SaveDataStageEditorOptions =
    * Theme in the Stage Editor.
    * @default `StageEditorTheme.Light`
    */
+  @:deprecated("Use editorTheme instead!")
+  @:optional
   var ?theme:StageEditorTheme;
+
+  /**
+   * Theme in the Stage Editor
+   * @default `LIGHT_THEME`
+   */
+  var ?editorTheme:EditorTheme;
 };

--- a/source/funkin/ui/debug/DebugMenuSubState.hx
+++ b/source/funkin/ui/debug/DebugMenuSubState.hx
@@ -141,3 +141,18 @@ class DebugMenuSubState extends MusicBeatSubState
     this.close();
   }
 }
+
+// used for BOTH chart editor AND stage editor
+// maybe even some editors in the future who knows.....
+enum abstract EditorTheme(String) from String to String
+{
+  /**
+   * The default theme for the current editor.
+   */
+  var LIGHT_THEME = "light";
+
+  /**
+   * A theme which introduces darker colors.
+   */
+  var DARK_THEME = "dark";
+}

--- a/source/funkin/ui/debug/charting/ChartEditorState.hx
+++ b/source/funkin/ui/debug/charting/ChartEditorState.hx
@@ -39,6 +39,7 @@ import funkin.data.song.SongData.NoteParamData;
 import funkin.data.song.SongDataUtils;
 import funkin.data.song.SongRegistry;
 import funkin.data.stage.StageData;
+import funkin.ui.debug.DebugMenuSubState.EditorTheme;
 import funkin.graphics.FunkinCamera;
 import funkin.graphics.FunkinSprite;
 import funkin.input.Cursor;
@@ -286,16 +287,16 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
   /**
    * A map of the keys for every live input style.
    */
-  public static final LIVE_INPUT_KEYS:Map<ChartEditorLiveInputStyle, Array<FlxKey>> = [
-    NumberKeys => [
+  public static final LIVE_INPUT_KEYS:Map<LiveInputStyle, Array<FlxKey>> = [
+    NUMBER_KEYS => [
       FIVE, SIX, SEVEN, EIGHT,
        ONE, TWO, THREE,  FOUR
     ],
-    WASDKeys => [
+    WASD_KEYS => [
       LEFT, DOWN, UP, RIGHT,
          A,    S,  W,     D
     ],
-    None => []
+    NONE => []
   ];
 
   /**
@@ -600,7 +601,7 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
   /**
    * The currently selected live input style.
    */
-  var currentLiveInputStyle:ChartEditorLiveInputStyle = None;
+  var currentLiveInputStyle:LiveInputStyle = NONE;
 
   /**
    * If true, playtesting a chart will skip to the current playhead position.
@@ -655,9 +656,9 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
    * Dictates the appearance of many UI elements.
    * Currently hardcoded to just Light and Dark.
    */
-  var currentTheme(default, set):ChartEditorTheme = ChartEditorTheme.Light;
+  var currentTheme(default, set):EditorTheme = LIGHT_THEME;
 
-  function set_currentTheme(value:ChartEditorTheme):ChartEditorTheme
+  function set_currentTheme(value:EditorTheme):EditorTheme
   {
     if (value == null || value == currentTheme) return currentTheme;
 
@@ -2990,17 +2991,17 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
     };
 
     menuBarItemInputStyleNone.onClick = function(event:UIEvent) {
-      currentLiveInputStyle = None;
+      currentLiveInputStyle = NONE;
     };
-    menuBarItemInputStyleNone.selected = currentLiveInputStyle == None;
+    menuBarItemInputStyleNone.selected = currentLiveInputStyle == NONE;
     menuBarItemInputStyleNumberKeys.onClick = function(event:UIEvent) {
-      currentLiveInputStyle = NumberKeys;
+      currentLiveInputStyle = NUMBER_KEYS;
     };
-    menuBarItemInputStyleNumberKeys.selected = currentLiveInputStyle == NumberKeys;
+    menuBarItemInputStyleNumberKeys.selected = currentLiveInputStyle == NUMBER_KEYS;
     menuBarItemInputStyleWASD.onClick = function(event:UIEvent) {
-      currentLiveInputStyle = WASDKeys;
+      currentLiveInputStyle = WASD_KEYS;
     };
-    menuBarItemInputStyleWASD.selected = currentLiveInputStyle == WASDKeys;
+    menuBarItemInputStyleWASD.selected = currentLiveInputStyle == WASD_KEYS;
 
     menubarItemAbout.onClick = _ -> this.openAboutDialog();
     menubarItemWelcomeDialog.onClick = _ -> this.openWelcomeDialog(true);
@@ -3021,14 +3022,14 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
     menubarItemDifficultyDown.onClick = _ -> incrementDifficulty(-1);
 
     menuBarItemThemeLight.onChange = function(event:UIEvent) {
-      if (event.target.value) currentTheme = ChartEditorTheme.Light;
+      if (event.target.value) currentTheme = LIGHT_THEME;
     };
-    menuBarItemThemeLight.selected = currentTheme == ChartEditorTheme.Light;
+    menuBarItemThemeLight.selected = currentTheme == LIGHT_THEME;
 
     menuBarItemThemeDark.onChange = function(event:UIEvent) {
-      if (event.target.value) currentTheme = ChartEditorTheme.Dark;
+      if (event.target.value) currentTheme = DARK_THEME;
     };
-    menuBarItemThemeDark.selected = currentTheme == ChartEditorTheme.Dark;
+    menuBarItemThemeDark.selected = currentTheme == DARK_THEME;
 
     menubarItemPlayPause.onClick = _ -> toggleAudioPlayback();
 
@@ -3876,26 +3877,26 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
     }
 
     // Up Arrow = Scroll Up
-    if (upKeyHandler.activated && currentLiveInputStyle == None)
+    if (upKeyHandler.activated && currentLiveInputStyle == NONE)
     {
       scrollAmount = -GRID_SIZE * 4;
       shouldPause = true;
     }
     // Down Arrow = Scroll Down
-    if (downKeyHandler.activated && currentLiveInputStyle == None)
+    if (downKeyHandler.activated && currentLiveInputStyle == NONE)
     {
       scrollAmount = GRID_SIZE * 4;
       shouldPause = true;
     }
 
     // W = Scroll Up (doesn't work with Ctrl+Scroll)
-    if (wKeyHandler.activated && currentLiveInputStyle == None && !FlxG.keys.pressed.CONTROL)
+    if (wKeyHandler.activated && currentLiveInputStyle == NONE && !FlxG.keys.pressed.CONTROL)
     {
       scrollAmount = -GRID_SIZE * 4;
       shouldPause = true;
     }
     // S = Scroll Down (doesn't work with Ctrl+Scroll)
-    if (sKeyHandler.activated && currentLiveInputStyle == None && !FlxG.keys.pressed.CONTROL)
+    if (sKeyHandler.activated && currentLiveInputStyle == NONE && !FlxG.keys.pressed.CONTROL)
     {
       scrollAmount = GRID_SIZE * 4;
       shouldPause = true;
@@ -4085,7 +4086,7 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
    */
   function handleSnap():Void
   {
-    if (currentLiveInputStyle == None)
+    if (currentLiveInputStyle == NONE)
     {
       if (FlxG.keys.justPressed.LEFT && !FlxG.keys.pressed.CONTROL)
       {
@@ -5617,7 +5618,7 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
    */
   function handleViewKeybinds():Void
   {
-    if (currentLiveInputStyle == None)
+    if (currentLiveInputStyle == NONE)
     {
       if (FlxG.keys.pressed.CONTROL && FlxG.keys.justPressed.LEFT)
       {
@@ -6538,6 +6539,24 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
     }
     return params;
   }
+}
+
+enum abstract LiveInputStyle(String) from String to String
+{
+  /**
+   * No hotkeys to place notes at the playbar.
+   */
+  var NONE = "none";
+
+  /**
+   * 1/2/3/4 to place notes on opponent's side, 5/6/7/8 to place notes on player's side.
+   */
+  var NUMBER_KEYS = "number_keys";
+
+  /**
+   * WASD to place notes on opponent's side, Arrow keys to place notes on player's side.
+   */
+  var WASD_KEYS = "wasd_keys";
 }
 
 /**

--- a/source/funkin/ui/debug/charting/handlers/ChartEditorThemeHandler.hx
+++ b/source/funkin/ui/debug/charting/handlers/ChartEditorThemeHandler.hx
@@ -96,8 +96,8 @@ class ChartEditorThemeHandler
     if (state.menuBG == null) return;
     state.menuBG.color = switch (state.currentTheme)
     {
-      case ChartEditorTheme.Light: BACKGROUND_COLOR_LIGHT;
-      case ChartEditorTheme.Dark: BACKGROUND_COLOR_DARK;
+      case LIGHT_THEME: BACKGROUND_COLOR_LIGHT;
+      case DARK_THEME: BACKGROUND_COLOR_DARK;
       default: BACKGROUND_COLOR_LIGHT;
     }
   }
@@ -110,15 +110,15 @@ class ChartEditorThemeHandler
   {
     var gridColor1:FlxColor = switch (state.currentTheme)
     {
-      case Light: GRID_COLOR_1_LIGHT;
-      case Dark: GRID_COLOR_1_DARK;
+      case LIGHT_THEME: GRID_COLOR_1_LIGHT;
+      case DARK_THEME: GRID_COLOR_1_DARK;
       default: GRID_COLOR_1_LIGHT;
     };
 
     var gridColor2:FlxColor = switch (state.currentTheme)
     {
-      case Light: GRID_COLOR_2_LIGHT;
-      case Dark: GRID_COLOR_2_DARK;
+      case LIGHT_THEME: GRID_COLOR_2_LIGHT;
+      case DARK_THEME: GRID_COLOR_2_DARK;
       default: GRID_COLOR_2_LIGHT;
     };
 
@@ -133,8 +133,8 @@ class ChartEditorThemeHandler
     // Selection borders
     var selectionBorderColor:FlxColor = switch (state.currentTheme)
     {
-      case Light: GRID_COLOR_3_LIGHT;
-      case Dark: GRID_COLOR_3_DARK;
+      case LIGHT_THEME: GRID_COLOR_3_LIGHT;
+      case DARK_THEME: GRID_COLOR_3_DARK;
       default: GRID_COLOR_3_LIGHT;
     };
 
@@ -178,8 +178,8 @@ class ChartEditorThemeHandler
 
     var gridMeasureDividerColor:FlxColor = switch (state.currentTheme)
     {
-      case Light: GRID_MEASURE_DIVIDER_COLOR_LIGHT;
-      case Dark: GRID_MEASURE_DIVIDER_COLOR_DARK;
+      case LIGHT_THEME: GRID_MEASURE_DIVIDER_COLOR_LIGHT;
+      case DARK_THEME: GRID_MEASURE_DIVIDER_COLOR_DARK;
       default: GRID_MEASURE_DIVIDER_COLOR_LIGHT;
     };
 
@@ -193,8 +193,8 @@ class ChartEditorThemeHandler
 
     var gridBeatDividerColor:FlxColor = switch (state.currentTheme)
     {
-      case Light: GRID_BEAT_DIVIDER_COLOR_LIGHT;
-      case Dark: GRID_BEAT_DIVIDER_COLOR_DARK;
+      case LIGHT_THEME: GRID_BEAT_DIVIDER_COLOR_LIGHT;
+      case DARK_THEME: GRID_BEAT_DIVIDER_COLOR_DARK;
       default: GRID_BEAT_DIVIDER_COLOR_LIGHT;
     };
 
@@ -214,8 +214,8 @@ class ChartEditorThemeHandler
 
     var gridStrumlineDividerColor:FlxColor = switch (state.currentTheme)
     {
-      case Light: GRID_STRUMLINE_DIVIDER_COLOR_LIGHT;
-      case Dark: GRID_STRUMLINE_DIVIDER_COLOR_DARK;
+      case LIGHT_THEME: GRID_STRUMLINE_DIVIDER_COLOR_LIGHT;
+      case DARK_THEME: GRID_STRUMLINE_DIVIDER_COLOR_DARK;
       default: GRID_STRUMLINE_DIVIDER_COLOR_LIGHT;
     };
 
@@ -348,15 +348,15 @@ class ChartEditorThemeHandler
   {
     var selectionSquareBorderColor:FlxColor = switch (state.currentTheme)
     {
-      case Light: SELECTION_SQUARE_BORDER_COLOR_LIGHT;
-      case Dark: SELECTION_SQUARE_BORDER_COLOR_DARK;
+      case LIGHT_THEME: SELECTION_SQUARE_BORDER_COLOR_LIGHT;
+      case DARK_THEME: SELECTION_SQUARE_BORDER_COLOR_DARK;
       default: SELECTION_SQUARE_BORDER_COLOR_LIGHT;
     };
 
     var selectionSquareFillColor:FlxColor = switch (state.currentTheme)
     {
-      case Light: SELECTION_SQUARE_FILL_COLOR_LIGHT;
-      case Dark: SELECTION_SQUARE_FILL_COLOR_DARK;
+      case LIGHT_THEME: SELECTION_SQUARE_FILL_COLOR_LIGHT;
+      case DARK_THEME: SELECTION_SQUARE_FILL_COLOR_DARK;
       default: SELECTION_SQUARE_FILL_COLOR_LIGHT;
     };
 
@@ -387,15 +387,15 @@ class ChartEditorThemeHandler
   {
     var viewportBorderColor:FlxColor = switch (state.currentTheme)
     {
-      case Light: NOTE_PREVIEW_VIEWPORT_BORDER_COLOR_LIGHT;
-      case Dark: NOTE_PREVIEW_VIEWPORT_BORDER_COLOR_DARK;
+      case LIGHT_THEME: NOTE_PREVIEW_VIEWPORT_BORDER_COLOR_LIGHT;
+      case DARK_THEME: NOTE_PREVIEW_VIEWPORT_BORDER_COLOR_DARK;
       default: NOTE_PREVIEW_VIEWPORT_BORDER_COLOR_LIGHT;
     };
 
     var viewportFillColor:FlxColor = switch (state.currentTheme)
     {
-      case Light: NOTE_PREVIEW_VIEWPORT_FILL_COLOR_LIGHT;
-      case Dark: NOTE_PREVIEW_VIEWPORT_FILL_COLOR_DARK;
+      case LIGHT_THEME: NOTE_PREVIEW_VIEWPORT_FILL_COLOR_LIGHT;
+      case DARK_THEME: NOTE_PREVIEW_VIEWPORT_FILL_COLOR_DARK;
       default: NOTE_PREVIEW_VIEWPORT_FILL_COLOR_LIGHT;
     };
 

--- a/source/funkin/ui/debug/stageeditor/StageEditorState.hx
+++ b/source/funkin/ui/debug/stageeditor/StageEditorState.hx
@@ -50,6 +50,7 @@ import funkin.audio.FunkinSound;
 import haxe.ui.notifications.NotificationType;
 import haxe.ui.notifications.NotificationManager;
 import funkin.util.logging.CrashHandler;
+import funkin.ui.debug.DebugMenuSubState.EditorTheme;
 
 /**
  * Da Stage Editor woo!!
@@ -138,6 +139,7 @@ class StageEditorState extends UIState
 
   function set_selectedSprite(value:StageEditorObject)
   {
+    selectedSprite?.selectedShader.setAmount(0);
     this.selectedSprite = value;
     updateDialog(StageEditorDialogType.OBJECT);
 
@@ -583,6 +585,7 @@ class StageEditorState extends UIState
       if (FlxG.keys.justPressed.ENTER) onMenuItemClick("test stage");
       if (FlxG.keys.justPressed.ESCAPE) onMenuItemClick("exit");
       if (FlxG.keys.justPressed.F1) onMenuItemClick("user guide");
+      if (FlxG.keys.justPressed.BACKSPACE) selectedSprite = null;
 
       if (FlxG.keys.justPressed.T)
       {
@@ -627,7 +630,6 @@ class StageEditorState extends UIState
 
           if (FlxG.mouse.justPressed && allowInput && spr.visible && !FlxG.keys.pressed.SHIFT && !isCursorOverHaxeUI)
           {
-            selectedSprite.selectedShader.setAmount(0);
             selectedSprite = spr;
             updateDialog(StageEditorDialogType.OBJECT);
           }
@@ -928,7 +930,7 @@ class StageEditorState extends UIState
 
   function updateBGColors():Void
   {
-    var colArray = Save.instance.stageEditorTheme == StageEditorTheme.Dark ? DARK_MODE_COLORS : LIGHT_MODE_COLORS;
+    var colArray = Save.instance.stageEditorTheme == DARK_THEME ? DARK_MODE_COLORS : LIGHT_MODE_COLORS;
 
     var index = members.indexOf(bg);
     bg.kill();
@@ -1038,17 +1040,17 @@ class StageEditorState extends UIState
     menubarItemWindowStage.onChange = function(_) toggleDialog(StageEditorDialogType.STAGE, menubarItemWindowStage.selected);
 
     menubarItemThemeLight.onClick = function(_) {
-      Save.instance.stageEditorTheme = StageEditorTheme.Light;
+      Save.instance.stageEditorTheme = LIGHT_THEME;
       updateBGColors();
     }
 
     menubarItemThemeDark.onClick = function(_) {
-      Save.instance.stageEditorTheme = StageEditorTheme.Dark;
+      Save.instance.stageEditorTheme = DARK_THEME;
       updateBGColors();
     }
 
-    menubarItemThemeDark.selected = Save.instance.stageEditorTheme == StageEditorTheme.Dark;
-    menubarItemThemeLight.selected = Save.instance.stageEditorTheme == StageEditorTheme.Light;
+    menubarItemThemeDark.selected = Save.instance.stageEditorTheme == DARK_THEME;
+    menubarItemThemeLight.selected = Save.instance.stageEditorTheme == LIGHT_THEME;
 
     menubarItemViewChars.onChange = function(_) showChars = menubarItemViewChars.selected;
     menubarItemViewNameText.onChange = function(_) nameTxt.visible = menubarItemViewNameText.selected;
@@ -1138,8 +1140,6 @@ class StageEditorState extends UIState
           currentFile = path;
         }, null, stageName + "." + FileUtil.FILE_EXTENSION_INFO_FNFS.extension);
 
-        bitmaps.clear();
-
       case "save stage":
         if (currentFile == "")
         {
@@ -1158,10 +1158,7 @@ class StageEditorState extends UIState
         FileUtil.writeBytesToPath(currentFile, bytes, Force); // mhm
 
         saved = true;
-
         updateRecentFiles();
-        bitmaps.clear();
-
       case "open stage":
         if (!saved)
         {


### PR DESCRIPTION
## Does this PR close any issues? If so, link them below.
[3679](https://github.com/FunkinCrew/Funkin/issues/3679)

## Briefly describe the issue(s) fixed.
Modifies the Save File so that it uses Enum Abstracts instead of Enum fields. Also adds a proper backup system, in case of something going horrible.

## Include any relevant screenshots or videos.
https://github.com/user-attachments/assets/85d2c631-0b63-4087-ac22-622ec8e72c14

## Note
Considering Enum fields are bugged, they are the only ones that get reset when changing from the current version to a version in the title. A fix to this would require a fix to haxe's Serializer classes, which is unlikely to happen (both flixel uses openfl to store things and openfl uses haxe's Serializer classes to store the data).

But also like who the hell would play on an older version after 0.3.0 like I get for previous versions but why this range lol