### PR TITLE
Playback speed not being used fix

### DIFF
--- a/source/funkin/play/PlayState.hx
+++ b/source/funkin/play/PlayState.hx
@@ -937,7 +937,9 @@ class PlayState extends MusicBeatSubState
         Conductor.instance.formatOffset = 0.0;
       }
 
-      Conductor.instance.update(Conductor.instance.songPosition + elapsed * 1000, false); // Normal conductor update.
+      // Pass the music time instead if the pitch is different, aka, the song is lower or faster
+      Conductor.instance.update((FlxG.sound.music.pitch != 1) ? FlxG.sound.music.time + elapsed * 1000 : (Conductor.instance.songPosition + elapsed * 1000),
+        false); // Normal conductor update.
 
       // If, after updating the conductor, the instrumental has finished, end the song immediately.
       // This helps prevent a major bug where the level suddenly loops back to the start or middle.


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->
## Does this PR close any issues? If so, link them below.
Fixes #4176 
## Briefly describe the issue(s) fixed.
The change to the conductor to fix the resync didn't account for if the music's pitch was different. This PR fixes that.

Maybe the check isn't needed and the music time can be used instead? IDK. 
## Include any relevant screenshots or videos.

https://github.com/user-attachments/assets/77473112-e2bf-4bbf-9d9e-2b5a3bc2afaa

<details>

<summary>Bonus: Ugh at 2 times playback speed</summary>

https://github.com/user-attachments/assets/458149be-53e2-4cd2-ac8b-cf24b9d477b6

</details>