### PR TITLE
[ENHANCEMENT] Enable time travel when playtesting

### DIFF
--- a/source/funkin/play/PlayState.hx
+++ b/source/funkin/play/PlayState.hx
@@ -2742,6 +2742,16 @@ class PlayState extends MusicBeatSubState
     // PAGEDOWN: Skip backward two section. Doesn't replace notes.
     // SHIFT+PAGEDOWN: Skip backward twenty sections.
     if (FlxG.keys.justPressed.PAGEDOWN) changeSection(FlxG.keys.pressed.SHIFT ? -20 : -2);
+    #else
+    if (isChartingMode)
+    {
+      // PAGEUP: Skip forward two sections.
+      // SHIFT+PAGEUP: Skip forward twenty sections.
+      if (FlxG.keys.justPressed.PAGEUP) changeSection(FlxG.keys.pressed.SHIFT ? 20 : 2);
+      // PAGEDOWN: Skip backward two section. Doesn't replace notes.
+      // SHIFT+PAGEDOWN: Skip backward twenty sections.
+      if (FlxG.keys.justPressed.PAGEDOWN) changeSection(FlxG.keys.pressed.SHIFT ? -20 : -2);
+    }
     #end
 
     if (FlxG.keys.justPressed.B) trace(inputSpitter.join('\n'));
@@ -3463,7 +3473,6 @@ class PlayState extends MusicBeatSubState
     scrollSpeedTweens = [];
   }
 
-  #if FEATURE_DEBUG_FUNCTIONS
   /**
      * Jumps forward or backward a number of sections in the song.
      * Accounts for BPM changes, does not prevent death from skipped notes.
@@ -3492,5 +3501,4 @@ class PlayState extends MusicBeatSubState
 
     resyncVocals();
   }
-  #end
 }


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->
## Briefly describe the issue(s) fixed.
Simple change that allows you to time travel (PAGEUP and PAGEDOWN) when playtesting in the chart editor. This is a really useful debug feature!

This is my first and *probably* only ~~non-legacy~~ Chart Editor-related PR since the code scares me.

## Include any relevant screenshots or videos.

https://github.com/user-attachments/assets/ff3197b3-2ee2-48a6-9015-ff5b55218557

