### PR TITLE
[BUGFIX] Improvements to the save data system to prevent overwriting when resolution fails.

### DIFF
--- a/hmm.json
+++ b/hmm.json
@@ -11,7 +11,7 @@
       "name": "flixel",
       "type": "git",
       "dir": null,
-      "ref": "f2b090d6c608471e730b051c8ee22b8b378964b1",
+      "ref": "ffa691cb2d2d81de35b900a4411e4062ac84ab58",
       "url": "https://github.com/FunkinCrew/flixel"
     },
     {

--- a/project.hxp
+++ b/project.hxp
@@ -474,7 +474,10 @@ class Project extends HXProject {
 
 		// Should be true on debug builds or if GITHUB_BUILD is enabled.
 		FEATURE_DEBUG_FUNCTIONS.apply(this, isDebug() || GITHUB_BUILD.isEnabled(this));
-		FEATURE_LOG_TRACE.apply(this, isDebug());
+
+		// Got a lot of complains about this being turned off by default on some builds.
+		// TODO: Look into ways to optimize logging (maybe by using a thread pool?)
+		FEATURE_LOG_TRACE.apply(this, true);
 
 		// Should default to true on workspace builds and false on release builds.
 		REDIRECT_ASSETS_FOLDER.apply(this, isDebug() && isDesktop());

--- a/project.hxp
+++ b/project.hxp
@@ -460,7 +460,6 @@ class Project extends HXProject {
 
 		// Should be false unless explicitly requested.
 		GITHUB_BUILD.apply(this, false);
-		FEATURE_STAGE_EDITOR.apply(this, false);
 		FEATURE_NEWGROUNDS.apply(this, false);
 		FEATURE_GHOST_TAPPING.apply(this, false);
 
@@ -471,6 +470,7 @@ class Project extends HXProject {
 		FEATURE_FUNKVIS.apply(this, true);
 		FEATURE_PARTIAL_SOUNDS.apply(this, true);
 		FEATURE_VIDEO_PLAYBACK.apply(this, true);
+		FEATURE_STAGE_EDITOR.apply(this, true);
 
 		// Should be true on debug builds or if GITHUB_BUILD is enabled.
 		FEATURE_DEBUG_FUNCTIONS.apply(this, isDebug() || GITHUB_BUILD.isEnabled(this));

--- a/source/funkin/save/Save.hx
+++ b/source/funkin/save/Save.hx
@@ -961,10 +961,7 @@ class Save
    */
   static function loadFromSlot(slot:Int):Save
   {
-    trace("[SAVE] Loading save from slot " + slot + "...");
-
-    // Prevent crashes if the save data is corrupted.
-    SerializerUtil.initSerializer();
+    trace('[SAVE] Loading save from slot $slot...');
 
     FlxG.save.bind('$SAVE_NAME${slot}', SAVE_PATH);
 

--- a/source/funkin/save/Save.hx
+++ b/source/funkin/save/Save.hx
@@ -1,25 +1,23 @@
 package funkin.save;
 
 import flixel.util.FlxSave;
-import funkin.util.FileUtil;
 import funkin.input.Controls.Device;
 import funkin.play.scoring.Scoring;
 import funkin.play.scoring.Scoring.ScoringRank;
 import funkin.save.migrator.RawSaveData_v1_0_0;
 import funkin.save.migrator.SaveDataMigrator;
-import funkin.save.migrator.SaveDataMigrator;
 import funkin.ui.debug.charting.ChartEditorState.ChartEditorLiveInputStyle;
 import funkin.ui.debug.charting.ChartEditorState.ChartEditorTheme;
 import funkin.ui.debug.stageeditor.StageEditorState.StageEditorTheme;
+import funkin.util.FileUtil;
 import funkin.util.SerializerUtil;
-import thx.semver.Version;
 import thx.semver.Version;
 
 @:nullSafety
 class Save
 {
-  public static final SAVE_DATA_VERSION:thx.semver.Version = "2.0.6";
-  public static final SAVE_DATA_VERSION_RULE:thx.semver.VersionRule = "2.0.x";
+  public static final SAVE_DATA_VERSION:thx.semver.Version = "2.1.0";
+  public static final SAVE_DATA_VERSION_RULE:thx.semver.VersionRule = ">=2.1.0 <2.2.0";
 
   // We load this version's saves from a new save path, to maintain SOME level of backwards compatibility.
   static final SAVE_PATH:String = 'FunkinCrew';
@@ -965,32 +963,57 @@ class Save
 
     FlxG.save.bind('$SAVE_NAME${slot}', SAVE_PATH);
 
-    if (FlxG.save.isEmpty())
+    switch (FlxG.save.status)
     {
-      trace('[SAVE] Save data is empty, checking for legacy save data...');
-      var legacySaveData = fetchLegacySaveData();
-      if (legacySaveData != null)
-      {
-        trace('[SAVE] Found legacy save data, converting...');
-        var gameSave = SaveDataMigrator.migrateFromLegacy(legacySaveData);
+      case EMPTY:
+        trace('[SAVE] Save data in slot ${slot} is empty, checking for legacy save data...');
+        var legacySaveData = fetchLegacySaveData();
+        if (legacySaveData != null)
+        {
+          trace('[SAVE] Found legacy save data, converting...');
+          var gameSave = SaveDataMigrator.migrateFromLegacy(legacySaveData);
+          FlxG.save.mergeData(gameSave.data, true);
+          return gameSave;
+        }
+        else
+        {
+          trace('[SAVE] No legacy save data found.');
+          var gameSave = new Save();
+          FlxG.save.mergeData(gameSave.data, true);
+          return gameSave;
+        }
+      case ERROR(_):
+        return handleSaveDataError(slot);
+      case BOUND(_, _):
+        trace('[SAVE] Loaded existing save data in slot ${slot}.');
+        var gameSave = SaveDataMigrator.migrate(FlxG.save.data);
         FlxG.save.mergeData(gameSave.data, true);
+
         return gameSave;
-      }
-      else
-      {
-        trace('[SAVE] No legacy save data found.');
-        var gameSave = new Save();
-        FlxG.save.mergeData(gameSave.data, true);
-        return gameSave;
-      }
+    }
+  }
+
+  /**
+   * Call this when there is an error loading the save data in slot X.
+   */
+  static function handleSaveDataError(slot:Int):Save
+  {
+    var msg = 'There was an error loading your save data in slot ${slot}.';
+    msg += '\nPlease report this issue to the developers.';
+    lime.app.Application.current.window.alert(msg, "Save Data Failure");
+
+    // Don't touch that slot anymore.
+    // Instead, load the next available slot.
+
+    var nextSlot = slot + 1;
+
+    if (nextSlot < 1000)
+    {
+      return loadFromSlot(nextSlot);
     }
     else
     {
-      trace('[SAVE] Found existing save data.');
-      var gameSave = SaveDataMigrator.migrate(FlxG.save.data);
-      FlxG.save.mergeData(gameSave.data, true);
-
-      return gameSave;
+      throw "End of save data slots. Can't load any more.";
     }
   }
 
@@ -1055,7 +1078,15 @@ class Save
   {
     var targetSaveData = new FlxSave();
     targetSaveData.bind('$SAVE_NAME${slot}', SAVE_PATH);
-    return !targetSaveData.isEmpty();
+    switch (targetSaveData.status)
+    {
+      case EMPTY:
+        return false;
+      case ERROR(_):
+        return false;
+      case BOUND(_, _):
+        return true;
+    }
   }
 
   /**

--- a/source/funkin/save/Save.hx
+++ b/source/funkin/save/Save.hx
@@ -18,7 +18,7 @@ import thx.semver.Version;
 @:nullSafety
 class Save
 {
-  public static final SAVE_DATA_VERSION:thx.semver.Version = "2.0.4";
+  public static final SAVE_DATA_VERSION:thx.semver.Version = "2.0.6";
   public static final SAVE_DATA_VERSION_RULE:thx.semver.VersionRule = "2.0.x";
 
   // We load this version's saves from a new save path, to maintain SOME level of backwards compatibility.

--- a/source/funkin/save/changelog.md
+++ b/source/funkin/save/changelog.md
@@ -5,11 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.0.4] - 2024-09-12
-Note to self: Only update to 2.1.0 when migration is needed.
+## [2.0.6] - 2024-10-11
 ### Added
-- `unlocks.charactersSeen:Array<String>` to `Save`
-- `unlocks.oldChar:Bool` to `Save`
+- `optionsStageEditor` to `Save` for storing user preferences for the stage editor.
 
 ## [2.0.5] - 2024-05-21
 ### Fixed
@@ -17,6 +15,8 @@ Note to self: Only update to 2.1.0 when migration is needed.
 
 ## [2.0.4] - 2024-05-21
 ### Added
+- `unlocks.charactersSeen:Array<String>` to `Save`
+- `unlocks.oldChar:Bool` to `Save`
 - `favoriteSongs:Array<String>` to `Save`
 
 ## [2.0.3] - 2024-01-09

--- a/source/funkin/save/changelog.md
+++ b/source/funkin/save/changelog.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.0] - 2024-10-18
+This version introduces changes to save data loading in order to improve compatibility with older versions.
+### Changed
+- `optionsStageEditor.theme` converted from an Enum to a String to fix save data compatibility issues.
+  - In the future, Enum values should not be used in order to prevent incompatibilities caused by introducing new types to the save data that older versions cannot parse.
+- `optionsChartEditor.theme` converted from an Enum to a String to fix save data compatibility issues.
+- `optionsChartEditor.chartEditorLiveInputStyle` converted from an Enum to a String to fix save data compatibility issues.
+
 ## [2.0.6] - 2024-10-11
 ### Added
 - `optionsStageEditor` to `Save` for storing user preferences for the stage editor.

--- a/source/funkin/save/migrator/SaveDataMigrator.hx
+++ b/source/funkin/save/migrator/SaveDataMigrator.hx
@@ -32,6 +32,10 @@ class SaveDataMigrator
         var save:Save = new Save(saveDataWithDefaults);
         return save;
       }
+      else if (VersionUtil.validateVersion(version, "2.0.x"))
+      {
+        return migrate_v2_0_0(inputData);
+      }
       else
       {
         var message:String = 'Error migrating save data, expected ${Save.SAVE_DATA_VERSION}.';
@@ -41,6 +45,20 @@ class SaveDataMigrator
         return new Save(Save.getDefault());
       }
     }
+  }
+
+  static function migrate_v2_0_0(inputData:Dynamic):Save
+  {
+    // Import the structured data.
+    var saveDataWithDefaults:RawSaveData = cast thx.Objects.deepCombine(Save.getDefault(), inputData);
+
+    // Reset these values to valid ones.
+    saveDataWithDefaults.optionsChartEditor.chartEditorLiveInputStyle = funkin.ui.debug.charting.ChartEditorLiveInputStyle.None;
+    saveDataWithDefaults.optionsChartEditor.theme = funkin.ui.debug.charting.ChartEditorTheme.Light;
+    saveDataWithDefaults.optionsStageEditor.theme = funkin.ui.debug.stageeditor.StageEditorTheme.Light;
+
+    var save:Save = new Save(saveDataWithDefaults);
+    return save;
   }
 
   /**

--- a/source/funkin/save/migrator/SaveDataMigrator.hx
+++ b/source/funkin/save/migrator/SaveDataMigrator.hx
@@ -53,9 +53,9 @@ class SaveDataMigrator
     var saveDataWithDefaults:RawSaveData = cast thx.Objects.deepCombine(Save.getDefault(), inputData);
 
     // Reset these values to valid ones.
-    saveDataWithDefaults.optionsChartEditor.chartEditorLiveInputStyle = funkin.ui.debug.charting.ChartEditorLiveInputStyle.None;
-    saveDataWithDefaults.optionsChartEditor.theme = funkin.ui.debug.charting.ChartEditorTheme.Light;
-    saveDataWithDefaults.optionsStageEditor.theme = funkin.ui.debug.stageeditor.StageEditorTheme.Light;
+    saveDataWithDefaults.optionsChartEditor.chartEditorLiveInputStyle = funkin.ui.debug.charting.ChartEditorState.ChartEditorLiveInputStyle.None;
+    saveDataWithDefaults.optionsChartEditor.theme = funkin.ui.debug.charting.ChartEditorState.ChartEditorTheme.Light;
+    saveDataWithDefaults.optionsStageEditor.theme = funkin.ui.debug.stageeditor.StageEditorState.StageEditorTheme.Light;
 
     var save:Save = new Save(saveDataWithDefaults);
     return save;

--- a/source/funkin/save/migrator/SaveData_v2_0_0.hx
+++ b/source/funkin/save/migrator/SaveData_v2_0_0.hx
@@ -1,0 +1,26 @@
+package funkin.save.migrator;
+
+// Internal enums used to ensure old save data can be parsed by the default Haxe unserializer.
+// In the future, only primitive types and abstract enums should be used in save data!
+
+@:native("funkin.ui.debug.stageeditor.StageEditorTheme")
+enum StageEditorTheme
+{
+  Light;
+  Dark;
+}
+
+@:native("funkin.ui.debug.charting.ChartEditorTheme")
+enum ChartEditorTheme
+{
+  Light;
+  Dark;
+}
+
+@:native("funkin.ui.debug.charting.ChartEditorLiveInputStyle")
+enum ChartEditorLiveInputStyle
+{
+  None;
+  NumberKeys;
+  WASDKeys;
+}

--- a/source/funkin/ui/debug/DebugMenuSubState.hx
+++ b/source/funkin/ui/debug/DebugMenuSubState.hx
@@ -55,12 +55,14 @@ class DebugMenuSubState extends MusicBeatSubState
     // Create each menu item.
     // Call onMenuChange when the first item is created to move the camera .
     #if FEATURE_CHART_EDITOR
-    onMenuChange(createItem("CHART EDITOR", openChartEditor));
+    createItem("CHART EDITOR", openChartEditor);
+    #end
+    createItem("ANIMATION EDITOR", openAnimationEditor);
+    #if FEATURE_STAGE_EDITOR
+    createItem("STAGE EDITOR", openStageEditor);
     #end
     // createItem("Input Offset Testing", openInputOffsetTesting);
-    createItem("CHARACTER SELECT", openCharSelect, true);
-    createItem("ANIMATION EDITOR", openAnimationEditor);
-    createItem("STAGE EDITOR", openStageEditor);
+    // createItem("CHARACTER SELECT", openCharSelect, true);
     // createItem("TEST STICKERS", testStickers);
     #if sys
     createItem("OPEN CRASH LOG FOLDER", openLogFolder);

--- a/source/funkin/ui/debug/charting/ChartEditorState.hx
+++ b/source/funkin/ui/debug/charting/ChartEditorState.hx
@@ -5654,7 +5654,8 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
   function handleHelpKeybinds():Void
   {
     // F1 = Open Help
-    if (FlxG.keys.justPressed.F1 && !isHaxeUIDialogOpen) {
+    if (FlxG.keys.justPressed.F1 && !isHaxeUIDialogOpen)
+    {
       this.openUserGuideDialog();
     }
   }
@@ -6543,22 +6544,22 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
 /**
  * Available input modes for the chart editor state. Numbers/arrows/WASD available for other keybinds.
  */
-enum ChartEditorLiveInputStyle
+enum abstract ChartEditorLiveInputStyle(String)
 {
   /**
    * No hotkeys to place notes at the playbar.
    */
-  None;
+  var None;
 
   /**
    * 1/2/3/4 to place notes on opponent's side, 5/6/7/8 to place notes on player's side.
    */
-  NumberKeys;
+  var NumberKeys;
 
   /**
    * WASD to place notes on opponent's side, Arrow keys to place notes on player's side.
    */
-  WASDKeys;
+  var WASDKeys;
 }
 
 typedef ChartEditorParams =
@@ -6577,15 +6578,15 @@ typedef ChartEditorParams =
 /**
  * Available themes for the chart editor state.
  */
-enum ChartEditorTheme
+enum abstract ChartEditorTheme(String)
 {
   /**
    * The default theme for the chart editor.
    */
-  Light;
+  var Light;
 
   /**
    * A theme which introduces darker colors.
    */
-  Dark;
+  var Dark;
 }

--- a/source/funkin/ui/debug/stageeditor/StageEditorState.hx
+++ b/source/funkin/ui/debug/stageeditor/StageEditorState.hx
@@ -1458,17 +1458,17 @@ class StageEditorState extends UIState
 /**
  * Available themes for the stage editor state.
  */
-enum StageEditorTheme
+enum abstract StageEditorTheme(String)
 {
   /**
    * The default theme for the stage editor.
    */
-  Light;
+  var Light;
 
   /**
    * A theme which introduces stage colors.
    */
-  Dark;
+  var Dark;
 }
 
 enum StageEditorDialogType

--- a/source/funkin/util/SerializerUtil.hx
+++ b/source/funkin/util/SerializerUtil.hx
@@ -63,31 +63,6 @@ class SerializerUtil
     }
   }
 
-  public static function initSerializer():Void
-  {
-    haxe.Unserializer.DEFAULT_RESOLVER = new FunkinTypeResolver();
-  }
-
-  /**
-   * Serialize a Haxe object using the built-in Serializer.
-   * @param input The object to serialize
-   * @return The serialized object as a string
-   */
-  public static function fromHaxeObject(input:Dynamic):String
-  {
-    return haxe.Serializer.run(input);
-  }
-
-  /**
-   * Convert a serialized Haxe object back into a Haxe object.
-   * @param input The serialized object as a string
-   * @return The deserialized object
-   */
-  public static function toHaxeObject(input:String):Dynamic
-  {
-    return haxe.Unserializer.run(input);
-  }
-
   /**
    * Customize how certain types are serialized when converting to JSON.
    */
@@ -114,27 +89,4 @@ class SerializerUtil
     if (value.build.length > 0) result += '+${value.build}';
     return result;
   }
-}
-
-class FunkinTypeResolver
-{
-  public function new()
-  {
-    // Blank constructor.
-  }
-
-  public function resolveClass(name:String):Class<Dynamic>
-  {
-    if (name == 'Dynamic')
-    {
-      FlxG.log.warn('Found invalid class type in save data, indicates partial save corruption.');
-      return null;
-    }
-    return Type.resolveClass(name);
-  };
-
-  public function resolveEnum(name:String):Enum<Dynamic>
-  {
-    return Type.resolveEnum(name);
-  };
 }


### PR DESCRIPTION
<!-- Please check for duplicates or similar PRs before submitting this PR. -->
## Does this PR close any issues? If so, link them below.

#3679 

## Briefly describe the issue(s) fixed.

- Replaced all Enum fields with Enum Abstract fields.
- Incremented the Save data version to `2.1.0` (since this is a breaking change) and implemented migration.
  - Older versions of the game will now complain that the save data is too new when trying to load.
  - Had to create some dummy enums in the save data migrator to prevent errors from loading older saves.
- In the event that the save data fails to parse, the game will now display a big warning popup telling the user to report the issue. It will then create a new save, leaving the broken save in place.

## Include any relevant screenshots or videos.

![image](https://github.com/user-attachments/assets/a6a01936-ba09-4227-96e4-10b36a49bd21)
