### PR TITLE
[CLEANUP] Remove unused code from `FreeplayState`

### DIFF
--- a/source/funkin/ui/freeplay/FreeplayState.hx
+++ b/source/funkin/ui/freeplay/FreeplayState.hx
@@ -270,12 +270,6 @@ class FreeplayState extends MusicBeatSubState
     DiscordClient.instance.setPresence({state: 'In the Menus', details: null});
     #end
 
-    var isDebug:Bool = false;
-
-    #if FEATURE_DEBUG_FUNCTIONS
-    isDebug = true;
-    #end
-
     // Block input until the intro finishes.
     busy = true;
 


### PR DESCRIPTION
For some reason there's this useless boolean in Freeplay?? It doesn't do anything so this PR removes it.