### PR TITLE
[BUGFIX] Fix early return in `hasBeatenSong()`

### DIFF
--- a/source/funkin/save/Save.hx
+++ b/source/funkin/save/Save.hx
@@ -623,7 +623,7 @@ class Save
         else
         {
           // Level has score data, but the score is 0.
-          return false;
+          continue;
         }
       }
     }
@@ -818,7 +818,7 @@ class Save
         else
         {
           // Level has score data, but the score is 0.
-          return false;
+          continue;
         }
       }
     }


### PR DESCRIPTION
This PR fixes an early return in `hasBeatenSong()` and replaces it with `continue;` instead (since it's a `for` loop). There's already a `return false;` below the loop in the event that the song hasn't been beaten.
