### PR TITLE
[GITHUB] Changes to the PR labeler workflow

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,11 +1,18 @@
 # Add Documentation tag to PR's changing markdown files, or anything in the docs folder
-Documentation:
+'pr: documentation':
 - changed-files:
   - any-glob-to-any-file:
       - docs/*
       - '**/*.md'
 
 # Add Haxe tag to PR's changing haxe code files
-Haxe:
+'pr: haxe':
 - changed-files:
   - any-glob-to-any-file: '**/*.hx'
+
+# Add GitHub tag to PR's changing yml files, or anything in the .github folder 
+'pr: github':
+- changed-files:
+  - any-glob-to-any-file:
+      - github/*
+      - '**/*.yml'


### PR DESCRIPTION
This PR changes the PR labeler workflow to account for the changes made in #3920.

### Changes
- Changed `Documentation` and `Haxe` to `pr: documentation` and `pr: haxe` respectively.
- Added a new function for the new `pr: github` label. This label gets applied if a user either modifies a `.yml` file, or modifies any file in the `.github` folder.