### PR TITLE
Chart editor state: target song difficulty & variation

### DIFF
--- a/source/funkin/ui/debug/charting/ChartEditorState.hx
+++ b/source/funkin/ui/debug/charting/ChartEditorState.hx
@@ -2263,7 +2263,10 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
     }
     else if (params != null && params.targetSongId != null)
     {
-      this.loadSongAsTemplate(params.targetSongId);
+      // pass the targetSongDifficulty if one was given, otherwise, don't
+      if (params.targetSongDifficulty != null) this.loadSongAsTemplate(params.targetSongId, params.targetSongDifficulty);
+      else
+        this.loadSongAsTemplate(params.targetSongId, Constants.DEFAULT_DIFFICULTY);
     }
     else
     {
@@ -6528,6 +6531,10 @@ typedef ChartEditorParams =
    * If non-null, load this song immediately instead of the welcome screen.
    */
   var ?targetSongId:String;
+  /**
+   * If non-null, load this difficulty immediately instead of the default difficulty.
+   */
+  var ?targetSongDifficulty:String;
 };
 
 /**

--- a/source/funkin/ui/debug/charting/ChartEditorState.hx
+++ b/source/funkin/ui/debug/charting/ChartEditorState.hx
@@ -2263,10 +2263,9 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
     }
     else if (params != null && params.targetSongId != null)
     {
-      // pass the targetSongDifficulty if one was given, otherwise, don't
-      if (params.targetSongDifficulty != null) this.loadSongAsTemplate(params.targetSongId, params.targetSongDifficulty);
-      else
-        this.loadSongAsTemplate(params.targetSongId, Constants.DEFAULT_DIFFICULTY);
+      var targetSongDifficulty = params.targetSongDifficulty ?? Constants.DEFAULT_DIFFICULTY;
+      var targetSongVariation = params.targetSongVariation ?? Constants.DEFAULT_VARIATION;
+      this.loadSongAsTemplate(params.targetSongId, targetSongDifficulty, targetSongVariation);
     }
     else
     {
@@ -6535,6 +6534,10 @@ typedef ChartEditorParams =
    * If non-null, load this difficulty immediately instead of the default difficulty.
    */
   var ?targetSongDifficulty:String;
+  /**
+   * If non-null, load this variation immediately instead of the default variation.
+   */
+  var ?targetSongVariation:String;
 };
 
 /**

--- a/source/funkin/ui/debug/charting/dialogs/ChartEditorWelcomeDialog.hx
+++ b/source/funkin/ui/debug/charting/dialogs/ChartEditorWelcomeDialog.hx
@@ -157,7 +157,7 @@ class ChartEditorWelcomeDialog extends ChartEditorBaseDialog
         this.hideDialog(DialogButton.CANCEL);
 
         // Load song from template
-        chartEditorState.loadSongAsTemplate(targetSongId);
+        chartEditorState.loadSongAsTemplate(targetSongId, Constants.DEFAULT_DIFFICULTY);
       });
     }
   }

--- a/source/funkin/ui/debug/charting/dialogs/ChartEditorWelcomeDialog.hx
+++ b/source/funkin/ui/debug/charting/dialogs/ChartEditorWelcomeDialog.hx
@@ -157,7 +157,7 @@ class ChartEditorWelcomeDialog extends ChartEditorBaseDialog
         this.hideDialog(DialogButton.CANCEL);
 
         // Load song from template
-        chartEditorState.loadSongAsTemplate(targetSongId, Constants.DEFAULT_DIFFICULTY);
+        chartEditorState.loadSongAsTemplate(targetSongId, Constants.DEFAULT_DIFFICULTY, Constants.DEFAULT_VARIATION);
       });
     }
   }

--- a/source/funkin/ui/debug/charting/handlers/ChartEditorImportExportHandler.hx
+++ b/source/funkin/ui/debug/charting/handlers/ChartEditorImportExportHandler.hx
@@ -26,7 +26,7 @@ class ChartEditorImportExportHandler
   /**
    * Fetch's a song's existing chart and audio and loads it, replacing the current song.
    */
-  public static function loadSongAsTemplate(state:ChartEditorState, songId:String):Void
+  public static function loadSongAsTemplate(state:ChartEditorState, songId:String, targetSongDifficulty:String):Void
   {
     trace('===============START');
 
@@ -94,6 +94,10 @@ class ChartEditorImportExportHandler
         {
           trace('[WARN] Strange quantity of voice paths for difficulty ${difficultyId}: ${voiceList.length}');
         }
+        // Set the difficulty of the song if one was passed in the params, and it isn't the default
+        if (targetSongDifficulty != null
+          && targetSongDifficulty != state.selectedDifficulty
+          && targetSongDifficulty == difficultyId) state.selectedDifficulty = targetSongDifficulty;
       }
     }
 

--- a/source/funkin/ui/debug/charting/handlers/ChartEditorImportExportHandler.hx
+++ b/source/funkin/ui/debug/charting/handlers/ChartEditorImportExportHandler.hx
@@ -26,7 +26,7 @@ class ChartEditorImportExportHandler
   /**
    * Fetch's a song's existing chart and audio and loads it, replacing the current song.
    */
-  public static function loadSongAsTemplate(state:ChartEditorState, songId:String, targetSongDifficulty:String):Void
+  public static function loadSongAsTemplate(state:ChartEditorState, songId:String, targetSongDifficulty:String, targetSongVariation:String):Void
   {
     trace('===============START');
 
@@ -97,7 +97,11 @@ class ChartEditorImportExportHandler
         // Set the difficulty of the song if one was passed in the params, and it isn't the default
         if (targetSongDifficulty != null
           && targetSongDifficulty != state.selectedDifficulty
-          && targetSongDifficulty == difficultyId) state.selectedDifficulty = targetSongDifficulty;
+          && targetSongDifficulty == diff.difficulty) state.selectedDifficulty = targetSongDifficulty;
+        // Set the variation of the song if one was passed in the params, and it isn't the default
+        if (targetSongVariation != null
+          && targetSongVariation != state.selectedVariation
+          && targetSongVariation == diff.variation) state.selectedVariation = targetSongVariation;
       }
     }
 


### PR DESCRIPTION
<!-- Please check for duplicates or similar PRs before submitting this PR. -->
## Does this PR close any issues? If so, link them below.
https://github.com/FunkinCrew/Funkin/issues/3157
## Briefly describe the issue(s) fixed.
The chart editor state only had a parameter for the target song id. It now also has parameters for the target difficulty and variation, and it'll use them if they're not set to the default when loading a song.
## Include any relevant screenshots or videos.

https://github.com/user-attachments/assets/2401b753-3b6b-4641-b07e-7d66a83a5975


