### PR TITLE
[ENHANCEMENT/BUGFIX] Bopper sync and bpm change events

### DIFF
--- a/source/funkin/Conductor.hx
+++ b/source/funkin/Conductor.hx
@@ -76,6 +76,17 @@ class Conductor
   public var onStepHit(default, null):FlxSignal = new FlxSignal();
 
   /**
+   * Signal fired when the current Conductor instance changes BPM.
+   */
+  public static var bpmChange(default, null):FlxSignal = new FlxSignal();
+
+  /**
+   * Signal fired when THIS Conductor instance changes BPM.
+   * TODO: This naming sucks but we can't make a static and instance field with the same name!
+   */
+  public var onBpmChange(default, null):FlxSignal = new FlxSignal();
+
+  /**
    * The list of time changes in the song.
    * There should be at least one time change (at the beginning of the song) to define the BPM.
    */
@@ -328,6 +339,11 @@ class Conductor
     Conductor.stepHit.dispatch();
   }
 
+  static function dispatchBpmChange():Void
+  {
+    Conductor.bpmChange.dispatch();
+  }
+
   static function setupSingleton(input:Conductor):Void
   {
     input.onMeasureHit.add(dispatchMeasureHit);
@@ -335,6 +351,8 @@ class Conductor
     input.onBeatHit.add(dispatchBeatHit);
 
     input.onStepHit.add(dispatchStepHit);
+
+    input.onBpmChange.add(dispatchBpmChange);
   }
 
   static function clearSingleton(input:Conductor):Void
@@ -344,6 +362,8 @@ class Conductor
     input.onBeatHit.remove(dispatchBeatHit);
 
     input.onStepHit.remove(dispatchStepHit);
+
+    input.onBpmChange.remove(dispatchBpmChange);
   }
 
   static function get_instance():Conductor
@@ -418,6 +438,7 @@ class Conductor
     var oldMeasure:Float = this.currentMeasure;
     var oldBeat:Float = this.currentBeat;
     var oldStep:Float = this.currentStep;
+    var oldBpm:Float = this.bpm;
 
     // If the song is playing, limit the song position to the length of the song or beginning of the song.
     if (FlxG.sound.music != null && FlxG.sound.music.playing)
@@ -469,6 +490,11 @@ class Conductor
     }
 
     // FlxSignals are really cool.
+    if (bpm != oldBpm)
+    {
+      this.onBpmChange.dispatch();
+    }
+
     if (currentStep != oldStep)
     {
       this.onStepHit.dispatch();

--- a/source/funkin/modding/IScriptedClass.hx
+++ b/source/funkin/modding/IScriptedClass.hx
@@ -82,6 +82,11 @@ interface INoteScriptedClass extends IScriptedClass
 interface IBPMSyncedScriptedClass extends IScriptedClass
 {
   /**
+   * Called when the BPM changes.
+   */
+  public function onBpmChange(event:SongTimeScriptEvent):Void;
+
+  /**
    * Called once every step of the song.
    */
   public function onStepHit(event:SongTimeScriptEvent):Void;

--- a/source/funkin/modding/events/ScriptEventDispatcher.hx
+++ b/source/funkin/modding/events/ScriptEventDispatcher.hx
@@ -105,6 +105,9 @@ class ScriptEventDispatcher
         case SONG_STEP_HIT:
           t.onStepHit(cast event);
           return;
+        case SONG_BPM_CHANGE:
+          t.onBpmChange(cast event);
+          return;
         default: // Continue;
       }
     }

