### PR TITLE
[ENHANCEMENT] ResultState Accept Keybinds

### DIFF
--- a/source/funkin/play/ResultState.hx
+++ b/source/funkin/play/ResultState.hx
@@ -22,6 +22,7 @@ import funkin.ui.freeplay.charselect.PlayableCharacter;
 import flixel.util.FlxColor;
 import flixel.tweens.FlxEase;
 import funkin.graphics.FunkinCamera;
+import funkin.input.Controls;
 import funkin.ui.freeplay.FreeplayState;
 import flixel.tweens.FlxTween;
 import flixel.addons.display.FlxBackdrop;
@@ -727,7 +728,7 @@ class ResultState extends MusicBeatSubState
       speedOfTween.x -= 0.1;
     }
 
-    if (controls.PAUSE)
+    if (controls.PAUSE || controls.ACCEPT)
     {
       if (introMusicAudio != null)
       {


### PR DESCRIPTION
# Fix:
This PR allows users to press the accept keybinds when coming from the ResultsState, before you could only press the pause keybinds which I thought was strange, but I kept that in there just in case if there is a reason for it, and also allowing the player to press the accept keybinds as well.
# Media:
Uhh, I made this just so that KreekCraft and his 8 year old audience don't freak out again (lol), along with saving other streamers. Sure, it doesn't get rid of the cartoon sex, but since people assume that space (which is usually an accept keybind set by default) is the way to close the menus, it will for sure help them right before the you know happens.

https://www.youtube.com/live/CeQQamE9kJs?si=y77S6iEvmtZN_mMA
