### PR TITLE
[ENHANCEMENT] Faster scrolling in Freeplay

### DIFF
--- a/source/funkin/input/Controls.hx
+++ b/source/funkin/input/Controls.hx
@@ -67,6 +67,8 @@ class Controls extends FlxActionSet
   var _freeplay_left = new FunkinAction(Action.FREEPLAY_LEFT);
   var _freeplay_right = new FunkinAction(Action.FREEPLAY_RIGHT);
   var _freeplay_char_select = new FunkinAction(Action.FREEPLAY_CHAR_SELECT);
+  var _freeplay_top_scroll = new FunkinAction(Action.FREEPLAY_TOP_SCROLL);
+  var _freeplay_bottom_scroll = new FunkinAction(Action.FREEPLAY_BOTTOM_SCROLL);
   var _cutscene_advance = new FunkinAction(Action.CUTSCENE_ADVANCE);
   var _debug_menu = new FunkinAction(Action.DEBUG_MENU);
   #if FEATURE_CHART_EDITOR
@@ -276,6 +278,16 @@ class Controls extends FlxActionSet
   inline function get_FREEPLAY_CHAR_SELECT()
     return _freeplay_char_select.check();
 
+  public var FREEPLAY_BOTTOM_SCROLL(get, never):Bool;
+
+  inline function get_FREEPLAY_BOTTOM_SCROLL()
+    return _freeplay_bottom_scroll.check();
+
+  public var FREEPLAY_TOP_SCROLL(get, never):Bool;
+
+  inline function get_FREEPLAY_TOP_SCROLL()
+    return _freeplay_top_scroll.check();
+
   public var CUTSCENE_ADVANCE(get, never):Bool;
 
   inline function get_CUTSCENE_ADVANCE()
@@ -337,6 +349,8 @@ class Controls extends FlxActionSet
     add(_freeplay_left);
     add(_freeplay_right);
     add(_freeplay_char_select);
+    add(_freeplay_bottom_scroll);
+    add(_freeplay_top_scroll);
     add(_cutscene_advance);
     add(_debug_menu);
     #if FEATURE_CHART_EDITOR add(_debug_chart); #end
@@ -462,6 +476,8 @@ class Controls extends FlxActionSet
       case FREEPLAY_LEFT: _freeplay_left;
       case FREEPLAY_RIGHT: _freeplay_right;
       case FREEPLAY_CHAR_SELECT: _freeplay_char_select;
+      case FREEPLAY_BOTTOM_SCROLL: _freeplay_bottom_scroll;
+      case FREEPLAY_TOP_SCROLL: _freeplay_top_scroll;
       case CUTSCENE_ADVANCE: _cutscene_advance;
       case DEBUG_MENU: _debug_menu;
       #if FEATURE_CHART_EDITOR case DEBUG_CHART: _debug_chart; #end
@@ -542,6 +558,10 @@ class Controls extends FlxActionSet
         func(_freeplay_right, JUST_PRESSED);
       case FREEPLAY_CHAR_SELECT:
         func(_freeplay_char_select, JUST_PRESSED);
+      case FREEPLAY_BOTTOM_SCROLL:
+        func(_freeplay_bottom_scroll, JUST_PRESSED);
+      case FREEPLAY_TOP_SCROLL:
+        func(_freeplay_top_scroll, JUST_PRESSED);
       case CUTSCENE_ADVANCE:
         func(_cutscene_advance, JUST_PRESSED);
       case DEBUG_MENU:
@@ -770,6 +790,8 @@ class Controls extends FlxActionSet
     bindKeys(Control.FREEPLAY_LEFT, getDefaultKeybinds(scheme, Control.FREEPLAY_LEFT));
     bindKeys(Control.FREEPLAY_RIGHT, getDefaultKeybinds(scheme, Control.FREEPLAY_RIGHT));
     bindKeys(Control.FREEPLAY_CHAR_SELECT, getDefaultKeybinds(scheme, Control.FREEPLAY_CHAR_SELECT));
