### PR TITLE
[FIX] Don't allow fullscreen keybind in type fields

### DIFF
--- a/source/funkin/util/WindowUtil.hx
+++ b/source/funkin/util/WindowUtil.hx
@@ -117,6 +117,11 @@ class WindowUtil
 
     #if (desktop || html5)
     openfl.Lib.current.stage.addEventListener(openfl.events.KeyboardEvent.KEY_DOWN, (e:openfl.events.KeyboardEvent) -> {
+      if (haxe.ui.focus.FocusManager.instance.focus != null)
+      {
+        return;
+      }
+
       for (key in PlayerSettings.player1.controls.getKeysForAction(WINDOW_FULLSCREEN))
       {
         // FlxG.stage.focus is set to null by the debug console stuff,


### PR DESCRIPTION
## ISSUES
#3923

## DESCRIPTION
This pr adds a check to the event listener in `WindowUtil`. It checks whether haxe ui is focused or not.

Before when you were typing in a field and would press the button that is bound to the fullscreen toggle, you would toggle fullscreen.

Now this doesn't happen anymore.