### PR TITLE
Chart editor window toggle fix

### DIFF
--- a/source/funkin/ui/debug/charting/ChartEditorState.hx
+++ b/source/funkin/ui/debug/charting/ChartEditorState.hx
@@ -2879,6 +2879,7 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
     playbarBPM.onClick = _ -> {
       if (FlxG.keys.pressed.CONTROL)
       {
+        if (menubarItemToggleToolboxMetadata.selected) return;
         this.setToolboxState(CHART_EDITOR_TOOLBOX_METADATA_LAYOUT, true);
         // TODO: Figure out a way to prevent this from calling the on change event / opening the dialog twice
         menubarItemToggleToolboxMetadata.selected = true;
@@ -2898,6 +2899,7 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
     playbarDifficulty.onClick = _ -> {
       if (FlxG.keys.pressed.CONTROL)
       {
+        if (menubarItemToggleToolboxDifficulty.selected) return;
         this.setToolboxState(CHART_EDITOR_TOOLBOX_DIFFICULTY_LAYOUT, true);
         // TODO: Figure out a way to prevent this from calling the on change event / opening the dialog twice
         menubarItemToggleToolboxDifficulty.selected = true;

--- a/source/funkin/ui/debug/charting/ChartEditorState.hx
+++ b/source/funkin/ui/debug/charting/ChartEditorState.hx
@@ -2880,6 +2880,8 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
       if (FlxG.keys.pressed.CONTROL)
       {
         this.setToolboxState(CHART_EDITOR_TOOLBOX_METADATA_LAYOUT, true);
+        // TODO: Figure out a way to prevent this from calling the on change event / opening the dialog twice
+        menubarItemToggleToolboxMetadata.selected = true;
       }
       else
       {
@@ -2897,6 +2899,8 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
       if (FlxG.keys.pressed.CONTROL)
       {
         this.setToolboxState(CHART_EDITOR_TOOLBOX_DIFFICULTY_LAYOUT, true);
+        // TODO: Figure out a way to prevent this from calling the on change event / opening the dialog twice
+        menubarItemToggleToolboxDifficulty.selected = true;
       }
       else
       {


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->
## Does this PR close any issues? If so, link them below.
Fixes #4141 
## Briefly describe the issue(s) fixed.
The window .selected for the metadata and difficulty dialogues that can be opened by control clicking the BPM or difficulty isn't updated. Now it is.

It introduces a new tiny problem in that the technically dialogue opens twice when opening this way (and the first time you open the window tab it opens the windows again), but that's less big of a deal than this.
## Include any relevant screenshots or videos.
https://github.com/user-attachments/assets/073292a1-aa89-43a9-b47a-b1199b86da54