+    bindKeys(Control.FREEPLAY_BOTTOM_SCROLL, getDefaultKeybinds(scheme, Control.FREEPLAY_BOTTOM_SCROLL));
+    bindKeys(Control.FREEPLAY_TOP_SCROLL, getDefaultKeybinds(scheme, Control.FREEPLAY_TOP_SCROLL));
     bindKeys(Control.CUTSCENE_ADVANCE, getDefaultKeybinds(scheme, Control.CUTSCENE_ADVANCE));
     bindKeys(Control.DEBUG_MENU, getDefaultKeybinds(scheme, Control.DEBUG_MENU));
     #if FEATURE_CHART_EDITOR
@@ -810,6 +832,8 @@ class Controls extends FlxActionSet
           case Control.FREEPLAY_LEFT: return [Q]; // Switch tabs on the menu
           case Control.FREEPLAY_RIGHT: return [E]; // Switch tabs on the menu
           case Control.FREEPLAY_CHAR_SELECT: return [TAB];
+          case Control.FREEPLAY_BOTTOM_SCROLL: return [END];
+          case Control.FREEPLAY_TOP_SCROLL: return [HOME];
           case Control.CUTSCENE_ADVANCE: return [Z, ENTER];
           case Control.DEBUG_MENU: return [GRAVEACCENT];
           #if FEATURE_CHART_EDITOR case Control.DEBUG_CHART: return []; #end
@@ -839,6 +863,8 @@ class Controls extends FlxActionSet
           case Control.FREEPLAY_LEFT: return [Q]; // Switch tabs on the menu
           case Control.FREEPLAY_RIGHT: return [E]; // Switch tabs on the menu
           case Control.FREEPLAY_CHAR_SELECT: return [TAB];
+          case Control.FREEPLAY_BOTTOM_SCROLL: return [END];
+          case Control.FREEPLAY_TOP_SCROLL: return [HOME];
           case Control.CUTSCENE_ADVANCE: return [G, Z];
           case Control.DEBUG_MENU: return [GRAVEACCENT];
           #if FEATURE_CHART_EDITOR case Control.DEBUG_CHART: return []; #end
@@ -868,6 +894,8 @@ class Controls extends FlxActionSet
           case Control.FREEPLAY_LEFT: return [];
           case Control.FREEPLAY_RIGHT: return [];
           case Control.FREEPLAY_CHAR_SELECT: return [];
+          case Control.FREEPLAY_BOTTOM_SCROLL: return [];
+          case Control.FREEPLAY_TOP_SCROLL: return [];
           case Control.CUTSCENE_ADVANCE: return [ENTER];
           case Control.DEBUG_MENU: return [];
           #if FEATURE_CHART_EDITOR case Control.DEBUG_CHART: return []; #end
@@ -984,6 +1012,8 @@ class Controls extends FlxActionSet
       Control.FREEPLAY_LEFT => getDefaultGamepadBinds(Control.FREEPLAY_LEFT),
       Control.FREEPLAY_RIGHT => getDefaultGamepadBinds(Control.FREEPLAY_RIGHT),
       Control.FREEPLAY_CHAR_SELECT => getDefaultGamepadBinds(Control.FREEPLAY_CHAR_SELECT),
+      Control.FREEPLAY_BOTTOM_SCROLL => getDefaultGamepadBinds(Control.FREEPLAY_BOTTOM_SCROLL),
+      Control.FREEPLAY_TOP_SCROLL => getDefaultGamepadBinds(Control.FREEPLAY_TOP_SCROLL),
       Control.VOLUME_UP => getDefaultGamepadBinds(Control.VOLUME_UP),
       Control.VOLUME_DOWN => getDefaultGamepadBinds(Control.VOLUME_DOWN),
       Control.VOLUME_MUTE => getDefaultGamepadBinds(Control.VOLUME_MUTE),
@@ -1041,6 +1071,10 @@ class Controls extends FlxActionSet
         return [RIGHT_SHOULDER];
       case Control.FREEPLAY_CHAR_SELECT:
         return [X];
+      case Control.FREEPLAY_BOTTOM_SCROLL:
+        return [];
+      case Control.FREEPLAY_TOP_SCROLL:
+        return [];
       case Control.VOLUME_UP:
         [];
       case Control.VOLUME_DOWN:
