### PR TITLE
[GITHUB] Add Links to Guides in Issue Templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -8,8 +8,9 @@ body:
       label: Issue Checklist
       description: Be sure to complete these steps to increase the chances of your issue being addressed!
       options:
-        - label: I have properly named my issue
+        - label: I have read the pinned [Issues Guide](https://github.com/FunkinCrew/Funkin/issues/4050)
         - label: I have checked the Issues/Discussions pages to see if my issue has already been reported
+        - label: I have properly named my issue
 
   - type: dropdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/charting.yml
+++ b/.github/ISSUE_TEMPLATE/charting.yml
@@ -8,8 +8,9 @@ body:
       label: Issue Checklist
       description: Be sure to complete these steps to increase the chances of your issue being addressed!
       options:
-        - label: I have properly named my issue
+        - label: I have read the pinned [Issues Guide](https://github.com/FunkinCrew/Funkin/issues/4050)
         - label: I have checked the Issues/Discussions pages to see if my issue has already been reported
+        - label: I have properly named my issue
 
   - type: dropdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/compiling.yml
+++ b/.github/ISSUE_TEMPLATE/compiling.yml
@@ -1,23 +1,27 @@
-name: Compiling Report
+name: Compiling Help
 description: Report an issue with compiling the game.
 labels: ["type: compilation help", "status: pending triage"]
-title: "Compiling Report: "
+title: "Compiling Help: "
 body:
   - type: checkboxes
     attributes:
       label: Issue Checklist
       description: Be sure to complete these steps to increase the chances of your issue being addressed!
       options:
-        - label: I have properly named my issue
+        - label: I have read the pinned [Issues Guide](https://github.com/FunkinCrew/Funkin/issues/4050)
+        - label: I have followed the [Compiling Guide](https://github.com/FunkinCrew/Funkin/blob/main/docs/COMPILING.md) and the [Troubleshooting Guide](https://github.com/FunkinCrew/Funkin/blob/main/docs/TROUBLESHOOTING.md)
         - label: I have checked the Issues/Discussions pages to see if my issue has already been reported
+        - label: I have properly named my issue
 
   - type: dropdown
     attributes:
       label: Platform
-      description: Which platform are you compiling to/for?
+      description: Which platform are you compiling for?
       options:
        - Web/HTML5
-       - Desktop
+       - Desktop (Windows)
+       - Desktop (Mac)
+       - Desktop (Linux)
        - Other
     validations:
       required: true
@@ -32,7 +36,7 @@ body:
   
   - type: markdown
     attributes:
-      value: "## Describe your compiling error."
+      value: "## Describe your compiling issue."
 
   - type: markdown
     attributes:
@@ -40,8 +44,16 @@ body:
 
   - type: textarea
     attributes:
-      label: Description (include any images, videos, errors of terminal or console, error logs)
-      description: Provide as much detail as you can. The better others understand your issue, the more they can help you!  
-      placeholder: Describe your issue here...
+      label: Console Output
+      description: Paste any errors or warnings from the console here.
+      placeholder: Paste output here...
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Context
+      description: Provide as much detail as you can. Did you modify any code? Provide any relevant images or videos.
+      placeholder: Describe the context here...
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/crash.yml
+++ b/.github/ISSUE_TEMPLATE/crash.yml
@@ -8,8 +8,9 @@ body:
       label: Issue Checklist
       description: Be sure to complete these steps to increase the chances of your issue being addressed!
       options:
-        - label: I have properly named my issue
+        - label: I have read the pinned [Issues Guide](https://github.com/FunkinCrew/Funkin/issues/4050)
         - label: I have checked the Issues/Discussions pages to see if my issue has already been reported
+        - label: I have properly named my issue
 
   - type: dropdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/enhancement.yml
+++ b/.github/ISSUE_TEMPLATE/enhancement.yml
@@ -8,8 +8,9 @@ body:
       label: Issue Checklist
       description: Be sure to complete these steps to increase the chances of your suggestion being considered!
       options:
-        - label: I have properly named my enhancement
+        - label: I have read the pinned [Issues Guide](https://github.com/FunkinCrew/Funkin/issues/4050)
         - label: I have checked the Issues/Discussions pages to see if my enhancement has already been suggested
+        - label: I have properly named my enhancement
 
   - type: textarea
     attributes:


### PR DESCRIPTION
## Changes
- Adds a link to the [Issues Guide](https://github.com/FunkinCrew/Funkin/issues/4050) to all 5 issue templates.
- Includes links to the [Compiling Guide](https://github.com/FunkinCrew/Funkin/blob/main/docs/COMPILING.md) and [Troubleshooting Guide](https://github.com/FunkinCrew/Funkin/blob/main/docs/TROUBLESHOOTING.md) in the compiling help template.
- Adds a `Console Output` field to the compiling help template.

## Screenshot
![image](https://github.com/user-attachments/assets/ef6fa63f-42b0-4f3d-822b-d075e3a4a82d)
