### PR TITLE
[DOCS + GITHUB] Add CONTRIBUTING.md links to README and Issue Templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -3,14 +3,18 @@ description: Report a bug or an issue in the game.
 labels: ["type: minor bug", "status: pending triage"]
 title: "Bug Report: "
 body:
+  - type: markdown
+    attributes:
+      value: "# PLEASE READ THE [CONTRIBUTING GUIDE](https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) BEFORE OPENING ISSUES!"
+      
   - type: checkboxes
     attributes:
       label: Issue Checklist
       description: Be sure to complete these steps to increase the chances of your issue being addressed!
       options:
-        - label: I have read the pinned [Issues Guide](https://github.com/FunkinCrew/Funkin/issues/4050)
+        - label: I have read the [Contributing Guide](https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md)
         - label: I have checked the Issues/Discussions pages to see if my issue has already been reported
-        - label: I have properly named my issue
+        - label: I have properly titled my issue
 
   - type: dropdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/charting.yml
+++ b/.github/ISSUE_TEMPLATE/charting.yml
@@ -3,14 +3,18 @@ description: Report an issue with the placement of notes in the game.
 labels: ["type: charting issue", "status: pending triage"]
 title: "Charting Issue: "
 body:
+  - type: markdown
+    attributes:
+      value: "# PLEASE READ THE [CONTRIBUTING GUIDE](https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) BEFORE OPENING ISSUES!"
+      
   - type: checkboxes
     attributes:
       label: Issue Checklist
       description: Be sure to complete these steps to increase the chances of your issue being addressed!
       options:
-        - label: I have read the pinned [Issues Guide](https://github.com/FunkinCrew/Funkin/issues/4050)
+        - label: I have read the [Contributing Guide](https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md)
         - label: I have checked the Issues/Discussions pages to see if my issue has already been reported
-        - label: I have properly named my issue
+        - label: I have properly titled my issue
 
   - type: dropdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/compiling.yml
+++ b/.github/ISSUE_TEMPLATE/compiling.yml
@@ -3,15 +3,19 @@ description: Report an issue with compiling the game.
 labels: ["type: compilation help", "status: pending triage"]
 title: "Compiling Help: "
 body:
+  - type: markdown
+    attributes:
+      value: "# PLEASE READ THE [CONTRIBUTING GUIDE](https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) BEFORE OPENING ISSUES!"
+      
   - type: checkboxes
     attributes:
       label: Issue Checklist
       description: Be sure to complete these steps to increase the chances of your issue being addressed!
       options:
-        - label: I have read the pinned [Issues Guide](https://github.com/FunkinCrew/Funkin/issues/4050)
         - label: I have followed the [Compiling Guide](https://github.com/FunkinCrew/Funkin/blob/main/docs/COMPILING.md) and the [Troubleshooting Guide](https://github.com/FunkinCrew/Funkin/blob/main/docs/TROUBLESHOOTING.md)
+        - label: I have read the [Contributing Guide](https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md)
         - label: I have checked the Issues/Discussions pages to see if my issue has already been reported
-        - label: I have properly named my issue
+        - label: I have properly titled my issue
 
   - type: dropdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/crash.yml
+++ b/.github/ISSUE_TEMPLATE/crash.yml
@@ -3,14 +3,18 @@ description: Report a crash that occurred while playing the game.
 labels: ["type: major bug", "status: pending triage"]
 title: "Crash Report: "
 body:
+  - type: markdown
+    attributes:
+      value: "# PLEASE READ THE [CONTRIBUTING GUIDE](https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) BEFORE OPENING ISSUES!"
+      
   - type: checkboxes
     attributes:
       label: Issue Checklist
       description: Be sure to complete these steps to increase the chances of your issue being addressed!
       options:
-        - label: I have read the pinned [Issues Guide](https://github.com/FunkinCrew/Funkin/issues/4050)
+        - label: I have read the [Contributing Guide](https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md)
         - label: I have checked the Issues/Discussions pages to see if my issue has already been reported
-        - label: I have properly named my issue
+        - label: I have properly titled my issue
 
   - type: dropdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/enhancement.yml
+++ b/.github/ISSUE_TEMPLATE/enhancement.yml
@@ -3,14 +3,18 @@ description: Suggest a new feature.
 labels: ["type: enhancement", "status: pending triage"]
 title: "Enhancement: "
 body:
+  - type: markdown
+    attributes:
+      value: "# PLEASE READ THE [CONTRIBUTING GUIDE](https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) BEFORE OPENING ISSUES!"
+      
   - type: checkboxes
     attributes:
       label: Issue Checklist
       description: Be sure to complete these steps to increase the chances of your suggestion being considered!
       options:
-        - label: I have read the pinned [Issues Guide](https://github.com/FunkinCrew/Funkin/issues/4050)
+        - label: I have read the [Contributing Guide](https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md)
         - label: I have checked the Issues/Discussions pages to see if my enhancement has already been suggested
-        - label: I have properly named my enhancement
+        - label: I have properly titled my enhancement
 
   - type: textarea
     attributes:

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,4 @@
-<!-- Please read the [Contributing Guide](https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->
+<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->
 ## Does this PR close any issues? If so, link them below.
 
 ## Briefly describe the issue(s) fixed.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,4 @@
-<!-- Please check for duplicates or similar PRs before submitting this PR. -->
+<!-- Please read the [Contributing Guide](https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->
 ## Does this PR close any issues? If so, link them below.
 
 ## Briefly describe the issue(s) fixed.

--- a/README.md
+++ b/README.md
@@ -11,11 +11,11 @@ This game was made with love to Newgrounds and its community. Extra love to Tom 
 
 **PLEASE USE THE LINKS ABOVE IF YOU JUST WANT TO PLAY THE GAME**
 
-To learn how to install the necessary dependencies and compile the game from source, please check out our [building the game](/docs/COMPILING.md) guide.
+To learn how to install the necessary dependencies and compile the game from source, please follow our [Compiling Guide](/docs/COMPILING.md).
 
 # Contributing
 
-You can actively participate in the development of Friday Night Funkin' by opening a [bug report](https://github.com/FunkinCrew/Funkin/issues) or submitting a [code contribution](https://github.com/FunkinCrew/Funkin/pulls)!
+Check out our [Contributing Guide](/docs/CONTRIBUTING.md) to learn how you can actively contribute to the development of Friday Night Funkin'!
 
 # Modding
 


### PR DESCRIPTION
# Changes
Links README and Issue Templates to [CONTRIBUTING.md](https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md)

## Screenshot
![image](https://github.com/user-attachments/assets/65fc5900-b718-46d3-98b5-bfcfbef66f6a)