### PR TITLE
Better descriptions for items within `Prefrences`

### DIFF
--- a/source/funkin/ui/options/PreferencesMenu.hx
+++ b/source/funkin/ui/options/PreferencesMenu.hx
@@ -95,31 +95,33 @@ class PreferencesMenu extends Page
    */
   function createPrefItems():Void
   {
-    createPrefItemCheckbox('Naughtyness', 'If enabled, raunchy content (such as swearing, etc.) will be displayed.', function(value:Bool):Void {
+    createPrefItemCheckbox('Naughtyness', 'Enables content that is not suitable for a younger audience. (Profanity, gore, etc.)', function(value:Bool):Void {
       Preferences.naughtyness = value;
     }, Preferences.naughtyness);
-    createPrefItemCheckbox('Downscroll', 'If enabled, this will make the notes move downwards.', function(value:Bool):Void {
+    createPrefItemCheckbox('Downscroll', 'Vertically flips the playfield, DDR style.', function(value:Bool):Void {
       Preferences.downscroll = value;
     }, Preferences.downscroll);
-    createPrefItemCheckbox('Flashing Lights', 'If disabled, it will dampen flashing effects. Useful for people with photosensitive epilepsy.', function(value:Bool):Void {
-      Preferences.flashingLights = value;
-    }, Preferences.flashingLights);
-    createPrefItemCheckbox('Camera Zooms', 'If disabled, camera stops bouncing to the song.', function(value:Bool):Void {
+    createPrefItemCheckbox('Flashing Lights', 'Shows rapid, high-contrast lighting effects during certain events. (Disable if sensitive to epilepsy)',
+      function(value:Bool):Void {
+        Preferences.flashingLights = value;
+      }, Preferences.flashingLights);
+    createPrefItemCheckbox('Camera Zooming on Beat', 'Whether or not the camera should bop/bounce\non beat with the song.', function(value:Bool):Void {
       Preferences.zoomCamera = value;
     }, Preferences.zoomCamera);
-    createPrefItemCheckbox('Debug Display', 'If enabled, FPS and other debug stats will be displayed.', function(value:Bool):Void {
-      Preferences.debugDisplay = value;
-    }, Preferences.debugDisplay);
-    createPrefItemCheckbox('Auto Pause', 'If enabled, game automatically pauses when it loses focus.', function(value:Bool):Void {
+    createPrefItemCheckbox('Debug Display', 'Enables an overlay that shows additional debugging information. (frame rate & memory usage)',
+      function(value:Bool):Void {
+        Preferences.debugDisplay = value;
+      }, Preferences.debugDisplay);
+    createPrefItemCheckbox('Auto Pause', 'Automatically pauses the game when tabbed out.', function(value:Bool):Void {
       Preferences.autoPause = value;
     }, Preferences.autoPause);
 
     #if web
-    createPrefItemCheckbox('Unlocked Framerate', 'Enable to unlock the framerate', function(value:Bool):Void {
+    createPrefItemCheckbox('Unlocked Framerate', 'Disables the frame rate cap.\n(Performance may vary depending on system specs)', function(value:Bool):Void {
       Preferences.unlockedFramerate = value;
     }, Preferences.unlockedFramerate);
     #else
-    createPrefItemNumber('FPS', 'The maximum framerate that the game targets', function(value:Float) {
+    createPrefItemNumber('FPS', "Adjust the game's target frame rate.", function(value:Float) {
       Preferences.framerate = Std.int(value);
     }, null, Preferences.framerate, 30, 300, 5, 0);
     #end

--- a/source/funkin/ui/options/PreferencesMenu.hx
+++ b/source/funkin/ui/options/PreferencesMenu.hx
@@ -75,7 +75,7 @@ class PreferencesMenu extends Page
   function createPrefDescription():Void
   {
     itemDescBox.makeSolidColor(1, 1, FlxColor.BLACK);
-    itemDescBox.alpha = 0.6;
+    itemDescBox.alpha = 0.8;
     itemDesc.setFormat(Paths.font('vcr.ttf'), 32, FlxColor.WHITE, FlxTextAlign.CENTER, FlxTextBorderStyle.OUTLINE, FlxColor.BLACK);
     itemDesc.borderSize = 3;
 


### PR DESCRIPTION
<!-- Please check for duplicates or similar PRs before submitting this PR. -->
## Does this PR close any issues? If so, link them below.
N/A

## Briefly describe the issue(s) fixed.
* Re-wrote descriptions for each item within `Preferences` to be more clear and concise.
  * Renamed `Camera Zooms` back to `Camera Zooming on Beat` as I feel like, when you say `Camera Zooms` it can also, technically, mean general camera zooming like zooming onto a character, or a certain prop within a stage, where as `Camera Zooming on Beat` is a little dragged out but is more concise on what the option does.
* Set the `alpha` value of `itemDescBox` to `0.8`, retaining transparency while also increasing readability.

## Include any relevant screenshots or videos.
### Native (Windows)
https://github.com/user-attachments/assets/035fa9f5-c490-4b89-be86-a7d18e57f149

### Web
https://github.com/user-attachments/assets/eab22cf4-a660-41d0-80b2-7c4d3a60e7cf