### PR TITLE
Set `skipDependencyErrors` to true

### DIFF
--- a/source/funkin/modding/PolymodHandler.hx
+++ b/source/funkin/modding/PolymodHandler.hx
@@ -156,6 +156,8 @@ class PolymodHandler
         // Parsing rules for various data formats.
         parseRules: buildParseRules(),
 
+        skipDependencyErrors: true,
+
         // Parse hxc files and register the scripted classes in them.
         useScriptedClasses: true,
         loadScriptsAsync: #if html5 true #else false #end,


### PR DESCRIPTION
<!-- Please check for duplicates or similar PRs before submitting this PR. -->
## Does this PR close any issues? If so, link them below.
Partially fixes https://github.com/FunkinCrew/Funkin/issues/3991

## Briefly describe the issue(s) fixed.
Currently, Funkin' will refuse to load any mods at all if one mod has a missing dependency. This can cause a bit of confusion for someone just trying to mod the game.

This PR sets `skipDependencyErrors` to true, which only skips mods that have missing dependencies, instead of disabling every mod.
![Screenshot 2025-01-11 at 11 25 08 PM](https://github.com/user-attachments/assets/d0fcc6be-0adb-427d-865e-072636867543)

Side note: There should probably be a popup or something to notify the user if a dependency error has occurred. That's probably something for another PR.