### PR TITLE
Add more functionality to label actions

### DIFF
--- a/.github/label-actions.yml
+++ b/.github/label-actions.yml
@@ -8,37 +8,97 @@
       This issue is a duplicate. Please direct all discussion to the original issue.
     # Close the issue
     close: true
-    # Remove other status labels
-    unlabel:
-      - 'status: pending triage'
     # Set a close reason
     close-reason: 'not planned'
+    # Remove other status labels
+    unlabel:
+      - 'status: accepted'
+      - 'status: bug reproduced'
+      - 'status: cannot reproduce'
+      - 'status: needs clarification'
+      - 'status: needs revision'
+      - 'status: pending pull request'
+      - 'status: pending triage'
+      - 'status: rejected'
+      - 'status: resolved'
+      - 'status: reviewing internally'
+      - 'status: stale'
   prs:
     # Post a comment
     comment: >
       This pull request is a duplicate. Please direct all discussion to the original pull request.
-    # Remove other status labels
-    unlabel:
-      - 'status: pending triage'
     # Close the pull request
     close: true
     # Set a close reason
     close-reason: 'not planned'
+    # Remove other status labels
+    unlabel:
+      - 'status: accepted'
+      - 'status: bug reproduced'
+      - 'status: cannot reproduce'
+      - 'status: needs clarification'
+      - 'status: needs revision'
+      - 'status: pending pull request'
+      - 'status: pending triage'
+      - 'status: rejected'
+      - 'status: resolved'
+      - 'status: reviewing internally'
+      - 'status: stale'
 
 'status: rejected':
   issues:
     # Close the issue
     close: true
-    # Remove other status labels
-    unlabel:
-      - 'status: pending triage'
     # Set a close reason
     close-reason: 'not planned'
+    # Remove other status labels
+    unlabel:
+      - 'status: accepted'
+      - 'status: bug reproduced'
+      - 'status: cannot reproduce'
+      - 'status: duplicate'
+      - 'status: needs clarification'
+      - 'status: needs revision'
+      - 'status: pending pull request'
+      - 'status: pending triage'
+      - 'status: resolved'
+      - 'status: reviewing internally'
+      - 'status: stale'
   prs:
     # Close the pull request
     close: true
-    # Remove other status labels
-    unlabel:
-      - 'status: pending triage'
     # Set a close reason
     close-reason: 'not planned'
+    # Remove other status labels
+    unlabel:
+      - 'status: accepted'
+      - 'status: bug reproduced'
+      - 'status: cannot reproduce'
+      - 'status: duplicate'
+      - 'status: needs clarification'
+      - 'status: needs revision'
+      - 'status: pending pull request'
+      - 'status: pending triage'
+      - 'status: resolved'
+      - 'status: reviewing internally'
+      - 'status: stale'
+
+'status: resolved':
+  issues:
+    # Close the issue
+    close: true
+    # Set a close reason
+    close-reason: 'completed'
+    # Remove other status labels
+    unlabel:
+      - 'status: accepted'
+      - 'status: bug reproduced'
+      - 'status: cannot reproduce'
+      - 'status: duplicate'
+      - 'status: needs clarification'
+      - 'status: needs revision'
+      - 'status: pending pull request'
+      - 'status: pending triage'
+      - 'status: rejected'
+      - 'status: reviewing internally'
+      - 'status: stale'


### PR DESCRIPTION
## Changes
* Automatically closes issues as completed when `status: resolved` is added 
  * (see https://github.com/FunkinCrew/Funkin/issues/3196#issuecomment-2438656788 and https://github.com/FunkinCrew/Funkin/issues/2214#issuecomment-2417564882)
* Removes every other status label when the `status: duplicate`, `status: rejected`, or `status: resolved` label is applied.

Ideally, Eric should be able to label something as resolved without having to worry about removing the existing status label or manually closing it.

Additionally, we could make it so that every status label removes every other status label when applied, but I'll only make that change if Eric says he prefers it.