### PR TITLE
FreeplayScore seventh/million number not being cleared fix

### DIFF
--- a/source/funkin/ui/freeplay/FreeplayScore.hx
+++ b/source/funkin/ui/freeplay/FreeplayScore.hx
@@ -33,7 +33,7 @@ class FreeplayScore extends FlxTypedSpriteGroup<ScoreNum>
       loopNum--;
     }
 
-    while (loopNum > 0)
+    while (loopNum >= 0)
     {
       group.members[loopNum].digit = 0;
       loopNum--;


### PR DESCRIPTION
<!-- Please check for duplicates or similar PRs before submitting this PR. -->
## Does this PR close any issues? If so, link them below.
Fixes #2318 
## Briefly describe the issue(s) fixed.
The last digit of the FreeplayScore doesn't get cleared before it sets a new number.
## Include any relevant screenshots or videos.
https://github.com/user-attachments/assets/bd2cd058-8754-47cb-a888-264ed1ba06da

I uhhhhh think I understand how the code for the FreeplayScore now? I spent way too much time staring at the code trying to figure out how it works (and where I could set the intendedscore to 1M to test the fix), like a few hours. Ah well, I fixed it in the end, didn't I?

Ok, let's try that again, this time without accidentally starting the new branch from another fix.