### PR TITLE
[ENHANCEMENT + BUGFIX] IntervalShake absolute coords

### DIFF
--- a/source/funkin/effects/IntervalShake.hx
+++ b/source/funkin/effects/IntervalShake.hx
@@ -5,7 +5,6 @@ import flixel.util.FlxDestroyUtil.IFlxDestroyable;
 import flixel.util.FlxPool;
 import flixel.util.FlxTimer;
 import flixel.math.FlxPoint;
-import flixel.util.FlxAxes;
 import flixel.tweens.FlxEase.EaseFunction;
 import flixel.math.FlxMath;
 
@@ -30,13 +29,14 @@ class IntervalShake implements IFlxDestroyable
    * @param   Interval             In what interval to update the shake position. Set to `FlxG.elapsed` if `<= 0`!
    * @param   StartIntensity       The starting intensity of the shake.
    * @param   EndIntensity         The ending intensity of the shake.
+   * @param   Scale                The scale of the shake on the x and y axes. Defaults to (1, 1).
    * @param   Ease                 Control the easing of the intensity over the shake.
    * @param   CompletionCallback   Callback on shake completion
    * @param   ProgressCallback     Callback on each shake interval
    * @return The `IntervalShake` object. `IntervalShake`s are pooled internally, so beware of storing references.
    */
   public static function shake(Object:FlxObject, Duration:Float = 1, Interval:Float = 0.04, StartIntensity:Float = 0, EndIntensity:Float = 0,
-      Ease:EaseFunction, ?CompletionCallback:IntervalShake->Void, ?ProgressCallback:IntervalShake->Void):IntervalShake
+      ?Scale:FlxPoint, Ease:EaseFunction, ?CompletionCallback:IntervalShake->Void, ?ProgressCallback:IntervalShake->Void):IntervalShake
   {
     if (isShaking(Object))
     {
@@ -57,7 +57,7 @@ class IntervalShake implements IFlxDestroyable
     }
 
     var shake:IntervalShake = _pool.get();
-    shake.start(Object, Duration, Interval, StartIntensity, EndIntensity, Ease, CompletionCallback, ProgressCallback);
+    shake.start(Object, Duration, Interval, StartIntensity, EndIntensity, Scale, Ease, CompletionCallback, ProgressCallback);
     return _boundObjects[Object] = shake;
   }
 
@@ -116,9 +116,9 @@ class IntervalShake implements IFlxDestroyable
   public var interval(default, null):Float;
 
   /**
-   * Defines on what axes to `shake()`. Default value is `XY` / both.
+   * The scale of the shake on the x and y axes. Defaults to (1, 1).
    */
-  public var axes(default, null):FlxAxes;
+  public var scale(default, null):FlxPoint;
 
   /**
    * Defines the initial position of the object at the beginning of the shake effect.
@@ -155,8 +155,8 @@ class IntervalShake implements IFlxDestroyable
   /**
    * Starts shaking behavior.
    */
-  function start(Object:FlxObject, Duration:Float = 1, Interval:Float = 0.04, StartIntensity:Float = 0, EndIntensity:Float = 0, Ease:EaseFunction,
-      ?CompletionCallback:IntervalShake->Void, ?ProgressCallback:IntervalShake->Void):Void
+  function start(Object:FlxObject, Duration:Float = 1, Interval:Float = 0.04, StartIntensity:Float = 0, EndIntensity:Float = 0, ?Scale:FlxPoint,
+      Ease:EaseFunction, ?CompletionCallback:IntervalShake->Void, ?ProgressCallback:IntervalShake->Void):Void
   {
     object = Object;
     duration = Duration;
@@ -165,8 +165,8 @@ class IntervalShake implements IFlxDestroyable
     startIntensity = StartIntensity;
     endIntensity = EndIntensity;
     initialOffset = new FlxPoint(Object.x, Object.y);
+    scale = Scale ?? new FlxPoint(1, 1);
     ease = Ease;
-    axes = FlxAxes.XY;
     _secondsSinceStart = 0;
     timer = new FlxTimer().start(interval, shakeProgress, Std.int(duration / interval));
   }
