### PR TITLE
[BUGFIX] Fix the difficulty graphic cutoff in the Results Screen

### DIFF
--- a/source/funkin/play/ResultState.hx
+++ b/source/funkin/play/ResultState.hx
@@ -278,8 +278,7 @@ class ResultState extends MusicBeatSubState
     songName.shader = maskShaderSongName;
     difficulty.shader = maskShaderDifficulty;
 
-    // maskShaderSongName.swagMaskX = difficulty.x - 15;
-    maskShaderDifficulty.swagMaskX = difficulty.x - 15;
+    maskShaderDifficulty.swagMaskX = difficulty.x - 30;
 
     var blackTopBar:FlxSprite = new FlxSprite().loadGraphic(Paths.image("resultScreen/topBarBlack"));
     blackTopBar.y = -blackTopBar.height;


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->
## Does this PR close any issues? If so, link them below.
Closes #2283

## Briefly describe the issue(s) fixed.
Just one simple line change to move the mask shader more to the left.

## Include any relevant screenshots or videos.
![screenshot-2025-02-16-20-58-14](https://github.com/user-attachments/assets/992ec520-4803-4930-9a64-7945ce7d7c81)
