### PR TITLE
[ENHANCEMENT] Add `readDirectory` to FileUtil

### DIFF
--- a/source/funkin/util/FileUtil.hx
+++ b/source/funkin/util/FileUtil.hx
@@ -357,6 +357,23 @@ class FileUtil
     #end
   }
 
+  /**
+   * Read directory contents direct from a given path.
+   * Only works on desktop.
+   *
+   * @param dir The path to the directory.
+   * @return The directory contents.
+   */
+  public static function readDirContent(dir:String):Array<String>
+  {
+    #if sys
+    if (!doesFileExist(dir) || !sys.FileSystem.isDirectory(dir)) return [];
+    return sys.FileSystem.readDirectory(dir);
+    #else
+    return [];
+    #end
+  }
+
   public static function doesFileExist(path:String):Bool
   {
     #if sys


### PR DESCRIPTION
back when i was making a menu for my replay mod i had to use a dinky ass method of listing all replay files, which was saving the file paths to the save file and then later checking if they exist, yikes! 
this PR adds a wrapper for FileSystem's `readDirectory` in FileUtil to avoid having modders struggling and doing something similar to the method described above