### PR TITLE
[ENHANCEMENT] Put every Console Trace in the Crash Logs

### DIFF
--- a/source/funkin/util/logging/AnsiTrace.hx
+++ b/source/funkin/util/logging/AnsiTrace.hx
@@ -2,6 +2,8 @@ package funkin.util.logging;
 
 class AnsiTrace
 {
+  public static var allTraces:Array<String> = [];
+
   // mostly a copy of haxe.Log.trace()
   // but adds nice cute ANSI things
   public static function trace(v:Dynamic, ?info:haxe.PosInfos)
@@ -10,6 +12,7 @@ class AnsiTrace
     return;
     #end
     var str = formatOutput(v, info);
+    allTraces.push(str);
     #if js
     if (js.Syntax.typeof(untyped console) != "undefined" && (untyped console).log != null) (untyped console).log(str);
     #elseif lua

--- a/source/funkin/util/logging/CrashHandler.hx
+++ b/source/funkin/util/logging/CrashHandler.hx
@@ -195,6 +195,19 @@ class CrashHandler
 
     fullContents += '\n';
 
+    fullContents += '=====================\n';
+
+    fullContents += '\n';
+
+    fullContents += 'Console Traces: \n';
+
+    for (line in AnsiTrace.allTraces)
+    {
+      fullContents += '${line}\n';
+    }
+
+    fullContents += '\n';
+
     return fullContents;
   }
   #end


### PR DESCRIPTION
## Description
This Pull Request adds everything printed on the console via `trace` to crash logs in order to better determine the culprit of the crash.

## Potential Drawbacks
1. In one of the printed lines from the Discord RPC, the discord tag of the current user is mentioned, which could be considered an "attack on privacy" or whatevs - though considering the driver info is in the same log file I guess it doesn't hurt to have it be there
2. The Memory Size of the Log has been increased tremendously - from 4KB to at least 30KB, and would continue to increase the longer the user plays the game, which could fill up the user's used space on the drive. A potential fix to that would be deleting logs that are older than a certain time period

## Include any relevant screenshots or videos.
https://github.com/user-attachments/assets/0f8d9715-3ea6-4cd7-9378-fca764565f92
