### PR TITLE
[Enhancement] Built in alt inst unlocking

### DIFF
--- a/docs/Funkin' Debug Hotkeys.md
+++ b/docs/Funkin' Debug Hotkeys.md
@@ -36,3 +36,5 @@ Most of this functionality is only available on debug builds of the game!
 - `CTRL-ALT-SHIFT-P`: ***CHARACTER UNLOCK SCREEN***: Forces the Character Select screen to play Pico's unlocking animation. Only available on debug builds.
 - `CTRL-ALT-SHIFT-N`: ***CHARACTER NOT SEEN***: Marks all characters as not seen and enables BF's new character unlocked animation in Freeplay. Only available on debug builds.
 - `CTRL-ALT-SHIFT-E`: ***DUMP SAVE DATA***: Prompts the user to save their save data as a JSON file, so its contents can be viewed. Only available on debug builds.
+- `CTRL-ALT-SHIFT-O`: ***ALT INST***: Unlocks Bopeebo (Pico Mix) alt inst in Freeplay. Only available on debug builds.
+- `CTRL-ALT-SHIFT-I`:***NO ALT INST***:  Locks back Bopeebo (Pico Mix) alt inst in Freeplay. Only available on debug builds.

--- a/source/funkin/data/song/SongData.hx
+++ b/source/funkin/data/song/SongData.hx
@@ -552,8 +552,12 @@ class SongCharacterData implements ICloneable<SongCharacterData>
   @:optional
   public var playerVocals:Null<Array<String>> = null;
 
+  @:optional
+  @:default(true)
+  public var unlockedInstByDefault:Null<Bool> = true;
+
   public function new(player:String = '', girlfriend:String = '', opponent:String = '', instrumental:String = '', ?altInstrumentals:Array<String>,
-      ?opponentVocals:Array<String>, ?playerVocals:Array<String>)
+      ?opponentVocals:Array<String>, ?playerVocals:Array<String>, ?unlockedInstByDefault:Bool)
   {
     this.player = player;
     this.girlfriend = girlfriend;
@@ -563,6 +567,7 @@ class SongCharacterData implements ICloneable<SongCharacterData>
     this.altInstrumentals = altInstrumentals;
     this.opponentVocals = opponentVocals;
     this.playerVocals = playerVocals;
+    this.unlockedInstByDefault = unlockedInstByDefault;
 
     if (opponentVocals == null) this.opponentVocals = [opponent];
     if (playerVocals == null) this.playerVocals = [player];
@@ -572,6 +577,7 @@ class SongCharacterData implements ICloneable<SongCharacterData>
   {
     var result:SongCharacterData = new SongCharacterData(this.player, this.girlfriend, this.opponent, this.instrumental);
     result.altInstrumentals = this.altInstrumentals.clone();
+    result.unlockedInstByDefault = this.unlockedInstByDefault;
 
     return result;
   }
@@ -581,7 +587,8 @@ class SongCharacterData implements ICloneable<SongCharacterData>
    */
   public function toString():String
   {
-    return 'SongCharacterData(${this.player}, ${this.girlfriend}, ${this.opponent}, ${this.instrumental}, [${this.altInstrumentals.join(', ')}])';
+    return
+      'SongCharacterData(${this.player}, ${this.girlfriend}, ${this.opponent}, ${this.instrumental}, [${this.altInstrumentals.join(', ')}], ${this.unlockedInstByDefault})';
   }
 }
 

--- a/source/funkin/play/song/Song.hx
+++ b/source/funkin/play/song/Song.hx
@@ -16,6 +16,7 @@ import funkin.modding.IScriptedClass.IPlayStateScriptedClass;
 import funkin.modding.events.ScriptEvent;
 import funkin.ui.freeplay.charselect.PlayableCharacter;
 import funkin.data.freeplay.player.PlayerRegistry;
