### PR TITLE
Remove spammy traces from `DiscordClient`

### DIFF
--- a/source/funkin/api/discord/DiscordClient.hx
+++ b/source/funkin/api/discord/DiscordClient.hx
@@ -56,8 +56,6 @@ class DiscordClient
   {
     while (true)
     {
-      trace('[DISCORD] Performing client update...');
-
       #if DISCORD_DISABLE_IO_THREAD
       Discord.updateConnection();
       #end
@@ -76,8 +74,6 @@ class DiscordClient
 
   public function setPresence(params:DiscordClientPresenceParams):Void
   {
-    trace('[DISCORD] Updating presence... (${params})');
-
     Discord.updatePresence(buildPresence(params));
   }
 
@@ -100,8 +96,6 @@ class DiscordClient
     // This should probably be album art.
     // IMPORTANT NOTE: This can be an asset key uploaded to Discord's developer panel OR any URL you like.
     presence.largeImageKey = cast(params.largeImageKey, Null<String>) ?? "album-volume1";
-
-    trace('[DISCORD] largeImageKey: ${presence.largeImageKey}');
 
     // TODO: Make this use the song's album art.
     // presence.largeImageKey = "icon";


### PR DESCRIPTION
These traces would flood the console, which would make finding certain logs harder. This PR simply removes them.
![Screenshot 2025-02-22 at 1 29 31 PM](https://github.com/user-attachments/assets/1187dfd1-d27e-4937-8c5f-47a0289d4670)
![Screenshot 2025-02-22 at 1 28 51 PM](https://github.com/user-attachments/assets/12cd167e-a284-4272-bcc0-78cd4a414218)
