### PR TITLE
[BUGFIX] Chart Editor - Fix selection breaking when notes are dragged to the same place

### DIFF
--- a/source/funkin/ui/debug/charting/ChartEditorState.hx
+++ b/source/funkin/ui/debug/charting/ChartEditorState.hx
@@ -4721,6 +4721,7 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
           else if (dragTargetEvent != null)
           {
             data = ChartEditorState.STRUMLINE_SIZE * 2 + 1;
+            noteGridPos = noteDataToGridColumn(data) - 1;
           }
           var dragDistanceColumns:Int = cursorGridPos - noteGridPos;
 

--- a/source/funkin/ui/debug/charting/ChartEditorState.hx
+++ b/source/funkin/ui/debug/charting/ChartEditorState.hx
@@ -4645,6 +4645,16 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
           }
           var dragDistanceColumns:Int = dragTargetCurrentColumn;
 
+          if (dragDistanceMs == 0 && dragDistanceColumns == 0)
+          {
+            // There's no need to move anything
+            dragTargetNote = null;
+            dragTargetEvent = null;
+            dragTargetCurrentStep = 0;
+            dragTargetCurrentColumn = 0;
+            return;
+          }
+
           if (currentNoteSelection.length > 0 && currentEventSelection.length > 0)
           {
             // Both notes and events are selected.

--- a/source/funkin/ui/debug/charting/ChartEditorState.hx
+++ b/source/funkin/ui/debug/charting/ChartEditorState.hx
@@ -4647,7 +4647,8 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
 
           if (dragDistanceMs == 0 && dragDistanceColumns == 0)
           {
-            // There's no need to move anything
+            // There's no need to move anything.
+            // Also prevents the selection boxes on notes from disappearing when they're 'moved' like this.
             dragTargetNote = null;
             dragTargetEvent = null;
             dragTargetCurrentStep = 0;


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->
## Does this PR close any issues? If so, link them below.
Fixes #3761 
## Briefly describe the issue(s) fixed.
When you move a bunch of items or notes and move them back into the same position and release, it removes the selection boxes on the notes for some reason.

To fix this, the code now returns if they weren't actually moved. This doesn't fix actually fix the issue in the code, it just bypasses it. I have no clue where it happens, but it has something to do with when the move command is performed but the notes don't actually need to move at all, and something note specific because it doesn't happen to events when moved but not actually moved. 

## Include any relevant screenshots or videos.

https://github.com/user-attachments/assets/b6e83955-280d-448e-bc18-6406a25c2832


~~Wait, that's weird, the move events command can still preform.~~

~~Ah, it's because dragDistanceColumns is always 8. I'll make an additional change for that to keep the functionally the same.~~ Done.