@@ -1620,6 +1654,8 @@ enum Control
   FREEPLAY_LEFT;
   FREEPLAY_RIGHT;
   FREEPLAY_CHAR_SELECT;
+  FREEPLAY_BOTTOM_SCROLL;
+  FREEPLAY_TOP_SCROLL;
   // WINDOW
   #if FEATURE_SCREENSHOTS WINDOW_SCREENSHOT; #end
   WINDOW_FULLSCREEN;
@@ -1677,6 +1713,8 @@ enum abstract Action(String) to String from String
   var FREEPLAY_LEFT = "freeplay_left";
   var FREEPLAY_RIGHT = "freeplay_right";
   var FREEPLAY_CHAR_SELECT = "freeplay_char_select";
+  var FREEPLAY_BOTTOM_SCROLL = "freeplay_bottom_scroll";
+  var FREEPLAY_TOP_SCROLL = "freeplay_top_scroll";
   // VOLUME
   var VOLUME_UP = "volume_up";
   var VOLUME_DOWN = "volume_down";

--- a/source/funkin/input/Controls.hx
+++ b/source/funkin/input/Controls.hx
@@ -67,8 +67,8 @@ class Controls extends FlxActionSet
   var _freeplay_left = new FunkinAction(Action.FREEPLAY_LEFT);
   var _freeplay_right = new FunkinAction(Action.FREEPLAY_RIGHT);
   var _freeplay_char_select = new FunkinAction(Action.FREEPLAY_CHAR_SELECT);
-  var _freeplay_top_scroll = new FunkinAction(Action.FREEPLAY_TOP_SCROLL);
-  var _freeplay_bottom_scroll = new FunkinAction(Action.FREEPLAY_BOTTOM_SCROLL);
+  var _freeplay_jump_to_top = new FunkinAction(Action.FREEPLAY_JUMP_TO_TOP);
+  var _freeplay_jump_to_bottom = new FunkinAction(Action.FREEPLAY_JUMP_TO_BOTTOM);
   var _cutscene_advance = new FunkinAction(Action.CUTSCENE_ADVANCE);
   var _debug_menu = new FunkinAction(Action.DEBUG_MENU);
   #if FEATURE_CHART_EDITOR
@@ -278,15 +278,15 @@ class Controls extends FlxActionSet
   inline function get_FREEPLAY_CHAR_SELECT()
     return _freeplay_char_select.check();
 
-  public var FREEPLAY_BOTTOM_SCROLL(get, never):Bool;
+  public var FREEPLAY_JUMP_TO_TOP(get, never):Bool;
 
-  inline function get_FREEPLAY_BOTTOM_SCROLL()
-    return _freeplay_bottom_scroll.check();
+  inline function get_FREEPLAY_JUMP_TO_TOP()
+    return _freeplay_jump_to_top.check();
 
-  public var FREEPLAY_TOP_SCROLL(get, never):Bool;
+  public var FREEPLAY_JUMP_TO_BOTTOM(get, never):Bool;
 
-  inline function get_FREEPLAY_TOP_SCROLL()
-    return _freeplay_top_scroll.check();
+  inline function get_FREEPLAY_JUMP_TO_BOTTOM()
+    return _freeplay_jump_to_bottom.check();
 
   public var CUTSCENE_ADVANCE(get, never):Bool;
 
@@ -349,8 +349,8 @@ class Controls extends FlxActionSet
     add(_freeplay_left);
     add(_freeplay_right);
     add(_freeplay_char_select);
-    add(_freeplay_bottom_scroll);
-    add(_freeplay_top_scroll);
+    add(_freeplay_jump_to_top);
+    add(_freeplay_jump_to_bottom);
     add(_cutscene_advance);
     add(_debug_menu);
     #if FEATURE_CHART_EDITOR add(_debug_chart); #end
@@ -476,8 +476,8 @@ class Controls extends FlxActionSet
       case FREEPLAY_LEFT: _freeplay_left;
       case FREEPLAY_RIGHT: _freeplay_right;
       case FREEPLAY_CHAR_SELECT: _freeplay_char_select;
