### PR TITLE
[ENHANCEMENT] Chart/stage name in backup filename

### DIFF
--- a/source/funkin/ui/debug/charting/handlers/ChartEditorDialogHandler.hx
+++ b/source/funkin/ui/debug/charting/handlers/ChartEditorDialogHandler.hx
@@ -168,11 +168,10 @@ class ChartEditorDialogHandler
     var backupTimeLabel:Null<Label> = dialog.findComponent('backupTimeLabel', Label);
     if (backupTimeLabel == null) throw 'Could not locate backupTimeLabel button in Backup Available dialog';
 
-    var latestBackupDate:Null<Date> = ChartEditorImportExportHandler.getLatestBackupDate();
+    var latestBackupDate:Null<String> = ChartEditorImportExportHandler.getLatestBackupDate();
     if (latestBackupDate != null)
     {
-      var latestBackupDateStr:String = DateUtil.generateCleanTimestamp(latestBackupDate);
-      backupTimeLabel.text = latestBackupDateStr;
+      backupTimeLabel.text = latestBackupDate;
     }
 
     var buttonCancel:Null<Button> = dialog.findComponent('dialogCancel', Button);

--- a/source/funkin/ui/debug/charting/handlers/ChartEditorImportExportHandler.hx
+++ b/source/funkin/ui/debug/charting/handlers/ChartEditorImportExportHandler.hx
@@ -368,7 +368,7 @@ class ChartEditorImportExportHandler
     #end
   }
 
