### PR TITLE
Chart editor low playspeed song not playing/stuttering fix

### DIFF
--- a/source/funkin/ui/debug/charting/ChartEditorState.hx
+++ b/source/funkin/ui/debug/charting/ChartEditorState.hx
@@ -728,6 +728,11 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
   // Audio
 
   /**
+   * This is used rather than the audiotrack time if it's higher. Low playspeeds cause the audiotrack's time to sometimes be set ~10ms before somehow.
+   */
+  var oldTime:Float;
+
+  /**
    * Whether to play a metronome sound while the playhead is moving, and what volume.
    */
   var metronomeVolume:Float = 1.0;
@@ -3416,6 +3421,7 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
         {
           trace('Resetting instrumental time to ${- Conductor.instance.instrumentalOffset}ms');
           audioInstTrack.time = -Conductor.instance.instrumentalOffset;
+          oldTime = audioInstTrack.time;
         }
       }
 
@@ -3432,14 +3438,27 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
 
         var oldStepTime:Float = Conductor.instance.currentStepTime;
         var oldSongPosition:Float = Conductor.instance.songPosition + Conductor.instance.instrumentalOffset;
-        Conductor.instance.update(audioInstTrack.time);
+        // Don't go backwards in the song, only forwards
+        if (oldTime < audioInstTrack.time)
+        {
+          Conductor.instance.update(audioInstTrack.time);
+          oldTime = audioInstTrack.time;
+        }
+        else
+        {
+          Conductor.instance.update(oldTime);
+          trace('oldTime was used! audioInstTrack.time ${audioInstTrack.time} < oldTime ${oldTime}');
+        }
         handleHitsounds(oldSongPosition, Conductor.instance.songPosition + Conductor.instance.instrumentalOffset);
         // Resync vocals.
         if (Math.abs(audioInstTrack.time - audioVocalTrackGroup.time) > 100)
         {
           audioVocalTrackGroup.time = audioInstTrack.time;
         }
-        var diffStepTime:Float = Conductor.instance.currentStepTime - oldStepTime;
+        var diffStepTime:Float;
+        if ((Conductor.instance.currentStepTime - oldStepTime) < 0) diffStepTime = oldStepTime - Conductor.instance.currentStepTime;
+        else
+          diffStepTime = Conductor.instance.currentStepTime - oldStepTime;
 
         // Move the playhead.
         playheadPositionInPixels += diffStepTime * GRID_SIZE;
@@ -3450,7 +3469,18 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
       {
         // Else, move the entire view.
         var oldSongPosition:Float = Conductor.instance.songPosition + Conductor.instance.instrumentalOffset;
-        Conductor.instance.update(audioInstTrack.time);
+        // Don't go backwards in the song, only forwards
+        if (oldTime < audioInstTrack.time)
+        {
+          Conductor.instance.update(audioInstTrack.time);
+          oldTime = audioInstTrack.time;
+        }
+        else
+        {
+          Conductor.instance.update(oldTime);
+          trace('oldTime was used! audioInstTrack.time ${audioInstTrack.time} < oldTime ${oldTime}');
+        }
+
         handleHitsounds(oldSongPosition, Conductor.instance.songPosition + Conductor.instance.instrumentalOffset);
         // Resync vocals.
         if (Math.abs(audioInstTrack.time - audioVocalTrackGroup.time) > 100)
@@ -6296,6 +6326,7 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
   {
     if (audioInstTrack != null) audioInstTrack.pause();
     audioVocalTrackGroup.pause();
+    oldTime = 0;
 
     playbarPlay.text = '>';
   }


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->
## Does this PR close any issues? If so, link them below.
https://github.com/FunkinCrew/Funkin/issues/4155
## Briefly describe the issue(s) fixed.
Low playspeeds cause the audiotrack's time to sometimes be set ~10ms before somehow. To fix this, a global float stores the previous time used to update the conductor and it'll be used instead for that if the audiotrack time is lower than it. 

This isn't a perfect fix ofc, but it's better than the song stuttering because it goes back in time.
## Include any relevant screenshots or videos.

https://github.com/user-attachments/assets/82b6a600-291f-4414-9c24-e05e526c6c54

