### PR TITLE
Quick `develop` branch fix (again)

### DIFF
--- a/source/funkin/data/stage/StageData.hx
+++ b/source/funkin/data/stage/StageData.hx
@@ -268,10 +268,10 @@ typedef StageDataCharacter =
    * [1, 1] means the character moves 1:1 with the camera.
    * [0.5, 0.5] means the character moves half as much as the camera.
    * [0, 0] means the character is not moved.
-   * @default [0, 0]
+   * @default [1, 1]
    */
   @:optional
-  @:default([0, 0])
+  @:default([1, 1])
   var scroll:Array<Float>;
 
   /**


### PR DESCRIPTION
I fucked up the scrollfactor by having the default be `[0, 0]` instead of `[1, 1]`. This made the characters move all weird as seen in https://github.com/FunkinCrew/Funkin/pull/3720#issuecomment-2664816013

My bad!!!