### PR TITLE
Use "event.isComboBreak" instead of "isComboBreak"

### DIFF
--- a/source/funkin/play/PlayState.hx
+++ b/source/funkin/play/PlayState.hx
@@ -2546,7 +2546,7 @@ class PlayState extends MusicBeatSubState
 
     Highscore.tallies.totalNotesHit++;
     // Display the hit on the strums
-    playerStrumline.hitNote(note, !isComboBreak);
+    playerStrumline.hitNote(note, !event.isComboBreak);
     if (event.doesNotesplash) playerStrumline.playNoteSplash(note.noteData.getDirection());
     if (note.isHoldNote && note.holdNoteSprite != null) playerStrumline.playNoteHoldCover(note.holdNoteSprite);
     vocals.playerVolume = 1;


### PR DESCRIPTION
## Briefly describe the issue(s) fixed.
This PR changes playerStrumline's hitNote call to use !event.isComboBreak instead of the regular !isComboBreak. This makes it so mods can overwrite it.


this is my first pr to use the github pr extension lol
