### PR TITLE
[BUGFIX] Fix the Crash when loading an Instrumental-Only song in the Chart Editor

### DIFF
--- a/source/funkin/ui/debug/charting/handlers/ChartEditorAudioHandler.hx
+++ b/source/funkin/ui/debug/charting/handlers/ChartEditorAudioHandler.hx
@@ -51,7 +51,7 @@ class ChartEditorAudioHandler
    */
   public static function loadVocalsFromAsset(state:ChartEditorState, path:String, charId:String, instId:String = '', wipeFirst:Bool = false):Bool
   {
-    var trackData:Null<Bytes> = Assets.getBytes(path);
+    var trackData:Null<Bytes> = Assets.exists(path) ? Assets.getBytes(path) : null;
     if (trackData != null)
     {
       return loadVocalsFromBytes(state, trackData, charId, instId, wipeFirst);
@@ -102,7 +102,7 @@ class ChartEditorAudioHandler
    */
   public static function loadInstFromAsset(state:ChartEditorState, path:String, instId:String = '', wipeFirst:Bool = false):Bool
   {
-    var trackData:Null<Bytes> = Assets.getBytes(path);
+    var trackData:Null<Bytes> = Assets.exists(path) ? Assets.getBytes(path) : null;
     if (trackData != null)
     {
       return loadInstFromBytes(state, trackData, instId, wipeFirst);


### PR DESCRIPTION
## Does this PR close any issues? If so, link them below.
[3925](https://github.com/FunkinCrew/Funkin/issues/3925) [3857](https://github.com/FunkinCrew/Funkin/issues/3857) (let me know if i missed one)

## Briefly describe the issue(s) fixed.
use the `Assets.exists` before retriveing openfl bytes !!!!! otherwise it throws an error and it sucks ass !!!
yeah that's the fix

## Include any relevant screenshots or videos.
https://github.com/user-attachments/assets/d023a93b-bcaf-400b-a7d4-b5646fa08e34