-      case FREEPLAY_BOTTOM_SCROLL: _freeplay_bottom_scroll;
-      case FREEPLAY_TOP_SCROLL: _freeplay_top_scroll;
+      case FREEPLAY_JUMP_TO_TOP: _freeplay_jump_to_top;
+      case FREEPLAY_JUMP_TO_BOTTOM: _freeplay_jump_to_bottom;
       case CUTSCENE_ADVANCE: _cutscene_advance;
       case DEBUG_MENU: _debug_menu;
       #if FEATURE_CHART_EDITOR case DEBUG_CHART: _debug_chart; #end
@@ -558,10 +558,10 @@ class Controls extends FlxActionSet
         func(_freeplay_right, JUST_PRESSED);
       case FREEPLAY_CHAR_SELECT:
         func(_freeplay_char_select, JUST_PRESSED);
-      case FREEPLAY_BOTTOM_SCROLL:
-        func(_freeplay_bottom_scroll, JUST_PRESSED);
-      case FREEPLAY_TOP_SCROLL:
-        func(_freeplay_top_scroll, JUST_PRESSED);
+      case FREEPLAY_JUMP_TO_TOP:
+        func(_freeplay_jump_to_top, JUST_PRESSED);
+      case FREEPLAY_JUMP_TO_BOTTOM:
+        func(_freeplay_jump_to_bottom, JUST_PRESSED);
       case CUTSCENE_ADVANCE:
         func(_cutscene_advance, JUST_PRESSED);
       case DEBUG_MENU:
@@ -790,8 +790,8 @@ class Controls extends FlxActionSet
     bindKeys(Control.FREEPLAY_LEFT, getDefaultKeybinds(scheme, Control.FREEPLAY_LEFT));
     bindKeys(Control.FREEPLAY_RIGHT, getDefaultKeybinds(scheme, Control.FREEPLAY_RIGHT));
     bindKeys(Control.FREEPLAY_CHAR_SELECT, getDefaultKeybinds(scheme, Control.FREEPLAY_CHAR_SELECT));
-    bindKeys(Control.FREEPLAY_BOTTOM_SCROLL, getDefaultKeybinds(scheme, Control.FREEPLAY_BOTTOM_SCROLL));
-    bindKeys(Control.FREEPLAY_TOP_SCROLL, getDefaultKeybinds(scheme, Control.FREEPLAY_TOP_SCROLL));
+    bindKeys(Control.FREEPLAY_JUMP_TO_TOP, getDefaultKeybinds(scheme, Control.FREEPLAY_JUMP_TO_TOP));
+    bindKeys(Control.FREEPLAY_JUMP_TO_BOTTOM, getDefaultKeybinds(scheme, Control.FREEPLAY_JUMP_TO_BOTTOM));
     bindKeys(Control.CUTSCENE_ADVANCE, getDefaultKeybinds(scheme, Control.CUTSCENE_ADVANCE));
     bindKeys(Control.DEBUG_MENU, getDefaultKeybinds(scheme, Control.DEBUG_MENU));
     #if FEATURE_CHART_EDITOR
@@ -832,8 +832,8 @@ class Controls extends FlxActionSet
           case Control.FREEPLAY_LEFT: return [Q]; // Switch tabs on the menu
           case Control.FREEPLAY_RIGHT: return [E]; // Switch tabs on the menu
           case Control.FREEPLAY_CHAR_SELECT: return [TAB];
-          case Control.FREEPLAY_BOTTOM_SCROLL: return [END];
-          case Control.FREEPLAY_TOP_SCROLL: return [HOME];
+          case Control.FREEPLAY_JUMP_TO_TOP: return [HOME];
+          case Control.FREEPLAY_JUMP_TO_BOTTOM: return [END];
           case Control.CUTSCENE_ADVANCE: return [Z, ENTER];
           case Control.DEBUG_MENU: return [GRAVEACCENT];
           #if FEATURE_CHART_EDITOR case Control.DEBUG_CHART: return []; #end
@@ -863,8 +863,8 @@ class Controls extends FlxActionSet
           case Control.FREEPLAY_LEFT: return [Q]; // Switch tabs on the menu
           case Control.FREEPLAY_RIGHT: return [E]; // Switch tabs on the menu
           case Control.FREEPLAY_CHAR_SELECT: return [TAB];
