### PR TITLE
[ENHANCEMENT] Faster Game Over Mashing (and some cherries on top)

### DIFF
--- a/source/funkin/effects/RetroCameraFade.hx
+++ b/source/funkin/effects/RetroCameraFade.hx
@@ -7,6 +7,8 @@ import openfl.filters.ColorMatrixFilter;
 @:nullSafety
 class RetroCameraFade
 {
+  static var fadeTimer:Null<FlxTimer>;
+
   // im lazy, but we only use this for week 6
   // and also sorta yoinked for djflixel, lol !
   public static function fadeWhite(camera:FlxCamera, camSteps:Int = 5, time:Float = 1):Void
@@ -14,7 +16,16 @@ class RetroCameraFade
     var steps:Int = 0;
     var stepsTotal:Int = camSteps;
 
-    new FlxTimer().start(time / stepsTotal, _ ->
+    if (fadeTimer != null)
+    {
+      fadeTimer.cancel();
+      fadeTimer.destroy();
+      fadeTimer = null;
+
+      camera.filters = [];
+    }
+
+    fadeTimer = new FlxTimer().start(time / stepsTotal, _ ->
     {
       var V:Float = (1 / stepsTotal) * steps;
       if (steps == stepsTotal) V = 1;
@@ -27,6 +38,13 @@ class RetroCameraFade
       ];
       camera.filters = [new ColorMatrixFilter(matrix)];
       steps++;
+
+      if (fadeTimer != null && fadeTimer.loopsLeft < 1)
+      {
+        fadeTimer.cancel();
+        fadeTimer.destroy();
+        fadeTimer = null;
+      }
     }, stepsTotal + 1);
   }
 
@@ -34,6 +52,13 @@ class RetroCameraFade
   {
     var steps:Int = camSteps;
     var stepsTotal:Int = camSteps;
+
+    if (fadeTimer != null)
+    {
+      fadeTimer.cancel();
+      fadeTimer.destroy();
+      fadeTimer = null;
+    }
 
     var matrixDerp = [
       1, 0, 0, 0, 1.0 * 255,
@@ -45,7 +70,7 @@ class RetroCameraFade
       new ColorMatrixFilter(matrixDerp)
     ];
 
-    new FlxTimer().start(time / stepsTotal, _ ->
+    fadeTimer = new FlxTimer().start(time / stepsTotal, _ ->
     {
       var V:Float = (1 / stepsTotal) * steps;
       if (steps == stepsTotal) V = 1;
@@ -58,6 +83,13 @@ class RetroCameraFade
       ];
       camera.filters = [new ColorMatrixFilter(matrix)];
       steps--;
+
+      if (fadeTimer != null && fadeTimer.loopsLeft < 1)
+      {
+        fadeTimer.cancel();
+        fadeTimer.destroy();
+        fadeTimer = null;
+      }
     }, camSteps);
   }
 
@@ -66,7 +98,16 @@ class RetroCameraFade
     var steps:Int = 0;
     var stepsTotal:Int = camSteps;
 
-    new FlxTimer().start(time / stepsTotal, _ ->
+    if (fadeTimer != null)
+    {
+      fadeTimer.cancel();
+      fadeTimer.destroy();
+      fadeTimer = null;
+
+      camera.filters = [];
+    }
+
+    fadeTimer = new FlxTimer().start(time / stepsTotal, _ ->
     {
       var V:Float = (1 / stepsTotal) * steps;
       if (steps == stepsTotal) V = 1;
@@ -79,6 +120,13 @@ class RetroCameraFade
       ];
       camera.filters = [new ColorMatrixFilter(matrix)];
       steps++;
+
+      if (fadeTimer != null && fadeTimer.loopsLeft < 1)
+      {
+        fadeTimer.cancel();
+        fadeTimer.destroy();
+        fadeTimer = null;
+      }
     }, camSteps);
   }
 