@@ -177,7 +177,6 @@ class IntervalShake implements IFlxDestroyable
   public function stop():Void
   {
     timer.cancel();
-    // object.visible = true;
     object.x = initialOffset.x;
     object.y = initialOffset.y;
     release();
@@ -194,7 +193,7 @@ class IntervalShake implements IFlxDestroyable
 
   public var _secondsSinceStart(default, null):Float = 0;
 
-  public var scale(default, null):Float = 0;
+  public var easeScale(default, null):Float = 0;
 
   /**
    * Just a helper function for shake() to update object's position.
@@ -202,20 +201,17 @@ class IntervalShake implements IFlxDestroyable
   function shakeProgress(timer:FlxTimer):Void
   {
     _secondsSinceStart += interval;
-    scale = _secondsSinceStart / duration;
+    easeScale = _secondsSinceStart / duration;
     if (ease != null)
     {
-      scale = 1 - ease(scale);
-      // trace(scale);
+      easeScale = 1 - ease(easeScale);
+      // trace(easeScale);
     }
 
-    var curIntensity:Float = 0;
-    curIntensity = FlxMath.lerp(endIntensity, startIntensity, scale);
-
-    if (axes.x) object.x = initialOffset.x + FlxG.random.float((-curIntensity) * object.width, (curIntensity) * object.width);
-    if (axes.y) object.y = initialOffset.y + FlxG.random.float((-curIntensity) * object.width, (curIntensity) * object.width);
-
-    // object.visible = !object.visible;
+    var curIntensity:FlxPoint = FlxPoint.weak(scale.x, scale.y).scale(FlxMath.lerp(endIntensity, startIntensity, easeScale));
+    object.x = initialOffset.x + FlxG.random.float(-curIntensity.x, curIntensity.x);
+    object.y = initialOffset.y + FlxG.random.float(-curIntensity.y, curIntensity.y);
+    curIntensity.putWeak();
 
     if (progressCallback != null) progressCallback(this);
 

--- a/source/funkin/ui/freeplay/FreeplayState.hx
+++ b/source/funkin/ui/freeplay/FreeplayState.hx
@@ -959,7 +959,7 @@ class FreeplayState extends MusicBeatSubState
       capsuleToRank.capsule.angle = -3;
       FlxTween.tween(capsuleToRank.capsule, {angle: 0}, 0.5, {ease: FlxEase.backOut});
 
-      IntervalShake.shake(capsuleToRank.capsule, 0.3, 1 / 30, 0.1, 0, FlxEase.quadOut);
+      IntervalShake.shake(capsuleToRank.capsule, 0.3, 1 / 30, 0.1, 0, new FlxPoint(capsuleToRank.capsule.width, capsuleToRank.capsule.height), FlxEase.quadOut);
     });
 
     new FlxTimer().start(0.4, _ -> {
@@ -1034,7 +1034,7 @@ class FreeplayState extends MusicBeatSubState
 
             capsule.doLerp = false;
             capsule.setPosition(originalPos.x, originalPos.y);
-            IntervalShake.shake(capsule, 0.6, 1 / 24, 0.12, 0, FlxEase.quadOut, function(_) {
+            IntervalShake.shake(capsule, 0.6, 1 / 24, 0.12, 0, new FlxPoint(capsule.width, capsule.height), FlxEase.quadOut, function(_) {
               capsule.doLerp = true;
               capsule.cameras = [funnyCam];
 
@@ -1062,7 +1062,7 @@ class FreeplayState extends MusicBeatSubState
               capsule.capsule.angle = FlxG.random.float(-10 + (distFromSelected * 2), 10 - (distFromSelected * 2));
               FlxTween.tween(capsule.capsule, {angle: 0}, 0.5, {ease: FlxEase.backOut});
 
-              IntervalShake.shake(capsule, 0.6, 1 / 24, 0.12 / (distFromSelected + 1), 0, FlxEase.quadOut, function(_) {
+              IntervalShake.shake(capsule, 0.6, 1 / 24, 0.12 / (distFromSelected + 1), 0, new FlxPoint(capsule.width, capsule.height), FlxEase.quadOut, function(_) {
                 capsule.doLerp = true;
               });
             });
@@ -1077,7 +1077,7 @@ class FreeplayState extends MusicBeatSubState
               capsule.capsule.angle = FlxG.random.float(-10 + (distFromSelected * 2), 10 - (distFromSelected * 2));
               FlxTween.tween(capsule.capsule, {angle: 0}, 0.5, {ease: FlxEase.backOut});
 
-              IntervalShake.shake(capsule, 0.6, 1 / 24, 0.12 / (distFromSelected + 1), 0, FlxEase.quadOut, function(_) {
+              IntervalShake.shake(capsule, 0.6, 1 / 24, 0.12 / (distFromSelected + 1), 0, new FlxPoint(capsule.width, capsule.height), FlxEase.quadOut, function(_) {
                 capsule.doLerp = true;
               });
             });


### PR DESCRIPTION
- `IntervalShake` now uses absolute coordinates instead of being based on width/height
- `axes` replaced with `scale` point
- fixed current usage y axis using `width` instead of `height` for the scalar