### PR TITLE
[BUGFIX] Prevent constant Vocal Resyncs on Inst-only songs

### DIFF
--- a/source/funkin/play/song/Song.hx
+++ b/source/funkin/play/song/Song.hx
@@ -955,12 +955,14 @@ class SongDifficulty
     // Add player vocals.
     for (playerVoice in playerVoiceList)
     {
+      if (!Assets.exists(playerVoice)) continue;
       result.addPlayerVoice(FunkinSound.load(playerVoice));
     }
 
     // Add opponent vocals.
     for (opponentVoice in opponentVoiceList)
     {
+      if (!Assets.exists(opponentVoice)) continue;
       result.addOpponentVoice(FunkinSound.load(opponentVoice));
     }
 


### PR DESCRIPTION
## Does this PR close any issues? If so, link them below.
[3856](https://github.com/FunkinCrew/Funkin/issues/3856)

## Briefly describe the issue(s) fixed.
For some reason when building the voice group in `Song`, whether or not the vocal files existed wasn't checked, which this PR aims to fix. 

## Include any relevant screenshots or videos.
Before:
https://github.com/user-attachments/assets/4152f062-c0ad-4855-960a-7971fc05c4b6

After:
https://github.com/user-attachments/assets/810f87e9-78f0-42de-a43d-a94ebd19d5a4
(please ignore there being wrong icons in the footage that's just a side effect of a thing im working on)