@@ -86,6 +134,15 @@ class RetroCameraFade
   {
     var steps:Int = camSteps;
     var stepsTotal:Int = camSteps;
+
+    if (fadeTimer != null)
+    {
+      fadeTimer.cancel();
+      fadeTimer.destroy();
+      fadeTimer = null;
+
+      camera.filters = [];
+    }
 
     var matrixDerp = [
       1, 0, 0, 0, -1.0 * 255,
@@ -97,7 +154,7 @@ class RetroCameraFade
       new ColorMatrixFilter(matrixDerp)
     ];
 
-    new FlxTimer().start(time / stepsTotal, _ ->
+    fadeTimer = new FlxTimer().start(time / stepsTotal, _ ->
     {
       var V:Float = (1 / stepsTotal) * steps;
       if (steps == stepsTotal) V = 1;
@@ -110,6 +167,13 @@ class RetroCameraFade
       ];
       camera.filters = [new ColorMatrixFilter(matrix)];
       steps--;
+
+      if (fadeTimer != null && fadeTimer.loopsLeft < 1)
+      {
+        fadeTimer.cancel();
+        fadeTimer.destroy();
+        fadeTimer = null;
+      }
     }, camSteps + 1);
   }
 }

--- a/source/funkin/effects/RetroCameraFade.hx
+++ b/source/funkin/effects/RetroCameraFade.hx
@@ -7,6 +7,8 @@ import openfl.filters.ColorMatrixFilter;
 @:nullSafety
 class RetroCameraFade
 {
+  static var fadeTimer:Null<FlxTimer>;
+
   // im lazy, but we only use this for week 6
   // and also sorta yoinked for djflixel, lol !
   public static function fadeWhite(camera:FlxCamera, camSteps:Int = 5, time:Float = 1):Void
@@ -14,7 +16,16 @@ class RetroCameraFade
     var steps:Int = 0;
     var stepsTotal:Int = camSteps;
 
-    new FlxTimer().start(time / stepsTotal, _ ->
+    if (fadeTimer != null)
+    {
+      fadeTimer.cancel();
+      fadeTimer.destroy();
+      fadeTimer = null;
+
+      camera.filters = [];
+    }
+
+    fadeTimer = new FlxTimer().start(time / stepsTotal, _ ->
     {
       var V:Float = (1 / stepsTotal) * steps;
       if (steps == stepsTotal) V = 1;
@@ -27,6 +38,13 @@ class RetroCameraFade
       ];
       camera.filters = [new ColorMatrixFilter(matrix)];
       steps++;
+
+      if (fadeTimer != null && fadeTimer.loopsLeft < 1)
+      {
+        fadeTimer.cancel();
+        fadeTimer.destroy();
+        fadeTimer = null;
+      }
     }, stepsTotal + 1);
   }
 
@@ -34,6 +52,13 @@ class RetroCameraFade
   {
     var steps:Int = camSteps;
     var stepsTotal:Int = camSteps;
+
+    if (fadeTimer != null)
+    {
+      fadeTimer.cancel();
+      fadeTimer.destroy();
+      fadeTimer = null;
+    }
 
     var matrixDerp = [
       1, 0, 0, 0, 1.0 * 255,
@@ -43,7 +68,7 @@ class RetroCameraFade
     ];
     camera.filters = [new ColorMatrixFilter(matrixDerp)];
 
-    new FlxTimer().start(time / stepsTotal, _ ->
+    fadeTimer = new FlxTimer().start(time / stepsTotal, _ ->
     {
       var V:Float = (1 / stepsTotal) * steps;
       if (steps == stepsTotal) V = 1;
@@ -56,6 +81,13 @@ class RetroCameraFade
       ];
       camera.filters = [new ColorMatrixFilter(matrix)];
       steps--;
+
+      if (fadeTimer != null && fadeTimer.loopsLeft < 1)
+      {
+        fadeTimer.cancel();
+        fadeTimer.destroy();
+        fadeTimer = null;
+      }
     }, camSteps);
   }
 
@@ -64,7 +96,16 @@ class RetroCameraFade
     var steps:Int = 0;
     var stepsTotal:Int = camSteps;
 
-    new FlxTimer().start(time / stepsTotal, _ ->
+    if (fadeTimer != null)
+    {
+      fadeTimer.cancel();
+      fadeTimer.destroy();
+      fadeTimer = null;
+
+      camera.filters = [];
+    }
+
+    fadeTimer = new FlxTimer().start(time / stepsTotal, _ ->
     {
       var V:Float = (1 / stepsTotal) * steps;
       if (steps == stepsTotal) V = 1;
@@ -77,6 +118,13 @@ class RetroCameraFade
       ];
       camera.filters = [new ColorMatrixFilter(matrix)];
       steps++;
+
+      if (fadeTimer != null && fadeTimer.loopsLeft < 1)
+      {
+        fadeTimer.cancel();
+        fadeTimer.destroy();
+        fadeTimer = null;
+      }
     }, camSteps);
   }
 
