### PR TITLE
[GITHUB] Create a dedicated charting issue template (and bump version to 0.5.3)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -41,7 +41,7 @@ body:
     attributes:
       label: Version
       description: Which version are you playing on? The game version is in the bottom left corner of the main menu. 
-      placeholder: ex. 0.5.0
+      placeholder: ex. 0.5.3
     validations:
       required: true
   

--- a/.github/ISSUE_TEMPLATE/charting.yml
+++ b/.github/ISSUE_TEMPLATE/charting.yml
@@ -56,7 +56,7 @@ body:
   - type: textarea
     attributes:
       label: Location
-      description: Where did you find the issue(s)? Include the name of the song, the variation, the difficulty, the time/section of the song, and any other relevant details.
+      description: Where did you find the issue(s)? Include the name of the song, the variation, the difficulty, the time/section of the song, and any images or videos.
       placeholder: ex. Cocoa Erect on Erect/Nightmare difficulties at Section 30
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/charting.yml
+++ b/.github/ISSUE_TEMPLATE/charting.yml
@@ -1,0 +1,70 @@
+name: Charting Issue
+description: Report an issue with the placement of notes in the game.
+labels: ["type: charting issue", "status: pending triage"]
+title: "Charting Issue: "
+body:
+  - type: checkboxes
+    attributes:
+      label: Issue Checklist
+      description: Be sure to complete these steps to increase the chances of your issue being addressed!
+      options:
+        - label: I have properly named my issue
+        - label: I have checked the Issues/Discussions pages to see if my issue has already been reported
+
+  - type: dropdown
+    attributes:
+      label: Platform
+      description: Which platform are you playing on?
+      options:
+        - Newgrounds (Web/HTML5)
+        - Itch.io (Web/HTML5)
+        - Itch.io (Downloadable Build) - Windows
+        - Itch.io (Downloadable Build) - MacOS
+        - Itch.io (Downloadable Build) - Linux
+        - Compiled from GitHub Source Code
+    validations:
+      required: true
+
+  - type: dropdown
+    attributes:
+      label: Browser
+      description: (Web/HTML5 users only) Which browser are you playing on?
+      options:
+        - Google Chrome
+        - Microsoft Edge
+        - Firefox
+        - Opera
+        - Safari
+        - Other (Specify in Description field)
+
+  - type: input
+    attributes:
+      label: Version
+      description: Which version are you playing on? The game version is in the bottom left corner of the main menu. 
+      placeholder: ex. 0.5.3
+    validations:
+      required: true
+  
+  - type: markdown
+    attributes:
+      value: "## Describe the charting issue(s)."
+
+  - type: markdown
+    attributes:
+      value: "### Please do not report issues from other engines. These must be reported in their respective repositories."
+
+  - type: textarea
+    attributes:
+      label: Location
+      description: Where did you find the issue(s)? Include the name of the song, the variation, the difficulty, the time/section of the song, and any other relevant details.
+      placeholder: ex. Cocoa Erect on Erect/Nightmare difficulties at Section 30
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Description
+      description: Why do you believe this is an issue? Is a note at the wrong time, a hold note too short/long, or something else?
+      placeholder: Describe the charting issue(s) here...
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/crash.yml
+++ b/.github/ISSUE_TEMPLATE/crash.yml
@@ -41,7 +41,7 @@ body:
     attributes:
       label: Version
       description: Which version are you playing on? The game version is in the bottom left corner of the main menu. 
-      placeholder: ex. 0.5.0
+      placeholder: ex. 0.5.3
     validations:
       required: true
 


### PR DESCRIPTION
I've seen a lot of charting issue reports over the past several months. 
One problem I've noticed is that reporters sometimes describe a charting error without providing directions to find it.

That's why I've decided to create a new issue template that:
* automatically applies the `type: charting issue` label
* includes a required "Location" field
* adapts the existing "Description" field to better suit charting issues

I've also bumped the bug report and crash report templates to 0.5.3

![image](https://github.com/user-attachments/assets/9a198832-f149-4884-918b-825dc8a1197f)