--- a/source/funkin/modding/events/ScriptEventType.hx
+++ b/source/funkin/modding/events/ScriptEventType.hx
@@ -64,6 +64,13 @@ enum abstract ScriptEventType(String) from String to String
   var SONG_STEP_HIT = 'STEP_HIT';
 
   /**
+   * Called when the BPM changes.
+   *
+   * This event is not cancelable.
+   */
+  var SONG_BPM_CHANGE = 'BPM_CHANGE';
+
+  /**
    * Called when a note comes on screen and starts approaching the strumline.
    *
    * This event is not cancelable.

--- a/source/funkin/modding/module/Module.hx
+++ b/source/funkin/modding/module/Module.hx
@@ -91,6 +91,8 @@ class Module implements IPlayStateScriptedClass implements IStateChangingScripte
 
   public function onNoteGhostMiss(event:GhostMissNoteScriptEvent) {}
 
+  public function onBpmChange(event:SongTimeScriptEvent) {}
+
   public function onStepHit(event:SongTimeScriptEvent) {}
 
   public function onBeatHit(event:SongTimeScriptEvent) {}

--- a/source/funkin/play/character/BaseCharacter.hx
+++ b/source/funkin/play/character/BaseCharacter.hx
@@ -429,6 +429,7 @@ class BaseCharacter extends Bopper
       // super.onBeatHit handles the regular `dance()` calls.
     }
     FlxG.watch.addQuick('holdTimer-${characterId}', holdTimer);
+    FlxG.watch.addQuick('_realDanceEvery-${characterId}', _realDanceEvery);
   }
 
   public function isSinging():Bool

--- a/source/funkin/play/song/Song.hx
+++ b/source/funkin/play/song/Song.hx
@@ -655,6 +655,8 @@ class Song implements IPlayStateScriptedClass implements IRegistryEntry<SongMeta
 
   public function onSongEvent(event:SongEventScriptEvent):Void {};
 
+  public function onBpmChange(event:SongTimeScriptEvent):Void {};
+
   public function onStepHit(event:SongTimeScriptEvent):Void {};
 
   public function onBeatHit(event:SongTimeScriptEvent):Void {};

--- a/source/funkin/play/stage/Bopper.hx
+++ b/source/funkin/play/stage/Bopper.hx
@@ -2,6 +2,7 @@ package funkin.play.stage;
 
 import flixel.FlxSprite;
 import flixel.FlxCamera;
+import flixel.math.FlxMath;
 import flixel.math.FlxPoint;
 import flixel.util.FlxTimer;
 import funkin.modding.IScriptedClass.IPlayStateScriptedClass;
@@ -23,7 +24,16 @@ class Bopper extends StageProp implements IPlayStateScriptedClass
    * Supports up to 0.25 precision.
    * @default 0.0 on props, 1.0 on characters
    */
-  public var danceEvery:Float = 0.0;
+  public var danceEvery(default, set):Float = 0;
+
+  var _realDanceEvery:Float = 1;
+
+  function set_danceEvery(value:Float):Float
+  {
+    this.danceEvery = value;
+    this.update_danceEvery();
+    return value;
+  }
 
   /**
    * Whether the bopper should dance left and right.
@@ -45,6 +55,14 @@ class Bopper extends StageProp implements IPlayStateScriptedClass
    */
   public var idleSuffix(default, set):String = '';
 
+  function set_idleSuffix(value:String):String
+  {
+    this.idleSuffix = value;
+    this.update_danceEvery();
+    this.dance();
+    return value;
+  }
+
   /**
    * If this bopper is rendered with pixel art, disable anti-aliasing.
    * @default `false`
@@ -62,13 +80,6 @@ class Bopper extends StageProp implements IPlayStateScriptedClass
    * for characters/players, it should be false so it doesn't cut off their animations!!!!!
    */
   public var shouldBop:Bool = true;
-
-  function set_idleSuffix(value:String):String
-  {
-    this.idleSuffix = value;
-    this.dance();
-    return value;
-  }
 
   /**
    * The offset of the character relative to the position specified by the stage.
@@ -160,17 +171,59 @@ class Bopper extends StageProp implements IPlayStateScriptedClass
   }
 
   /**
+   * Called when the BPM of the song changes.
+   */
+  public function onBpmChange(event:SongTimeScriptEvent)
+  {
+    update_danceEvery();
+  }
+
+  /**
    * Called once every step of the song.
    */
   public function onStepHit(event:SongTimeScriptEvent)
   {
-    if (danceEvery > 0 && (event.step % (danceEvery * Constants.STEPS_PER_BEAT)) == 0)
+    if (_realDanceEvery > 0 && (event.step % (_realDanceEvery * Constants.STEPS_PER_BEAT)) == 0)
     {
       dance(shouldBop);
     }
   }
 
   public function onBeatHit(event:SongTimeScriptEvent):Void {}