@@ -84,6 +132,15 @@ class RetroCameraFade
   {
     var steps:Int = camSteps;
     var stepsTotal:Int = camSteps;
+
+    if (fadeTimer != null)
+    {
+      fadeTimer.cancel();
+      fadeTimer.destroy();
+      fadeTimer = null;
+
+      camera.filters = [];
+    }
 
     var matrixDerp = [
       1, 0, 0, 0, -1.0 * 255,
@@ -93,7 +150,7 @@ class RetroCameraFade
     ];
     camera.filters = [new ColorMatrixFilter(matrixDerp)];
 
-    new FlxTimer().start(time / stepsTotal, _ ->
+    fadeTimer = new FlxTimer().start(time / stepsTotal, _ ->
     {
       var V:Float = (1 / stepsTotal) * steps;
       if (steps == stepsTotal) V = 1;
@@ -106,6 +163,13 @@ class RetroCameraFade
       ];
       camera.filters = [new ColorMatrixFilter(matrix)];
       steps--;
+
+      if (fadeTimer != null && fadeTimer.loopsLeft < 1)
+      {
+        fadeTimer.cancel();
+        fadeTimer.destroy();
+        fadeTimer = null;
+      }
     }, camSteps + 1);
   }
 }

--- a/source/funkin/play/GameOverSubState.hx
+++ b/source/funkin/play/GameOverSubState.hx
@@ -69,6 +69,11 @@ class GameOverSubState extends MusicBeatSubState
   var boyfriend:Null<BaseCharacter> = null;
 
   /**
+   * If this instance is a "fakeout death".
+   */
+  var isFakeout:Bool;
+
+  /**
    * The invisible object in the scene which the camera focuses on.
    */
   var cameraFollowPoint:FlxObject;
@@ -77,6 +82,11 @@ class GameOverSubState extends MusicBeatSubState
    * The music playing in the background of the state.
    */
   var gameOverMusic:Null<FunkinSound> = null;
