### PR TITLE
[BUGFIX] Actually check if the Playable Character is unlocked

### DIFF
--- a/source/funkin/ui/charSelect/CharSelectSubState.hx
+++ b/source/funkin/ui/charSelect/CharSelectSubState.hx
@@ -474,7 +474,10 @@ class CharSelectSubState extends MusicBeatSubState
       }
       else
       {
-        if (availableChars.exists(i)) nonLocks.push(i);
+        var playableCharacterId:String = availableChars.get(i);
+        var player:Null<PlayableCharacter> = PlayerRegistry.instance.fetchEntry(playableCharacterId);
+        var isPlayerUnlocked:Bool = player?.isUnlocked() ?? false;
+        if (availableChars.exists(i) && isPlayerUnlocked) nonLocks.push(i);
 
         var temp:Lock = new Lock(0, 0, i);
         temp.ID = 1;


### PR DESCRIPTION
<!-- Please check for duplicates or similar PRs before submitting this PR. -->
## Does this PR close any issues? If so, link them below.
Fixes #3747

## Briefly describe the issue(s) fixed.
`CharSelectSubState` never actually checked to see if the playable character was unlocked before pushing them to `nonLocks` (to play the unlock animation). The only thing it did was check to see if the playable character ID was in `Save.instance.charactersSeen`, if it wasn't, it would be pushed to `nonLocks` and still play the unlock animation despite never actually unlocking them.

This, in turn, basically unlocked Pico right from the get-go if you entered the Character Select screen early, whether it be through a modded Playable Character, or the Debug Menu.

## Include any relevant screenshots or videos.
![screenshot-2024-10-21-10-26-47](https://github.com/user-attachments/assets/2447df6a-0107-4200-a111-b9a16c82e9a9)
Now, Pico remains locked (since WeekEnd 1 was never beaten), while Madoka (a modded playable character) is unlocked.