### PR TITLE
no dialogue music crash fix

### DIFF
--- a/source/funkin/play/cutscene/dialogue/Conversation.hx
+++ b/source/funkin/play/cutscene/dialogue/Conversation.hx
@@ -407,7 +407,7 @@ class Conversation extends FlxSpriteGroup implements IDialogueScriptedClass impl
             ease: EaseUtil.stepped(8)
           });
 
-        FlxTween.tween(this.music, {volume: 0.0}, outroData.fadeTime);
+        if (this.music != null) FlxTween.tween(this.music, {volume: 0.0}, outroData.fadeTime);
       case NONE(_):
         // Immediately clean up.
         endOutro();


### PR DESCRIPTION
<!-- Please check for duplicates or similar PRs before submitting this PR. -->
## Does this PR close any issues? If so, link them below.

## Briefly describe the issue(s) fixed.
A one line fix that prevents a null reference error crash if a dialogue doesn't have any music set when the dialogue ends.
## Include any relevant screenshots or videos.