+
+  /**
+   * The sound effect playing for this state.
+   */
+  var gameOverSfx:Null<FunkinSound> = null;
 
   /**
    * Whether the player has confirmed and prepared to restart the level or to go back to the freeplay menu.
@@ -93,6 +103,8 @@ class GameOverSubState extends MusicBeatSubState
   var mustNotExit:Bool = false;
   var transparent:Bool;
 
+  var confirmTimer:FlxTimer;
+
   static final CAMERA_ZOOM_DURATION:Float = 0.5;
 
   var targetCameraZoom:Float = 1.0;
@@ -105,12 +117,10 @@ class GameOverSubState extends MusicBeatSubState
     this.isChartingMode = params?.isChartingMode ?? false;
     transparent = params.transparent;
 
+    isFakeout = FlxG.random.bool((1 / 4096) * 100);
+
     cameraFollowPoint = new FlxObject(0, 0, 1, 1);
-    if (parentPlayState != null)
-    {
-      cameraFollowPoint.x = parentPlayState.cameraFollowPoint.x;
-      cameraFollowPoint.y = parentPlayState.cameraFollowPoint.y;
-    }
+    confirmTimer = new FlxTimer();
   }
 
   /**
@@ -140,6 +150,12 @@ class GameOverSubState extends MusicBeatSubState
     super.create();
 
     parentPlayState = cast _parentState;
+
+    if (parentPlayState != null)
+    {
+      cameraFollowPoint.x = parentPlayState.cameraFollowPoint.x;
+      cameraFollowPoint.y = parentPlayState.cameraFollowPoint.y;
+    }
 
     //
     // Set up the visuals
@@ -240,14 +256,21 @@ class GameOverSubState extends MusicBeatSubState
     {
       hasStartedAnimation = true;
 
-      if (boyfriend == null || (parentPlayState?.isMinimalMode ?? true))
+      if (!isFakeout)
       {
         // Play the "blue balled" sound. May play a variant if one has been assigned.
         playBlueBalledSFX();
+
+        if (gameOverSfx != null)
+        {
+          // Destroy when finished.
+          gameOverSfx.onComplete = destroyGameOverSfx;
+        }
       }
-      else
+
+      if (boyfriend != null && !(parentPlayState?.isMinimalMode ?? false))
       {
-        if (boyfriend.hasAnimation('fakeoutDeath') && FlxG.random.bool((1 / 4096) * 100))
+        if (boyfriend.hasAnimation('fakeoutDeath') && isFakeout)
         {
           boyfriend.playAnimation('fakeoutDeath', true, false);
         }
@@ -255,8 +278,6 @@ class GameOverSubState extends MusicBeatSubState
         {
           boyfriend.playAnimation('firstDeath' + animationSuffix, true,
             false); // ignoreOther is set to FALSE since you WANT to be able to mash and confirm game over!
-          // Play the "blue balled" sound. May play a variant if one has been assigned.
-          playBlueBalledSFX();
         }
       }
     }
@@ -264,20 +285,7 @@ class GameOverSubState extends MusicBeatSubState
     // Smoothly lerp the camera
     FlxG.camera.zoom = MathUtil.smoothLerpPrecision(FlxG.camera.zoom, targetCameraZoom, elapsed, CAMERA_ZOOM_DURATION);
 
-    //
-    // Handle user inputs.
-    //
-
-    // Restart the level when pressing the assigned key.
-    if ((controls.ACCEPT_P #if mobile || (TouchUtil.pressAction() && !TouchUtil.overlaps(backButton) && canInput) #end)
-      && blueballed
-      && !mustNotExit)
-    {
-      blueballed = false;
-      confirmDeath();
-    }
-
-    if (controls.BACK_P && !mustNotExit && !isEnding) goBack();
+    if (!mustNotExit #if mobile && canInput #end) updateInputs(elapsed);
 
     if (gameOverMusic != null && gameOverMusic.playing)
     {
@@ -317,6 +325,23 @@ class GameOverSubState extends MusicBeatSubState
 
     // Start death music before firstDeath gets replaced
     super.update(elapsed);
+  }
+
+  /**
+   * Handle user inputs.
+   * @param elapsed Time elapsed since last frame.
+   */
+  function updateInputs(elapsed:Float):Void
+  {
+    // Restart the level when pressing the assigned key.
+    // You can mash the key to restart faster.
+    if ((controls.ACCEPT_P #if mobile || (TouchUtil.pressAction() && !TouchUtil.overlaps(backButton)) #end))
+    {
+      if (blueballed) blueballed = false;
+      confirmDeath();
+    }
+
+    if (controls.BACK) goBack();
   }
 
   var deathQuoteSound:Null<FunkinSound> = null;
@@ -381,80 +406,82 @@ class GameOverSubState extends MusicBeatSubState
       final FADE_TIMER:Float = (gameOverMusic?.length ?? 0) / 7000;
 
       // After the animation finishes...
-      new FlxTimer().start(FADE_TIMER, function(tmr:FlxTimer)
+      confirmTimer.start(FADE_TIMER, function(tmr:FlxTimer)
       {
-        // ...fade out the graphics. Then after that happens...
-
-        var resetPlaying = function(pixel:Bool = false)
-        {
-          // ...close the GameOverSubState.
-          if (pixel) RetroCameraFade.fadeBlack(FlxG.camera, 10, 1);
-          else
-            FlxG.camera.fade(FlxColor.BLACK, 1, true, null, true);
-          if (parentPlayState != null) parentPlayState.needsReset = true;
-
-          if ((parentPlayState?.isMinimalMode ?? true) || boyfriend == null)
-          {
-          }
-          else
-          {
-            // Readd Boyfriend to the stage.
-            boyfriend.isDead = false;
-            remove(boyfriend);
-            parentPlayState?.currentStage?.addCharacter(boyfriend, BF);
-          }
-
-          // Snap reset the camera which may have changed because of the player character data.
-          resetCameraZoom();
-
-          // Close the substate.
-          close();
-        };
-
-        if (musicSuffix.contains('-pixel'))
+        // ...fade out the graphics.
+        if (musicSuffix == '-pixel')
         {
           RetroCameraFade.fadeToBlack(FlxG.camera, 10, 2);
-          new FlxTimer().start(2, _ ->
-          {
-            FlxG.camera.filters = [];
-            #if FEATURE_MOBILE_ADVERTISEMENTS
-            if (AdMobUtil.PLAYING_COUNTER >= AdMobUtil.MAX_BEFORE_AD)
-            {
-              AdMobUtil.loadInterstitial(function():Void
-              {
-                AdMobUtil.PLAYING_COUNTER = 0;
-                resetPlaying(true);
-              });
-            }
-            else
-              resetPlaying(true);
-            #else
-            resetPlaying(true);
-            #end
-          });
         }
         else
         {
-          FlxG.camera.fade(FlxColor.BLACK, 2, false, function()
-          {
-            #if FEATURE_MOBILE_ADVERTISEMENTS
-            if (AdMobUtil.PLAYING_COUNTER >= AdMobUtil.MAX_BEFORE_AD)
-            {
-              AdMobUtil.loadInterstitial(function():Void
-              {
-                AdMobUtil.PLAYING_COUNTER = 0;
-                resetPlaying();
-              });
-            }
-            else
-              resetPlaying();
-            #else
-            resetPlaying();
-            #end
-          }, true);
+          FlxG.camera.fade(FlxColor.BLACK, 2, false, null, true);
         }
+
+        confirmTimer.start(2, _ ->
+        {
+          FlxG.camera.filters = [];
+          resetPlaying(musicSuffix == '-pixel');
+        });
       });
     }
+    else
+    {
+      resetPlaying(musicSuffix == '-pixel');
+
+      if (confirmTimer != null)
+      {
+        confirmTimer.cancel();
+        confirmTimer.destroy();
+      }
+    }
+  }
+
+  /**
+   * Get's ready to restart the song.
+   * @param pixel If the transition should be pixelated or not.
+   */
+  public function resetPlaying(pixel:Bool = false):Void
+  {
+    mustNotExit = true;
+
+    #if FEATURE_MOBILE_ADVERTISEMENTS
+    if (AdMobUtil.PLAYING_COUNTER >= AdMobUtil.MAX_BEFORE_AD)
+    {
+      AdMobUtil.loadInterstitial(function():Void
+      {
+        AdMobUtil.PLAYING_COUNTER = 0;
+        resetPlaying(pixel);
+      });
+      return;
+    }
+    #end
+
+    // Close the GameOverSubState.
+    if (pixel) RetroCameraFade.fadeBlack(FlxG.camera, 10, 1);
+    else
+      FlxG.camera.fade(FlxColor.BLACK, 1, true, null, true);
+    if (parentPlayState != null) parentPlayState.needsReset = true;
+
+    if ((parentPlayState?.isMinimalMode ?? true) || boyfriend == null)
+    {
+    }
+    else
+    {
+      // Readd Boyfriend to the stage.
+      boyfriend.isDead = false;
+      remove(boyfriend);
+      parentPlayState?.currentStage?.addCharacter(boyfriend, BF);
+    }
+
+    // Stop playing the music.
+    gameOverMusic.stop();
+
+    // Snap reset the camera which may have changed because of the player character data.
+    resetCameraZoom();
+
+    // Close the substate.
+    close();
   }
 
   override public function dispatchEvent(event:ScriptEvent):Void
@@ -494,6 +521,8 @@ class GameOverSubState extends MusicBeatSubState
   {
     var musicPath:Null<String> = resolveMusicPath(musicSuffix, isStarting, isEnding);
     var onComplete:Void->Void = () -> {};
+
+    if (gameOverSfx != null && isEnding) destroyGameOverSfx();
 
     if (isStarting)
     {
@@ -543,7 +572,7 @@ class GameOverSubState extends MusicBeatSubState
    */
   public function goBack():Void
   {
-    if (!blueballed || mustNotExit) return;
+    if (!blueballed || isEnding) return;
     isEnding = true;
     blueballed = false;
     if (parentPlayState != null) parentPlayState.deathCounter = 0;
@@ -597,17 +626,30 @@ class GameOverSubState extends MusicBeatSubState
    * Play the sound effect that occurs when
    * boyfriend's testicles get utterly annihilated.
    */
-  public static function playBlueBalledSFX():Void
+  public function playBlueBalledSFX():Void
   {
     blueballed = true;
 
     if (Assets.exists(Paths.sound('gameplay/gameover/fnf_loss_sfx' + blueBallSuffix)))
     {
-      FunkinSound.playOnce(Paths.sound('gameplay/gameover/fnf_loss_sfx' + blueBallSuffix));
+      gameOverSfx = FunkinSound.playOnce(Paths.sound('gameplay/gameover/fnf_loss_sfx' + blueBallSuffix));
     }
     else
     {
       FlxG.log.error('Missing blue ball sound effect: ' + Paths.sound('gameplay/gameover/fnf_loss_sfx' + blueBallSuffix));
+    }
+  }
+
+  /**
+   * Destroy the Death Sound Effect used in this instance.
+   * Used to clean up memory.
+   */
+  public function destroyGameOverSfx():Void
+  {
+    if (gameOverSfx != null)
+    {
+      gameOverSfx.destroy();
+      gameOverSfx = null;
     }
   }
 

--- a/source/funkin/play/GameOverSubState.hx
+++ b/source/funkin/play/GameOverSubState.hx
@@ -69,6 +69,11 @@ class GameOverSubState extends MusicBeatSubState
   var boyfriend:Null<BaseCharacter> = null;
 
   /**
+   * If this instance is a "fakeout death".
+   */
+  var isFakeout:Bool;
+
+  /**
    * The invisible object in the scene which the camera focuses on.
    */
   var cameraFollowPoint:FlxObject;
@@ -77,6 +82,11 @@ class GameOverSubState extends MusicBeatSubState
    * The music playing in the background of the state.
    */
   var gameOverMusic:Null<FunkinSound> = null;
+
+  /**
+   * The sound effect playing for this state.
+   */
+  var gameOverSfx:Null<FunkinSound> = null;
 
   /**
    * Whether the player has confirmed and prepared to restart the level or to go back to the freeplay menu.
@@ -92,6 +102,7 @@ class GameOverSubState extends MusicBeatSubState
   var isChartingMode:Bool = false;
   var mustNotExit:Bool = false;
   var transparent:Bool;
+  var confirmTimer:FlxTimer;
 
   static final CAMERA_ZOOM_DURATION:Float = 0.5;
 
@@ -105,12 +116,10 @@ class GameOverSubState extends MusicBeatSubState
     this.isChartingMode = params?.isChartingMode ?? false;
     transparent = params.transparent;
 
+    isFakeout = FlxG.random.bool((1 / 4096) * 100);
+
     cameraFollowPoint = new FlxObject(0, 0, 1, 1);
-    if (parentPlayState != null)
-    {
-      cameraFollowPoint.x = parentPlayState.cameraFollowPoint.x;
-      cameraFollowPoint.y = parentPlayState.cameraFollowPoint.y;
-    }
+    confirmTimer = new FlxTimer();
   }
 
   /**
@@ -140,6 +149,12 @@ class GameOverSubState extends MusicBeatSubState
     super.create();
 
     parentPlayState = cast _parentState;
+
+    if (parentPlayState != null)
+    {
+      cameraFollowPoint.x = parentPlayState.cameraFollowPoint.x;
+      cameraFollowPoint.y = parentPlayState.cameraFollowPoint.y;
+    }
 
     //
     // Set up the visuals
@@ -240,14 +255,21 @@ class GameOverSubState extends MusicBeatSubState
     {
       hasStartedAnimation = true;
 
-      if (boyfriend == null || (parentPlayState?.isMinimalMode ?? true))
+      if (!isFakeout)
       {
         // Play the "blue balled" sound. May play a variant if one has been assigned.
         playBlueBalledSFX();
+
+        if (gameOverSfx != null)
+        {
+          // Destroy when finished.
+          gameOverSfx.onComplete = destroyGameOverSfx;
+        }
       }
-      else
+
+      if (boyfriend != null && !(parentPlayState?.isMinimalMode ?? false))
       {
-        if (boyfriend.hasAnimation('fakeoutDeath') && FlxG.random.bool((1 / 4096) * 100))
+        if (boyfriend.hasAnimation('fakeoutDeath') && isFakeout)
         {
           boyfriend.playAnimation('fakeoutDeath', true, false);
         }
@@ -258,8 +280,6 @@ class GameOverSubState extends MusicBeatSubState
             true,
             false
           ); // ignoreOther is set to FALSE since you WANT to be able to mash and confirm game over!
-          // Play the "blue balled" sound. May play a variant if one has been assigned.
-          playBlueBalledSFX();
         }
       }
     }
@@ -267,19 +287,7 @@ class GameOverSubState extends MusicBeatSubState
     // Smoothly lerp the camera
     FlxG.camera.zoom = MathUtil.smoothLerpPrecision(FlxG.camera.zoom, targetCameraZoom, elapsed, CAMERA_ZOOM_DURATION);
 
-    //
-    // Handle user inputs.
-    //
-
-    // Restart the level when pressing the assigned key.
-    final bfTouched:Bool = #if FEATURE_TOUCH_CONTROLS TouchUtil.pressAction() && !TouchUtil.overlaps(backButton) && canInput #else false #end;
-    if ((controls.ACCEPT_P || bfTouched) && blueballed && !mustNotExit)
-    {
-      blueballed = false;
-      confirmDeath();
-    }
-
-    if (controls.BACK_P && !mustNotExit && !isEnding) goBack();
+    if (!mustNotExit #if mobile && canInput #end) updateInputs(elapsed);
 
     if (gameOverMusic != null && gameOverMusic.playing)
     {
@@ -321,6 +329,23 @@ class GameOverSubState extends MusicBeatSubState
     super.update(elapsed);
   }
 
+  /**
+   * Handle user inputs.
+   * @param elapsed Time elapsed since last frame.
+   */
+  function updateInputs(elapsed:Float):Void
+  {
+    // Restart the level when pressing the assigned key.
+    // You can mash the key to restart faster.
+    if ((controls.ACCEPT_P #if mobile || (TouchUtil.pressAction() && !TouchUtil.overlaps(backButton)) #end))
+    {
+      if (blueballed) blueballed = false;
+      confirmDeath();
+    }
+
+    if (controls.BACK) goBack();
+  }
+
   var deathQuoteSound:Null<FunkinSound> = null;
 
   function playDeathQuote():Void
@@ -341,7 +366,7 @@ class GameOverSubState extends MusicBeatSubState
     // Start music at lower volume
     startDeathMusic(0.2, false);
     boyfriend.playAnimation('deathLoop' + animationSuffix);
-    deathQuoteSound = FunkinSound.playOnce(deathQuote, function()
+    deathQuoteSound = FunkinSound.playOnce(deathQuote, () ->
     {
       // Once the quote ends, fade in the game over music.
       if (!isEnding && gameOverMusic != null)
@@ -383,80 +408,82 @@ class GameOverSubState extends MusicBeatSubState
       final FADE_TIMER:Float = (gameOverMusic?.length ?? 0) / 7000;
 
       // After the animation finishes...
-      new FlxTimer().start(FADE_TIMER, function(tmr:FlxTimer)
+      confirmTimer.start(FADE_TIMER, function(tmr:FlxTimer)
       {
-        // ...fade out the graphics. Then after that happens...
-
-        var resetPlaying = function(pixel:Bool = false)
-        {
-          // ...close the GameOverSubState.
-          if (pixel) RetroCameraFade.fadeBlack(FlxG.camera, 10, 1);
-          else
-            FlxG.camera.fade(FlxColor.BLACK, 1, true, null, true);
-          if (parentPlayState != null) parentPlayState.needsReset = true;
-
-          if ((parentPlayState?.isMinimalMode ?? true) || boyfriend == null)
-          {
-          }
-          else
-          {
-            // Readd Boyfriend to the stage.
-            boyfriend.isDead = false;
-            remove(boyfriend);
-            parentPlayState?.currentStage?.addCharacter(boyfriend, BF);
-          }
-
-          // Snap reset the camera which may have changed because of the player character data.
-          resetCameraZoom();
-
-          // Close the substate.
-          close();
-        };
-
-        if (musicSuffix.contains('-pixel'))
+        // ...fade out the graphics.
+        if (musicSuffix == '-pixel')
         {
           RetroCameraFade.fadeToBlack(FlxG.camera, 10, 2);
-          new FlxTimer().start(2, _ ->
-          {
-            FlxG.camera.filters = [];
-            #if FEATURE_MOBILE_ADVERTISEMENTS
-            if (AdMobUtil.PLAYING_COUNTER >= AdMobUtil.MAX_BEFORE_AD)
-            {
-              AdMobUtil.loadInterstitial(function():Void
-              {
-                AdMobUtil.PLAYING_COUNTER = 0;
-                resetPlaying(true);
-              });
-            }
-            else
-              resetPlaying(true);
-            #else
-            resetPlaying(true);
-            #end
-          });
         }
         else
         {
-          FlxG.camera.fade(FlxColor.BLACK, 2, false, function()
-          {
-            #if FEATURE_MOBILE_ADVERTISEMENTS
-            if (AdMobUtil.PLAYING_COUNTER >= AdMobUtil.MAX_BEFORE_AD)
-            {
-              AdMobUtil.loadInterstitial(function():Void
-              {
-                AdMobUtil.PLAYING_COUNTER = 0;
-                resetPlaying();
-              });
-            }
-            else
-              resetPlaying();
-            #else
-            resetPlaying();
-            #end
-          }, true);
+          FlxG.camera.fade(FlxColor.BLACK, 2, false, null, true);
         }
+
+        confirmTimer.start(2, _ ->
+        {
+          FlxG.camera.filters = [];
+          resetPlaying(musicSuffix == '-pixel');
+        });
       });
     }
+    else
+    {
+      resetPlaying(musicSuffix == '-pixel');
+
+      if (confirmTimer != null)
+      {
+        confirmTimer.cancel();
+        confirmTimer.destroy();
+      }
+    }
+  }
+
+  /**
+   * Get's ready to restart the song.
+   * @param pixel If the transition should be pixelated or not.
+   */
+  public function resetPlaying(pixel:Bool = false):Void
+  {
+    mustNotExit = true;
+
+    #if FEATURE_MOBILE_ADVERTISEMENTS
+    if (AdMobUtil.PLAYING_COUNTER >= AdMobUtil.MAX_BEFORE_AD)
+    {
+      AdMobUtil.loadInterstitial(function():Void
+      {
+        AdMobUtil.PLAYING_COUNTER = 0;
+        resetPlaying(pixel);
+      });
+      return;
+    }
+    #end
+
+    // Close the GameOverSubState.
+    if (pixel) RetroCameraFade.fadeBlack(FlxG.camera, 10, 1);
+    else
+      FlxG.camera.fade(FlxColor.BLACK, 1, true, null, true);
+    if (parentPlayState != null) parentPlayState.needsReset = true;
+
+    if ((parentPlayState?.isMinimalMode ?? true) || boyfriend == null)
+    {
+    }
+    else
+    {
+      // Readd Boyfriend to the stage.
+      boyfriend.isDead = false;
+      remove(boyfriend);
+      parentPlayState?.currentStage?.addCharacter(boyfriend, BF);
+    }
+
+    // Stop playing the music.
+    gameOverMusic.stop();
+
+    // Snap reset the camera which may have changed because of the player character data.
+    resetCameraZoom();
+
+    // Close the substate.
+    close();
   }
 
   override public function dispatchEvent(event:ScriptEvent):Void
@@ -521,6 +548,8 @@ class GameOverSubState extends MusicBeatSubState
     var musicPath:Null<String> = resolveMusicPath(musicSuffix, isStarting, isEnding);
     var onComplete:Void->Void = () -> {};
 
+    if (gameOverSfx != null && isEnding) destroyGameOverSfx();
+
     if (isStarting)
     {
       if (musicPath == null)
@@ -568,7 +597,7 @@ class GameOverSubState extends MusicBeatSubState
    */
   public function goBack():Void
   {
-    if (!blueballed || mustNotExit) return;
+    if (!blueballed || isEnding) return;
     isEnding = true;
     blueballed = false;
     if (parentPlayState != null) parentPlayState.deathCounter = 0;
@@ -633,7 +662,7 @@ class GameOverSubState extends MusicBeatSubState
     final soundPath:String = Paths.sound(getDeathAudioPath('loss-sfx' + blueBallSuffix));
     if (Assets.exists(soundPath))
     {
-      FunkinSound.playOnce(soundPath);
+      gameOverSfx = FunkinSound.playOnce(soundPath);
     }
     else
     {
@@ -647,6 +676,19 @@ class GameOverSubState extends MusicBeatSubState
 
     final audioPath:String = 'gameplay/playable-characters/$playerID/game-over/$location';
     return audioPath;
+  }
+
+  /**
+   * Destroy the Death Sound Effect used in this instance.
+   * Used to clean up memory.
+   */
+  public function destroyGameOverSfx():Void
+  {
+    if (gameOverSfx != null)
+    {
+      gameOverSfx.destroy();
+      gameOverSfx = null;
+    }
   }
 
   var hasPlayedDeathQuote:Bool = false;


### PR DESCRIPTION
## About:
This PR adds the ability to skip the confirm sound in GameOverSubState, making it even faster to restart a song. Also, this PR prevents death sound effects from colliding into each other, and organizes a little bit.

## Associated Assets PR:
FunkinCrew/funkin.assets#287

## Video:
[yt video cuz its over 10MB](https://youtu.be/2Taq-ll05c8)

## Important Info
This PR has changes for `admob` ad displaying, which I cannot test.

