### PR TITLE
fix: re-enable precise chart editor scrolling, and also fix smooth scroll playhead/playbar playback

### DIFF
--- a/source/funkin/ui/debug/charting/ChartEditorState.hx
+++ b/source/funkin/ui/debug/charting/ChartEditorState.hx
@@ -2729,6 +2729,7 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
       {
         // Update the conductor and audio tracks to match.
         currentScrollEase = d.value;
+        easeSongToScrollPosition(currentScrollEase);
       }
     }
 
@@ -2741,7 +2742,7 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
         playbarHeadDraggingWasPlaying = false;
 
         // Disabled code to resume song playback on drag.
-        // startAudioPlayback();
+        startAudioPlayback();
       }
     }
 
@@ -3873,7 +3874,7 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
     }
 
     // Mouse Wheel = Scroll
-    if (FlxG.mouse.wheel != 0 && !FlxG.keys.pressed.CONTROL)
+    if (FlxG.mouse.wheel != 0)
     {
       scrollAmount = -50 * FlxG.mouse.wheel;
       shouldPause = true;
@@ -4469,6 +4470,7 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
           0, songLengthInPixels);
 
         currentScrollEase = clickedPosInPixels;
+        easeSongToScrollPosition(currentScrollEase);
       }
       else if (scrollAnchorScreenPos != null)
       {


### PR DESCRIPTION
my previous smooth scroll implementation seemed to have regressed some functionality with how clicking on the playbar/playhead of the track. This PR re-enables things the old functionality

along with that, also allow for CTRL + mouse wheel to scroll the chart in fine precise increments, which seemed like it was there mostly, but intentionally disabled at some point