### PR TITLE
[DOCS] Added missing debug hotkeys

### DIFF
--- a/docs/Funkin' Debug Hotkeys.md
+++ b/docs/Funkin' Debug Hotkeys.md
@@ -29,9 +29,9 @@ Most of this functionality is only available on debug builds of the game!
 ## **Main Menu**
 - `~`: ***DEBUG***: Opens a menu to access the Chart Editor and other work-in-progress editors. Rebindable in the options menu.
 - `CTRL-ALT-SHIFT-W`: ***ALL ACCESS***: Unlocks all songs in Freeplay. Only available on debug builds.
-- `CTRL-ALT-SHIFT-M`: ***NO MORE ACCESS***: Locks back songs in Freeplay (those unloked by default aren't locked. Only available on debug builds.
+- `CTRL-ALT-SHIFT-M`: ***NO MORE ACCESS***: Re-locks all songs in Freeplay except those unlocked by default. Only available on debug builds.
 - `CTRL-ALT-SHIFT-R`: ***GREAT SCORE?***: Give the user a hypothetical overridden score, and see if we can maintain that golden P rank. Only available on debug builds.
-- `Ctrl-Alt-Shift-P`: ***Character Unlock screen***: Froce the character select screen to play Pico being unlocked. Only available on debug builds.
-- `Ctrl-Alt-Shift-N`: ***Character Not seen***: Mark all characters as not seen and make BF glow again as there is a character to unlock. Only available on debug builds.
-- `Ctrl-Alt-Shift-E`: ***Dump save data***: Self explainatory. Only available on debug builds.
-- `Ctrl-Alt-Shift-L`: ***Force crash***: Force crash and create a log dump. Only available on debug builds.
+- `CTRL-ALT-SHIFT-P`: ***CHARACTER UNLOCK SCREEN***: Forces the Character Select screen to play Pico's unlocking animation. Only available on debug builds.
+- `CTRL-ALT-SHIFT-N`: ***CHARACTER NOT SEEN***: Marks all characters as not seen and enables BF's new character unlocked animation in Freeplay. Only available on debug builds.
+- `CTRL-ALT-SHIFT-E`: ***DUMP SAVE DATA***: Export a JSON file of your current save data. Only available on debug builds.
+- `CTRL-ALT-SHIFT-L`: ***FORCE CRASH***: Immediately crash the game with a detailed crash log and a stack trace. Only available on debug builds.

--- a/docs/Funkin' Debug Hotkeys.md
+++ b/docs/Funkin' Debug Hotkeys.md
@@ -29,3 +29,9 @@ Most of this functionality is only available on debug builds of the game!
 ## **Main Menu**
 - `~`: ***DEBUG***: Opens a menu to access the Chart Editor and other work-in-progress editors. Rebindable in the options menu.
 - `CTRL-ALT-SHIFT-W`: ***ALL ACCESS***: Unlocks all songs in Freeplay. Only available on debug builds.
+- `CTRL-ALT-SHIFT-M`: ***NO MORE ACCESS***: Locks back songs in Freeplay (those unloked by default aren't locked. Only available on debug builds.
+- `CTRL-ALT-SHIFT-R`: ***GREAT SCORE?***: Give the user a hypothetical overridden score, and see if we can maintain that golden P rank. Only available on debug builds.
+- `Ctrl-Alt-Shift-P`: ***Character Unlock screen***: Froce the character select screen to play Pico being unlocked. Only available on debug builds.
+- `Ctrl-Alt-Shift-N`: ***Character Not seen***: Mark all characters as not seen and make BF glow again as there is a character to unlock. Only available on debug builds.
+- `Ctrl-Alt-Shift-E`: ***Dump save data***: Self explainatory. Only available on debug builds.
+- `Ctrl-Alt-Shift-L`: ***Force crash***: Force crash and create a log dump. Only available on debug builds.

--- a/docs/Funkin' Debug Hotkeys.md
+++ b/docs/Funkin' Debug Hotkeys.md
@@ -7,6 +7,8 @@ Most of this functionality is only available on debug builds of the game!
 - `F3`: ***SCREENSHOT***: Takes a screenshot of the game and saves it to the local `screenshots` directory. Works outside of debug builds too!
 - `F4`: ***EJECT***: Forcibly switch state to the Main Menu (with no extra transition). Useful if you're stuck in a level and you need to get out!
 - `F5`: ***HOT RELOAD***: Forcibly reload the game's scripts and data files, then restart the current state. If any files in the `assets` folder have been modified, the game should process the changes for you! NOTE: Known bug, this does not reset song charts or song scripts, but it should reset everything else (such as stage layout data and character animation data).
+- `CTRL-ALT-SHIFT-L`: ***FORCE CRASH***: Immediately crash the game with a detailed crash log and a stack trace. (Only works in the Main Menu on debug builds).
+
 - `CTRL-SHIFT-L`: ***FORCE CRASH***: Immediately crash the game with a detailed crash log and a stack trace.
 
 ## **Play State**
@@ -33,5 +35,4 @@ Most of this functionality is only available on debug builds of the game!
 - `CTRL-ALT-SHIFT-R`: ***GREAT SCORE?***: Give the user a hypothetical overridden score, and see if we can maintain that golden P rank. Only available on debug builds.
 - `CTRL-ALT-SHIFT-P`: ***CHARACTER UNLOCK SCREEN***: Forces the Character Select screen to play Pico's unlocking animation. Only available on debug builds.
 - `CTRL-ALT-SHIFT-N`: ***CHARACTER NOT SEEN***: Marks all characters as not seen and enables BF's new character unlocked animation in Freeplay. Only available on debug builds.
-- `CTRL-ALT-SHIFT-E`: ***DUMP SAVE DATA***: Export a JSON file of your current save data. Only available on debug builds.
-- `CTRL-ALT-SHIFT-L`: ***FORCE CRASH***: Immediately crash the game with a detailed crash log and a stack trace. Only available on debug builds.
+- `CTRL-ALT-SHIFT-E`: ***DUMP SAVE DATA***: Prompts the user to save their save data as a JSON file, so its contents can be viewed. Only available on debug builds.


### PR DESCRIPTION
After checking the docs and `MainMenuState.hx`, I noticed only one of the 7 hotkeys is listed, so there is the list updated
