### PR TITLE
[ENHANCEMENT + BUGFIX] small script event/module overhaul

### DIFF
--- a/source/funkin/InitState.hx
+++ b/source/funkin/InitState.hx
@@ -260,7 +260,7 @@ class InitState extends FlxState
 
     ModuleHandler.buildModuleCallbacks();
     ModuleHandler.loadModuleCache();
-    ModuleHandler.callOnCreate();
+    ModuleHandler.callOnGameInit();
 
     funkin.input.Cursor.hide();
 

--- a/source/funkin/modding/IScriptedClass.hx
+++ b/source/funkin/modding/IScriptedClass.hx
@@ -113,6 +113,16 @@ interface IBPMSyncedScriptedClass extends IScriptedClass
 interface IPlayStateScriptedClass extends INoteScriptedClass extends IBPMSyncedScriptedClass
 {
   /**
+   * Called after `PlayState` creation, right before the countdown starts.
+   */
+  public function onPlayStateCreate(event:ScriptEvent):Void;
+
+  /**
+   * Called immediately before `PlayState` cleanup.
+   */
+  public function onPlayStateClose(event:ScriptEvent):Void;
+
+  /**
    * Called when the game is paused.
    * Has properties to set whether the pause easter egg will happen,
    * and can be cancelled by scripts.
@@ -190,4 +200,22 @@ interface IDialogueScriptedClass extends IScriptedClass
   public function onDialogueLine(event:DialogueScriptEvent):Void;
   public function onDialogueSkip(event:DialogueScriptEvent):Void;
   public function onDialogueEnd(event:DialogueScriptEvent):Void;
+}
+
+/**
+ * Defines a set of callbacks available to scripted classes which are global and not tied to a specific state.
+ */
+interface IGlobalScriptedClass extends IPlayStateScriptedClass extends IStateChangingScriptedClass
+{
+  /**
+   * Called when the game is first initialized, before the title screen appears.
+   * This event is only called once.
+   */
+  public function onGameInit(event:ScriptEvent):Void;
+
+  /**
+   * Called when the game is closed for any reason.
+   * This event is only called once.
+   */
+  public function onGameClose(event:GameCloseScriptEvent):Void;
 }

--- a/source/funkin/modding/events/ScriptEvent.hx
+++ b/source/funkin/modding/events/ScriptEvent.hx
@@ -556,3 +556,20 @@ class PauseScriptEvent extends ScriptEvent
     this.gitaroo = gitaroo;
   }
 }
+
+/**
+ * An event which is called when the game is closed for any reason.
+ */
+class GameCloseScriptEvent extends ScriptEvent
+{
+  /**
+   * The exit code. Any non-zero value is likely an error.
+   */
+  public var exitCode(default, null):Int;
+
+  public function new(exitCode:Int):Void
+  {
+    super(GAME_CLOSE, false);
+    this.exitCode = exitCode;
+  }
+}

--- a/source/funkin/modding/events/ScriptEventDispatcher.hx
+++ b/source/funkin/modding/events/ScriptEventDispatcher.hx
@@ -1,6 +1,5 @@
 package funkin.modding.events;
 
-import funkin.modding.IScriptedClass.IPlayStateScriptedClass;
 import funkin.modding.IScriptedClass;
 
 /**
@@ -118,6 +117,12 @@ class ScriptEventDispatcher
       var t:IPlayStateScriptedClass = cast(target, IPlayStateScriptedClass);
       switch (event.type)
       {
+        case PLAYSTATE_CREATE:
+          t.onPlayStateCreate(event);
+          return;
+        case PLAYSTATE_CLOSE:
+          t.onPlayStateClose(event);
+          return;
         case NOTE_GHOST_MISS:
           t.onNoteGhostMiss(cast event);
           return;
@@ -186,6 +191,21 @@ class ScriptEventDispatcher
           return;
         case FOCUS_GAINED:
           t.onFocusGained(cast event);
+          return;
+        default: // Continue;
+      }
+    }
+
+    if (Std.isOfType(target, IGlobalScriptedClass))
+    {
+      var t = cast(target, IGlobalScriptedClass);
+      switch (event.type)
+      {
+        case GAME_INIT:
+          t.onGameInit(event);
+          return;
+        case GAME_CLOSE:
+          t.onGameClose(cast event);
           return;
         default: // Continue;
       }

--- a/source/funkin/modding/events/ScriptEventType.hx
+++ b/source/funkin/modding/events/ScriptEventType.hx
@@ -4,6 +4,22 @@ package funkin.modding.events;
 enum abstract ScriptEventType(String) from String to String
 {
   /**
+   * Called when the game is first initialized, before the title screen appears.
+   * This event is only called once.
+   *
+   * This event is not cancelable.
+   */
+  var GAME_INIT = 'GAME_INIT';
+
+  /**
+   * Called when the game is closed for any reason.
+   * This event is only called once.
+   *
+   * This event is not cancelable.
+   */
+  var GAME_CLOSE = 'GAME_CLOSE';
+
+  /**
    * Called when the relevant object is created.
    * Keep in mind that the constructor may be called before the object is needed,
    * for the purposes of caching data or otherwise.
@@ -35,6 +51,20 @@ enum abstract ScriptEventType(String) from String to String
    * This event is not cancelable.
    */
   var UPDATE = 'UPDATE';
