### PR TITLE
[ENHANCEMENT] Smoother Health Bar and use OUTLINE_FAST for Score Text Outline [FIXED, AGAIN]

### DIFF
--- a/source/funkin/play/PlayState.hx
+++ b/source/funkin/play/PlayState.hx
@@ -1584,11 +1584,15 @@ class PlayState extends MusicBeatSubState
     healthBar.scrollFactor.set();
     healthBar.createFilledBar(Constants.COLOR_HEALTH_BAR_RED, Constants.COLOR_HEALTH_BAR_GREEN);
     healthBar.zIndex = 801;
+    // One division for each pixel of the bar's width ensures maximum bar smoothness.
+    // This is better looking, and syncs with the lerped icon movement better.
+    // This can be slightly more heavy on the CPU, though, so if lower end device performance options are added, maybe make them affect this?
+    healthBar.numDivisions = Std.int(healthBarBG.width - 8);
     add(healthBar);
 
     // The score text below the health bar.
     scoreText = new FlxText(healthBarBG.x + healthBarBG.width - 190, healthBarBG.y + 30, 0, '', 20);
-    scoreText.setFormat(Paths.font('vcr.ttf'), 16, FlxColor.WHITE, RIGHT, FlxTextBorderStyle.OUTLINE, FlxColor.BLACK);
+    scoreText.setFormat(Paths.font('vcr.ttf'), 16, FlxColor.WHITE, RIGHT, FlxTextBorderStyle.OUTLINE_FAST, FlxColor.BLACK);
     scoreText.scrollFactor.set();
     scoreText.zIndex = 802;
     add(scoreText);


### PR DESCRIPTION
Redo, AGAIN, of PR #3680 and PR #4021 because I'm an absolute genius and don't know how to use git that well. Same ordeal as the last 2, just actually proper.

below is the original description:

The healthbar is currently choppy, and doesn't smoothly line up with the lerp and health icon positions. This fixes this by giving the healthbar the same number of divisions as its width in pixels (effectively the maximum that fit in the space of the healthbar).

This PR also switches the FlxTextBorderStyle of scoreText from OUTLINE to OUTLINE_FAST, which is not noticeable visually (especially with the pixel font that scoreText uses) and is slightly more optimized.