### PR TITLE
[FEATURE] Enums in Hscript

### DIFF
--- a/project.hxp
+++ b/project.hxp
@@ -588,6 +588,7 @@ class Project extends HXProject {
 	function configureCustomMacros() {
 		// This macro allows addition of new functionality to existing Flixel. -->
 		addHaxeMacro("addMetadata('@:build(funkin.util.macro.FlxMacro.buildFlxBasic())', 'flixel.FlxBasic')");
+		addHaxeMacro("funkin.util.macro.PolymodMacro.buildPolymodEnums()");
 	}
 
   function configureOutputDir() {

--- a/source/funkin/modding/PolymodHandler.hx
+++ b/source/funkin/modding/PolymodHandler.hx
@@ -248,6 +248,11 @@ class PolymodHandler
     Polymod.addImportAlias('lime.utils.Assets', funkin.Assets);
     Polymod.addImportAlias('openfl.utils.Assets', funkin.Assets);
 
+    for (key => value in funkin.util.macro.PolymodMacro.aliases)
+    {
+      Polymod.addImportAlias(key, Type.resolveClass(value));
+    }
+
     // Add blacklisting for prohibited classes and packages.
 
     // `Sys`
@@ -333,8 +338,19 @@ class PolymodHandler
   {
     return {
       assetLibraryPaths: [
-        'default' => 'preload', 'shared' => 'shared', 'songs' => 'songs', 'videos' => 'videos', 'tutorial' => 'tutorial', 'week1' => 'week1',
-        'week2' => 'week2', 'week3' => 'week3', 'week4' => 'week4', 'week5' => 'week5', 'week6' => 'week6', 'week7' => 'week7', 'weekend1' => 'weekend1',
+        'default' => 'preload',
+        'shared' => 'shared',
+        'songs' => 'songs',
+        'videos' => 'videos',
+        'tutorial' => 'tutorial',
+        'week1' => 'week1',
+        'week2' => 'week2',
+        'week3' => 'week3',
+        'week4' => 'week4',
+        'week5' => 'week5',
+        'week6' => 'week6',
+        'week7' => 'week7',
+        'weekend1' => 'weekend1',
       ],
       coreAssetRedirect: CORE_FOLDER,
     }

--- a/source/funkin/util/macro/PolymodMacro.hx
+++ b/source/funkin/util/macro/PolymodMacro.hx
@@ -1,0 +1,101 @@
+package funkin.util.macro;
+
+import haxe.macro.Context;
+import haxe.macro.Expr;
+import haxe.macro.Type;
+
+using haxe.macro.ExprTools;
+using StringTools;
+
+enum TestEnum
+{
+  Windows(x:Float, y:Float);
+  Linux(str:String);
+  Mac();
+}
+
+class PolymodMacro
+{
+  public static var aliases(get, never):Map<String, String>;
+
+  static function get_aliases():Map<String, String>
+  {
+    // truly a sight to behold
+    return Reflect.callMethod(null, Reflect.field(Type.resolveClass('funkin.util.macro.EnumAliases'), 'get'), []);
+  }
+
+  public static macro function buildPolymodEnums():Void
+  {
+    Context.onAfterTyping((types) -> {
+      if (alreadyCalled)
+      {
+        return;
+      }
+      var aliases:Map<String, String> = new Map<String, String>();
+      for (type in types)
+      {
+        switch (type)
+        {
+          case ModuleType.TEnumDecl(e):
+            var enm = e.get();
+            if (enm.name != 'TestEnum')
+            {
+              continue;
+            }
+            for (value in enm.constructs)
+            {
+              trace(value.type);
+            }
+            aliases.set('${enm.pack.join('.')}.${enm.name}', 'polymod.enums.${enm.pack.join('.')}.${enm.name}');
+          // buildEnum(enm);
+          default:
+            // do nothing
+        }
+      }
+      Context.defineModule('funkin.util.macro.PolymodMacro', [
+        {
+          pack: ['funkin', 'util', 'macro'],
+          name: 'EnumAliases',
+          kind: TypeDefKind.TDClass(null, [], false, false, false),
+          fields: [
+            {
+              name: 'get',
+              access: [Access.APublic, Access.AStatic],
+              kind: FieldType.FFun(
+                {
+                  args: [],
+                  ret: (macro :Map<String, String>),
+                  expr: macro
+                  {
+                    return $v{aliases};
+                  }
+                }),
+              pos: Context.currentPos()
+            }
+          ],
+          pos: Context.currentPos()
+        }
+      ]);
+      // the callback is called twice, which this leads to issues
+      alreadyCalled = true;
+    });
+  }
+
+  #if macro
+  static var alreadyCalled:Bool = false;
+  static var skipFields:Array<String> = [];
+
+  static function buildEnum(enm:EnumType):Void
+  {
+    var fields:Array<Field> = [];
+    Context.defineType(
+      {
+        pos: Context.currentPos(),
+        pack: ['polymod', 'enums'].concat(enm.module.split('.')),
+        name: enm.name,
+        kind: TypeDefKind.TDClass(null, [], false, false, false),
+        fields: fields,
+      }, null);
+  }
+  #end
+}

--- a/source/funkin/util/macro/PolymodMacro.hx
+++ b/source/funkin/util/macro/PolymodMacro.hx
@@ -46,11 +46,6 @@ class PolymodMacro
         }
       }
 
-      for (key => value in aliases)
-      {
-        trace(key, value);
-      }
-
       Context.defineModule('funkin.util.macro.PolymodMacro', [
         {
           pack: ['funkin', 'util', 'macro'],

--- a/source/funkin/util/macro/PolymodMacro.hx
+++ b/source/funkin/util/macro/PolymodMacro.hx
@@ -137,7 +137,7 @@ class PolymodMacro
     Context.defineType(
       {
         pos: Context.currentPos(),
-        pack: ['polymod', 'enums'].concat(enm.module.split('.')),
+        pack: ['polymod', 'enums'].concat(enm.pack),
         name: enm.name,
         kind: TypeDefKind.TDClass(null, [], false, false, false),
         fields: fields,


### PR DESCRIPTION
## DESCRIPTION
This pr aims to make it possible to import enums.
The macro creates "wrappers" around the actual enum.

## EXPLANATION
For example `funkin.ui.NavControls`:
We create a class `polymod.enums.funkin.ui.NavControls`.
This class has all fields of `funkin.ui.NavControls`, and treats them as regular variables and functions, which call the respective fields from the actual `funkin.ui.NavControls` enum. 
We then create an alias for `funkin.ui.NavControls` and make it point to `polymod.enums.funkin.ui.NavControls`.

## EXAMPLES
```haxe
import funkin.play.song.Song;
import funkin.ui.NavControls;

class ExampleSong extends Song
{
	function new()
	{
		super('exampleSong');
		
		trace(NavControls.Columns(5)); // Columns(5)
		trace(NavControls.Rows(5)); // Rows(5)
		trace(NavControls.Both); // Both

		trace(NavControls.Rows(5) == NavControls.Rows(3)); // false
		trace(NavControls.Rows(5) == NavControls.Rows(5)); // true
	}
}
```

## TODO
- [x] Make all enums accessible
- [ ] Make switch statements work