### PR TITLE
[GITHUB] Auto-close issues with the `status: stale` label

### DIFF
--- a/.github/label-actions.yml
+++ b/.github/label-actions.yml
@@ -7,9 +7,9 @@
     comment: >
       This issue is a duplicate. Please direct all discussion to the original issue.
     # Close the issue
-    close: true
+    close: false
     # Set a close reason
-    close-reason: 'not planned'
+    # close-reason: 'not planned'
     # Remove other status labels
     unlabel:
       - 'status: accepted'
@@ -22,12 +22,55 @@
       - 'status: planned'
       - 'status: rejected'
       - 'status: resolved'
+      - 'status: resolved internally'
       - 'status: reviewing internally'
       - 'status: stale'
   prs:
     # Post a comment
     comment: >
       This pull request is a duplicate. Please direct all discussion to the original pull request.
+    # Close the pull request
+    close: false
+    # Set a close reason
+    # close-reason: 'not planned'
+    # Remove other status labels
+    unlabel:
+      - 'status: accepted'
+      - 'status: bug reproduced'
+      - 'status: cannot reproduce'
+      - 'status: needs clarification'
+      - 'status: needs revision'
+      - 'status: pending pull request'
+      - 'status: pending triage'
+      - 'status: planned'
+      - 'status: rejected'
+      - 'status: resolved'
+      - 'status: resolved internally'
+      - 'status: reviewing internally'
+      - 'status: stale'
+
+'status: stale':
+  issues:
+    # Close the issue
+    close: true
+    # Set a close reason
+    close-reason: 'not planned'
+    # Remove other status labels
+    unlabel:
+      - 'status: accepted'
+      - 'status: bug reproduced'
+      - 'status: cannot reproduce'
+      - 'status: duplicate'
+      - 'status: needs clarification'
+      - 'status: needs revision'
+      - 'status: pending pull request'
+      - 'status: pending triage'
+      - 'status: planned'
+      - 'status: rejected'
+      - 'status: resolved'
+      - 'status: resolved internally'
+      - 'status: reviewing internally'
+  prs:
     # Close the pull request
     close: true
     # Set a close reason
@@ -37,6 +80,7 @@
       - 'status: accepted'
       - 'status: bug reproduced'
       - 'status: cannot reproduce'
+      - 'status: duplicate'
       - 'status: needs clarification'
       - 'status: needs revision'
       - 'status: pending pull request'
@@ -44,8 +88,8 @@
       - 'status: planned'
       - 'status: rejected'
       - 'status: resolved'
+      - 'status: resolved internally'
       - 'status: reviewing internally'
-      - 'status: stale'
 
 'status: rejected':
   issues:
@@ -65,6 +109,7 @@
       - 'status: pending triage'
       - 'status: planned'
       - 'status: resolved'
+      - 'status: resolved internally'
       - 'status: reviewing internally'
       - 'status: stale'
   prs:
@@ -84,6 +129,7 @@
       - 'status: pending triage'
       - 'status: planned'
       - 'status: resolved'
+      - 'status: resolved internally'
       - 'status: reviewing internally'
       - 'status: stale'
 
@@ -105,5 +151,6 @@
       - 'status: pending triage'
       - 'status: planned'
       - 'status: rejected'
+      - 'status: resolved internally'
       - 'status: reviewing internally'
       - 'status: stale'


### PR DESCRIPTION
GitHub Actions will now auto-close issues when assigned the `status: stale` label.

Also:

- adds the new `status: resolved internally` label into every unlabel list. Originally from (https://github.com/FunkinCrew/Funkin/pull/3919)
- no longer auto-closes `status: duplicate` issues due to GitHub's new close reason.