### PR TITLE
Chart editor context menu solitaire fix

### DIFF
--- a/source/funkin/ui/debug/charting/ChartEditorState.hx
+++ b/source/funkin/ui/debug/charting/ChartEditorState.hx
@@ -6385,7 +6385,7 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
 
     cleanupAutoSave();
 
-    this.closeAllMenus();
+    this.closeExistingMenu();
 
     // Hide the mouse cursor on other states.
     Cursor.hide();

--- a/source/funkin/ui/debug/charting/contextmenus/ChartEditorEventContextMenu.hx
+++ b/source/funkin/ui/debug/charting/contextmenus/ChartEditorEventContextMenu.hx
@@ -13,7 +13,7 @@ class ChartEditorEventContextMenu extends ChartEditorBaseContextMenu
   var contextmenuEdit:MenuItem;
   var contextmenuDelete:MenuItem;
 
-  var data:SongEventData;
+  public var data:SongEventData;
 
   public function new(chartEditorState2:ChartEditorState, xPos2:Float = 0, yPos2:Float = 0, data:SongEventData)
   {
@@ -23,7 +23,7 @@ class ChartEditorEventContextMenu extends ChartEditorBaseContextMenu
     initialize();
   }
 
-  function initialize()
+  public function initialize()
   {
     contextmenuEdit.onClick = function(_) {
       chartEditorState.showToolbox(ChartEditorState.CHART_EDITOR_TOOLBOX_EVENT_DATA_LAYOUT);

--- a/source/funkin/ui/debug/charting/contextmenus/ChartEditorHoldNoteContextMenu.hx
+++ b/source/funkin/ui/debug/charting/contextmenus/ChartEditorHoldNoteContextMenu.hx
@@ -15,7 +15,7 @@ class ChartEditorHoldNoteContextMenu extends ChartEditorBaseContextMenu
   var contextmenuFlip:MenuItem;
   var contextmenuDelete:MenuItem;
 
-  var data:SongNoteData;
+  public var data:SongNoteData;
 
   public function new(chartEditorState2:ChartEditorState, xPos2:Float = 0, yPos2:Float = 0, data:SongNoteData)
   {
@@ -25,7 +25,7 @@ class ChartEditorHoldNoteContextMenu extends ChartEditorBaseContextMenu
     initialize();
   }
 
-  function initialize():Void
+  public function initialize():Void
   {
     // NOTE: Remember to use commands here to ensure undo/redo works properly
     contextmenuFlip.onClick = function(_) {

--- a/source/funkin/ui/debug/charting/contextmenus/ChartEditorNoteContextMenu.hx
+++ b/source/funkin/ui/debug/charting/contextmenus/ChartEditorNoteContextMenu.hx
@@ -15,7 +15,7 @@ class ChartEditorNoteContextMenu extends ChartEditorBaseContextMenu
   var contextmenuFlip:MenuItem;
   var contextmenuDelete:MenuItem;
 
-  var data:SongNoteData;
+  public var data:SongNoteData;
 
   public function new(chartEditorState2:ChartEditorState, xPos2:Float = 0, yPos2:Float = 0, data:SongNoteData)
   {
@@ -25,7 +25,7 @@ class ChartEditorNoteContextMenu extends ChartEditorBaseContextMenu
     initialize();
   }
 
-  function initialize():Void
+  public function initialize():Void
   {
     // NOTE: Remember to use commands here to ensure undo/redo works properly
     contextmenuFlip.onClick = function(_) {

--- a/source/funkin/ui/debug/charting/contextmenus/ChartEditorSelectionContextMenu.hx
+++ b/source/funkin/ui/debug/charting/contextmenus/ChartEditorSelectionContextMenu.hx
@@ -28,7 +28,7 @@ class ChartEditorSelectionContextMenu extends ChartEditorBaseContextMenu
     initialize();
   }
 
-  function initialize():Void
+  public function initialize():Void
   {
     contextmenuCut.onClick = (_) -> {
       chartEditorState.performCommand(new CutItemsCommand(chartEditorState.currentNoteSelection, chartEditorState.currentEventSelection));

--- a/source/funkin/ui/debug/charting/handlers/ChartEditorContextMenuHandler.hx
+++ b/source/funkin/ui/debug/charting/handlers/ChartEditorContextMenuHandler.hx
@@ -9,6 +9,7 @@ import haxe.ui.containers.menus.Menu;
 import haxe.ui.core.Screen;
 import funkin.data.song.SongData.SongNoteData;
 import funkin.data.song.SongData.SongEventData;
+import haxe.ui.events.UIEvent;
 
 /**
  * Handles context menus (the little menus that appear when you right click on stuff) for the new Chart Editor.
@@ -17,11 +18,28 @@ import funkin.data.song.SongData.SongEventData;
 @:access(funkin.ui.debug.charting.ChartEditorState)
 class ChartEditorContextMenuHandler
 {
-  static var existingMenus:Array<Menu> = [];
+  static var existingMenu:Null<Menu>;
+  static var existingDefaultContextMenu:Null<ChartEditorDefaultContextMenu>;
+  static var existingSelectionContextMenu:Null<ChartEditorSelectionContextMenu>;
+  static var existingNoteContextMenu:Null<ChartEditorNoteContextMenu>;
+  static var existingHoldNoteContextMenu:Null<ChartEditorHoldNoteContextMenu>;
+  static var existingEventContextMenu:Null<ChartEditorEventContextMenu>;
 
   public static function openDefaultContextMenu(state:ChartEditorState, xPos:Float, yPos:Float)
   {
-    displayMenu(state, new ChartEditorDefaultContextMenu(state, xPos, yPos));
+    if (existingDefaultContextMenu != null)
+    {
+      existingDefaultContextMenu.left = xPos;
+      existingDefaultContextMenu.top = yPos;
+      Screen.instance.addComponent(existingDefaultContextMenu);
+
+    }
+    else
+    {
+      var targetMenu = new ChartEditorDefaultContextMenu(state, xPos, yPos);
+      displayMenu(state, targetMenu);
+      existingDefaultContextMenu = targetMenu;
+    }
   }
 
   /**
@@ -29,7 +47,19 @@ class ChartEditorContextMenuHandler
    */
   public static function openSelectionContextMenu(state:ChartEditorState, xPos:Float, yPos:Float)
   {
-    displayMenu(state, new ChartEditorSelectionContextMenu(state, xPos, yPos));
+    if (existingSelectionContextMenu != null)
+    {
+      existingSelectionContextMenu.left = xPos;
+      existingSelectionContextMenu.top = yPos;
+      existingSelectionContextMenu.initialize();
+      Screen.instance.addComponent(existingSelectionContextMenu);
+    }
+    else
+    {
+      var targetMenu = new ChartEditorSelectionContextMenu(state, xPos, yPos);
+      displayMenu(state, targetMenu);
+      existingSelectionContextMenu = targetMenu;
+    }
   }
 
   /**
@@ -37,7 +67,20 @@ class ChartEditorContextMenuHandler
    */
   public static function openNoteContextMenu(state:ChartEditorState, xPos:Float, yPos:Float, data:SongNoteData)
   {
-    displayMenu(state, new ChartEditorNoteContextMenu(state, xPos, yPos, data));
+    if (existingNoteContextMenu != null)
+    {
+      existingNoteContextMenu.left = xPos;
+      existingNoteContextMenu.top = yPos;
+      existingNoteContextMenu.data = data;
+      existingNoteContextMenu.initialize();
+      Screen.instance.addComponent(existingNoteContextMenu);
+    }
+    else
+    {
+      var targetMenu = new ChartEditorNoteContextMenu(state, xPos, yPos, data);
+      displayMenu(state, targetMenu);
+      existingNoteContextMenu = targetMenu;
+    }
   }
 
   /**
@@ -45,7 +88,20 @@ class ChartEditorContextMenuHandler
    */
   public static function openHoldNoteContextMenu(state:ChartEditorState, xPos:Float, yPos:Float, data:SongNoteData)
   {
-    displayMenu(state, new ChartEditorHoldNoteContextMenu(state, xPos, yPos, data));
+    if (existingHoldNoteContextMenu != null)
+    {
+      existingHoldNoteContextMenu.left = xPos;
+      existingHoldNoteContextMenu.top = yPos;
+      existingHoldNoteContextMenu.data = data;
+      existingHoldNoteContextMenu.initialize();
+      Screen.instance.addComponent(existingHoldNoteContextMenu);
+    }
+    else
+    {
+      var targetMenu = new ChartEditorHoldNoteContextMenu(state, xPos, yPos, data);
+      displayMenu(state, targetMenu);
+      existingHoldNoteContextMenu = targetMenu;
+    }
   }
 
   /**
@@ -53,30 +109,44 @@ class ChartEditorContextMenuHandler
    */
   public static function openEventContextMenu(state:ChartEditorState, xPos:Float, yPos:Float, data:SongEventData)
   {
-    displayMenu(state, new ChartEditorEventContextMenu(state, xPos, yPos, data));
+    if (existingEventContextMenu != null)
+    {
+      existingEventContextMenu.left = xPos;
+      existingEventContextMenu.top = yPos;
+      existingEventContextMenu.data = data;
+      existingEventContextMenu.initialize();
+      Screen.instance.addComponent(existingEventContextMenu);
+    }
+    else
+    {
+      var targetMenu = new ChartEditorEventContextMenu(state, xPos, yPos, data);
+      displayMenu(state, targetMenu);
+      existingEventContextMenu = targetMenu;
+    }
   }
 
   static function displayMenu(state:ChartEditorState, targetMenu:Menu)
   {
-    // Close any existing menus
-    closeAllMenus(state);
+    // Close the existing menu because it's of a different type
+    closeExistingMenu(state);
 
     // Show the new menu
     Screen.instance.addComponent(targetMenu);
-    existingMenus.push(targetMenu);
+    existingMenu = targetMenu;
   }
 
-  public static function closeMenu(state:ChartEditorState, targetMenu:Menu)
+  public static function closeExistingMenu(state:ChartEditorState)
   {
-    // targetMenu.close();
-    existingMenus.remove(targetMenu);
-  }
-
-  public static function closeAllMenus(state:ChartEditorState)
-  {
-    for (existingMenu in existingMenus)
+    if (existingMenu != null)
     {
-      closeMenu(state, existingMenu);
+      Screen.instance.removeComponent(existingMenu);
+
+      existingDefaultContextMenu = null;
+      existingSelectionContextMenu = null;
+      existingNoteContextMenu = null;
+      existingHoldNoteContextMenu = null;
+      existingEventContextMenu = null;
+      existingMenu = null;
     }
   }
 }


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->
## Does this PR close any issues? If so, link them below.
https://github.com/FunkinCrew/Funkin/issues/3338
## Briefly describe the issue(s) fixed.
Holding shift and right click while moving your mouse over a note causes additional context menus to appear.
## Include any relevant screenshots or videos.
https://github.com/user-attachments/assets/61ad6d1d-7b4b-4903-abaf-5915b102fa2e

