### PR TITLE
[CODE REWORK] Replace ControlsMenu's Header Hard-code with a Soft-code

### DIFF
--- a/source/funkin/ui/options/ControlsMenu.hx
+++ b/source/funkin/ui/options/ControlsMenu.hx
@@ -96,46 +96,12 @@ class ControlsMenu extends funkin.ui.options.OptionsState.Page
     {
       var control = controlList[i];
       var name = control.getName();
-      if (currentHeader != "UI_" && name.indexOf("UI_") == 0)
+
+      var headerName = name.split("_")[0];
+      if (currentHeader != headerName && name.indexOf("_") != -1)
       {
-        currentHeader = "UI_";
-        headers.add(new AtlasText(0, y, "UI", AtlasFont.BOLD)).screenCenter(X);
-        y += spacer;
-      }
-      else if (currentHeader != "NOTE_" && name.indexOf("NOTE_") == 0)
-      {
-        currentHeader = "NOTE_";
-        headers.add(new AtlasText(0, y, "NOTES", AtlasFont.BOLD)).screenCenter(X);
-        y += spacer;
-      }
-      else if (currentHeader != "CUTSCENE_" && name.indexOf("CUTSCENE_") == 0)
-      {
-        currentHeader = "CUTSCENE_";
-        headers.add(new AtlasText(0, y, "CUTSCENE", AtlasFont.BOLD)).screenCenter(X);
-        y += spacer;
-      }
-      else if (currentHeader != "FREEPLAY_" && name.indexOf("FREEPLAY_") == 0)
-      {
-        currentHeader = "FREEPLAY_";
-        headers.add(new AtlasText(0, y, "FREEPLAY", AtlasFont.BOLD)).screenCenter(X);
-        y += spacer;
-      }
-      else if (currentHeader != "WINDOW_" && name.indexOf("WINDOW_") == 0)
-      {
-        currentHeader = "WINDOW_";
-        headers.add(new AtlasText(0, y, "WINDOW", AtlasFont.BOLD)).screenCenter(X);
-        y += spacer;
-      }
-      else if (currentHeader != "VOLUME_" && name.indexOf("VOLUME_") == 0)
-      {
-        currentHeader = "VOLUME_";
-        headers.add(new AtlasText(0, y, "VOLUME", AtlasFont.BOLD)).screenCenter(X);
-        y += spacer;
-      }
-      else if (currentHeader != "DEBUG_" && name.indexOf("DEBUG_") == 0)
-      {
-        currentHeader = "DEBUG_";
-        headers.add(new AtlasText(0, y, "DEBUG", AtlasFont.BOLD)).screenCenter(X);
+        currentHeader = headerName;
+        headers.add(new AtlasText(0, y, headerName, AtlasFont.BOLD)).screenCenter(X);
         y += spacer;
       }
 


### PR DESCRIPTION
## Does this PR close any issues? If so, link them below.
Technically it helps answer the discussion [3906](https://github.com/FunkinCrew/Funkin/discussions/3906) because custom headers aren't otherwise possible (even though custom controls aren't possible either)

## Briefly describe the issue(s) fixed.
Replaces the somewhat big hardcode in `ControlsMenu` with softcode. For comparison, this is how the game handles the name of the headers currently: 
![image](https://github.com/user-attachments/assets/ac4c22e1-0d82-4973-a851-c6e545686321)
(insert that one yanderedev tweet)

## Tiny Issue
The header for Note controls is now named "Note" instead of "Notes" - to fix it I would have to change the names of the values for the enum Control, which would break a lot of things, or to add a hardcode for this scenario which I was trying to avoid this entire time