### PR TITLE
FreeplayState loading all songs after exiting Erect/Nightmare songs fix

### DIFF
--- a/source/funkin/ui/freeplay/FreeplayState.hx
+++ b/source/funkin/ui/freeplay/FreeplayState.hx
@@ -700,7 +700,7 @@ class FreeplayState extends MusicBeatSubState
       // Gets all available difficulties for our character, via our available variations
       var difficultiesAvailable:Array<String> = song.data.listDifficulties(null, characterVariations);
 
-      return difficultiesAvailable.contains(currentDifficulty);
+      return difficultiesAvailable.contains(rememberedDifficulty);
     });
 
     if (onlyIfChanged)
@@ -1147,6 +1147,9 @@ class FreeplayState extends MusicBeatSubState
 
     // Get this character's transition delay, with a reasonable default.
     var transitionDelay:Float = currentCharacter.getFreeplayDJData()?.getCharSelectTransitionDelay() ?? 0.25;
+
+    // Some characters don't have higher difficulties for their songs
+    rememberedDifficulty = Constants.DEFAULT_DIFFICULTY;
 
     new FlxTimer().start(transitionDelay, _ -> {
       transitionToCharSelect();


### PR DESCRIPTION
<!-- Please check for duplicates or similar PRs before submitting this PR. -->
## Does this PR close any issues? If so, link them below.
Fixes #3514 
## Briefly describe the issue(s) fixed.
It's this https://github.com/FunkinCrew/Funkin/pull/3711 fix without the weird changelog commit. I don't want the credit for doing this (unless this fix wouldn't of happened at all otherwise, though if so make sure to credit @KoloInDaCrib too).
## Include any relevant screenshots or videos.
See the original pull request above.