### PR TITLE
Freeplay UI fixes

### DIFF
--- a/source/funkin/ui/freeplay/CapsuleOptionsMenu.hx
+++ b/source/funkin/ui/freeplay/CapsuleOptionsMenu.hx
@@ -24,6 +24,10 @@ class CapsuleOptionsMenu extends FlxSpriteGroup
 
   var busy:Bool = false;
 
+  var leftArrow:InstrumentalSelector;
+
+  var rightArrow:InstrumentalSelector;
+
   public function new(parent:FreeplayState, x:Float = 0, y:Float = 0, instIds:Array<String>):Void
   {
     super(x, y);
@@ -41,8 +45,8 @@ class CapsuleOptionsMenu extends FlxSpriteGroup
     currentInstrumental.setFormat('VCR OSD Mono', 40, FlxTextAlign.CENTER, true);
 
     final PAD = 4;
-    var leftArrow = new InstrumentalSelector(parent, PAD, 30, false, parent.getControls());
-    var rightArrow = new InstrumentalSelector(parent, capsuleMenuBG.width - leftArrow.width - PAD, 30, true, parent.getControls());
+    leftArrow = new InstrumentalSelector(parent, PAD, 30, false, parent.getControls());
+    rightArrow = new InstrumentalSelector(parent, capsuleMenuBG.width - leftArrow.width - PAD, 30, true, parent.getControls());
 
     var label:FlxText = new FlxText(0, 5, capsuleMenuBG.width, 'INSTRUMENTAL');
     label.setFormat('VCR OSD Mono', 24, FlxTextAlign.CENTER, true);
@@ -109,6 +113,8 @@ class CapsuleOptionsMenu extends FlxSpriteGroup
   {
     // Play in reverse.
     capsuleMenuBG.animation.play('open', true, true);
+    if (leftArrow.moveShitDownTimer != null) leftArrow.moveShitDownTimer.cancel();
+    if (rightArrow.moveShitDownTimer != null) rightArrow.moveShitDownTimer.cancel();
     capsuleMenuBG.animation.finishCallback = function(_) {
       parent.cleanupCapsuleOptionsMenu();
       queueDestroy = true;
@@ -135,6 +141,8 @@ class InstrumentalSelector extends FunkinSprite
   var parent:FreeplayState;
 
   var baseScale:Float = 0.6;
+
+  public var moveShitDownTimer:FlxTimer;
 
   public function new(parent:FreeplayState, x:Float, y:Float, flipped:Bool, controls:Controls)
   {
@@ -174,7 +182,7 @@ class InstrumentalSelector extends FunkinSprite
 
     scale.x = scale.y = 0.5 * baseScale;
 
-    new FlxTimer().start(2 / 24, function(tmr) {
+    moveShitDownTimer = new FlxTimer().start(2 / 24, function(tmr) {
       scale.x = scale.y = 1 * baseScale;
       whiteShader.colorSet = false;
       updateHitbox();

--- a/source/funkin/ui/freeplay/CapsuleText.hx
+++ b/source/funkin/ui/freeplay/CapsuleText.hx
@@ -168,6 +168,8 @@ class CapsuleText extends FlxSpriteGroup
 
   public function resetText():Void
   {
+    scale.x = 1;
+    scale.y = 1;
     if (moveTween != null) moveTween.cancel();
     if (moveTimer != null) moveTimer.cancel();
     whiteText.offset.x = 0;

--- a/source/funkin/ui/freeplay/FreeplayState.hx
+++ b/source/funkin/ui/freeplay/FreeplayState.hx
@@ -1769,7 +1769,7 @@ class FreeplayState extends MusicBeatSubState
       intendedScore = songScore?.score ?? 0;
       intendedCompletion = songScore == null ? 0.0 : ((songScore.tallies.sick + songScore.tallies.good) / songScore.tallies.totalNotes);
       rememberedDifficulty = currentDifficulty;
-      grpCapsules.members[curSelected].refreshDisplay();
+      grpCapsules.members[curSelected].refreshDisplay((prepForNewRank == true) ? false : true);
     }
     else
     {
@@ -2072,7 +2072,7 @@ class FreeplayState extends MusicBeatSubState
       intendedCompletion = songScore == null ? 0.0 : ((songScore.tallies.sick + songScore.tallies.good) / songScore.tallies.totalNotes);
       rememberedSongId = daSongCapsule.freeplayData.data.id;
       changeDiff();
-      daSongCapsule.refreshDisplay();
+      daSongCapsule.refreshDisplay((prepForNewRank == true) ? false : true);
     }
     else
     {

--- a/source/funkin/ui/freeplay/FreeplayState.hx
+++ b/source/funkin/ui/freeplay/FreeplayState.hx
@@ -776,12 +776,10 @@ class FreeplayState extends MusicBeatSubState
       funnyMenu.hsvShader = hsvShader;
       funnyMenu.newText.animation.curAnim.curFrame = 45 - ((i * 4) % 45);
 
-      // This stops the bounce-in animation.
-      // I would like to use to use the jump in now that it looks better,
-      // but I still can't because switching from harder to normal difficulties causes the x positions to mess up
-      /*if (fromCharSelect)*/ funnyMenu.forcePosition();
-      /*else
-        funnyMenu.initJumpIn(0, force); */
+      // Stops the bounce-in animation when returning to freeplay from the character selection screen.
+      if (fromCharSelect) funnyMenu.forcePosition();
+      else
+        funnyMenu.initJumpIn(0, force);
 
       grpCapsules.add(funnyMenu);
     }
@@ -2087,6 +2085,8 @@ class FreeplayState extends MusicBeatSubState
       index += 1;
 
       capsule.selected = index == curSelected + 1;
+
+      if (index > 1) capsule.curSelected = curSelected;
 
       capsule.targetPos.y = capsule.intendedY(index - curSelected);
       capsule.targetPos.x = capsule.intendedX(index - curSelected);

--- a/source/funkin/ui/freeplay/FreeplayState.hx
+++ b/source/funkin/ui/freeplay/FreeplayState.hx
@@ -638,7 +638,8 @@ class FreeplayState extends MusicBeatSubState
     allDifficulties = SongRegistry.instance.listAllDifficulties(currentCharacterId);
 
     // Generates song list with the starter params (who our current character is, last remembered difficulty, etc.)
-    generateSongList(null, false);
+    // Set this to false if you prefer the 50% transparency on the capsules when they first appear.
+    generateSongList(null, true);
 
     // dedicated camera for the state so we don't need to fuk around with camera scrolls from the mainmenu / elsewhere
     funnyCam.bgColor = FlxColor.TRANSPARENT;
@@ -734,10 +735,10 @@ class FreeplayState extends MusicBeatSubState
     // Initialize the random capsule, with empty/blank info (which we display once bf/pico does his hand)
     var randomCapsule:SongMenuItem = grpCapsules.recycle(SongMenuItem);
     randomCapsule.initPosition(FlxG.width, 0);
-    randomCapsule.initData(null, styleData, 0);
+    randomCapsule.initData(null, styleData, 1);
     randomCapsule.y = randomCapsule.intendedY(0) + 10;
     randomCapsule.targetPos.x = randomCapsule.x;
-    randomCapsule.alpha = 0;
+    randomCapsule.alpha = 0.5;
     randomCapsule.songText.visible = false;
     randomCapsule.favIcon.visible = false;
     randomCapsule.favIconBlurred.visible = false;
@@ -749,8 +750,7 @@ class FreeplayState extends MusicBeatSubState
     if (fromCharSelect) randomCapsule.forcePosition();
     else
     {
-      // randomCapsule.initJumpIn(0, force);
-      randomCapsule.forcePosition();
+      randomCapsule.initJumpIn(0, force);
     }
 
     var hsvShader:HSVShader = new HSVShader();
@@ -776,7 +776,7 @@ class FreeplayState extends MusicBeatSubState
       funnyMenu.hsvShader = hsvShader;
       funnyMenu.newText.animation.curAnim.curFrame = 45 - ((i * 4) % 45);
 
-      // Stops the bounce-in animation when returning to freeplay from the character selection screen.
+      // Stop the bounce-in animation when returning to freeplay from the character selection screen.
       if (fromCharSelect) funnyMenu.forcePosition();
       else
         funnyMenu.initJumpIn(0, force);
@@ -2086,7 +2086,7 @@ class FreeplayState extends MusicBeatSubState
 
       capsule.selected = index == curSelected + 1;
 
-      if (index > 1) capsule.curSelected = curSelected;
+      capsule.curSelected = curSelected;
 
       capsule.targetPos.y = capsule.intendedY(index - curSelected);
       capsule.targetPos.x = capsule.intendedX(index - curSelected);

--- a/source/funkin/ui/freeplay/FreeplayState.hx
+++ b/source/funkin/ui/freeplay/FreeplayState.hx
@@ -734,7 +734,7 @@ class FreeplayState extends MusicBeatSubState
     // Initialize the random capsule, with empty/blank info (which we display once bf/pico does his hand)
     var randomCapsule:SongMenuItem = grpCapsules.recycle(SongMenuItem);
     randomCapsule.initPosition(FlxG.width, 0);
-    randomCapsule.initData(null, styleData);
+    randomCapsule.initData(null, styleData, 0);
     randomCapsule.y = randomCapsule.intendedY(0) + 10;
     randomCapsule.targetPos.x = randomCapsule.x;
     randomCapsule.alpha = 0;
@@ -765,7 +765,7 @@ class FreeplayState extends MusicBeatSubState
       var funnyMenu:SongMenuItem = grpCapsules.recycle(SongMenuItem);
 
       funnyMenu.initPosition(FlxG.width, 0);
-      funnyMenu.initData(tempSong, styleData);
+      funnyMenu.initData(tempSong, styleData, i + 1);
       funnyMenu.onConfirm = function() {
         capsuleOnOpenDefault(funnyMenu);
       };
@@ -777,9 +777,11 @@ class FreeplayState extends MusicBeatSubState
       funnyMenu.newText.animation.curAnim.curFrame = 45 - ((i * 4) % 45);
 
       // This stops the bounce-in animation.
-      funnyMenu.forcePosition();
-
-      // funnyMenu.initJumpIn(0, force);
+      // I would like to use to use the jump in now that it looks better,
+      // but I still can't because switching from harder to normal difficulties causes the x positions to mess up
+      /*if (fromCharSelect)*/ funnyMenu.forcePosition();
+      /*else
+        funnyMenu.initJumpIn(0, force); */
 
       grpCapsules.add(funnyMenu);
     }
@@ -2087,7 +2089,7 @@ class FreeplayState extends MusicBeatSubState
       capsule.selected = index == curSelected + 1;
 
       capsule.targetPos.y = capsule.intendedY(index - curSelected);
-      capsule.targetPos.x = 270 + (60 * (Math.sin(index - curSelected)));
+      capsule.targetPos.x = capsule.intendedX(index - curSelected);
 
       if (index < curSelected) capsule.targetPos.y -= 100; // another 100 for good measure
     }

--- a/source/funkin/ui/freeplay/FreeplayState.hx
+++ b/source/funkin/ui/freeplay/FreeplayState.hx
@@ -1873,11 +1873,15 @@ class FreeplayState extends MusicBeatSubState
    */
   function capsuleOnOpenDefault(cap:SongMenuItem):Void
   {
+    busy = true;
+    letterSort.inputEnabled = false;
     var targetSongId:String = cap?.freeplayData?.data.id ?? 'unknown';
     var targetSongNullable:Null<Song> = SongRegistry.instance.fetchEntry(targetSongId);
     if (targetSongNullable == null)
     {
       FlxG.log.warn('WARN: could not find song with id (${targetSongId})');
+      busy = false;
+      letterSort.inputEnabled = true;
       return;
     }
     var targetSong:Song = targetSongNullable;
@@ -1891,6 +1895,8 @@ class FreeplayState extends MusicBeatSubState
     if (targetDifficulty == null)
     {
       FlxG.log.warn('WARN: could not find difficulty with id (${targetDifficultyId})');
+      busy = false;
+      letterSort.inputEnabled = true;
       return;
     }
 
@@ -1920,9 +1926,7 @@ class FreeplayState extends MusicBeatSubState
 
   function openInstrumentalList(cap:SongMenuItem, instrumentalIds:Array<String>):Void
   {
-    busy = true;
-
-    capsuleOptionsMenu = new CapsuleOptionsMenu(this, cap.x + 175, cap.y + 115, instrumentalIds);
+    capsuleOptionsMenu = new CapsuleOptionsMenu(this, cap.targetPos.x + 175, cap.targetPos.y + 115, instrumentalIds);
     capsuleOptionsMenu.cameras = [funnyCam];
     capsuleOptionsMenu.zIndex = 10000;
     add(capsuleOptionsMenu);
@@ -1937,6 +1941,7 @@ class FreeplayState extends MusicBeatSubState
   public function cleanupCapsuleOptionsMenu():Void
   {
     this.busy = false;
+    letterSort.inputEnabled = true;
 
     if (capsuleOptionsMenu != null)
     {
@@ -1950,9 +1955,6 @@ class FreeplayState extends MusicBeatSubState
    */
   function capsuleOnConfirmDefault(cap:SongMenuItem, ?targetInstId:String):Void
   {
-    busy = true;
-    letterSort.inputEnabled = false;
-
     PlayStatePlaylist.isStoryMode = false;
 
     var targetSongId:String = cap?.freeplayData?.data.id ?? 'unknown';
@@ -1960,6 +1962,8 @@ class FreeplayState extends MusicBeatSubState
     if (targetSongNullable == null)
     {
       FlxG.log.warn('WARN: could not find song with id (${targetSongId})');
+      busy = false;
+      letterSort.inputEnabled = true;
       return;
     }
     var targetSong:Song = targetSongNullable;
@@ -1971,6 +1975,8 @@ class FreeplayState extends MusicBeatSubState
     if (targetDifficulty == null)
     {
       FlxG.log.warn('WARN: could not find difficulty with id (${currentDifficulty})');
+      busy = false;
+      letterSort.inputEnabled = true;
       return;
     }
 

--- a/source/funkin/ui/freeplay/LetterSort.hx
+++ b/source/funkin/ui/freeplay/LetterSort.hx
@@ -204,6 +204,9 @@ class FreeplayLetter extends FlxAtlasSprite
       this.anim.play(animLetters[letterInd] + " move");
       this.anim.pause();
       curLetter = letterInd;
+      this.anim.onComplete.add(function() {
+        this.anim.play(animLetters[curLetter] + " move");
+      });
     }
   }
 
@@ -231,7 +234,7 @@ class FreeplayLetter extends FlxAtlasSprite
         animName = "T move";
     }
 
-    this.anim.play(animName);
+    this.anim.play(animName, true);
     if (curSelection != curLetter)
     {
       this.anim.pause();

--- a/source/funkin/ui/freeplay/SongMenuItem.hx
+++ b/source/funkin/ui/freeplay/SongMenuItem.hx
@@ -392,7 +392,7 @@ class SongMenuItem extends FlxSpriteGroup
     return evilTrail.color;
   }
 
-  public function refreshDisplay():Void
+  public function refreshDisplay(updateRank:Bool = true):Void
   {
     if (freeplayData == null)
     {
@@ -410,7 +410,7 @@ class SongMenuItem extends FlxSpriteGroup
       pixelIcon.visible = true;
       updateBPM(Std.int(freeplayData.songStartingBpm) ?? 0);
       updateDifficultyRating(freeplayData.difficultyRating ?? 0);
-      updateScoringRank(freeplayData.scoringRank);
+      if (updateRank) updateScoringRank(freeplayData.scoringRank);
       newText.visible = freeplayData.isNew;
       favIcon.visible = freeplayData.isFav;
       favIconBlurred.visible = freeplayData.isFav;

--- a/source/funkin/ui/freeplay/SongMenuItem.hx
+++ b/source/funkin/ui/freeplay/SongMenuItem.hx
@@ -74,6 +74,8 @@ class SongMenuItem extends FlxSpriteGroup
 
   var sparkleTimer:FlxTimer;
 
+  var index:Int;
+
   public function new(x:Float, y:Float)
   {
     super(x, y);
@@ -489,7 +491,7 @@ class SongMenuItem extends FlxSpriteGroup
       spr.visible = value;
     }
 
-    if (value) textAppear();
+    textAppear();
 
     updateSelected();
   }
@@ -500,9 +502,11 @@ class SongMenuItem extends FlxSpriteGroup
     this.y = y;
   }
 
-  public function initData(freeplayData:Null<FreeplaySongData>, ?styleData:FreeplayStyle = null):Void
+  public function initData(freeplayData:Null<FreeplaySongData>, ?styleData:FreeplayStyle = null, index:Int = null):Void
   {
     this.freeplayData = freeplayData;
+
+    if (index != null) this.index = index;
 
     // im so mad i have to do this but im pretty sure with the capsules recycling i cant call the new function properly :/
     // if thats possible someone Please change the new function to be something like
@@ -605,12 +609,17 @@ class SongMenuItem extends FlxSpriteGroup
 
         capsule.scale.x = xFrames[frameInTypeBeat];
         capsule.scale.y = 1 / xFrames[frameInTypeBeat];
-        x = FlxG.width * xPosLerpLol[Std.int(Math.min(frameInTypeBeat, xPosLerpLol.length - 1))];
+        targetPos.x = FlxG.width * xPosLerpLol[Std.int(Math.min(frameInTypeBeat, xPosLerpLol.length - 1))];
 
         capsule.scale.x *= realScaled;
         capsule.scale.y *= realScaled;
 
         frameInTypeBeat += 1;
+      }
+      else if (frameInTypeBeat == xFrames.length)
+      {
+        doJumpIn = false;
+        targetPos.x = intendedX(index);
       }
     }
 
@@ -624,12 +633,16 @@ class SongMenuItem extends FlxSpriteGroup
 
         capsule.scale.x = xFrames[frameOutTypeBeat];
         capsule.scale.y = 1 / xFrames[frameOutTypeBeat];
-        x = FlxG.width * xPosOutLerpLol[Std.int(Math.min(frameOutTypeBeat, xPosOutLerpLol.length - 1))];
+        this.x = FlxG.width * xPosOutLerpLol[Std.int(Math.min(frameOutTypeBeat, xPosOutLerpLol.length - 1))];
 
         capsule.scale.x *= realScaled;
         capsule.scale.y *= realScaled;
 
         frameOutTypeBeat += 1;
+      }
+      else if (frameOutTypeBeat == xFrames.length)
+      {
+        doJumpOut = false;
       }
     }
 
@@ -652,6 +665,11 @@ class SongMenuItem extends FlxSpriteGroup
     {
       pixelIcon.animation.play('confirm');
     }
+  }
+
+  public function intendedX(index:Int):Float
+  {
+    return 270 + (60 * (Math.sin(index)));
   }
 
   public function intendedY(index:Int):Float

--- a/source/funkin/ui/freeplay/SongMenuItem.hx
+++ b/source/funkin/ui/freeplay/SongMenuItem.hx
@@ -536,7 +536,7 @@ class SongMenuItem extends FlxSpriteGroup
   var frameOutTypeBeat:Int = 0;
 
   var xFrames:Array<Float> = [1.7, 1.8, 0.85, 0.85, 0.97, 0.97, 1];
-  var xPosLerpLol:Array<Float> = [0.9, 0.4, 0.16, 0.16, 0.22, 0.22, 0.245]; // NUMBERS ARE JANK CUZ THE SCALING OR WHATEVER
+  var xPosLerpLol:Array<Float> = [0, 0, 0.16, 0.16, 0.22, 0.22, 0.245]; // NUMBERS ARE JANK CUZ THE SCALING OR WHATEVER
   var xPosOutLerpLol:Array<Float> = [0.245, 0.75, 0.98, 0.98, 1.2]; // NUMBERS ARE JANK CUZ THE SCALING OR WHATEVER
 
   public var realScaled:Float = 0.8;
@@ -547,9 +547,6 @@ class SongMenuItem extends FlxSpriteGroup
 
     new FlxTimer().start((1 / 24) * maxTimer, function(doShit) {
       doJumpIn = true;
-    });
-
-    new FlxTimer().start((0.09 * maxTimer) + 0.85, function(lerpTmr) {
       doLerp = true;
     });
 

--- a/source/funkin/ui/freeplay/SongMenuItem.hx
+++ b/source/funkin/ui/freeplay/SongMenuItem.hx
@@ -75,6 +75,7 @@ class SongMenuItem extends FlxSpriteGroup
   var sparkleTimer:FlxTimer;
 
   var index:Int;
+  public var curSelected:Int;
 
   public function new(x:Float, y:Float)
   {
@@ -615,11 +616,13 @@ class SongMenuItem extends FlxSpriteGroup
         capsule.scale.y *= realScaled;
 
         frameInTypeBeat += 1;
+        // Move the targetPos set to the if statement below if you want them to shift to their target positions after jumping in instead
+        // I have no idea why this if instead of frameInTypeBeat == xFrames.length works even though they're the same thing
+        if (targetPos.x <= 320) targetPos.x = intendedX(index - curSelected);
       }
       else if (frameInTypeBeat == xFrames.length)
       {
         doJumpIn = false;
-        targetPos.x = intendedX(index);
       }
     }
 


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->
## Does this PR close any issues? If so, link them below.
Fixes #3190, fixes #3627, fixes #3703, fixes #3890, fixes #2351
## Briefly describe the issue(s) fixed.
This PR fixes ~~seven~~ six issues:

1. The letters not ~~looping their animation and~~ restarting their animation when selected
2. Lettersort input not being disabled when a capsule is opened
3. The first rank of a song overriding itself
4. The instrument selector using the capsule's current position rather than the position the capsule is targeting
5. A null reference fix for when the instrumental selector is exited while a timer for the arrows is still running 
6. ~~The remembered difficulty being set to constants.DEFAULT_DIFFICULTY when random is selected rather than only using it as a fallback.~~
The random capsule jumping into it's position.

Also, if the capsule has a null target song or difficulty, it now also re-enables input before returning.

~~Another thing I noticed while doing this - only the random capsule does it's jump in, the rest of the capsules don't. I tried making the rest of the capsules jump in and I can see why they currently don't - they don't move very smoothly to their positions when they jump in and it looks really obvious. Setting the value to the targetPos.x rather than the capsule's x position fixes it, but then the capsules aren't set to their proper positions until you change selection. I'll figure out a fix proper fix for this later.~~

~~I fixed the above thing (sorta), but it introduced another issue that I'd need to figure out later.~~ Finally, all the capsules use that jump in animation!

Also partially fixes https://github.com/FunkinCrew/Funkin/issues/2659 
## Include any relevant screenshots or videos.

<details>

<summary>old video with fixes for the first two issues</summary>

https://github.com/user-attachments/assets/c8918360-949c-4606-8ddd-861fe9a1ef24

</details>

https://github.com/user-attachments/assets/f68a0398-d326-4d63-bf0b-830ece7d00de

https://github.com/user-attachments/assets/9450ef41-d05e-426f-b0ed-9ad250dea372

Capsule jumpin fixed (and now used):

https://github.com/user-attachments/assets/0d3f9b8c-19cb-40ea-a045-f76669472131


