### PR TITLE
Chart editor - Deselect items after moving

### DIFF
--- a/source/funkin/ui/debug/charting/commands/SetItemSelectionCommand.hx
+++ b/source/funkin/ui/debug/charting/commands/SetItemSelectionCommand.hx
@@ -80,6 +80,7 @@ class SetItemSelectionCommand implements ChartEditorCommand
     }
 
     state.noteDisplayDirty = true;
+    state.notePreviewDirty = true;
   }
 
   public function undo(state:ChartEditorState):Void
@@ -88,6 +89,7 @@ class SetItemSelectionCommand implements ChartEditorCommand
     state.currentEventSelection = previousEventSelection;
 
     state.noteDisplayDirty = true;
+    state.notePreviewDirty = true;
   }
 
   public function shouldAddToHistory(state:ChartEditorState):Bool


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->
## Does this PR close any issues? If so, link them below.
https://github.com/FunkinCrew/Funkin/issues/3761
## Briefly describe the issue(s) fixed.
After a selection of notes is moved, it doesn't also deselect them. This fixes that? 
## Include any relevant screenshots or videos.