-  public static function getLatestBackupDate():Null<Date>
+  public static function getLatestBackupDate():Null<String>
   {
     #if sys
     var latestBackupPath:Null<String> = getLatestBackupPath();
@@ -377,19 +377,10 @@ class ChartEditorImportExportHandler
     var latestBackupName:String = haxe.io.Path.withoutDirectory(latestBackupPath);
     latestBackupName = haxe.io.Path.withoutExtension(latestBackupName);
 
-    var parts = latestBackupName.split('-');
+    var stat = sys.FileSystem.stat(latestBackupPath);
+    var sizeInMB = (stat.size / 1000000).round(3);
 
-    // var chart:String = parts[0];
-    // var editor:String = parts[1];
-    var year:Int = Std.parseInt(parts[2] ?? '0') ?? 0;
-    var month:Int = Std.parseInt(parts[3] ?? '1') ?? 1;
-    var day:Int = Std.parseInt(parts[4] ?? '0') ?? 0;
-    var hour:Int = Std.parseInt(parts[5] ?? '0') ?? 0;
-    var minute:Int = Std.parseInt(parts[6] ?? '0') ?? 0;
-    var second:Int = Std.parseInt(parts[7] ?? '0') ?? 0;
-
-    var date:Date = new Date(year, month - 1, day, hour, minute, second);
-    return date;
+    return "Full Name: " + latestBackupName + "\nLast Modified: " + stat.mtime.toString() + "\nSize: " + sizeInMB + " MB";
     #else
     return null;
     #end
@@ -470,9 +461,10 @@ class ChartEditorImportExportHandler
       {
         // Force writing to a generic path (autosave or crash recovery)
         targetMode = Skip;
+        if (state.currentSongId == '') state.currentSongName = 'New Chart'; // Hopefully no one notices this silliness
         targetPath = Path.join([
           BACKUPS_PATH,
-          'chart-editor-${DateUtil.generateTimestamp()}.${Constants.EXT_CHART}'
+            'chart-editor-${state.currentSongId}-${DateUtil.generateTimestamp()}.${Constants.EXT_CHART}'
         ]);
         // We have to force write because the program will die before the save dialog is closed.
         trace('Force exporting to $targetPath...');

--- a/source/funkin/ui/debug/stageeditor/StageEditorState.hx
+++ b/source/funkin/ui/debug/stageeditor/StageEditorState.hx
@@ -206,7 +206,7 @@ class StageEditorState extends UIState
         var data = this.packShitToZip();
         var path = haxe.io.Path.join([
           BACKUPS_PATH,
-          'stage-editor-${funkin.util.DateUtil.generateTimestamp()}.${FileUtil.FILE_EXTENSION_INFO_FNFS.extension}'
+          'stage-editor-${stageName}-${funkin.util.DateUtil.generateTimestamp()}.${FileUtil.FILE_EXTENSION_INFO_FNFS.extension}'
         ]);
 
         FileUtil.writeBytesToPath(path, data);

--- a/source/funkin/ui/debug/stageeditor/components/BackupAvailableDialog.hx
+++ b/source/funkin/ui/debug/stageeditor/components/BackupAvailableDialog.hx
@@ -9,11 +9,11 @@ import funkin.util.DateUtil;
 using StringTools;
 
 @:xml('
-<dialog id="backupAvailableDialog" width="475" height="150" title="Hey! Listen!">
+<dialog id="backupAvailableDialog" width="475" height="200" title="Hey! Listen!">
 	<vbox width="100%" height="100%">
 		<label text="There is a stage backup available, would you like to open it?\n" width="100%" textAlign="center" />
 		<spacer height="6" />
-		<label id="backupTimeLabel" text="Jan 1, 1970 0:00" width="100%" textAlign="center" />
+		<label id="backupTimeLabel" text="no sys? sus" width="100%" textAlign="center" />
 		<spacer height="100%" />
 		<hbox width="100%">
 			<button text="No Thanks" id="dialogCancel" />
@@ -34,20 +34,14 @@ class BackupAvailableDialog extends Dialog
     if (!FileUtil.fileExists(filePath)) return;
 
     // time text
-    var fileDate = Path.withoutExtension(Path.withoutDirectory(filePath));
-    var dateParts = fileDate.split("-");
+    var file = Path.withoutExtension(Path.withoutDirectory(filePath));
 
-    while (dateParts.length < 8)
-      dateParts.push("0");
+    #if sys
+    var stat = sys.FileSystem.stat(filePath);
+    var sizeInMB = (stat.size / 1000000).round(3);
 
-    var year:Int = Std.parseInt(dateParts[2]) ?? 0; // copied parts from ChartEditorImportExportHandler.hx
-    var month:Int = Std.parseInt(dateParts[3]) ?? 1;
-    var day:Int = Std.parseInt(dateParts[4]) ?? 0;
-    var hour:Int = Std.parseInt(dateParts[5]) ?? 0;
-    var minute:Int = Std.parseInt(dateParts[6]) ?? 0;
-    var second:Int = Std.parseInt(dateParts[7]) ?? 0;
-
-    backupTimeLabel.text = DateUtil.generateCleanTimestamp(new Date(year, month - 1, day, hour, minute, second));
+    backupTimeLabel.text = "Full Name: " + file + "\nLast Modified: " + stat.mtime.toString() + "\nSize: " + sizeInMB + " MB";
+    #end
 
     // button callbacks
     dialogCancel.onClick = function(_) hideDialog(DialogButton.CANCEL);

--- a/source/funkin/ui/debug/stageeditor/components/WelcomeDialog.hx
+++ b/source/funkin/ui/debug/stageeditor/components/WelcomeDialog.hx
@@ -47,9 +47,9 @@ class WelcomeDialog extends Dialog
 
       #if sys
       var stat = sys.FileSystem.stat(file);
-      var sizeInMB = (stat.size / 1000000).round(2);
+      var sizeInMB = (stat.size / 1000000).round(3);
 
-      fileText.tooltip = "Full Name: " + file + "\nLast Modified: " + stat.mtime.toString() + "\nSize: " + sizeInMB + "MB";
+      fileText.tooltip = "Full Name: " + file + "\nLast Modified: " + stat.mtime.toString() + "\nSize: " + sizeInMB + " MB";
       #end
 
       contentRecent.addComponent(fileText);


### PR DESCRIPTION
<!-- Please check for duplicates or similar PRs before submitting this PR. -->
## Does this PR close any issues? If so, link them below.
Closes #3931, fixes #3084 
## Briefly describe the issue(s) fixed.
Chart editor backups didn't include the song name in the save. Now they do (also renames songs to new chart if it has no name when it autosaves, but shhh, don't tell anyone that).

I've also gone ahead and done the same thing for the stage editor, and also removed the weird date and time thing the chart editor does as you can just use sys to get that (I noticed that's how the stage editor does it, so I copied it).

Requires this assets PR: funkincrew/funkin.assets#120
## Include any relevant screenshots or videos.

https://github.com/user-attachments/assets/28c34975-c4b7-4cc1-90d3-6f35e93d7deb



