### PR TITLE
[ENHANCEMENT + BUGFIX] Soft coding and improvement for visualizers

### DIFF
--- a/source/funkin/audio/visualize/ABotVis.hx
+++ b/source/funkin/audio/visualize/ABotVis.hx
@@ -6,6 +6,7 @@ import flixel.graphics.frames.FlxAtlasFrames;
 import flixel.group.FlxSpriteGroup.FlxTypedSpriteGroup;
 import flixel.sound.FlxSound;
 import funkin.vis.dsp.SpectralAnalyzer;
+import funkin.audio.visualize.dsp.FlxSoundAnalyzer;
 
 using Lambda;
 
@@ -13,23 +14,19 @@ using Lambda;
 class ABotVis extends FlxTypedSpriteGroup<FlxSprite>
 {
   // public var vis:VisShit;
-  var analyzer:Null<SpectralAnalyzer> = null;
+  var analyzer:Null<FlxSoundAnalyzer> = null;
 
   var volumes:Array<Float> = [];
 
-  public var snd:Null<FlxSound> = null;
-
-  static final BAR_COUNT:Int = 7;
-
-  // TODO: Make the sprites easier to soft code.
-  public function new(snd:FlxSound, pixel:Bool)
+  public function new(pixel:Bool)
   {
     super();
 
-    this.snd = snd;
-
     var visCount = pixel ? (BAR_COUNT + 1) : (BAR_COUNT + 1);
     var visScale = pixel ? 6 : 1;
+
+    // vis = new VisShit(snd);
+    // vis.snd = snd;
 
     var visFrms:FlxAtlasFrames = Paths.getSparrowAtlas(pixel ? 'characters/abotPixel/aBotVizPixel' : 'characters/abot/aBotViz');
 
@@ -59,18 +56,15 @@ class ABotVis extends FlxTypedSpriteGroup<FlxSprite>
     }
   }
 
