### PR TITLE
Pico freeplay - gunshot SFX on song confirm

### DIFF
--- a/source/funkin/ui/freeplay/FreeplayState.hx
+++ b/source/funkin/ui/freeplay/FreeplayState.hx
@@ -1958,7 +1958,13 @@ class FreeplayState extends MusicBeatSubState
     }
 
     // Visual and audio effects.
-    FunkinSound.playOnce(Paths.sound('confirmMenu'));
+    if (currentCharacterId == 'pico')
+    {
+      // Gunshot SFX when confirming a song as pico, why not?
+      FunkinSound.playOnce(Paths.soundRandom('shot', 1, 4, 'weekend1'));
+    }
+    else
+      FunkinSound.playOnce(Paths.sound('confirmMenu'));
     if (dj != null) dj.confirm();
 
     grpCapsules.members[curSelected].forcePosition();


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->
## Does this PR close any issues? If so, link them below.
https://github.com/FunkinCrew/Funkin/issues/3167
## Briefly describe the issue(s) fixed.
When a song is confirmed, if the character's pico, it'll play one of the 4 shot sfxs in weekend 1, rather than the song confirm sfx.
## Include any relevant screenshots or videos.

https://github.com/user-attachments/assets/57db4192-09da-4d4d-8cf2-0edb3b0359e2

