### PR TITLE
Open chart editor on selected song in freeplay state

### DIFF
--- a/source/funkin/ui/freeplay/FreeplayState.hx
+++ b/source/funkin/ui/freeplay/FreeplayState.hx
@@ -1660,6 +1660,18 @@ class FreeplayState extends MusicBeatSubState
     {
       grpCapsules.members[curSelected].onConfirm();
     }
+    if (controls.DEBUG_CHART && !busy)
+    {
+      /*
+        Doing it this way rather than passing the rememberedSongId
+        so that in the future, this can be made to load a random song when given this
+       */
+      var targetSong = grpCapsules.members[curSelected]?.freeplayData?.data.id ?? 'unknown';
+      FlxG.switchState(() -> new ChartEditorState(
+        {
+          targetSongId: targetSong,
+        }));
+    }
   }
 
   override function beatHit():Bool

--- a/source/funkin/ui/freeplay/FreeplayState.hx
+++ b/source/funkin/ui/freeplay/FreeplayState.hx
@@ -1663,14 +1663,41 @@ class FreeplayState extends MusicBeatSubState
     }
     if (controls.DEBUG_CHART && !busy)
     {
-      /*
-        Doing it this way rather than passing the rememberedSongId
-        so that in the future, this can be made to load a random song when given this
-       */
-      var targetSong = grpCapsules.members[curSelected]?.freeplayData?.data.id ?? 'unknown';
+      busy = true;
+      var targetSongID = grpCapsules.members[curSelected]?.freeplayData?.data.id ?? 'unknown';
+      if (targetSongID == 'unknown')
+      {
+        trace('CHART RANDOM SONG');
+        letterSort.inputEnabled = false;
+
+        var availableSongCapsules:Array<SongMenuItem> = grpCapsules.members.filter(function(cap:SongMenuItem) {
+          // Dead capsules are ones which were removed from the list when changing filters.
+          return cap.alive && cap.freeplayData != null;
+        });
+
+        trace('Available songs: ${availableSongCapsules.map(function(cap) {
+      return cap?.freeplayData?.data.songName;
+    })}');
+
+        if (availableSongCapsules.length == 0)
+        {
+          trace('No songs available!');
+          busy = false;
+          letterSort.inputEnabled = true;
+          FunkinSound.playOnce(Paths.sound('cancelMenu'));
+          return;
+        }
+
+        var targetSong:SongMenuItem = FlxG.random.getObject(availableSongCapsules);
+
+        // Seeing if I can do an animation...
+        curSelected = grpCapsules.members.indexOf(targetSong);
+        changeSelection(0);
+        targetSongID = grpCapsules.members[curSelected]?.freeplayData?.data.id ?? 'unknown';
+      }
       FlxG.switchState(() -> new ChartEditorState(
         {
-          targetSongId: targetSong,
+          targetSongId: targetSongID,
         }));
     }
   }
@@ -2111,7 +2138,7 @@ class FreeplayState extends MusicBeatSubState
       if (index < curSelected) capsule.targetPos.y -= 100; // another 100 for good measure
     }
 
-    if (grpCapsules.countLiving() > 0 && !prepForNewRank)
+    if (grpCapsules.countLiving() > 0 && !prepForNewRank && !busy)
     {
       playCurSongPreview(daSongCapsule);
       grpCapsules.members[curSelected].selected = true;

--- a/source/funkin/ui/freeplay/FreeplayState.hx
+++ b/source/funkin/ui/freeplay/FreeplayState.hx
@@ -45,6 +45,7 @@ import funkin.util.MathUtil;
 import funkin.util.SortUtil;
 import openfl.display.BlendMode;
 import funkin.data.freeplay.style.FreeplayStyleRegistry;
+import funkin.ui.debug.charting.ChartEditorState;
 #if FEATURE_DISCORD_RPC
 import funkin.api.discord.DiscordClient;
 #end


### PR DESCRIPTION
<!-- Please check for duplicates or similar PRs before submitting this PR. -->
## Does this PR close any issues? If so, link them below.
No, but it prevents one from being opened in the future!
## Briefly describe the issue(s) fixed.
You no longer have to enter a song first to open the chart editor on that song, you can instead open it directly from in the freeplay state.

~~I would also like to make it actually choose a random song when opening on random, as atm it opens a blank song.~~ Done!
## Include any relevant screenshots or videos.
https://github.com/user-attachments/assets/671adcd8-8d3f-41ea-b1e6-ecdb2638e18f