-          case Control.FREEPLAY_BOTTOM_SCROLL: return [END];
-          case Control.FREEPLAY_TOP_SCROLL: return [HOME];
+          case Control.FREEPLAY_JUMP_TO_TOP: return [HOME];
+          case Control.FREEPLAY_JUMP_TO_BOTTOM: return [END];
           case Control.CUTSCENE_ADVANCE: return [G, Z];
           case Control.DEBUG_MENU: return [GRAVEACCENT];
           #if FEATURE_CHART_EDITOR case Control.DEBUG_CHART: return []; #end
@@ -894,8 +894,8 @@ class Controls extends FlxActionSet
           case Control.FREEPLAY_LEFT: return [];
           case Control.FREEPLAY_RIGHT: return [];
           case Control.FREEPLAY_CHAR_SELECT: return [];
-          case Control.FREEPLAY_BOTTOM_SCROLL: return [];
-          case Control.FREEPLAY_TOP_SCROLL: return [];
+          case Control.FREEPLAY_JUMP_TO_TOP: return [];
+          case Control.FREEPLAY_JUMP_TO_BOTTOM: return [];
           case Control.CUTSCENE_ADVANCE: return [ENTER];
           case Control.DEBUG_MENU: return [];
           #if FEATURE_CHART_EDITOR case Control.DEBUG_CHART: return []; #end
@@ -1012,8 +1012,8 @@ class Controls extends FlxActionSet
       Control.FREEPLAY_LEFT => getDefaultGamepadBinds(Control.FREEPLAY_LEFT),
       Control.FREEPLAY_RIGHT => getDefaultGamepadBinds(Control.FREEPLAY_RIGHT),
       Control.FREEPLAY_CHAR_SELECT => getDefaultGamepadBinds(Control.FREEPLAY_CHAR_SELECT),
-      Control.FREEPLAY_BOTTOM_SCROLL => getDefaultGamepadBinds(Control.FREEPLAY_BOTTOM_SCROLL),
-      Control.FREEPLAY_TOP_SCROLL => getDefaultGamepadBinds(Control.FREEPLAY_TOP_SCROLL),
+      Control.FREEPLAY_JUMP_TO_TOP => getDefaultGamepadBinds(Control.FREEPLAY_JUMP_TO_TOP),
+      Control.FREEPLAY_JUMP_TO_BOTTOM => getDefaultGamepadBinds(Control.FREEPLAY_JUMP_TO_BOTTOM),
       Control.VOLUME_UP => getDefaultGamepadBinds(Control.VOLUME_UP),
       Control.VOLUME_DOWN => getDefaultGamepadBinds(Control.VOLUME_DOWN),
       Control.VOLUME_MUTE => getDefaultGamepadBinds(Control.VOLUME_MUTE),
@@ -1071,9 +1071,9 @@ class Controls extends FlxActionSet
         return [RIGHT_SHOULDER];
       case Control.FREEPLAY_CHAR_SELECT:
         return [X];
-      case Control.FREEPLAY_BOTTOM_SCROLL:
+      case Control.FREEPLAY_JUMP_TO_TOP:
         return [];
-      case Control.FREEPLAY_TOP_SCROLL:
+      case Control.FREEPLAY_JUMP_TO_BOTTOM:
         return [];
       case Control.VOLUME_UP:
         [];
@@ -1654,8 +1654,8 @@ enum Control
   FREEPLAY_LEFT;
   FREEPLAY_RIGHT;
   FREEPLAY_CHAR_SELECT;
-  FREEPLAY_BOTTOM_SCROLL;
-  FREEPLAY_TOP_SCROLL;
+  FREEPLAY_JUMP_TO_TOP;
+  FREEPLAY_JUMP_TO_BOTTOM;
   // WINDOW
   #if FEATURE_SCREENSHOTS WINDOW_SCREENSHOT; #end
   WINDOW_FULLSCREEN;
