### PR TITLE
build: enable compilationServer in vscode .settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -70,7 +70,7 @@
   "files.eol": "\n",
 
   "haxe.displayPort": "auto",
-  "haxe.enableCompilationServer": false,
+  "haxe.enableCompilationServer": true,
   "haxe.enableServerView": true,
   "haxe.displayServer": {
     "arguments": ["-v"]


### PR DESCRIPTION
Somewhat experimental, putting this PR out to see peoples insights.

We've had troubles with VSCode completion for a LOOOOONG time. Macro troubles and all that trollin us and busting completion

With Haxe 4.3.5 and 4.3.6 I believe there were changes to display different haxe diagnostics? and some vshaxe changes as well? Would appreciate the fellow vscoders out here to see if completion is better, worse, or the same with this change