### PR TITLE
Blacklist `openfl.net.SharedObject` from scripts

### DIFF
--- a/source/funkin/modding/PolymodHandler.hx
+++ b/source/funkin/modding/PolymodHandler.hx
@@ -290,6 +290,7 @@ class PolymodHandler
     Polymod.blacklistImport('openfl.utils.Assets');
     Polymod.blacklistImport('openfl.Lib');
     Polymod.blacklistImport('openfl.system.ApplicationDomain');
+    Polymod.blacklistImport('openfl.net.SharedObject');
 
     // `openfl.desktop.NativeProcess`
     // Can load native processes on the host operating system.


### PR DESCRIPTION
`openfl.net.SharedObject` just has a [`resolveClass` function](https://github.com/openfl/openfl/blob/9f0b2d66712b58c5cd28523c3e05ce8026ea9642/src/openfl/net/SharedObject.hx#L962C1-L995C3) lying around for some reason. This PR blacklists the class so scripts can't use it.