### PR TITLE
[ENHANCEMENT] Add `DEBUG_BUILD` to `Constants`.

### DIFF
--- a/source/funkin/util/Constants.hx
+++ b/source/funkin/util/Constants.hx
@@ -56,6 +56,11 @@ class Constants
   #end
 
   /**
+   * Whether or not the game is a debug build.
+   */
+  public static final DEBUG_BUILD:Bool = #if FEATURE_DEBUG_FUNCTIONS true #else false #end;
+
+  /**
    * URL DATA
    */
   // ==============================


### PR DESCRIPTION
Currently, there's no real way to detect whether or not the game is a debug build in HScript (`MacroUtil` doesn't work, so does basically anything that involves getting compiler defines), you COULD do something like this:
```haxe
function isDebugBuild():Bool {
  return Constants.versionSuffix == ' PROTOTYPE';
}
```
However, this is unreliable since V-Slice forks can change the version suffix.

This PR adds a new boolean to `Constants`, `DEBUG_BUILD`. Which is basically self-explanatory, `false` if it's a release build, and `true` if it's debug (has the `FEATURE_DEBUG_FUNCTIONS` compiler flag).