### PR TITLE
[BUGFIX] Sustains now give consistent scores [+ songScore as Float]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -181,16 +181,6 @@ The Pit Stop 2 update!
 - Removed an unused class from Polymod blacklist. ([06c12e3](https://github.com/FunkinCrew/Funkin/commit/06c12e36c6bd6df4e2be32a3bec540172e79e162)) - by @AbnormalPoof in [#3729](https://github.com/FunkinCrew/Funkin/pull/3729)
 - Many additional small bug fixes.
 
-### Fixed
-
-* @PatoFlamejanteTV made their first contribution in [#3843](https://github.com/FunkinCrew/Funkin/pull/3843)
-* @sphis-Sinco made their first contribution in [#3881](https://github.com/FunkinCrew/Funkin/pull/3881)
-* @MrMadera made their first contribution in [#3934](https://github.com/FunkinCrew/Funkin/pull/3934)
-* @MidyGamy made their first contribution in [#4068](https://github.com/FunkinCrew/Funkin/pull/4068)
-* @Lasercar made their first contribution in [#4082](https://github.com/FunkinCrew/Funkin/pull/4082)
-* @MrScottyPieey made their first contribution in [#4085](https://github.com/FunkinCrew/Funkin/pull/4085)
-
-
 ## New Contributors for 0.6.0
 
 * @PatoFlamejanteTV made their first contribution in [#3843](https://github.com/FunkinCrew/Funkin/pull/3843)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Renamed “Auto Pause” preference to “Pause on Unfocus” for clarity. ([52be941](https://github.com/FunkinCrew/Funkin/commit/52be941b4503da0ac76918e2482ab1804866f2cf)) - by @JackXson-Real in [#4346](https://github.com/FunkinCrew/Funkin/pull/4346)
 - Overhauled `FileUtil`, introducing various fixes, new functions, and sandboxing. ([95ade2a](https://github.com/FunkinCrew/Funkin/commit/95ade2a08b7709e8208ec1b3e123bf5b4308ba10)) - by @cyn0x8 in [#3032](https://github.com/FunkinCrew/Funkin/pull/3032)
 
+### Fixed
+
 - The Freeplay menu no longer displays songs without Erect variations when returning from an Erect variation song.
 - Fixed Freeplay DJ animations for Boyfriend and Pico when idling (properly this time).
 - Alternate instrumentals for Cocoa, Senpai, Roses, and Stress are now locked until their Pico Mix is beaten.

--- a/source/funkin/modding/events/ScriptEvent.hx
+++ b/source/funkin/modding/events/ScriptEvent.hx
@@ -138,7 +138,7 @@ class HitNoteScriptEvent extends NoteScriptEvent
   /**
    * The score the player received for hitting the note.
    */
-  public var score:Int;
+  public var score:Float;
 
   /**
    * If the hit causes a combo break.
@@ -156,7 +156,7 @@ class HitNoteScriptEvent extends NoteScriptEvent
    */
   public var doesNotesplash:Bool = false;
 
-  public function new(note:NoteSprite, healthChange:Float, score:Int, judgement:String, isComboBreak:Bool, comboCount:Int = 0, hitDiff:Float = 0,
+  public function new(note:NoteSprite, healthChange:Float, score:Float, judgement:String, isComboBreak:Bool, comboCount:Int = 0, hitDiff:Float = 0,
       doesNotesplash:Bool = false):Void
   {
     super(NOTE_HIT, note, healthChange, comboCount, true);
@@ -198,7 +198,7 @@ class GhostMissNoteScriptEvent extends ScriptEvent
   /**
    * How much score should be lost when this ghost note is pressed.
    */
-  public var scoreChange(default, default):Int;
+  public var scoreChange(default, default):Float;
 
   /**
    * Whether to play the record scratch sound.
@@ -210,7 +210,7 @@ class GhostMissNoteScriptEvent extends ScriptEvent
    */
   public var playAnim(default, default):Bool;
 
-  public function new(dir:NoteDirection, hasPossibleNotes:Bool, healthChange:Float, scoreChange:Int):Void
+  public function new(dir:NoteDirection, hasPossibleNotes:Bool, healthChange:Float, scoreChange:Float):Void
   {
     super(NOTE_GHOST_MISS, true);
     this.dir = dir;

--- a/source/funkin/play/PlayState.hx
+++ b/source/funkin/play/PlayState.hx
@@ -1793,8 +1793,10 @@ class PlayState extends MusicBeatSubState
 
     playerStrumline = new Strumline(noteStyle, !isBotPlayMode);
     playerStrumline.onNoteIncoming.add(onStrumlineNoteIncoming);
+    playerStrumline.onSustainHit = sustainHit;
     opponentStrumline = new Strumline(noteStyle, false);
     opponentStrumline.onNoteIncoming.add(onStrumlineNoteIncoming);
+    opponentStrumline.onSustainHit = sustainHit;
     add(playerStrumline);
     add(opponentStrumline);
 
@@ -2940,7 +2942,7 @@ class PlayState extends MusicBeatSubState
       Highscore.talliesLevel = Highscore.combineTallies(Highscore.tallies, Highscore.talliesLevel);
 
       #if FEATURE_NEWGROUNDS
-      Leaderboards.submitSongScore(currentSong.id, suffixedDifficulty, songScore);
+      Leaderboards.submitSongScore(currentSong.id, suffixedDifficulty, songScoreInt);
       #end
 
       if (!isPracticeMode && !isBotPlayMode)

--- a/source/funkin/play/PlayState.hx
+++ b/source/funkin/play/PlayState.hx
@@ -2540,7 +2540,7 @@ class PlayState extends MusicBeatSubState
       // Play the strumline animation.
       playerStrumline.playStatic(input.noteDirection);
 
-      playerStrumline.releaseKey(input.noteDirection);
+      playerStrumline.releaseKey(input.noteDirection, input.timestamp);
     }
   }
 
@@ -2970,7 +2970,7 @@ class PlayState extends MusicBeatSubState
       // Determine the score rank for this song we just finished.
       var scoreRank:ScoringRank = Scoring.calculateRank(
         {
-          score: songScore,
+          score: songScoreInt,
           tallies:
             {
               sick: Highscore.tallies.sick,

--- a/source/funkin/play/notes/Strumline.hx
+++ b/source/funkin/play/notes/Strumline.hx
@@ -604,7 +604,11 @@ class Strumline extends FlxSpriteGroup
         holdConfirm(holdNote.noteDirection);
         holdNote.visible = true;
 
-        holdNote.sustainLength = (holdNote.strumTime + holdNote.fullSustainLength) - conductorInUse.songPosition;
+        var lastLength = holdNote.sustainLength;
+        holdNote.sustainLength = (holdNote.strumTime + holdNote.fullSustainLength) - conductorInUse.songPosition + conductorInUse.inputOffset;
+
+        // Don't reward hitting too early, don't penalize hitting too late
+        if (isPlayer) PlayState?.instance.sustainHit(holdNote, lastLength);
 
         if (holdNote.sustainLength <= 10)
         {
@@ -817,7 +821,11 @@ class Strumline extends FlxSpriteGroup
       note.holdNoteSprite.hitNote = true;
       note.holdNoteSprite.missedNote = false;
 
-      note.holdNoteSprite.sustainLength = (note.holdNoteSprite.strumTime + note.holdNoteSprite.fullSustainLength) - conductorInUse.songPosition;
+      var lastLength = note.holdNoteSprite.sustainLength;
+      note.holdNoteSprite.sustainLength = (note.holdNoteSprite.strumTime + note.holdNoteSprite.fullSustainLength)
+        - (conductorInUse.songPosition - conductorInUse.inputOffset);
+
+      if (isPlayer) PlayState?.instance.sustainHit(note.holdNoteSprite, lastLength);
     }
 
     #if FEATURE_GHOST_TAPPING

--- a/source/funkin/play/notes/Strumline.hx
+++ b/source/funkin/play/notes/Strumline.hx
@@ -79,9 +79,14 @@ class Strumline extends FlxSpriteGroup
   /**
    * Whether this strumline should reward scores on hold.
    * Should usually be the same as isPlayer, but modders may want to modify sustain/input behavior.
-   * Assumes strumline is in PlayState, nothing happens otherwise.
    */
   public var rewardSustains:Bool;
+
+  /**
+   * Called when the strumline processes a held note.
+   * Should handle scoring and health gain for sustains.
+   */
+  public var onSustainHit:Null<(SustainTrail, Float) -> Void>;
 
   /**
    * Usually you want to keep this as is, but if you are using a Strumline and
@@ -551,7 +556,7 @@ class Strumline extends FlxSpriteGroup
               + conductorInUse.inputOffset;
 
             // Don't reward hitting too early, don't penalize hitting too late
-            if (rewardSustains) PlayState?.instance.sustainHit(holdNote, lastLength);
+            if (rewardSustains && onSustainHit != null) onSustainHit(holdNote, lastLength);
 
             releaseTime[holdNote.noteDirection] = null;
           }
@@ -634,7 +639,7 @@ class Strumline extends FlxSpriteGroup
         holdNote.sustainLength = (holdNote.strumTime + holdNote.fullSustainLength) - conductorInUse.songPosition + conductorInUse.inputOffset;
 
         // Don't reward hitting too early, don't penalize hitting too late
-        if (rewardSustains) PlayState?.instance.sustainHit(holdNote, lastLength);
+        if (rewardSustains && onSustainHit != null) onSustainHit(holdNote, lastLength);
 
         if (holdNote.sustainLength <= 10)
         {
@@ -853,7 +858,7 @@ class Strumline extends FlxSpriteGroup
       note.holdNoteSprite.sustainLength = (note.holdNoteSprite.strumTime + note.holdNoteSprite.fullSustainLength)
         - (conductorInUse.songPosition - conductorInUse.inputOffset);
 
-      if (rewardSustains) PlayState?.instance.sustainHit(note.holdNoteSprite, lastLength);
+      if (rewardSustains && onSustainHit != null) onSustainHit(note.holdNoteSprite, lastLength);
     }
 
     #if FEATURE_GHOST_TAPPING

--- a/source/funkin/play/notes/Strumline.hx
+++ b/source/funkin/play/notes/Strumline.hx
@@ -75,6 +75,13 @@ class Strumline extends FlxSpriteGroup
   public var isPlayer:Bool;
 
   /**
+   * Whether this strumline should reward scores on hold.
+   * Should usually be the same as isPlayer, but modders may want to modify sustain/input behavior.
+   * Assumes strumline is in PlayState, nothing happens otherwise.
+   */
+  public var rewardSustains:Bool;
+
+  /**
    * Usually you want to keep this as is, but if you are using a Strumline and
    * playing a sound that has it's own conductor, set this (LatencyState for example)
    */
@@ -160,6 +167,7 @@ class Strumline extends FlxSpriteGroup
     super();
 
     this.isPlayer = isPlayer;
+    this.rewardSustains = isPlayer;
     this.noteStyle = noteStyle;
 
     this.strumlineNotes = new FlxTypedSpriteGroup<StrumlineNote>();
@@ -608,7 +616,7 @@ class Strumline extends FlxSpriteGroup
         holdNote.sustainLength = (holdNote.strumTime + holdNote.fullSustainLength) - conductorInUse.songPosition + conductorInUse.inputOffset;
 
         // Don't reward hitting too early, don't penalize hitting too late
-        if (isPlayer) PlayState?.instance.sustainHit(holdNote, lastLength);
+        if (rewardSustains) PlayState?.instance.sustainHit(holdNote, lastLength);
 
         if (holdNote.sustainLength <= 10)
         {
@@ -825,7 +833,7 @@ class Strumline extends FlxSpriteGroup
       note.holdNoteSprite.sustainLength = (note.holdNoteSprite.strumTime + note.holdNoteSprite.fullSustainLength)
         - (conductorInUse.songPosition - conductorInUse.inputOffset);
 
-      if (isPlayer) PlayState?.instance.sustainHit(note.holdNoteSprite, lastLength);
+      if (rewardSustains) PlayState?.instance.sustainHit(note.holdNoteSprite, lastLength);
     }
 
     #if FEATURE_GHOST_TAPPING


### PR DESCRIPTION
<!-- Please check for duplicates or similar PRs before submitting this PR. -->
## Does this PR close any issues? If so, link them below.
N/A

## Briefly describe the issue(s) fixed.
Sustain notes previously did not consistently give score-- it was all dependent on how long you held it for, regardless of when you started holding, disconnected from the actual length of the note. This caused sustains hit earlier to reward more points than sustains hit later, as well as other undesirable effects. This behavior is now fixed.

These demonstrations are done with a script that disables regular note scoring, leaving only sustain scores to count.

Before: 

https://github.com/user-attachments/assets/6882c412-0b71-43a2-9f9e-3b5911b04122

After (VIDEO SLIGHTLY OUTDATED, 100% FIXED NOW): 

https://github.com/user-attachments/assets/96338947-9574-4bd8-b216-824e5288b921


This PR places scoring behavior in Strumline, which may be undesirable.
An alternative approach would be to add a variable in SustainTrail.hx that tracks PlayState's last read on it, and then performing logic where it used to be done anyway. I tried this, but it didn't exactly work out...

This PR also changes songScore to be a Float, and all score-related scripting variables to Float as well.
All saving and displaying of the score still uses the integer using songScoreInt.
Written with the assumption that https://github.com/FunkinCrew/Funkin/pull/3708 will be pulled. If it isn't, removals of offset corrections will be required.