+
+  function update_danceEvery():Void
+  {
+    if (danceEvery == 0 || shouldAlternate || this.animation.getByName('idle$idleSuffix') == null || shouldBop)
+    {
+      // for forced bopping, alternating dance and non-existing animation, it just works the same as before
+      _realDanceEvery = danceEvery;
+      return;
+    }
+
+    var daIdle = this.animation.getByName('idle$idleSuffix');
+    var numeratorTweak:Int = (Conductor.instance.timeSignatureNumerator % 2 == 0) ? 2 : Conductor.instance.timeSignatureNumerator; // hopefully we get only prime numbers...
+    if (FlxMath.getDecimals(danceEvery) == 0) // for int danceEvery
+    {
+      trace("THAT'S AN INT FOR DANCEEVERY");
+      var idlePerBeat:Float = (daIdle.numFrames / daIdle.frameRate) / (Conductor.instance.beatLengthMs / 1000);
+      var danceEveryNumBeats:Int = Math.ceil(idlePerBeat);
+      var numeratorTweak:Int = (Conductor.instance.timeSignatureNumerator % 2 == 0) ? 2 : 3;
+      if (danceEveryNumBeats > numeratorTweak)
+      {
+        while (danceEveryNumBeats % numeratorTweak != 0)
+          danceEveryNumBeats++;
+      }
+      _realDanceEvery = Math.max(danceEvery, danceEveryNumBeats);
+    }
+    else // to do: for danceEvery with decimals
+    else // for decymal danceEvery (X.25, X.50 and X.75)
+    {
+      // maybe to rework, for the moment it tries to have the same patern every sections
+      _realDanceEvery = danceEvery;
+      while ((4 * _realDanceEvery * Conductor.instance.stepLengthMs) < (daIdle.numFrames / daIdle.frameRate))
+        _realDanceEvery *= numeratorTweak;
+    }
+  }
 
   /**
    * Called every `danceEvery` beats of the song.

--- a/source/funkin/play/stage/Stage.hx
+++ b/source/funkin/play/stage/Stage.hx
@@ -772,6 +772,11 @@ class Stage extends FlxSpriteGroup implements IPlayStateScriptedClass implements
   }
 
   /**
+   * A function that gets called when the BPM of the song changes.
+   */
+  public function onBpmChange(event:SongTimeScriptEvent):Void {}
+
+  /**
    * A function that gets called once per step in the song.
    * @param curStep The current step number.
    */

--- a/source/funkin/ui/MusicBeatState.hx
+++ b/source/funkin/ui/MusicBeatState.hx
@@ -65,6 +65,7 @@ class MusicBeatState extends FlxTransitionableState implements IEventHandler
 
     Conductor.beatHit.add(this.beatHit);
     Conductor.stepHit.add(this.stepHit);
+    Conductor.bpmChange.add(this.bpmChange);
   }
 
   public override function destroy():Void
@@ -72,6 +73,7 @@ class MusicBeatState extends FlxTransitionableState implements IEventHandler
     super.destroy();
     Conductor.beatHit.remove(this.beatHit);
     Conductor.stepHit.remove(this.stepHit);
+    Conductor.bpmChange.remove(this.bpmChange);
   }
 
   function handleFunctionControls():Void
@@ -131,6 +133,15 @@ class MusicBeatState extends FlxTransitionableState implements IEventHandler
 
     // Create a new instance of the current state, so old data is cleared.
     FlxG.resetState();
+  }
+
+  public function bpmChange():Bool
+  {
+    var event = new SongTimeScriptEvent(SONG_BPM_CHANGE, conductorInUse.currentBeat, conductorInUse.currentStep);
+
+    dispatchEvent(event);
+
+    return true;
   }
 
   public function stepHit():Bool

--- a/source/funkin/ui/MusicBeatSubState.hx
+++ b/source/funkin/ui/MusicBeatSubState.hx
@@ -64,6 +64,7 @@ class MusicBeatSubState extends FlxSubState implements IEventHandler
 
     Conductor.beatHit.add(this.beatHit);
     Conductor.stepHit.add(this.stepHit);
+    Conductor.bpmChange.add(this.bpmChange);
 
     initConsoleHelpers();
   }
