### PR TITLE
[ENHANCEMENT] [MODDING] Custom render distance for Strumline.hx

### DIFF
--- a/source/funkin/play/notes/Strumline.hx
+++ b/source/funkin/play/notes/Strumline.hx
@@ -36,8 +36,21 @@ class Strumline extends FlxSpriteGroup
 
   static var RENDER_DISTANCE_MS(get, never):Float;
 
+  /**
+   * The custom render distance for the strumline.
+   * This should be in miliseconds only! Not pixels.
+   */
+  public static var CUSTOM_RENDER_DISTANCE_MS:Float = 0.0;
+
+  /**
+   * Whether to use the custom render distance.
+   * If false, the render distance will be calculated based on the screen height.
+   */
+  public static var USE_CUSTOM_RENDER_DISTANCE:Bool = false;
+
   static function get_RENDER_DISTANCE_MS():Float
   {
+    if (USE_CUSTOM_RENDER_DISTANCE) return CUSTOM_RENDER_DISTANCE_MS;
     return FlxG.height / Constants.PIXELS_PER_MS;
   }
 


### PR DESCRIPTION
<!-- Please check for duplicates or similar PRs before submitting this PR. -->
## Does this PR close any issues? If so, link them below.
N/A
## Briefly describe the issue(s) fixed.
Adds `CUSTOM_RENDER_DISTANCE_MS`, and `USE_CUSTOM_RENDER_DISTANCE` as public static variables in Strumline.hx.

These control the `get_RENDER_DISTANCE_MS()` private static getter and return a custom render distance if `USE_CUSTOM_RENDER_DISTANCE` is true.

These new public static variables are documented and shouldn't affect anything in vanilla base game at all.
The only problem I could see is a module forgetting to reset `USE_CUSTOM_RENDER_DISTANCE`.