### PR TITLE
Revert "chore: Blacklist an additional class in Polymod."

### DIFF
--- a/source/funkin/modding/PolymodHandler.hx
+++ b/source/funkin/modding/PolymodHandler.hx
@@ -290,7 +290,6 @@ class PolymodHandler
     Polymod.blacklistImport('openfl.utils.Assets');
     Polymod.blacklistImport('openfl.Lib');
     Polymod.blacklistImport('openfl.system.ApplicationDomain');
-    Polymod.blacklistImport('funkin.util.FunkinTypeResolver');
 
     // `openfl.desktop.NativeProcess`
     // Can load native processes on the host operating system.


### PR DESCRIPTION
Reverts FunkinCrew/Funkin#3607

The `FunkinTypeResolver` class was removed in the `develop` branch, so there's no need for this blacklist anymore.