@@ -73,6 +74,7 @@ class MusicBeatSubState extends FlxSubState implements IEventHandler
     super.destroy();
     Conductor.beatHit.remove(this.beatHit);
     Conductor.stepHit.remove(this.stepHit);
+    Conductor.bpmChange.remove(this.bpmChange);
   }
 
   override function update(elapsed:Float):Void
@@ -120,6 +122,15 @@ class MusicBeatSubState extends FlxSubState implements IEventHandler
   public function refresh()
   {
     sort(SortUtil.byZIndex, FlxSort.ASCENDING);
+  }
+
+  public function bpmChange():Bool
+  {
+    var event = new SongTimeScriptEvent(SONG_BPM_CHANGE, conductorInUse.currentBeat, conductorInUse.currentStep);
+
+    dispatchEvent(event);
+
+    return true;
   }
 
   /**

--- a/source/funkin/ui/charSelect/CharSelectGF.hx
+++ b/source/funkin/ui/charSelect/CharSelectGF.hx
@@ -73,6 +73,8 @@ class CharSelectGF extends FlxAtlasSprite implements IBPMSyncedScriptedClass
     #end
   }
 
+  public function onBpmChange(event:SongTimeScriptEvent):Void {}
+
   public function onStepHit(event:SongTimeScriptEvent):Void {}
 
   var danceEvery:Int = 2;

--- a/source/funkin/ui/charSelect/CharSelectPlayer.hx
+++ b/source/funkin/ui/charSelect/CharSelectPlayer.hx
@@ -35,6 +35,8 @@ class CharSelectPlayer extends FlxAtlasSprite implements IBPMSyncedScriptedClass
     });
   }
 
+  public function onBpmChange(event:SongTimeScriptEvent):Void {}
+
   public function onStepHit(event:SongTimeScriptEvent):Void {}
 
   public function onBeatHit(event:SongTimeScriptEvent):Void

--- a/source/funkin/ui/debug/charting/ChartEditorState.hx
+++ b/source/funkin/ui/debug/charting/ChartEditorState.hx
@@ -2167,6 +2167,8 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
           currentPlayerCharacterPlayer.onBeatHit(cast event);
         case SONG_STEP_HIT:
           currentPlayerCharacterPlayer.onStepHit(cast event);
+        case SONG_BPM_CHANGE:
+          currentPlayerCharacterPlayer.onBpmChange(cast event);
         case NOTE_HIT:
           currentPlayerCharacterPlayer.onNoteHit(cast event);
         default: // Continue
@@ -2183,6 +2185,8 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
           currentOpponentCharacterPlayer.onBeatHit(cast event);
         case SONG_STEP_HIT:
           currentOpponentCharacterPlayer.onStepHit(cast event);
+        case SONG_BPM_CHANGE:
+          currentPlayerCharacterPlayer.onBpmChange(cast event);
         case NOTE_HIT:
           currentOpponentCharacterPlayer.onNoteHit(cast event);
         default: // Continue

--- a/source/funkin/ui/haxeui/components/CharacterPlayer.hx
+++ b/source/funkin/ui/haxeui/components/CharacterPlayer.hx
@@ -198,6 +198,16 @@ class CharacterPlayer extends Box
   }
 
   /**
+   * Called when the BPM changes in the song
+   * Used to play character animations.
+   * @param event The event.
+   */
+  public function onBpmChange(event:SongTimeScriptEvent):Void
+  {
+    if (character != null) character.onBpmChange(event);
+  }
+
+  /**
    * Called when an beat is hit in the song
    * Used to play character animations.
    * @param event The event.


### PR DESCRIPTION
This fixes the bopper desyncing from each other, imitating the `if(curBeat % 2 == 0) dad.dance();` from the 0.3.X of the game, but calculate it automatically with the actual idle animation duration, using `danceEvery` as a well, making it consistent with the BPM and camera bopping.

For it to work, I also included `onBpmChange()` and the `bpmChange` `SongTimeScriptEvent`, called every time the bpm changes, allowing easier scripting instead of manually detecting it though `beatHit` if we use an `.hxc` script.

To do:
Find a way to handle the automation for a decimal `danceEvery`, currently ignored and works like before
