### PR TITLE
[DOCS] Add more console outputs to Troubleshooting Guide

### DIFF
--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -1,11 +1,19 @@
 # Troubleshooting Common Compilation Issues
 
+- Any output containing `WARNING` or `(WDeprecated)`
+  - Will not disrupt compilation and can be safely ignored.
+
+- `This version of hxcpp` ... `Would you like to do this now [y/n]`
+  - Type "y" into the console and press Enter.
+
 - Weird macro error with a very tall call stack: Restart Visual Studio Code
   - NOTE: This is caused by Polymod somewhere, and seems to only occur when there is another compile error somewhere in the program. There is a bounty up for it.
 
-- `Get Thread Context Failed`: Turn off other expensive applications while building
+- `Get Thread Context Failed`
+  - Turn off other expensive applications while building.
 
-- `Type not found: T1`: This is thrown by `json2object`, make sure the data type of `@:default` is correct.
+- `Type not found: T1`
+  - This is thrown by `json2object`, make sure the data type of `@:default` is correct.
   - NOTE: `flixel.util.typeLimit.OneOfTwo` isn't supported.
 
 - `Class lists not properly generated. Try cleaning out your export folder, restarting your IDE, and rebuilding your project.`
@@ -15,7 +23,7 @@
   - This error occurs if the PDB file located in your `export` folder is in use or exceeds 4 GB. Try deleting the `export` folder and building again from scratch.
 
 - `error: RPC failed; curl 92 HTTP/2 stream 0 was not closed cleanly: PROTOCOL_ERROR (err 1)`
-  - This error can happen during cloning as a result of poor network connectivity. A common fix is to run ` git config --global http.postBuffer 4096M` in your terminal.
+  - This error can happen during cloning as a result of poor network connectivity. A common fix is to run `git config --global http.postBuffer 4096M` in your terminal.
 
 - Repository is missing an `assets` folder, or `assets` folder is empty.
   - You did not clone the repository correctly! Copy the path to your `funkin` folder and run `cd the\path\you\copied`. Then follow the compilation guide starting from **Step 4**.


### PR DESCRIPTION
Adds the explanation from [this comment](https://github.com/FunkinCrew/Funkin/issues/4111#issuecomment-2644033905) to the Troubleshooting Guide.

## Changes
* Clarifies that warnings and deprecated functions can be safely ignored.
* Instructs user to type y when encountering the hxcpp prompt.
* Adjusts formatting for consistency