@@ -1713,8 +1713,8 @@ enum abstract Action(String) to String from String
   var FREEPLAY_LEFT = "freeplay_left";
   var FREEPLAY_RIGHT = "freeplay_right";
   var FREEPLAY_CHAR_SELECT = "freeplay_char_select";
-  var FREEPLAY_BOTTOM_SCROLL = "freeplay_bottom_scroll";
-  var FREEPLAY_TOP_SCROLL = "freeplay_top_scroll";
+  var FREEPLAY_JUMP_TO_TOP = "freeplay_jump_to_top";
+  var FREEPLAY_JUMP_TO_BOTTOM = "freeplay_jump_to_bottom";
   // VOLUME
   var VOLUME_UP = "volume_up";
   var VOLUME_DOWN = "volume_down";

--- a/source/funkin/ui/freeplay/FreeplayState.hx
+++ b/source/funkin/ui/freeplay/FreeplayState.hx
@@ -1400,6 +1400,16 @@ class FreeplayState extends MusicBeatSubState
       }
     }
 
+    if (controls.FREEPLAY_BOTTOM_SCROLL && !busy)
+    {
+      changeSelection(grpCapsules.countLiving() - curSelected - 1);
+    }
+
+    if (controls.FREEPLAY_TOP_SCROLL && !busy)
+    {
+      changeSelection(-curSelected);
+    }
+
     lerpScore = MathUtil.smoothLerp(lerpScore, intendedScore, elapsed, 0.5);
     lerpCompletion = MathUtil.smoothLerp(lerpCompletion, intendedCompletion, elapsed, 0.5);
 

--- a/source/funkin/ui/freeplay/FreeplayState.hx
+++ b/source/funkin/ui/freeplay/FreeplayState.hx
@@ -1400,14 +1400,14 @@ class FreeplayState extends MusicBeatSubState
       }
     }
 
-    if (controls.FREEPLAY_BOTTOM_SCROLL && !busy)
-    {
-      changeSelection(grpCapsules.countLiving() - curSelected - 1);
-    }
-
-    if (controls.FREEPLAY_TOP_SCROLL && !busy)
+    if (controls.FREEPLAY_JUMP_TO_TOP && !busy)
     {
       changeSelection(-curSelected);
+    }
+
+    if (controls.FREEPLAY_JUMP_TO_BOTTOM && !busy)
+    {
+      changeSelection(grpCapsules.countLiving() - curSelected - 1);
     }
 
     lerpScore = MathUtil.smoothLerp(lerpScore, intendedScore, elapsed, 0.5);

--- a/source/funkin/ui/options/ControlsMenu.hx
+++ b/source/funkin/ui/options/ControlsMenu.hx
@@ -50,6 +50,10 @@ class ControlsMenu extends funkin.ui.options.OptionsState.Page
   var currentDevice:Device = Keys;
   var deviceListSelected:Bool = false;
 
+  static final CONTROL_BASE_X = 50;
+  static final CONTROL_MARGIN_X = 700;
+  static final CONTROL_SPACING_X = 300;
+
   public function new()
   {
     super();
@@ -142,10 +146,10 @@ class ControlsMenu extends funkin.ui.options.OptionsState.Page
       if (currentHeader != null && name.indexOf(currentHeader) == 0) name = name.substr(currentHeader.length);
 
       var formatName = name.replace('_', ' ');
-      var label = labels.add(new AtlasText(100, y, formatName, AtlasFont.BOLD));
+      var label = labels.add(new AtlasText(CONTROL_BASE_X, y, formatName, AtlasFont.BOLD));
       label.alpha = 0.6;
       for (i in 0...COLUMNS)
-        createItem(label.x + 550 + i * 400, y, control, i);
+        createItem(label.x + CONTROL_MARGIN_X + i * CONTROL_SPACING_X, y, control, i);
 
       y += spacer;
     }


### PR DESCRIPTION
Inspired by [this comment from Eric](https://github.com/FunkinCrew/Funkin/issues/3034#issuecomment-2364762699), HOME and END now jump to the top and bottom of the Freeplay menu respectively.

https://github.com/user-attachments/assets/82cf062e-5641-4bfb-b51d-45a074410e63

If you have better names for the controls please let me know.