### PR TITLE
[GITHUB] Change size label names in PR labeler

### DIFF
--- a/.github/changed-lines-count-labeler.yml
+++ b/.github/changed-lines-count-labeler.yml
@@ -1,12 +1,12 @@
-# Add 'small' to any changes below 10 lines
-small:
+# Add 'size: small' to any changes below 10 lines
+'size: small':
   max: 9
 
-# Add 'medium' to any changes between 10 and 100 lines
-medium:
+# Add 'size: medium' to any changes between 10 and 100 lines
+'size: medium':
   min: 10
   max: 99
 
-# Add 'large' to any changes of at least 100 lines
-large:
+# Add 'size: large' to any changes of at least 100 lines
+'size: large':
   min: 100


### PR DESCRIPTION
## What is this?
This is an associated PR for the GitHub label cleanup proposal I'm currently working on.

> [!NOTE]
> Refer to https://github.com/FunkinCrew/Funkin/issues/3920 for the full label project.

## Manual Action Required
For this part of the label cleanup, please change the names of the three size labels in the following way:

| Label | New Name |
| ------------- | ------------- |
| `small` | `size: small` |
| `medium` | `size: medium` |
| `large` | `size: large` |

This change will help organize the [full list of labels](https://github.com/FunkinCrew/Funkin/labels) alphabetically and make it easier to use.