### PR TITLE
[BUGFIX] Remove old Stage editor keybind functionality

### DIFF
--- a/source/funkin/play/PlayState.hx
+++ b/source/funkin/play/PlayState.hx
@@ -49,7 +49,6 @@ import funkin.play.song.Song;
 import funkin.play.stage.Stage;
 import funkin.save.Save;
 import funkin.ui.debug.charting.ChartEditorState;
-import funkin.ui.debug.stage.StageOffsetSubState;
 import funkin.ui.mainmenu.MainMenuState;
 import funkin.ui.MusicBeatSubState;
 import funkin.ui.transition.LoadingState;
@@ -2672,17 +2671,6 @@ class PlayState extends MusicBeatSubState
      */
   function debugKeyShit():Void
   {
-    #if FEATURE_STAGE_EDITOR
-    // Open the stage editor overlaying the current state.
-    if (controls.DEBUG_STAGE)
-    {
-      // hack for HaxeUI generation, doesn't work unless persistentUpdate is false at state creation!!
-      disableKeys = true;
-      persistentUpdate = false;
-      openSubState(new StageOffsetSubState());
-    }
-    #end
-
     #if FEATURE_CHART_EDITOR
     // Redirect to the chart editor playing the current song.
     if (controls.DEBUG_CHART)


### PR DESCRIPTION
<!-- Please check for duplicates or similar PRs before submitting this PR. -->
## Does this PR close any issues? If so, link them below.
https://github.com/FunkinCrew/Funkin/issues/3850

## Briefly describe the issue(s) fixed.
- The Stage Editor keybind functionality has been removed as to fix an issue where the old stage editor would be enabled and basically break gameplay (even when resetting the song) until you leave to the menu and reenter the song.

## Include any relevant screenshots or videos.
Before:

https://github.com/user-attachments/assets/14426ae8-f262-449e-89f3-9f2a108531d4

After:

https://github.com/user-attachments/assets/62bdc4f9-d18d-404a-9886-be30926273d1