### PR TITLE
[ENHANCEMENT] Flash capsules slightly less when flashing lights are turned off

### DIFF
--- a/source/funkin/ui/freeplay/SongMenuItem.hx
+++ b/source/funkin/ui/freeplay/SongMenuItem.hx
@@ -25,6 +25,7 @@ import funkin.save.Save;
 import funkin.save.Save.SaveScoreData;
 import flixel.util.FlxColor;
 import funkin.ui.PixelatedIcon;
+import funkin.Preferences;
 
 class SongMenuItem extends FlxSpriteGroup
 {
@@ -236,9 +237,12 @@ class SongMenuItem extends FlxSpriteGroup
 
   function sparkleEffect(timer:FlxTimer):Void
   {
-    sparkle.setPosition(FlxG.random.float(ranking.x - 20, ranking.x + 3), FlxG.random.float(ranking.y - 29, ranking.y + 4));
-    sparkle.animation.play('sparkle', true);
-    sparkleTimer = new FlxTimer().start(FlxG.random.float(1.2, 4.5), sparkleEffect);
+    if (Preferences.flashingLights)
+    {
+      sparkle.setPosition(FlxG.random.float(ranking.x - 20, ranking.x + 3), FlxG.random.float(ranking.y - 29, ranking.y + 4));
+      sparkle.animation.play('sparkle', true);
+      sparkleTimer = new FlxTimer().start(FlxG.random.float(1.2, 4.5), sparkleEffect);
+    }
   }
 
   // no way to grab weeks rn, so this needs to be done :/
@@ -697,7 +701,7 @@ class SongMenuItem extends FlxSpriteGroup
    */
   public function confirm():Void
   {
-    if (songText != null) songText.flickerText();
+    if (songText != null && Preferences.flashingLights) songText.flickerText();
     if (pixelIcon != null && pixelIcon.visible)
     {
       pixelIcon.animation.play('confirm');


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->
## Does this PR close any issues? If so, link them below.
fixes https://github.com/FunkinCrew/Funkin/issues/3816
## Briefly describe the issue(s) fixed.
Makes the capsule text NOT flicker when flashing lights are turned off, maybe it's too subtle of a change and not even worth doing, just wanted to see if this was good
## Include any relevant screenshots or videos.
USING FLASHING LIGHTS

![2025-02-24_19-26-28-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/06e7eef8-7cc5-4e49-8f6a-53111ee3fa1b)

NOT USING FLASHING LIGHTS

![2025-02-24_19-36-05-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/8b291e07-4686-46ef-93ec-96daa0b19ff7)
