### PR TITLE
chore: Fix an inconsistency in one of the comments for `Stage.hx`

### DIFF
--- a/source/funkin/play/stage/Stage.hx
+++ b/source/funkin/play/stage/Stage.hx
@@ -31,7 +31,7 @@ typedef StagePropGroup = FlxTypedSpriteGroup<StageProp>;
 /**
  * A Stage is a group of objects rendered in the PlayState.
  *
- * A Stage is comprised of one or more props, each of which is a FlxSprite.
+ * A Stage is comprised of one or more props, each of which is an FlxSprite.
  */
 class Stage extends FlxSpriteGroup implements IPlayStateScriptedClass implements IRegistryEntry<StageData>
 {


### PR DESCRIPTION
When referring to `FlxSprite`s in the comments, it's usually written as "an FlxSprite". 

However, `Stage.hx` is the ONLY file to refer to `FlxSprite`s as "a FlxSprite".
Literally fucking unplayable.
This PR fixes this grave mistake, making the game playable again. :)

(This PR also serves as a test to see if label actions are working properly again!)