### PR TITLE
[FEATURE] Screenshot Display Gallery and Edit Menu

### DIFF
--- a/source/funkin/ui/debug/DebugMenuSubState.hx
+++ b/source/funkin/ui/debug/DebugMenuSubState.hx
@@ -61,6 +61,11 @@ class DebugMenuSubState extends MusicBeatSubState
     #if FEATURE_STAGE_EDITOR
     createItem("STAGE EDITOR", openStageEditor);
     #end
+
+    #if FEATURE_SCREENSHOTS
+    createItem("GALLERY", () -> FlxG.switchState(() -> new funkin.ui.gallery.ScreenshotGalleryState()));
+    #end
+
     // createItem("Input Offset Testing", openInputOffsetTesting);
     // createItem("CHARACTER SELECT", openCharSelect, true);
     // createItem("TEST STICKERS", testStickers);

--- a/source/funkin/ui/gallery/EditScreenshotBox.hx
+++ b/source/funkin/ui/gallery/EditScreenshotBox.hx
@@ -1,0 +1,383 @@
+package funkin.ui.gallery;
+
+import haxe.ui.components.popups.ColorPickerPopup;
+import haxe.ui.containers.Box;
+import haxe.ui.containers.Grid;
+import haxe.ui.containers.HBox;
+import haxe.ui.containers.VBox;
+import haxe.ui.containers.ScrollView;
+import haxe.ui.components.Button;
+import haxe.ui.components.CheckBox;
+import haxe.ui.components.DropDown;
+import haxe.ui.components.DropDown.DropDownBuilder;
+import haxe.ui.components.DropDown.DropDownEvents;
+import haxe.ui.components.DropDown.DropDownHandler;
+import haxe.ui.components.HorizontalSlider;
+import haxe.ui.components.Image;
+import haxe.ui.components.Label;
+import haxe.ui.components.NumberStepper;
+import haxe.ui.components.OptionBox;
+import haxe.ui.components.SectionHeader;
+import haxe.ui.components.VerticalRule;
+import haxe.ui.events.UIEvent;
+import funkin.util.SortUtil;
+import flixel.FlxSprite;
+import openfl.text.Font;
+
+@:xml("
+  <box>
+    <style>
+      body, .label, .link {
+        font-size: 18px;
+        font-family: 'Inconsolata';
+        font-bold: true;
+      }
+      .button, .menu, .menuitem, .menuLabel, .menuitem-checkbox {
+        font-size: 12px;
+        font-family: 'Inconsolata';
+        font-bold: true;
+      }
+      .menuHeader {
+        font-size: 16px;
+        font-family: 'Inconsolata';
+        font-bold: true;
+      }
+      .textfield {
+        font-size: 10px;
+        font-bold: true;
+      }
+      .compact {
+        margin: 0px;
+        padding: 0px;
+      }
+      .compactButton {
+        margin: 0px;
+        padding-top: 4px;
+        padding-right: 0px;
+        padding-bottom: 4px;
+        padding-left: 0px;
+      }
+      .disable-validation.invalid-value {
+        border: $normal-border-size solid $normal-border-color;
+        background-color: $tertiary-background-color;
+      }
+      .offset-ticks-label {
+        color: #FFFFFF;
+        font-size: 12px;
+        font-weight: bold;
+      }
+      .absolute {
+        clip: false;
+      }
+    </style>
+  </box>
+")
+@:access(funkin.ui.gallery.EditScreenshotSubState)
+class EditScreenshotBox extends Box
+{
+  var daState:EditScreenshotSubState = null;
+
+  var hboxLEFT:HBox = new HBox();
+  var hboxCENTER:HBox = new HBox();
+  var hboxRIGHT:HBox = new HBox();
+
+  public var allFonts:Array<String> = [];
+
+  public var selectScale:HorizontalSlider = new HorizontalSlider();
+  public var selectAngle:HorizontalSlider = new HorizontalSlider();
+  public var selectFlipX:CheckBox = new CheckBox();
+  public var selectFlipY:CheckBox = new CheckBox();
+
+  public var drawSize:HorizontalSlider = new HorizontalSlider();
+  public var drawColor:ColorPickerPopup = new ColorPickerPopup();
+
+  public var stickerDropdown:DropDown = new DropDown();
+
+  public var textSize:NumberStepper = new NumberStepper();
+  public var textFont:DropDown = new DropDown();
+  public var textBold:CheckBox = new CheckBox();
+  public var textItalic:CheckBox = new CheckBox();
+  public var textUnderline:CheckBox = new CheckBox();
+  public var textColor:ColorPickerPopup = new ColorPickerPopup();
+
+  override public function new(state:EditScreenshotSubState)
+  {
+    super();
+
+    daState = state;
+    padding = 8;
+    styleString = "background-color: $solid-background-color;";
+    cameras = [FlxG.cameras.list[FlxG.cameras.list.length - 1]];
+    width = FlxG.width;
+    height = 48;
+    y = FlxG.height - height;
+    screenCenter(X);
+
+    for (font in Font.enumerateFonts(true).concat(Font.enumerateFonts(false)))
+    {
+      if (font?.fontName == null) continue;
+      if (!allFonts.contains(font.fontName)) allFonts.push(font.fontName);
+    }
+    allFonts.sort(SortUtil.alphabetically);
+
+    generateBottomUI();
+    useSelectUI();
+  }
+
+  function generateBottomUI()
+  {
+    hboxLEFT.verticalAlign = hboxCENTER.verticalAlign = hboxRIGHT.verticalAlign = "center";
+    hboxLEFT.horizontalAlign = "left";
+    hboxCENTER.horizontalAlign = "center";
+    hboxRIGHT.horizontalAlign = "right";
+
+    addComponent(hboxLEFT);
+    addComponent(hboxCENTER);
+    addComponent(hboxRIGHT);
+
+    for (mode in EditScreenshotSubState.ALL_MODES)
+    {
+      var modeOption:OptionBox = new OptionBox();
+      modeOption.text = mode.toUpperKebabCase();
+      modeOption.componentGroup = "screenshotEditMode";
+      modeOption.selected = (mode == daState.curMode);
+
+      modeOption.pauseEvent(UIEvent.CHANGE);
+      modeOption.onChange = function(_) {
+        daState.curMode = mode;
+
+        switch (daState.curMode)
+        {
+          case SELECT:
+            useSelectUI();
+          case DRAW:
+            useDrawUI();
+          case STICKERS:
+            useStickerUI();
+          case TEXT:
+            useTextUI();
+          default:
+            hboxRIGHT.removeAllComponents(false);
+        }
+      }
+      hboxLEFT.addComponent(modeOption);
+      modeOption.resumeEvent(UIEvent.CHANGE, true);
+    }
+  }
+
+  function useSelectUI()
+  {
+    hboxRIGHT.removeAllComponents(false);
+
+    // labels
+    var scaleLabel:Label = new Label();
+    var angleLabel:Label = new Label();
+    var flipLabel:Label = new Label();
+
+    // rules
+    var scaleRule:VerticalRule = new VerticalRule();
+    var angleRule:VerticalRule = new VerticalRule();
+
+    // values
+    scaleLabel.text = "Scale:";
+
+    selectScale.max = 10;
+    selectScale.step = selectScale.min = 0.05;
+    selectScale.majorTicks = 1;
+    selectScale.minorTicks = 0.25;
+    selectScale.pos = 1;
+
+    angleLabel.text = "Angle:";
+
+    selectAngle.max = 360;
+    selectAngle.min = selectAngle.pos = 0;
+    selectAngle.minorTicks = selectAngle.step = 15;
+    selectAngle.majorTicks = 90;
+
+    flipLabel.text = "Flip:";
+
+    selectFlipX.text = "Horizontally";
+    selectFlipY.text = "Vertically";
+
+    angleRule.percentHeight = scaleRule.percentHeight = 80;
+    scaleLabel.verticalAlign = angleLabel.verticalAlign = flipLabel.verticalAlign = selectFlipX.verticalAlign = selectFlipY.verticalAlign = "center";
+
+    // order
+    hboxRIGHT.addComponent(scaleLabel);
+    hboxRIGHT.addComponent(selectScale);
+    hboxRIGHT.addComponent(scaleRule);
+    hboxRIGHT.addComponent(angleLabel);
+    hboxRIGHT.addComponent(selectAngle);
+    hboxRIGHT.addComponent(angleRule);
+    hboxRIGHT.addComponent(flipLabel);
+    hboxRIGHT.addComponent(selectFlipX);
+    hboxRIGHT.addComponent(selectFlipY);
+  }
+
+  function useDrawUI()
+  {
+    hboxRIGHT.removeAllComponents(false);
+
+    // labels
+    var sizeLabel:Label = new Label();
+    var colorLabel:Label = new Label();
+
+    // rules
+    var sizeRule:VerticalRule = new VerticalRule();
+
+    // values
+    sizeLabel.text = "Size:";
+
+    drawSize.max = 100;
+    drawSize.min = drawSize.step = 1;
+    drawSize.majorTicks = 25;
+    drawSize.minorTicks = 5;
+    drawSize.pos = daState.drawSprite.radius;
+
+    sizeRule.percentHeight = 80;
+
+    colorLabel.text = "Color:";
+
+    drawColor.selectedItem = haxe.ui.util.Color.fromString(daState.drawSprite.color.toHexString());
+
+    // order
+    hboxRIGHT.addComponent(sizeLabel);
+    hboxRIGHT.addComponent(drawSize);
+    hboxRIGHT.addComponent(sizeRule);
+    hboxRIGHT.addComponent(colorLabel);
+    hboxRIGHT.addComponent(drawColor);
+  }
+
+  function useStickerUI()
+  {
+    hboxRIGHT.removeAllComponents(false);
+
+    stickerDropdown.type = "stickers";
+    stickerDropdown.width = 150;
+    stickerDropdown.text = EditScreenshotSubState.selectedSticker;
+    DropDownBuilder.HANDLER_MAP.set("stickers", Type.getClassName(StickerDropdown));
+
+    hboxRIGHT.addComponent(stickerDropdown);
+  }
+
+  function useTextUI()
+  {
+    hboxRIGHT.removeAllComponents(false);
+
+    // labels
+    var sizeLabel:Label = new Label();
+    var fontLabel:Label = new Label();
+    var colorLabel:Label = new Label();
+
+    // rules
+    var sizeRule:VerticalRule = new VerticalRule();
+    var fontRule:VerticalRule = new VerticalRule();
+    var colorRule:VerticalRule = new VerticalRule();
+    var boldRule:VerticalRule = new VerticalRule();
+    var italicRule:VerticalRule = new VerticalRule();
+
+    // values
+    sizeLabel.text = "Size:";
+
+    textSize.pos = 16;
+    textSize.min = 1;
+    textSize.step = 1;
+
+    fontLabel.text = "Font:";
+
+    textFont.width = 150;
+    textFont.dataSource.clear();
+
+    for (font in allFonts)
+      textFont.dataSource.add({text: font});
+
+    textFont.selectedIndex = allFonts.indexOf(flixel.system.FlxAssets.FONT_DEFAULT);
+    textFont.searchable = true;
+    textFont.searchPrompt = "Find a Font";
+
+    colorLabel.text = "Color:";
+    textColor.selectedItem = haxe.ui.util.Color.fromString("white");
+
+    textBold.text = "Bold";
+    textItalic.text = "Italic";
+    textUnderline.text = "Underline";
+
+    sizeRule.percentHeight = fontRule.percentHeight = colorRule.percentHeight = boldRule.percentHeight = italicRule.percentHeight = 80;
+
+    // order
+    hboxRIGHT.addComponent(sizeLabel);
+    hboxRIGHT.addComponent(textSize);
+    hboxRIGHT.addComponent(sizeRule);
+    hboxRIGHT.addComponent(fontLabel);
+    hboxRIGHT.addComponent(textFont);
+    hboxRIGHT.addComponent(fontRule);
+    hboxRIGHT.addComponent(colorLabel);
+    hboxRIGHT.addComponent(textColor);
+    hboxRIGHT.addComponent(colorRule);
+    hboxRIGHT.addComponent(textBold);
+    hboxRIGHT.addComponent(boldRule);
+    hboxRIGHT.addComponent(textItalic);
+    hboxRIGHT.addComponent(italicRule);
+    hboxRIGHT.addComponent(textUnderline);
+  }
+}
+
+// nabbed from haxe ui examples!
+
+@:access(haxe.ui.core.Component)
+class StickerDropdown extends DropDownHandler
+{
+  var stickerBox:VBox;
+
+  override function get_component()
+  {
+    if (stickerBox == null)
+    {
+      stickerBox = new VBox();
+      stickerBox.width = 350;
+      stickerBox.height = 350;
+
+      var newScroll:ScrollView = new ScrollView();
+      newScroll.percentWidth = newScroll.percentHeight = newScroll.percentContentWidth = 100;
+      stickerBox.addComponent(newScroll);
+
+      var scrollBox:VBox = new VBox();
+      scrollBox.percentWidth = 100;
+      newScroll.addComponent(scrollBox);
+
+      // aight we making stickahs now
+      for (char => stickers in EditScreenshotSubState.stickerStuff)
+      {
+        var sect:SectionHeader = new SectionHeader();
+        sect.text = char;
+        scrollBox.addComponent(sect);
+
+        var buttonBox:Grid = new Grid();
+        buttonBox.percentWidth = 100;
+        buttonBox.columns = 3;
+        scrollBox.addComponent(buttonBox);
+
+        for (stickah in stickers)
+        {
+          var stickerButton:Button = new Button();
+          stickerButton.toggle = true;
+          stickerButton.text = stickah;
+          stickerButton.componentGroup = "sticker";
+          stickerButton.iconPosition = "top";
+          stickerButton.icon = EditScreenshotSubState.stickerSprites[stickah].frame;
+          stickerButton.width = 96;
+          stickerButton.height = 96;
+          stickerButton.selected = (EditScreenshotSubState.selectedSticker == stickah);
+
+          stickerButton.onChange = function(_) {
+            if (stickerButton.selected) _dropdown.text = stickah;
+          }
+
+          buttonBox.addComponent(stickerButton);
+        }
+      }
+    }
+
+    return stickerBox;
+  }
+}

--- a/source/funkin/ui/gallery/EditScreenshotSubState.hx
+++ b/source/funkin/ui/gallery/EditScreenshotSubState.hx
@@ -1,0 +1,497 @@
+package funkin.ui.gallery;
+
+import funkin.audio.FunkinSound;
+import funkin.graphics.FunkinCamera;
+import funkin.input.Cursor;
+import funkin.ui.transition.StickerSubState.StickerShit;
+import funkin.util.FileUtil;
+import flixel.FlxSprite;
+import flixel.addons.display.shapes.FlxShapeCircle;
+import flixel.group.FlxSpriteGroup;
+import flixel.input.keyboard.FlxKey;
+import flixel.math.FlxMath;
+import flixel.text.FlxText;
+import flixel.util.FlxColor;
+import openfl.display.BitmapData;
+import openfl.events.KeyboardEvent;
+
+using flixel.util.FlxSpriteUtil;
+using StringTools;
+
+class EditScreenshotSubState extends MusicBeatSubState
+{
+  public static final ALL_MODES:Array<ScreenshotEditMode> = [SELECT, DRAW, STICKERS, TEXT, DELETE];
+
+  var shotCopy:FlxSprite;
+  var shotName:String = "Unnamed";
+  var curMode:ScreenshotEditMode = SELECT;
+
+  var selectorSprite:FlxSprite;
+  var evilSelectorSprite:FlxSprite;
+
+  var drawSprite:FlxShapeCircle;
+  var invisDrawLayer:FlxSprite;
+  var drawLayerBitmap:BitmapData;
+
+  var objectLayer:FlxSpriteGroup;
+  var bottomBar:EditScreenshotBox;
+
+  var isCursorOverHaxeUI(get, never):Bool;
+  var finishCam:FunkinCamera;
+
+  public static var stickerSprites:Map<String, FlxSprite> = [];
+  public static var stickerStuff:Map<String, Array<String>> = [];
+  public static var selectedSticker:String = "";
+
+  var stickerSounds:Array<String> = [];
+
+  override public function new(daShot:FlxSprite, name:String = "Unnamed")
+  {
+    super(FlxColor.fromRGBFloat(0, 0, 0, 0.45));
+
+    shotCopy = new FlxSprite().loadGraphicFromSprite(daShot);
+    shotName = name;
+
+    selectorSprite = new FlxSprite().makeGraphic(25, 25, FlxColor.fromRGBFloat(1, 1, 1, 0.45));
+    selectorSprite.drawRect(0, 0, selectorSprite.width, selectorSprite.height, FlxColor.TRANSPARENT, {thickness: 2, color: FlxColor.WHITE});
+
+    evilSelectorSprite = new FlxSprite().loadGraphicFromSprite(selectorSprite);
+    evilSelectorSprite.color = FlxColor.RED;
+
+    drawSprite = new FlxShapeCircle(0, 0, 25, {thickness: 0, color: FlxColor.TRANSPARENT}, FlxColor.WHITE);
+    invisDrawLayer = new FlxSprite().makeGraphic(Math.floor(shotCopy.width), Math.floor(shotCopy.height), FlxColor.TRANSPARENT);
+    drawLayerBitmap = invisDrawLayer.pixels.clone();
+
+    objectLayer = new FlxSpriteGroup();
+
+    bottomBar = new EditScreenshotBox(this);
+
+    finishCam = new FunkinCamera("exportCamera");
+
+    stickerSprites = [];
+    stickerStuff = [];
+    selectedSticker = "";
+
+    var path:String = Paths.file('images/transitionSwag/stickers-set-1/stickers.json'); // will replace with actual entries at some point once poof's stickerregistry gets merged!
+    var json:StickerShit = cast haxe.Json.parse(Assets.getText(path));
+
+    for (key in Reflect.fields(json.stickers))
+    {
+      var stuff = Reflect.field(json.stickers, key);
+      stickerStuff.set(key, stuff);
+
+      for (thingy in stuff)
+      {
+        if (selectedSticker == "") selectedSticker = thingy;
+
+        var stickerSprite:FlxSprite = new FlxSprite().loadGraphic(Paths.image("transitionSwag/stickers-set-1/" + thingy));
+        stickerSprite.active = false;
+        stickerSprite.visible = false;
+        stickerSprites.set(thingy, stickerSprite);
+      }
+    }
+
+    // doing some neat stuff for placing stickers
+    var allSounds:Array<String> = Assets.list(SOUND);
+    var filterFunc = function(a:String) {
+      return a.startsWith('assets/shared/sounds/stickersounds/');
+    };
+
+    stickerSounds = allSounds.filter(filterFunc);
+
+    for (i in 0...stickerSounds.length)
+    {
+      stickerSounds[i] = stickerSounds[i].replace('assets/shared/sounds/', '');
+      stickerSounds[i] = stickerSounds[i].substring(0, stickerSounds[i].lastIndexOf('.'));
+    }
+
+    trace(stickerSounds);
+  }
+
+  override public function create()
+  {
+    super.create();
+
+    shotCopy.screenCenter();
+    invisDrawLayer.setPosition(shotCopy.x, shotCopy.y);
+
+    add(shotCopy);
+
+    add(objectLayer);
+    add(invisDrawLayer);
+
+    for (n => sticker in stickerSprites)
+    {
+      add(sticker);
+    }
+
+    add(drawSprite);
+    add(selectorSprite);
+    add(evilSelectorSprite);
+    add(bottomBar);
+
+    camera.zoom = 0.75;
+
+    shotCopy.cameras = [this.camera, finishCam];
+    objectLayer.cameras = [this.camera, finishCam];
+  }
+
+  override public function update(elapsed:Float)
+  {
+    super.update(elapsed);
+
+    if (FlxG.mouse.justPressed) FunkinSound.playOnce(Paths.sound("chartingSounds/ClickDown"));
+    if (FlxG.mouse.justReleased) FunkinSound.playOnce(Paths.sound("chartingSounds/ClickUp"));
+
+    drawSprite.visible = (curMode == DRAW && !isCursorOverHaxeUI);
+    drawSprite.x = FlxG.mouse.getWorldPosition(camera).x - drawSprite.width / 2;
+    drawSprite.y = FlxG.mouse.getWorldPosition(camera).y - drawSprite.height / 2;
+
+    stickerSprites[selectedSticker].visible = (curMode == STICKERS && !isCursorOverHaxeUI);
+    stickerSprites[selectedSticker].x = FlxG.mouse.getWorldPosition(camera).x - stickerSprites[selectedSticker].width / 2;
+    stickerSprites[selectedSticker].y = FlxG.mouse.getWorldPosition(camera).y - stickerSprites[selectedSticker].height / 2;
+
+    switch (curMode)
+    {
+      case SELECT:
+        selectLogic();
+      case DRAW:
+        drawLogic();
+      case STICKERS:
+        stickerLogic();
+      case TEXT:
+        textLogic();
+      case DELETE:
+        deleteLogic();
+    }
+
+    if (curMode != SELECT) selectorSprite.visible = false;
+    if (curMode != DELETE) evilSelectorSprite.visible = false;
+
+    if (placedText != null && curMode != TEXT) placeText();
+
+    if (FlxG.keys.pressed.CONTROL && FlxG.keys.justPressed.S && placedText == null)
+    {
+      var finishedBitmap:BitmapData = finishCam.grabScreen(true, true);
+      FileUtil.saveFile(finishedBitmap.image.encode(PNG), [FileUtil.FILE_FILTER_PNG], null, null, shotName);
+    }
+
+    if (controls.BACK && placedText == null) close();
+  }
+
+  var selectedThing:FlxSprite = null;
+  var moveOffset:Array<Float> = [];
+
+  function selectLogic()
+  {
+    Cursor.show();
+
+    if (FlxG.mouse.justReleased && moveOffset.length > 0) moveOffset = [];
+
+    var prevSelectedThing = selectedThing;
+    if (FlxG.mouse.justPressed && !isCursorOverHaxeUI) selectedThing = getObjectBelowMouse();
+
+    if (prevSelectedThing != selectedThing)
+    {
+      // update bottom bar
+      bottomBar.selectScale.pos = selectedThing?.scale.x ?? 1;
+      bottomBar.selectAngle.pos = selectedThing?.angle ?? 0;
+      bottomBar.selectFlipX.selected = selectedThing?.flipX ?? false;
+      bottomBar.selectFlipY.selected = selectedThing?.flipY ?? false;
+    }
+
+    if (selectedThing != null)
+    {
+      selectorSprite.visible = true;
+      selectorSprite.setGraphicSize(selectedThing.width, selectedThing.height);
+      selectorSprite.updateHitbox();
+      selectorSprite.setPosition(selectedThing.x, selectedThing.y);
+
+      selectedThing.scale.x = selectedThing.scale.y = bottomBar.selectScale.pos;
+      selectedThing.updateHitbox();
+      selectedThing.angle = bottomBar.selectAngle.pos;
+      selectedThing.flipX = bottomBar.selectFlipX.selected;
+      selectedThing.flipY = bottomBar.selectFlipY.selected;
+
+      if (FlxG.mouse.pressed && FlxG.mouse.overlaps(selectedThing, camera) && !isCursorOverHaxeUI)
+      {
+        if (moveOffset.length == 0)
+        {
+          moveOffset = [
+            FlxG.mouse.getWorldPosition(camera).x - selectedThing.x,
+            FlxG.mouse.getWorldPosition(camera).y - selectedThing.y
+          ];
+        }
+
+        selectedThing.x = FlxG.mouse.getWorldPosition(camera).x - moveOffset[0];
+        selectedThing.y = FlxG.mouse.getWorldPosition(camera).y - moveOffset[1];
+      }
+
+      if (FlxG.keys.justPressed.DELETE)
+      {
+        FunkinSound.playOnce(Paths.sound("chartingSounds/noteErase"));
+
+        selectedThing.kill();
+        objectLayer.remove(selectedThing, true);
+        selectedThing.destroy();
+        selectedThing = null;
+      }
+    }
+    else
+    {
+      selectorSprite.visible = false;
+    }
+  }
+
+  var drawMinX:Int = FlxMath.MAX_VALUE_INT;
+  var drawMinY:Int = FlxMath.MAX_VALUE_INT;
+  var drawMaxX:Int = 0;
+  var drawMaxY:Int = 0;
+
+  function drawLogic()
+  {
+    if (!isCursorOverHaxeUI) Cursor.hide();
+    else
+      Cursor.show();
+
+    drawSprite.radius = bottomBar.drawSize.pos;
+    drawSprite.color = cast(bottomBar.drawColor.selectedItem ?? 0xFFFFFFFF, Int);
+
+    var flooredMousePos:Array<Int> = [
+      Math.floor(drawSprite.x - invisDrawLayer.x),
+      Math.floor(drawSprite.y - invisDrawLayer.y)
+    ];
+
+    if (FlxG.mouse.pressed)
+    {
+      for (px in 0...drawSprite.pixels.width)
+      {
+        for (py in 0...drawSprite.pixels.height)
+        {
+          if (flooredMousePos[0] + px < 0) continue;
+          if (flooredMousePos[0] + px >= invisDrawLayer.width) continue;
+
+          if (flooredMousePos[1] + py < 0) continue;
+          if (flooredMousePos[1] + py >= invisDrawLayer.height) continue;
+
+          if ((drawSprite.pixels.getPixel32(px, py) : FlxColor) == FlxColor.TRANSPARENT) continue;
+          if (invisDrawLayer.pixels.getPixel32(flooredMousePos[0] + px, flooredMousePos[1] + py) == drawSprite.pixels.getPixel32(px, py)) continue;
+
+          var col:FlxColor = FlxColor.fromRGBFloat(drawSprite.color.redFloat, drawSprite.color.greenFloat, drawSprite.color.blueFloat, drawSprite.alpha);
+          var fillPixelX:Int = flooredMousePos[0] + px;
+          var fillPixelY:Int = flooredMousePos[1] + py;
+
+          invisDrawLayer.pixels.setPixel32(fillPixelX, fillPixelY, col);
+
+          // This part is used to make an object and add it to the objects list.
+          if (fillPixelX < drawMinX) drawMinX = fillPixelX;
+          if (fillPixelX > drawMaxX) drawMaxX = fillPixelX;
+          if (fillPixelY < drawMinY) drawMinY = fillPixelY;
+          if (fillPixelY > drawMaxY) drawMaxY = fillPixelY;
+        }
+      }
+    }
+
+    if (FlxG.mouse.justReleased && drawMinX != FlxMath.MAX_VALUE_INT && drawMinY != FlxMath.MAX_VALUE_INT)
+    {
+      FunkinSound.playOnce(Paths.sound("chartingSounds/noteLay"));
+
+      // Create a new object from all the drawn pixels.
+      var newObj:FlxSprite = new FlxSprite(invisDrawLayer.x + drawMinX, invisDrawLayer.y + drawMinY);
+      newObj.pixels = new BitmapData(drawMaxX - drawMinX, drawMaxY - drawMinY, true, 0x00000000);
+      newObj.active = false; // stop any updates for performance!
+
+      for (px in drawMinX...(drawMaxX + 1))
+      {
+        for (py in drawMinY...(drawMaxY + 1))
+        {
+          var col:Int = invisDrawLayer.pixels.getPixel32(px, py);
+          if (col != 0x00000000) newObj.pixels.setPixel32(px - drawMinX, py - drawMinY, col);
+        }
+      }
+
+      objectLayer.add(newObj);
+
+      // Reset the graphic of invisDrawLayer.
+      invisDrawLayer.pixels = drawLayerBitmap.clone();
+
+      drawMinX = FlxMath.MAX_VALUE_INT;
+      drawMinY = FlxMath.MAX_VALUE_INT;
+      drawMaxX = 0;
+      drawMaxY = 0;
+    }
+  }
+
+  function stickerLogic()
+  {
+    Cursor.show();
+
+    var stickerToSelect:String = bottomBar.stickerDropdown.text;
+
+    if (stickerToSelect != selectedSticker && stickerSprites.exists(stickerToSelect))
+    {
+      stickerSprites[selectedSticker].visible = false;
+      selectedSticker = stickerToSelect;
+    }
+
+    if (FlxG.mouse.justPressed && !isCursorOverHaxeUI)
+    {
+      FunkinSound.playOnce(Paths.sound(FlxG.random.getObject(stickerSounds)));
+
+      var newObj:FlxSprite = new FlxSprite(stickerSprites[selectedSticker].x, stickerSprites[selectedSticker].y);
+      newObj.loadGraphicFromSprite(stickerSprites[selectedSticker]);
+      newObj.active = false; // stop any updates for performance!
+
+      objectLayer.add(newObj);
+    }
+  }
+
+  var placedText:FlxText = null;
+
+  function textLogic()
+  {
+    Cursor.show();
+
+    if (placedText == null)
+    {
+      if (FlxG.mouse.justPressed && !isCursorOverHaxeUI)
+      {
+        placedText = new FlxText(FlxG.mouse.getWorldPosition(camera).x, FlxG.mouse.getWorldPosition(camera).y, 0, "", 16);
+        add(placedText);
+
+        FlxG.stage.addEventListener(KeyboardEvent.KEY_DOWN, updateText);
+      }
+    }
+    else
+    {
+      placedText.size = Std.int(bottomBar.textSize.pos);
+      placedText.font = bottomBar.allFonts[bottomBar.textFont.selectedIndex] ?? "Arial";
+      placedText.color = cast(bottomBar.textColor.selectedItem ?? 0xFFFFFFFF, Int);
+      placedText.bold = bottomBar.textBold.selected;
+      placedText.italic = bottomBar.textItalic.selected;
+      placedText.underline = bottomBar.textUnderline.selected;
+
+      if (FlxG.mouse.justPressed && !isCursorOverHaxeUI && !FlxG.mouse.overlaps(placedText, camera)) placeText();
+    }
+  }
+
+  function deleteLogic() // what if selectlogic was evil
+  {
+    Cursor.show();
+
+    var objToDelete:FlxSprite = getObjectBelowMouse();
+
+    if (objToDelete != null)
+    {
+      evilSelectorSprite.visible = true;
+      evilSelectorSprite.setGraphicSize(objToDelete.width, objToDelete.height);
+      evilSelectorSprite.updateHitbox();
+      evilSelectorSprite.setPosition(objToDelete.x, objToDelete.y);
+
+      if (FlxG.mouse.justPressed)
+      {
+        FunkinSound.playOnce(Paths.sound("chartingSounds/noteErase"));
+
+        objToDelete.kill();
+        objectLayer.remove(objToDelete, true);
+        objToDelete.destroy();
+        objToDelete = null;
+      }
+    }
+    else
+    {
+      evilSelectorSprite.visible = false;
+    }
+  }
+
+  function getObjectBelowMouse()
+  {
+    // return the latest added object below mouse
+    var objArray = objectLayer.members.copy();
+    objArray.reverse();
+
+    for (obj in objArray)
+    {
+      if (FlxG.mouse.overlaps(obj, camera) && !isCursorOverHaxeUI) return obj;
+    }
+
+    return null;
+  }
+
+  function placeText()
+  {
+    FlxG.stage.removeEventListener(KeyboardEvent.KEY_DOWN, updateText);
+
+    if (placedText.text.length > 0)
+    {
+      FunkinSound.playOnce(Paths.sound("chartingSounds/noteLay"));
+
+      var newObj:FlxSprite = new FlxSprite(placedText.x, placedText.y).loadGraphic(placedText.pixels.clone());
+      newObj.active = false;
+      objectLayer.add(newObj);
+    }
+
+    placedText.kill();
+    remove(placedText, true);
+    placedText.destroy();
+    placedText = null;
+  }
+
+  var isTabDown:Bool = false;
+
+  function updateText(event:KeyboardEvent) // mostly nabbed from FlxInputText! except this has mutliline!
+  {
+    var daCode:FlxKey = event.keyCode;
+
+    if (placedText == null) return;
+
+    switch (daCode)
+    {
+      case SHIFT | CONTROL | BACKSLASH | ESCAPE | LEFT | RIGHT | END | HOME | DELETE | UP | DOWN: // todo: add caret shit
+        return;
+
+      case TAB:
+        isTabDown = !isTabDown;
+
+      case BACKSPACE:
+        if (placedText.text.length > 0) placedText.text = placedText.text.substring(0, placedText.text.length - 1);
+
+        FunkinSound.playOnce(Paths.sound("chartingSounds/hitNotePlayer"));
+
+      case ENTER:
+        placedText.text += "\n";
+
+      case V if (event.ctrlKey):
+        // Reapply focus  when tabbing back into the window and selecting the field
+        #if (js && html5)
+        FlxG.stage.window.textInputEnabled = true;
+        #else
+        placedText.text += lime.system.Clipboard.text ?? "";
+        #end
+      default:
+        if (event.charCode == 0) return; // non-printable characters crash String.fromCharCode
+
+        var daString:String = String.fromCharCode(event.charCode);
+        if (event.shiftKey && !isTabDown) daString = daString.toUpperCase();
+        else if (!event.shiftKey && isTabDown) daString = daString.toUpperCase();
+
+        placedText.text += daString;
+
+        FunkinSound.playOnce(Paths.sound("chartingSounds/hitNotePlayer"));
+    }
+  }
+
+  function get_isCursorOverHaxeUI():Bool
+  {
+    return haxe.ui.core.Screen.instance.hasComponentUnderPoint(FlxG.mouse.viewX, FlxG.mouse.viewY);
+  }
+}
+
+enum abstract ScreenshotEditMode(String) from String to String
+{
+  var SELECT = "select";
+  var DRAW = "draw";
+  var STICKERS = "stickers";
+  var TEXT = "text";
+  var DELETE = "delete";
+}

--- a/source/funkin/ui/gallery/ScreenshotGalleryState.hx
+++ b/source/funkin/ui/gallery/ScreenshotGalleryState.hx
@@ -1,0 +1,166 @@
+package funkin.ui.gallery;
+
+import funkin.input.Cursor;
+import funkin.graphics.FunkinCamera;
+import funkin.util.plugins.ScreenshotPlugin;
+import flixel.FlxCamera;
+import flixel.FlxG;
+import flixel.FlxObject;
+import flixel.FlxSprite;
+import openfl.display.BitmapData;
+
+class ScreenshotGalleryState extends MusicBeatState
+{
+  inline static final ROWS:Int = 3;
+  inline static final BORDER_SIZE:Int = 5;
+
+  var allScreenshots:Array<FlxSprite> = [];
+  var screenshotNames:Array<String> = [];
+  var camFollow:FlxObject;
+  var shotOutline:FlxSprite;
+
+  var camSUB:FlxCamera;
+  var camHUD:FlxCamera;
+
+  override public function create()
+  {
+    super.create();
+
+    FlxG.cameras.reset(new FunkinCamera('gallery'));
+
+    camSUB = new FlxCamera();
+    camSUB.bgColor.alpha = 0;
+    camHUD = new FlxCamera();
+    camHUD.bgColor.alpha = 0;
+
+    FlxG.cameras.add(camSUB, false);
+    FlxG.cameras.add(camHUD, false);
+
+    camFollow = new FlxObject(0, 0, 1, 1);
+    camFollow.screenCenter(X);
+    add(camFollow);
+
+    FlxG.camera.follow(camFollow, null, 0.06);
+
+    Cursor.show();
+
+    persistentUpdate = false;
+    persistentDraw = true;
+
+    var menuBG = new FlxSprite().loadGraphic(Paths.image('menuDesat'));
+    menuBG.color = 0xFF874CAF;
+    menuBG.setGraphicSize(Std.int(menuBG.width * 1.1));
+    menuBG.updateHitbox();
+    menuBG.screenCenter();
+    menuBG.scrollFactor.set(0, 0);
+    add(menuBG);
+
+    shotOutline = new FlxSprite().makeGraphic(1, 1);
+    shotOutline.visible = false;
+    add(shotOutline);
+
+    reloadScreenshots();
+  }
+
+  var minCamY:Float = FlxG.height / 2;
+  var maxCamY:Float = FlxG.height / 2;
+
+  override public function update(elapsed:Float)
+  {
+    super.update(elapsed);
+
+    if (FlxG.mouse.wheel != 0) camFollow.y -= FlxG.mouse.wheel * 25;
+
+    if (camFollow.y > maxCamY) camFollow.y = maxCamY;
+    else if (camFollow.y < minCamY) camFollow.y = minCamY;
+
+    shotOutline.visible = false;
+    for (shot in allScreenshots)
+    {
+      if (FlxG.mouse.overlaps(shot))
+      {
+        shotOutline.visible = true;
+        shotOutline.x = shot.x - BORDER_SIZE;
+        shotOutline.y = shot.y - BORDER_SIZE;
+
+        if (FlxG.mouse.justPressed)
+        {
+          var sub = new EditScreenshotSubState(shot, screenshotNames[allScreenshots.indexOf(shot)]);
+          sub.cameras = [camSUB];
+          openSubState(sub);
+        }
+      }
+    }
+
+    #if FEATURE_SCREENSHOTS
+    if (controls.WINDOW_SCREENSHOT) reloadScreenshots();
+    #end
+
+    if (controls.BACK)
+    {
+      FlxG.switchState(() -> new funkin.ui.debug.DebugMenuSubState());
+    }
+  }
+
+  override public function onFocus()
+  {
+    super.onFocus();
+    reloadScreenshots();
+  }
+
+  function reloadScreenshots() // this should also activate when a screenshot is taken/deleted!
+  {
+    minCamY = FlxG.height / 2;
+    maxCamY = FlxG.height / 2;
+
+    while (allScreenshots.length > 0)
+    {
+      var daSS:FlxSprite = allScreenshots.pop();
+
+      daSS.kill();
+      remove(daSS, true);
+      daSS.destroy();
+    }
+
+    #if sys
+    var allFiles:Array<String> = sys.FileSystem.readDirectory(ScreenshotPlugin.SCREENSHOT_FOLDER);
+    allFiles.reverse();
+
+    var shotWidth:Float = FlxG.width / (ROWS + 1);
+    var shotHeight:Float = FlxG.height / (ROWS + 1);
+    var shotSpacing:Float = (FlxG.width - ROWS * shotWidth) / (ROWS + 1);
+
+    for (i in 0...allFiles.length)
+    {
+      var path:String = allFiles[i];
+      if (haxe.io.Path.extension(path) != "png") continue;
+
+      var shot:FlxSprite = new FlxSprite().loadGraphic(BitmapData.fromFile(ScreenshotPlugin.SCREENSHOT_FOLDER + "/" + path));
+      shot.setGraphicSize(Std.int(shotWidth), Std.int(shotHeight));
+      shot.updateHitbox();
+
+      // positioning da screenshots
+      var column:Int = Math.floor(i / ROWS);
+      var row:Int = i % ROWS;
+
+      shot.x = row * (shotWidth + shotSpacing) + shotSpacing;
+      shot.y = column * (shotHeight + shotSpacing / 2) + shotSpacing / 2;
+
+      add(shot);
+      allScreenshots.push(shot);
+      screenshotNames.push(haxe.io.Path.withoutExtension(path));
+
+      // update the maxcamy
+      if (shot.y + shot.height > FlxG.height)
+      {
+        maxCamY = shot.y + shot.height + shotSpacing / 2 - FlxG.height / 2;
+      }
+    }
+
+    shotOutline.setGraphicSize(allScreenshots.length > 0 ? Std.int(shotWidth + BORDER_SIZE * 2) : 1,
+      allScreenshots.length > 0 ? Std.int(shotHeight + BORDER_SIZE * 2) : 1);
+
+    shotOutline.updateHitbox();
+    #end
+  }
+}


### PR DESCRIPTION
## Description
idk it was kind of neat
sort of similar to how the nintendo switch handles screenshots
as for edit it contains ability to make texts, place stickers and draw over a screenshot
right now it's in the debug menu but i imagine it would be in the main menu at some point along with a much better UI lol
~~also this would go nicely with abnormalpoof's stickerregistry methinks~~
also unlike my other editors i havent modified any other file so should be easy to review

## Footage

https://github.com/user-attachments/assets/24f69341-eafa-419b-9bb7-e92c510f1365