-  public function initAnalyzer():Void
+  public function initAnalyzer(snd:FlxSound)
   {
-    if (snd == null) return;
-
+    if (analyzer != null)
+    {
+      analyzer.snd = snd;
+      return;
+    }
     @:privateAccess
-    analyzer = new SpectralAnalyzer(snd._channel.__audioSource, BAR_COUNT, 0.1, 40);
-    // A-Bot tuning...
-    analyzer.minDb = -65;
-    analyzer.maxDb = -25;
-    analyzer.maxFreq = 22000;
-    // we use a very low minFreq since some songs use low low subbass like a boss
-    analyzer.minFreq = 10;
+    analyzer = new FlxSoundAnalyzer(snd, 7, 0.1, 40);
 
     #if desktop
     // On desktop it uses FFT stuff that isn't as optimized as the direct browser stuff we use on HTML5

--- a/source/funkin/audio/visualize/audioclip/frontends/FlxAudioClip.hx
+++ b/source/funkin/audio/visualize/audioclip/frontends/FlxAudioClip.hx
@@ -1,0 +1,50 @@
+package funkin.audio.visualize.audioclip.frontends;
+
+import flixel.FlxG;
+import flixel.math.FlxMath;
+import flixel.sound.FlxSound;
+import funkin.vis.AudioBuffer;
+import lime.media.AudioSource;
+
+/**
+ * Implementation of AudioClip for flixel.
+ *
+ */
+class FlxAudioClip implements funkin.vis.AudioClip
+{
+  public var audioBuffer(default, null):AudioBuffer;
+  public var currentFrame(get, never):Int;
+  public var source:Dynamic;
+  public var snd:FlxSound;
+
+  public function new(snd:FlxSound)
+  {
+    this.snd = snd;
+    @:privateAccess
+    var audioSource = snd._channel.__audioSource;
+
+    var data:lime.utils.UInt16Array = cast audioSource.buffer.data;
+
+    #if web
+    var sampleRate:Float = audioSource.buffer.src._sounds[0]._node.context.sampleRate;
+    #else
+    var sampleRate = audioSource.buffer.sampleRate;
+    #end
+
+    this.audioBuffer = new AudioBuffer(data, sampleRate);
+    this.source = audioSource.buffer.src;
+  }
+
+  private function get_currentFrame():Int
+  {
+    var dataLength:Int = 0;
+
+    #if web
+    dataLength = source.length;
+    #else
+    dataLength = audioBuffer.data.length;
+    #end
+
+    return Std.int(FlxMath.remapToRange(snd.time, 0, snd.length, 0, dataLength));
+  }
+}

--- a/source/funkin/audio/visualize/dsp/FlxSoundAnalyzer.hx
+++ b/source/funkin/audio/visualize/dsp/FlxSoundAnalyzer.hx
@@ -1,0 +1,90 @@
+package funkin.audio.visualize.dsp;
+
+import funkin.audio.FunkinSound;
+import funkin.vis._internal.html5.AnalyzerNode;
+import funkin.audio.visualize.audioclip.frontends.FlxAudioClip;
+import funkin.vis.dsp.SpectralAnalyzer;
+import flixel.sound.FlxSound;
+
+class FlxSoundAnalyzer extends SpectralAnalyzer
+{
+  public var snd(default, set):FlxSound;
+
+  public function new(snd:FlxSound, barCount:Int, maxDelta:Float = 0.01, peakHold:Int = 30)
+  {
+    // reloadChannel(snd);
+    var isPlaying = snd.playing;
+    var daTime = snd.time;
+    snd.play(false);
+
+    // If only I could get rid of the super
+    @:privateAccess
+    super(snd._channel.__audioSource, barCount, maxDelta, peakHold);
+    if (!isPlaying)
+    {
+      snd.pause();
+      snd.time = daTime;
+    }
+
+    this.snd = snd;
+
+    #if desktop
+    // On desktop it uses FFT stuff that isn't as optimized as the direct browser stuff we use on HTML5
+    // So we want to manually change it!
+    fftN = 256;
+    #end
+  }
+
+  override public function getLevels(?levels:Array<Bar>):Array<Bar>
+  {
+    if (levels == null) levels = new Array<Bar>();
+    @:privateAccess
+    if (snd?.time == 0 && snd?._channel == null)
+    {
+      levels.resize(barCount);
+      for (i in 0...barCount)
+      {
+        var value = 0;
+        var recentPeak = 1;
+
+        if (levels[i] != null)
+        {
+          levels[i].value = value;
+          levels[i].peak = recentPeak;
+        }
+        else
+          levels[i] = {value: value, peak: recentPeak};
+      }
+      return levels;
+    }
+    super.getLevels(levels);
+    return levels;
+  }
+
+  function set_snd(sndValue:FlxSound):FlxSound
+  {
+    this.snd = sndValue;
+    var isPlaying = sndValue.playing;
+    var daTime = sndValue.time;
+
+    sndValue.play(false);
+
+    @:privateAccess
+    this.audioSource = sndValue._channel.__audioSource;
+    @:privateAccess
+    this.audioClip = new FlxAudioClip(sndValue);
+    #if web
+    htmlAnalyzer = new AnalyzerNode(this.audioClip);
+    #end
+
+    calcBars(barCount, peakHold);
+    resizeBlackmanWindow(fftN);
+    if (!isPlaying)
+    {
+      sndValue.pause();
+      sndValue.time = daTime;
+    }
+
+    return sndValue;
+  }
+}


### PR DESCRIPTION
<!-- Please check for duplicates or similar PRs before submitting this PR. -->
This is a retake of [#2994](https://github.com/FunkinCrew/Funkin/pull/2994)
This make visualize soft modable so nene.hxc now use it (making ABotVis.hx useless)

It also allows the visualizers to track different sounds than FlxG.sound.music, and support for cutscenes musics in Darnell and the Pico mixes of week 3.

It also fixes:
- [A-Bot is unaffected by shaders #3764](https://github.com/FunkinCrew/Funkin/issues/3764)
- The visualizer sometimes render bars when there is no sound (in countdowns, cutscenes but notably at the end of songs in freeplay)
- Abot still being bright in Blazin