### PR TITLE
[BUGFIX] Fix the instrumental selector being spammable

### DIFF
--- a/source/funkin/ui/freeplay/CapsuleOptionsMenu.hx
+++ b/source/funkin/ui/freeplay/CapsuleOptionsMenu.hx
@@ -22,6 +22,8 @@ class CapsuleOptionsMenu extends FlxSpriteGroup
 
   var currentInstrumental:FlxText;
 
+  var busy:Bool = false;
+
   public function new(parent:FreeplayState, x:Float = 0, y:Float = 0, instIds:Array<String>):Void
   {
     super(x, y);
@@ -66,35 +68,40 @@ class CapsuleOptionsMenu extends FlxSpriteGroup
       destroy();
       return;
     }
-    @:privateAccess
-    if (parent.controls.BACK)
+    var changedInst = false;
+
+    if (!busy)
     {
-      close();
-      return;
+      @:privateAccess
+      if (parent.controls.BACK)
+      {
+        close();
+        return;
+      }
+
+      if (parent.getControls().UI_LEFT_P)
+      {
+        currentInstrumentalIndex = (currentInstrumentalIndex + 1) % instrumentalIds.length;
+        changedInst = true;
+      }
+      if (parent.getControls().UI_RIGHT_P)
+      {
+        currentInstrumentalIndex = (currentInstrumentalIndex - 1 + instrumentalIds.length) % instrumentalIds.length;
+        changedInst = true;
+      }
+      if (parent.getControls().ACCEPT)
+      {
+        busy = true;
+        onConfirm(instrumentalIds[currentInstrumentalIndex] ?? '');
+      }
     }
 
-    var changedInst = false;
-    if (parent.getControls().UI_LEFT_P)
-    {
-      currentInstrumentalIndex = (currentInstrumentalIndex + 1) % instrumentalIds.length;
-      changedInst = true;
-    }
-    if (parent.getControls().UI_RIGHT_P)
-    {
-      currentInstrumentalIndex = (currentInstrumentalIndex - 1 + instrumentalIds.length) % instrumentalIds.length;
-      changedInst = true;
-    }
     if (!changedInst && currentInstrumental.text == '') changedInst = true;
 
     if (changedInst)
     {
       currentInstrumental.text = instrumentalIds[currentInstrumentalIndex].toTitleCase() ?? '';
       if (currentInstrumental.text == '') currentInstrumental.text = 'Default';
-    }
-
-    if (parent.getControls().ACCEPT)
-    {
-      onConfirm(instrumentalIds[currentInstrumentalIndex] ?? '');
     }
   }
 


### PR DESCRIPTION
<!-- Please check for duplicates or similar PRs before submitting this PR. -->
## Does this PR close any issues? If so, link them below.
Fixes #3562

## Briefly describe the issue(s) fixed.
`CapsuleOptionsMenu` has its own method of handling inputs, independent of `FreeplayState`. This, in turn, meant that inputs were still enabled even AFTER selecting a song.

This PR adds a Boolean called `busy`. This pretty much acts the same as the one in `FreeplayState`.

This is *sort of* a janky solution, but you can't really do anything much on the Freeplay side since `busy` is enabled to prevent `FreeplayState` from accepting inputs while the Instrumental Selector is open (unless you like... made a new boolean to check if the instrumental selector is open or something lol).

## Something to note
The arrows in the Instrumental Selector (`InstrumentalSelector`) can still be controlled, however, this is purely a visual thing.
I tried tackling the issue before opening this PR, but I couldn't really figure out a solution without it being a mess.