### PR TITLE
fix notelay sound when not in grid

### DIFF
--- a/source/funkin/ui/debug/charting/ChartEditorState.hx
+++ b/source/funkin/ui/debug/charting/ChartEditorState.hx
@@ -4565,7 +4565,7 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
           if (dragTargetCurrentStep != dragDistanceSteps || dragTargetCurrentColumn != dragDistanceColumns)
           {
             // Play a sound as we drag.
-            this.playSound(Paths.sound('chartingSounds/noteLay'));
+            if (overlapsGrid) this.playSound(Paths.sound('chartingSounds/noteLay'));
 
             trace('Dragged ${dragDistanceColumns} X and ${dragDistanceSteps} Y.');
             dragTargetCurrentStep = dragDistanceSteps;


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->
## Does this PR close any issues? If so, link them below.
https://github.com/FunkinCrew/Funkin/issues/4153
## Briefly describe the issue(s) fixed.
The editor would play notelay even when the cursor was outside the grid
## Include any relevant screenshots or videos.