+
+  /**
+   * Called after `PlayState` creation, right before the countdown starts.
+   *
+   * This event is not cancelable.
+   */
+  var PLAYSTATE_CREATE = 'PLAYSTATE_CREATE';
+
+  /**
+   * Called immediately before `PlayState` cleanup.
+   *
+   * This event is not cancelable.
+   */
+  var PLAYSTATE_CLOSE = 'PLAYSTATE_CLOSE';
 
   /**
    * Called when the player moves to pause the game.

--- a/source/funkin/modding/module/Module.hx
+++ b/source/funkin/modding/module/Module.hx
@@ -1,7 +1,6 @@
 package funkin.modding.module;
 
-import funkin.modding.IScriptedClass.IPlayStateScriptedClass;
-import funkin.modding.IScriptedClass.IStateChangingScriptedClass;
+import funkin.modding.IScriptedClass.IGlobalScriptedClass;
 import funkin.modding.events.ScriptEvent;
 
 /**
@@ -9,7 +8,7 @@ import funkin.modding.events.ScriptEvent;
  * You may have the module active at all times, or only when another script enables it.
  */
 @:nullSafety
-class Module implements IPlayStateScriptedClass implements IStateChangingScriptedClass
+class Module implements IGlobalScriptedClass
 {
   /**
    * Whether the module is currently active.
@@ -64,14 +63,26 @@ class Module implements IPlayStateScriptedClass implements IStateChangingScripte
   public function onScriptEvent(event:ScriptEvent) {}
 
   /**
-   * Called when the module is first created.
-   * This happens before the title screen appears!
+   * Called when the game is first initialized, before the title screen appears.
+   * This happens only once, immediately after the module's first `onCreate` event.
+   */
+  public function onGameInit(event:ScriptEvent) {}
+
+  /**
+   * Called when the game is closed for any reason.
+   * This happens only once, immediately before the module's last `onDestroy` event.
+   */
+  public function onGameClose(event:GameCloseScriptEvent) {}
+
+  /**
+   * Called when the module is created.
+   * This happens when the game is first initialized or after a mod reload.
    */
   public function onCreate(event:ScriptEvent) {}
 
   /**
    * Called when a module is destroyed.
-   * This currently only happens when reloading modules with F5.
+   * This happens when reloading modules with F5 or when the game is closed.
    */
   public function onDestroy(event:ScriptEvent) {}
 
@@ -79,6 +90,16 @@ class Module implements IPlayStateScriptedClass implements IStateChangingScripte
    * Called every frame.
    */
   public function onUpdate(event:UpdateScriptEvent) {}
+
+  /**
+   * Called after `PlayState` creation, right before the countdown starts.
+   */
+  public function onPlayStateCreate(event:ScriptEvent) {}
+
+  /**
+   * Called immediately before `PlayState` cleanup.
+   */
+  public function onPlayStateClose(event:ScriptEvent) {}
 
   /**
    * Called when the game is paused.

--- a/source/funkin/play/PlayState.hx
+++ b/source/funkin/play/PlayState.hx
@@ -803,6 +803,9 @@ class PlayState extends MusicBeatSubState
 
     FlxG.worldBounds.set(0, 0, FlxG.width, FlxG.height);
 
+    // Dispatch the `PlayState` create event.
+    dispatchEvent(new ScriptEvent(PLAYSTATE_CREATE, false));
+
     // The song is loaded and in the process of starting.
     // This gets set back to false when the chart actually starts.
     startingSong = true;
@@ -1380,7 +1383,7 @@ class PlayState extends MusicBeatSubState
     // Modules should get the first chance to cancel the event.
 
     // super.dispatchEvent(event) dispatches event to module scripts.
-    super.dispatchEvent(event);
+    if (event.type != DESTROY) super.dispatchEvent(event);
 
     // Dispatch event to note kind scripts
     NoteKindManager.callEvent(event);
@@ -3389,11 +3392,18 @@ class PlayState extends MusicBeatSubState
     super.close();
   }
 
+  private var cleanupDone:Bool = false;
+
   /**
-     * Perform necessary cleanup before leaving the PlayState.
-     */
+   * Perform necessary cleanup before leaving the PlayState.
+   */
   function performCleanup():Void
   {
+    if (cleanupDone) return;
+
+    // Dispatch the `PlayState` close event.
+    dispatchEvent(new ScriptEvent(PLAYSTATE_CLOSE, false));
+
     // If the camera is being tweened, stop it.
     cancelAllCameraTweens();
 
@@ -3454,6 +3464,8 @@ class PlayState extends MusicBeatSubState
 
     // Clear the static reference to this state.
     instance = null;
+
+    cleanupDone = true;
   }
 
   /**

--- a/source/funkin/play/song/Song.hx
+++ b/source/funkin/play/song/Song.hx
@@ -619,6 +619,10 @@ class Song implements IPlayStateScriptedClass implements IRegistryEntry<SongMeta
     }
   }
 
+  public function onPlayStateCreate(event:ScriptEvent):Void {};
+
+  public function onPlayStateClose(event:ScriptEvent):Void {};
+
   public function onPause(event:PauseScriptEvent):Void {};
 
   public function onResume(event:ScriptEvent):Void {};

--- a/source/funkin/play/stage/Bopper.hx
+++ b/source/funkin/play/stage/Bopper.hx
@@ -357,6 +357,10 @@ class Bopper extends StageProp implements IPlayStateScriptedClass
     return output;
   }
 
+  public function onPlayStateCreate(event:ScriptEvent) {}
+
+  public function onPlayStateClose(event:ScriptEvent) {}
+
   public function onPause(event:PauseScriptEvent) {}
 
   public function onResume(event:ScriptEvent) {}

--- a/source/funkin/play/stage/Stage.hx
+++ b/source/funkin/play/stage/Stage.hx
@@ -865,6 +865,10 @@ class Stage extends FlxSpriteGroup implements IPlayStateScriptedClass implements
     }
   }
 
+  public function onPlayStateCreate(event:ScriptEvent) {}
+
+  public function onPlayStateClose(event:ScriptEvent) {}
+
   public function onPause(event:PauseScriptEvent) {}
 
   public function onResume(event:ScriptEvent) {}


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->
## Does this PR close any issues? If so, link them below.

fixes #4167
fixes #3928

## Briefly describe the issue(s) fixed.

after messing with modules a lot, ive come up with a few changes id like implemented!

this pr makes some additions and changes to certain script events, primarily relating to modules and playstate

- module `onDestroy` now calls in reverse module priority order (its reverse so that modules dependent on others have the callback first)
- module `onCreate` is now called whenever the module is created, including after a mod reload
- modules use new `IGlobalScriptedClass` template (extends `IPlayStateScriptedClass` and `IStateChangingScriptedClass`) for the following:
  - new module `onGameInit(event:ScriptEvent)` callback for what is the current `onCreate` behavior, that is only called only when the game first starts
  - new module `onGameClose(event:GameCloseScriptEvent)` callback for whenever the game closes
  - new event type `GameCloseScriptEvent extends ScriptEvent` that holds the exit code
- `PlayState` no longer calls `onDestroy` in modules (only module destruction will)
- `IPlayStateScriptedClass` now has:
  - `onPlayStateCreate(event:ScriptEvent)` - helper event, called near the end of `PlayState.instance.create()` right before the countdown starts
  - `onPlayStateClose(event:ScriptEvent)` - helper event, called before `PlayState` does cleanup
- module `onCreate` will be called regardless of `active` (`onDestroy` currently does this)

> [!warning]
> this has breaking changes!!
> existing modules should:
> - change `onCreate` to `onGameInit`
> - check for `active` in `onCreate` if any code depends on it not running when inactive
> - move `onDestroy` code that deals with `PlayState` destruction to `onPlayStateClose`

## Include any relevant screenshots or videos.

https://github.com/user-attachments/assets/5824b19f-2029-4c2e-82df-4dd3a54cf050