+import funkin.save.Save;
 import funkin.util.SortUtil;
 
 /**
@@ -586,6 +587,25 @@ class Song implements IPlayStateScriptedClass implements IRegistryEntry<SongMeta
     var variation = _metadata.get(variationId);
     if (variation == null) return false;
     return variation.playData.difficulties.contains(diffId);
+  }
+
+  /**
+   * Return if the inst alt as been unlocked, default to true.
+   * @param variationId
+   * @param difficultyId
+   */
+  public function isAltInstUnlocked(difficultyId:String, variationId:String):Bool
+  {
+    var targetDifficulty:Null<SongDifficulty> = getDifficulty(difficultyId, variationId);
+    if (targetDifficulty == null) return true;
+
+    var unlocked:Bool = (targetDifficulty?.characters?.unlockedInstByDefault) || Save.instance.hasBeatenSong(this.id, null, variationId);
+
+    trace('Is ${this.id}-${variationId} alt inst unlocked: '
+      + unlocked
+      + ((targetDifficulty?.characters?.unlockedInstByDefault ?? true) ? ' (by default)' : ''));
+
+    return unlocked;
   }
 
   /**

--- a/source/funkin/ui/debug/charting/toolboxes/ChartEditorMetadataToolbox.hx
+++ b/source/funkin/ui/debug/charting/toolboxes/ChartEditorMetadataToolbox.hx
@@ -28,6 +28,7 @@ class ChartEditorMetadataToolbox extends ChartEditorBaseToolbox
   var inputSongCharter:TextField;
   var inputStage:DropDown;
   var inputNoteStyle:DropDown;
+  var inputIsunlockedInstByDefault:CheckBox;
   var buttonCharacterPlayer:Button;
   var buttonCharacterGirlfriend:Button;
   var buttonCharacterOpponent:Button;
@@ -118,6 +119,10 @@ class ChartEditorMetadataToolbox extends ChartEditorBaseToolbox
     var startingValueNoteStyle = ChartEditorDropdowns.populateDropdownWithNoteStyles(inputNoteStyle, chartEditorState.currentSongMetadata.playData.noteStyle);
     inputNoteStyle.value = startingValueNoteStyle;
 
+    inputIsunlockedInstByDefault.onChange = function(event:UIEvent) {
+      chartEditorState.currentSongMetadata.playData.characters.unlockedInstByDefault = event.target.value;
+    };
+
     inputBPM.onChange = function(event:UIEvent) {
       if (event.value == null || event.value <= 0) return;
 
@@ -192,6 +197,7 @@ class ChartEditorMetadataToolbox extends ChartEditorBaseToolbox
     inputSongCharter.value = chartEditorState.currentSongMetadata.charter;
     inputStage.value = chartEditorState.currentSongMetadata.playData.stage;
     inputNoteStyle.value = chartEditorState.currentSongMetadata.playData.noteStyle;
+    inputIsunlockedInstByDefault.selected = chartEditorState.currentSongMetadata.playData.characters.unlockedInstByDefault;
     inputBPM.value = chartEditorState.currentSongMetadata.timeChanges[0].bpm;
     inputDifficultyRating.value = chartEditorState.currentSongChartDifficultyRating;
     inputScrollSpeed.value = chartEditorState.currentSongChartScrollSpeed;

--- a/source/funkin/ui/freeplay/FreeplayState.hx
+++ b/source/funkin/ui/freeplay/FreeplayState.hx
@@ -1840,12 +1840,25 @@ class FreeplayState extends MusicBeatSubState
     trace('target variation: ${targetDifficulty?.variation ?? Constants.DEFAULT_VARIATION}');
 
     var baseInstrumentalId:String = targetSong.getBaseInstrumentalId(targetDifficultyId, targetDifficulty?.variation ?? Constants.DEFAULT_VARIATION) ?? '';
+    var hasBeenBeaten:Bool = Save.instance.hasBeatenSong(targetSongId, null, baseInstrumentalId);
+    trace('Has ${targetSongId}'
+      + ((baseInstrumentalId.length > 0) ? '-${baseInstrumentalId}' : '')
+      + " been beaten"
+      + hasBeenBeaten);
     var altInstrumentalIds:Array<String> = targetSong.listAltInstrumentalIds(targetDifficultyId,
       targetDifficulty?.variation ?? Constants.DEFAULT_VARIATION) ?? [];
-
-    if (altInstrumentalIds.length > 0)
+    var instrumentalIds = [baseInstrumentalId].concat(altInstrumentalIds);
+    for (altInstrumentalId in instrumentalIds)
     {
-      var instrumentalIds = [baseInstrumentalId].concat(altInstrumentalIds);
+      var altIsUnlocked = targetSong.isAltInstUnlocked(targetDifficultyId, altInstrumentalId) ?? true;
+      if (!altIsUnlocked)
+      {
+        instrumentalIds.remove(altInstrumentalId);
+      }
+    }
+
+    if (instrumentalIds.length > 1 && hasBeenBeaten)
+    {
       openInstrumentalList(cap, instrumentalIds);
     }
     else

--- a/source/funkin/ui/mainmenu/MainMenuState.hx
+++ b/source/funkin/ui/mainmenu/MainMenuState.hx
@@ -316,6 +316,8 @@ class MainMenuState extends MusicBeatState
     // Ctrl+Alt+Shift+M = Revoke requirements for Pico Unlock
     // Ctrl+Alt+Shift+R = Score/Rank conflict test
     // Ctrl+Alt+Shift+N = Mark all characters as not seen
+    // Ctrl+Alt+Shift+O = Meet requirements for Bopeebo alt inst
+    // Ctrl+Alt+Shift+I = Revoke requirements for Bopeebo alt inst
     // Ctrl+Alt+Shift+E = Dump save data
     // Ctrl+Alt+Shift+L = Force crash and create a log dump
 
@@ -397,46 +399,52 @@ class MainMenuState extends MusicBeatState
 
     if (FlxG.keys.pressed.CONTROL && FlxG.keys.pressed.ALT && FlxG.keys.pressed.SHIFT && FlxG.keys.justPressed.O)
     {
-      // Give the user a score of 1 point on Bopeebo Pico Mix (Easy difficulty).
+      // Give the user a score of 1 point on both Bopeebo regular and Pico Mix.
       // This makes the song count as cleared and allow alt inst selection for BF in Freeplay.
-      funkin.save.Save.instance.setSongScore('bopeebo', 'easy-pico',
-        {
-          score: 1,
-          tallies:
-            {
-              sick: 0,
-              good: 0,
-              bad: 0,
-              shit: 1,
-              missed: 0,
-              combo: 0,
-              maxCombo: 0,
-              totalNotesHit: 1,
-              totalNotes: 10,
-            }
-        });
+      for (diff in ['easy', 'easy-pico', 'normal', 'normal-pico', 'hard', 'hard-pico'])
+      {
+        funkin.save.Save.instance.setSongScore('bopeebo', diff,
+          {
+            score: 1,
+            tallies:
+              {
+                sick: 0,
+                good: 0,
+                bad: 0,
+                shit: 1,
+                missed: 0,
+                combo: 0,
+                maxCombo: 0,
+                totalNotesHit: 1,
+                totalNotes: 10,
+              }
+          });
+      }
     }
 
     if (FlxG.keys.pressed.CONTROL && FlxG.keys.pressed.ALT && FlxG.keys.pressed.SHIFT && FlxG.keys.justPressed.I)
     {
-      // Give the user a score of 0 point on Bopeebo Pico Mix (Easy difficulty).
+      // Give the user a score of 0 point on both Bopeebo regular and Pico Mix.
       // This makes the song count as uncleared and skips alt inst selection for BF in Freeplay.
-      funkin.save.Save.instance.setSongScore('bopeebo', 'easy-pico',
-        {
-          score: 0,
-          tallies:
-            {
-              sick: 0,
-              good: 0,
-              bad: 0,
-              shit: 0,
-              missed: 0,
-              combo: 0,
-              maxCombo: 0,
-              totalNotesHit: 0,
-              totalNotes: 0,
-            }
-        });
+      for (diff in ['easy', 'easy-pico', 'normal', 'normal-pico', 'hard', 'hard-pico'])
+      {
+        funkin.save.Save.instance.setSongScore('bopeebo', diff,
+          {
+            score: 0,
+            tallies:
+              {
+                sick: 0,
+                good: 0,
+                bad: 0,
+                shit: 0,
+                missed: 0,
+                combo: 0,
+                maxCombo: 0,
+                totalNotesHit: 0,
+                totalNotes: 0,
+              }
+          });
+      }
     }
 
     if (FlxG.keys.pressed.CONTROL && FlxG.keys.pressed.ALT && FlxG.keys.pressed.SHIFT && FlxG.keys.justPressed.N)

--- a/source/funkin/ui/mainmenu/MainMenuState.hx
+++ b/source/funkin/ui/mainmenu/MainMenuState.hx
@@ -395,6 +395,50 @@ class MainMenuState extends MusicBeatState
         });
     }
 
+    if (FlxG.keys.pressed.CONTROL && FlxG.keys.pressed.ALT && FlxG.keys.pressed.SHIFT && FlxG.keys.justPressed.O)
+    {
+      // Give the user a score of 1 point on Bopeebo Pico Mix (Easy difficulty).
+      // This makes the song count as cleared and allow alt inst selection for BF in Freeplay.
+      funkin.save.Save.instance.setSongScore('bopeebo', 'easy-pico',
+        {
+          score: 1,
+          tallies:
+            {
+              sick: 0,
+              good: 0,
+              bad: 0,
+              shit: 1,
+              missed: 0,
+              combo: 0,
+              maxCombo: 0,
+              totalNotesHit: 1,
+              totalNotes: 10,
+            }
+        });
+    }
+
+    if (FlxG.keys.pressed.CONTROL && FlxG.keys.pressed.ALT && FlxG.keys.pressed.SHIFT && FlxG.keys.justPressed.I)
+    {
+      // Give the user a score of 0 point on Bopeebo Pico Mix (Easy difficulty).
+      // This makes the song count as uncleared and skips alt inst selection for BF in Freeplay.
+      funkin.save.Save.instance.setSongScore('bopeebo', 'easy-pico',
+        {
+          score: 0,
+          tallies:
+            {
+              sick: 0,
+              good: 0,
+              bad: 0,
+              shit: 0,
+              missed: 0,
+              combo: 0,
+              maxCombo: 0,
+              totalNotesHit: 0,
+              totalNotes: 0,
+            }
+        });
+    }
+
     if (FlxG.keys.pressed.CONTROL && FlxG.keys.pressed.ALT && FlxG.keys.pressed.SHIFT && FlxG.keys.justPressed.N)
     {
       @:privateAccess


### PR DESCRIPTION
This add a built in check of available alt inst and if it's unlocked, allowing to remove that annoying function found in almost all song scripts (and will be easier do add more mixes)
```
  public override function listAltInstrumentalIds(difficultyId:String, variationId:String):Array<String> {
    if (difficultyId == 'easy' || difficultyId == 'normal' || difficultyId == 'hard') {
      var hasBeatenPicoMix = Save.instance.hasBeatenSong(this.id, null, 'pico');

      switch (variationId) {
        case 'pico':
          // return hasBeatenPicoMix ? [''] : [];
          // No Pico mix on BF instrumental, sorry!
          return [];
        default:
          return hasBeatenPicoMix ? ['pico'] : [];
      }
    }
  }
```

It also adds the `unlockedInstByDefault` property in the song metadata of a song alt to lock it (since it's unlocked by default if the property doesn't exits)
