### PR TITLE
Main menu - Cancel state change on debug menu open

### DIFF
--- a/source/funkin/ui/MenuList.hx
+++ b/source/funkin/ui/MenuList.hx
@@ -172,6 +172,12 @@ class MenuTypedList<T:MenuListItem> extends FlxTypedGroup<T>
     }
   }
 
+  public function cancelAccept()
+  {
+    FlxFlicker.stopFlickering(members[selectedIndex]);
+    busy = false;
+  }
+
   public function selectItem(index:Int)
   {
     members[selectedIndex].idle();

--- a/source/funkin/ui/mainmenu/MainMenuState.hx
+++ b/source/funkin/ui/mainmenu/MainMenuState.hx
@@ -353,6 +353,9 @@ class MainMenuState extends MusicBeatState
     {
       persistentUpdate = false;
 
+      // Cancel the currently flickering menu item because it's about to call a state switch
+      if (menuItems.busy) menuItems.cancelAccept();
+
       FlxG.state.openSubState(new DebugMenuSubState());
     }
 


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->
## Does this PR close any issues? If so, link them below.
Fixes #2438
## Briefly describe the issue(s) fixed.
When the debug menu is opened, it doesn't check if the menu is busy (aka about to call a state change) and cancel the currently flickering menu to stop the state change.

This PR simply changes it to do that.
## Include any relevant screenshots or videos.
