### PR TITLE
Main menu not remembering freeplay menu selection fix

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -6,7 +6,6 @@ body:
   - type: markdown
     attributes:
       value: "# PLEASE READ THE [CONTRIBUTING GUIDE](https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) BEFORE OPENING ISSUES!"
-  
   - type: checkboxes
     attributes:
       label: Issue Checklist
@@ -49,6 +48,7 @@ body:
       placeholder: ex. 0.5.3
     validations:
       required: true
+
   
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -6,6 +6,7 @@ body:
   - type: markdown
     attributes:
       value: "# PLEASE READ THE [CONTRIBUTING GUIDE](https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) BEFORE OPENING ISSUES!"
+      
   - type: checkboxes
     attributes:
       label: Issue Checklist
@@ -48,7 +49,6 @@ body:
       placeholder: ex. 0.5.3
     validations:
       required: true
-
   
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -5,14 +5,14 @@ title: "Bug Report: "
 body:
   - type: markdown
     attributes:
-      value: "# PLEASE READ THE [CONTRIBUTING GUIDE](/docs/CONTRIBUTING.md) BEFORE OPENING ISSUES!"
+      value: "# PLEASE READ THE [CONTRIBUTING GUIDE](https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) BEFORE OPENING ISSUES!"
   
   - type: checkboxes
     attributes:
       label: Issue Checklist
       description: Be sure to complete these steps to increase the chances of your issue being addressed!
       options:
-        - label: I have read the [Contributing Guide](/docs/CONTRIBUTING.md)
+        - label: I have read the [Contributing Guide](https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md)
         - label: I have checked the Issues/Discussions pages to see if my issue has already been reported
         - label: I have properly titled my issue
 

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -3,14 +3,18 @@ description: Report a bug or an issue in the game.
 labels: ["type: minor bug", "status: pending triage"]
 title: "Bug Report: "
 body:
+  - type: markdown
+    attributes:
+      value: "# PLEASE READ THE [CONTRIBUTING GUIDE](/docs/CONTRIBUTING.md) BEFORE OPENING ISSUES!
+  
   - type: checkboxes
     attributes:
       label: Issue Checklist
       description: Be sure to complete these steps to increase the chances of your issue being addressed!
       options:
-        - label: I have read the pinned [Issues Guide](https://github.com/FunkinCrew/Funkin/issues/4050)
+        - label: I have read the [Contributing Guide](/docs/CONTRIBUTING.md)
         - label: I have checked the Issues/Discussions pages to see if my issue has already been reported
-        - label: I have properly named my issue
+        - label: I have properly titled my issue
 
   - type: dropdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -5,7 +5,7 @@ title: "Bug Report: "
 body:
   - type: markdown
     attributes:
-      value: "# PLEASE READ THE [CONTRIBUTING GUIDE](/docs/CONTRIBUTING.md) BEFORE OPENING ISSUES!
+      value: "# PLEASE READ THE [CONTRIBUTING GUIDE](/docs/CONTRIBUTING.md) BEFORE OPENING ISSUES!"
   
   - type: checkboxes
     attributes:

--- a/.github/ISSUE_TEMPLATE/charting.yml
+++ b/.github/ISSUE_TEMPLATE/charting.yml
@@ -3,14 +3,18 @@ description: Report an issue with the placement of notes in the game.
 labels: ["type: charting issue", "status: pending triage"]
 title: "Charting Issue: "
 body:
+  - type: markdown
+    attributes:
+      value: "# PLEASE READ THE [CONTRIBUTING GUIDE](https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) BEFORE OPENING ISSUES!"
+      
   - type: checkboxes
     attributes:
       label: Issue Checklist
       description: Be sure to complete these steps to increase the chances of your issue being addressed!
       options:
-        - label: I have read the pinned [Issues Guide](https://github.com/FunkinCrew/Funkin/issues/4050)
+        - label: I have read the [Contributing Guide](https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md)
         - label: I have checked the Issues/Discussions pages to see if my issue has already been reported
-        - label: I have properly named my issue
+        - label: I have properly titled my issue
 
   - type: dropdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/compiling.yml
+++ b/.github/ISSUE_TEMPLATE/compiling.yml
@@ -3,15 +3,19 @@ description: Report an issue with compiling the game.
 labels: ["type: compilation help", "status: pending triage"]
 title: "Compiling Help: "
 body:
+  - type: markdown
+    attributes:
+      value: "# PLEASE READ THE [CONTRIBUTING GUIDE](https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) BEFORE OPENING ISSUES!"
+      
   - type: checkboxes
     attributes:
       label: Issue Checklist
       description: Be sure to complete these steps to increase the chances of your issue being addressed!
       options:
-        - label: I have read the pinned [Issues Guide](https://github.com/FunkinCrew/Funkin/issues/4050)
         - label: I have followed the [Compiling Guide](https://github.com/FunkinCrew/Funkin/blob/main/docs/COMPILING.md) and the [Troubleshooting Guide](https://github.com/FunkinCrew/Funkin/blob/main/docs/TROUBLESHOOTING.md)
+        - label: I have read the [Contributing Guide](https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md)
         - label: I have checked the Issues/Discussions pages to see if my issue has already been reported
-        - label: I have properly named my issue
+        - label: I have properly titled my issue
 
   - type: dropdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/crash.yml
+++ b/.github/ISSUE_TEMPLATE/crash.yml
@@ -3,14 +3,18 @@ description: Report a crash that occurred while playing the game.
 labels: ["type: major bug", "status: pending triage"]
 title: "Crash Report: "
 body:
+  - type: markdown
+    attributes:
+      value: "# PLEASE READ THE [CONTRIBUTING GUIDE](https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) BEFORE OPENING ISSUES!"
+      
   - type: checkboxes
     attributes:
       label: Issue Checklist
       description: Be sure to complete these steps to increase the chances of your issue being addressed!
       options:
-        - label: I have read the pinned [Issues Guide](https://github.com/FunkinCrew/Funkin/issues/4050)
+        - label: I have read the [Contributing Guide](https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md)
         - label: I have checked the Issues/Discussions pages to see if my issue has already been reported
-        - label: I have properly named my issue
+        - label: I have properly titled my issue
 
   - type: dropdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/enhancement.yml
+++ b/.github/ISSUE_TEMPLATE/enhancement.yml
@@ -3,14 +3,18 @@ description: Suggest a new feature.
 labels: ["type: enhancement", "status: pending triage"]
 title: "Enhancement: "
 body:
+  - type: markdown
+    attributes:
+      value: "# PLEASE READ THE [CONTRIBUTING GUIDE](https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) BEFORE OPENING ISSUES!"
+      
   - type: checkboxes
     attributes:
       label: Issue Checklist
       description: Be sure to complete these steps to increase the chances of your suggestion being considered!
       options:
-        - label: I have read the pinned [Issues Guide](https://github.com/FunkinCrew/Funkin/issues/4050)
+        - label: I have read the [Contributing Guide](https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md)
         - label: I have checked the Issues/Discussions pages to see if my enhancement has already been suggested
-        - label: I have properly named my enhancement
+        - label: I have properly titled my enhancement
 
   - type: textarea
     attributes:

--- a/.github/label-actions.yml
+++ b/.github/label-actions.yml
@@ -8,37 +8,102 @@
       This issue is a duplicate. Please direct all discussion to the original issue.
     # Close the issue
     close: true
-    # Remove other status labels
-    unlabel:
-      - 'status: pending triage'
     # Set a close reason
     close-reason: 'not planned'
+    # Remove other status labels
+    unlabel:
+      - 'status: accepted'
+      - 'status: bug reproduced'
+      - 'status: cannot reproduce'
+      - 'status: needs clarification'
+      - 'status: needs revision'
+      - 'status: pending pull request'
+      - 'status: pending triage'
+      - 'status: planned'
+      - 'status: rejected'
+      - 'status: resolved'
+      - 'status: reviewing internally'
+      - 'status: stale'
   prs:
     # Post a comment
     comment: >
       This pull request is a duplicate. Please direct all discussion to the original pull request.
-    # Remove other status labels
-    unlabel:
-      - 'status: pending triage'
     # Close the pull request
     close: true
     # Set a close reason
     close-reason: 'not planned'
+    # Remove other status labels
+    unlabel:
+      - 'status: accepted'
+      - 'status: bug reproduced'
+      - 'status: cannot reproduce'
+      - 'status: needs clarification'
+      - 'status: needs revision'
+      - 'status: pending pull request'
+      - 'status: pending triage'
+      - 'status: planned'
+      - 'status: rejected'
+      - 'status: resolved'
+      - 'status: reviewing internally'
+      - 'status: stale'
 
 'status: rejected':
   issues:
     # Close the issue
     close: true
-    # Remove other status labels
-    unlabel:
-      - 'status: pending triage'
     # Set a close reason
     close-reason: 'not planned'
+    # Remove other status labels
+    unlabel:
+      - 'status: accepted'
+      - 'status: bug reproduced'
+      - 'status: cannot reproduce'
+      - 'status: duplicate'
+      - 'status: needs clarification'
+      - 'status: needs revision'
+      - 'status: pending pull request'
+      - 'status: pending triage'
+      - 'status: planned'
+      - 'status: resolved'
+      - 'status: reviewing internally'
+      - 'status: stale'
   prs:
     # Close the pull request
     close: true
-    # Remove other status labels
-    unlabel:
-      - 'status: pending triage'
     # Set a close reason
     close-reason: 'not planned'
+    # Remove other status labels
+    unlabel:
+      - 'status: accepted'
+      - 'status: bug reproduced'
+      - 'status: cannot reproduce'
+      - 'status: duplicate'
+      - 'status: needs clarification'
+      - 'status: needs revision'
+      - 'status: pending pull request'
+      - 'status: pending triage'
+      - 'status: planned'
+      - 'status: resolved'
+      - 'status: reviewing internally'
+      - 'status: stale'
+
+'status: resolved':
+  issues:
+    # Close the issue
+    close: true
+    # Set a close reason
+    close-reason: 'completed'
+    # Remove other status labels
+    unlabel:
+      - 'status: accepted'
+      - 'status: bug reproduced'
+      - 'status: cannot reproduce'
+      - 'status: duplicate'
+      - 'status: needs clarification'
+      - 'status: needs revision'
+      - 'status: pending pull request'
+      - 'status: pending triage'
+      - 'status: planned'
+      - 'status: rejected'
+      - 'status: reviewing internally'
+      - 'status: stale'

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,4 @@
-<!-- Please read the [Contributing Guide](https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->
+<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->
 ## Does this PR close any issues? If so, link them below.
 
 ## Briefly describe the issue(s) fixed.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,4 @@
-<!-- Please check for duplicates or similar PRs before submitting this PR. -->
+<!-- Please read the [Contributing Guide](https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->
 ## Does this PR close any issues? If so, link them below.
 
 ## Briefly describe the issue(s) fixed.

--- a/.github/workflows/label-issue.yml
+++ b/.github/workflows/label-issue.yml
@@ -7,36 +7,6 @@ on:
       - edited
 
 jobs:
-  # When an issue is opened, perform a similarity check for potential duplicates.
-  # If some are found, add a label and comment listing the potential duplicate issues.
-  potential-duplicate:
-    name: Detect potential duplicate issues
-    runs-on: ubuntu-latest
-    steps:
-      - uses: wow-actions/potential-duplicates@v1
-        with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # Issue title filter work with anymatch https://www.npmjs.com/package/anymatch.
-          # Any matched issue will stop detection immediately.
-          # You can specify multi filters in each line.
-          filter: ''
-          # Exclude keywords in title before detecting.
-          exclude: ''
-          # Label to set, when potential duplicates are detected.
-          label: 'potential duplicate'
-          # Get issues with state to compare. Supported state: 'all', 'closed', 'open'.
-          state: all
-          # If similarity is higher than this threshold([0,1]), issue will be marked as duplicate.
-          # Turn this up if the detection is too sensitive
-          threshold: 0.6
-          # Reactions to be add to comment when potential duplicates are detected.
-          # Available reactions: "-1", "+1", "confused", "laugh", "heart", "hooray", "rocket", "eyes"
-          # reactions: '-1'
-          # Comment to post when potential duplicates are detected.
-          comment: >
-            Potential duplicates: {{#issues}}
-              - [#{{ number }}] {{ title }} ({{ accuracy }}%)
-            {{/issues}}
   # When an issue is opened, detect if it has an empty body or incomplete issue form.
   # If it does, close the issue immediately.
   empty-issues:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,47 +16,51 @@ This patch resolves a critical issue which could cause user's save data to becom
 - Fixed an issue where some publicly distributed builds of the game were debug builds instead of release builds.
 
 ## [0.5.2] - 2024-10-11
-
+### Added
+- Added InverseDotsShader that emulates flash selections ([097dbf5](https://github.com/FunkinCrew/Funkin/commit/097dbf5bb4346d431d8ca9f0ec4bc5b5e6f4523f)) - by @ninjamuffin99
+- Added a new reworked Stage Editor ([27a0b44](https://github.com/FunkinCrew/Funkin/pull/3482/commits/27a0b4426f86f04362f97e16e2eff580c9402f34)) - by @JustKolosaki in [#3482](https://github.com/FunkinCrew/Funkin/pull/3482)
+- Added the `color` attribute to stage prop JSON data to allow them to be tinted without code. ([27a0b44](https://github.com/FunkinCrew/Funkin/pull/3482/commits/27a0b4426f86f04362f97e16e2eff580c9402f34)) - by @JustKolosaki
+- Added the `angle` attribute to stage prop JSON data to allow them to be rotated without code. ([27a0b44](https://github.com/FunkinCrew/Funkin/pull/3482/commits/27a0b4426f86f04362f97e16e2eff580c9402f34)) - by @JustKolosaki
+- Added the `blend` attribute to the stage prop JSON data to allow blend modes to be applied without code. ([27a0b44](https://github.com/FunkinCrew/Funkin/pull/3482/commits/27a0b4426f86f04362f97e16e2eff580c9402f34)) - by @JustKolosaki
 ### Changed
 - (docs) Delete Modding.md since we have a separate modding documentation ([a42240e](https://github.com/FunkinCrew/Funkin/commit/a42240e6a595d33034f2c887bf38a350d1fa0f15)) - by @AbnormalPoof in [#3651](https://github.com/FunkinCrew/Funkin/pull/3651)
 - (docs) Create a git cliff template for easier changelog stuff ([91b4544](https://github.com/FunkinCrew/Funkin/commit/91b4544f7ebc51485e3e28c3d716ba6ee69ad885)) - by @ninjamuffin99 in [#3652](https://github.com/FunkinCrew/Funkin/pull/3652)
-- Added InverseDotsShader that emulates flash selections ([097dbf5](https://github.com/FunkinCrew/Funkin/commit/097dbf5bb4346d431d8ca9f0ec4bc5b5e6f4523f)) - by @ninjamuffin99
 - (docs) Add additional `variation` input parameter to `Save.hasBeatenSong()` to allow usage of the function by inputting a variation id ([4fa9a0d](https://github.com/FunkinCrew/Funkin/commit/4fa9a0daaa67e0977460b147bd1f74a118e3e2a5)) - by @ninjamuffin99
-- (docs) Added modding docs link in readme ([4b54118](https://github.com/FunkinCrew/Funkin/commit/4b54118731e26118111e06558ae4853c577fe4bb)) - by @Cartridge-Man
-- Fix some misspellings and grammar in code documentation ([2175bea](https://github.com/FunkinCrew/Funkin/commit/2175beaa651e009332202985be4b7eb4ed36e5a4)) - by @Hundrec
+- (docs) Added modding docs link in readme ([4b54118](https://github.com/FunkinCrew/Funkin/commit/4b54118731e26118111e06558ae4853c577fe4bb)) - by @Cartridge-Man in [#3082](https://github.com/FunkinCrew/Funkin/pull/3082)
+- (docs) Fix some misspellings and grammar in code documentation ([2175bea](https://github.com/FunkinCrew/Funkin/commit/2175beaa651e009332202985be4b7eb4ed36e5a4)) - by @Hundrec in [#3477](https://github.com/FunkinCrew/Funkin/pull/3477)
 - (docs) Improvements to Github Issues templates ([399869c](https://github.com/FunkinCrew/Funkin/commit/399869cdccc9c5ac27cecfbcdc33c3d7eb4b348c)) - by @Hundrec in [#3458](https://github.com/FunkinCrew/Funkin/pull/3458)
-- Fix some misspellings and grammar in code documentation ([6df80ba](https://github.com/FunkinCrew/Funkin/commit/6df80ba69d0e24269f40471f83462cab7d5e13cf)) - by @Hundrec in [#3477](https://github.com/FunkinCrew/Funkin/pull/3477)
-- (docs) Improvements to Github Issues templates ([67f7b63](https://github.com/FunkinCrew/Funkin/commit/67f7b638fb76840b868cbfa70a1c6063577984c5)) - by @Hundrec
-
 ### Fixed
-- Disable flickering when changing FPS in the options menu ([b2647fe](https://github.com/FunkinCrew/Funkin/commit/b2647fe09f5281ce7074b26d47bc1524764168ee)) - by @lemz1 in [#3629](https://github.com/FunkinCrew/Funkin/pull/3629)
-- Anti alias / smooth the volume sound tray ([e66290c](https://github.com/FunkinCrew/Funkin/commit/e66290c55f7141402223644f06ec8a69edeee089)) - by @Kn1ghtNight in [#2853](https://github.com/FunkinCrew/Funkin/pull/2853)
+- Fix the user song offsets being applied incorrectly, causing stuttering or skipping ([410cfe9](https://github.com/FunkinCrew/Funkin/commit/410cfe972d6df9de4d4d128375cf8380c4f06d92)) - by @JustKolosaki in [#3546](https://github.com/FunkinCrew/Funkin/pull/3546) in [#3506](https://github.com/FunkinCrew/Funkin/pull/3506)
+- Fixed issues with variation / difficulty loading for Freeplay Menu which caused some songs to disappear ([c0314c8](https://github.com/FunkinCrew/Funkin/commit/c0314c85ecd5116641aff3de8e9153f7fe48e79c)) - by @ninjamuffin99
+- Pico's songs now display properly on the Freeplay Menu ([1d2bd61](https://github.com/FunkinCrew/Funkin/commit/1d2bd61119e5f418df7f11d7ef2a0fdedee17d3d)) - by @ninjamuffin99 in [#3506](https://github.com/FunkinCrew/Funkin/pull/3506)
+- Exiting the chart editor doesn't crash the game anymore ([f52472a](https://github.com/FunkinCrew/Funkin/commit/f52472a4767388b22cfbab0f5f7860f6e6762856)) - by @EliteMasterEric and @ianharrigan in [#3519](https://github.com/FunkinCrew/Funkin/pull/3519)
+- Disable flickering when attempting to select FPS in the options menu ([b2647fe](https://github.com/FunkinCrew/Funkin/commit/b2647fe09f5281ce7074b26d47bc1524764168ee)) - by @lemz1 in [#3629](https://github.com/FunkinCrew/Funkin/pull/3629)
+- Anti-alias / smooth the volume sound tray ([e66290c](https://github.com/FunkinCrew/Funkin/commit/e66290c55f7141402223644f06ec8a69edeee089)) - by @Kn1ghtNight in [#2853](https://github.com/FunkinCrew/Funkin/pull/2853)
 - Don't restart the FreeplayState song preview when changing the difficulty within the same variation ([903b3fc](https://github.com/FunkinCrew/Funkin/commit/903b3fc59905a70802618a1cd67407722ea956ed)) - by @JustKolosaki in [#3587](https://github.com/FunkinCrew/Funkin/pull/3587)
-- Exiting the chart editor doesn't crash the game anymore ([f52472a](https://github.com/FunkinCrew/Funkin/commit/f52472a4767388b22cfbab0f5f7860f6e6762856)) - by @EliteMasterEric
 - Character Select cursor moves properly at lower framerates ([ab5bda3](https://github.com/FunkinCrew/Funkin/commit/ab5bda3ee573a6e03595ec6941e6de38df851889)) - by @ninjamuffin99 in [#3507](https://github.com/FunkinCrew/Funkin/pull/3507)
-- Stopped allowing F1 to create more than one help dialog window in the Charting Editor ([777978f](https://github.com/FunkinCrew/Funkin/commit/777978f5a544e1b7c89b47dcc365f734eb6d0df1)) - by @amyspark-ng
+- Stop allowing F1 to create more than one help dialog window in the Charting Editor ([777978f](https://github.com/FunkinCrew/Funkin/commit/777978f5a544e1b7c89b47dcc365f734eb6d0df1)) - by @amyspark-ng in [#3552](https://github.com/FunkinCrew/Funkin/pull/3552)
 - Main menu music doesn't cut out when switching states anymore. ([711e0a6](https://github.com/FunkinCrew/Funkin/commit/711e0a6b7547eb04113e9318dab900f01ad576a5)) - by @EliteMasterEric in [#3530](https://github.com/FunkinCrew/Funkin/pull/3530)
-- The dialog now shows up on the animation debugger view ([1fde59f](https://github.com/FunkinCrew/Funkin/commit/1fde59f999eac94eb10fc22094885de2f5310705)) - by @EliteMasterEric
+- The dialog now shows up on the animation debugger view ([1fde59f](https://github.com/FunkinCrew/Funkin/commit/1fde59f999eac94eb10fc22094885de2f5310705)) - by @EliteMasterEric in [#3530](https://github.com/FunkinCrew/Funkin/pull/3530)
 - Center preloader 'fnf' and 'dsp' text so it doesn't clip anymore ([165ad60](https://github.com/FunkinCrew/Funkin/commit/165ad6015539a295e9eefdaef291c312e9566b26)) - by @Burgerballs in [#3567](https://github.com/FunkinCrew/Funkin/pull/3567)
 - `Song.getFirstValidVariation()` now properly takes into account multiple variations/difficulty input ([d2e2987](https://github.com/FunkinCrew/Funkin/commit/d2e29879fe2acc6febfe0f335f655b741d630c34)) - by @ninjamuffin99 in [#3506](https://github.com/FunkinCrew/Funkin/pull/3506)
-- (freeplay) Proper variation / difficulty loading for Freeplay Menu ([c0314c8](https://github.com/FunkinCrew/Funkin/commit/c0314c85ecd5116641aff3de8e9153f7fe48e79c)) - by @ninjamuffin99
-- Picos songs properly load on freeplay ([1d2bd61](https://github.com/FunkinCrew/Funkin/commit/1d2bd61119e5f418df7f11d7ef2a0fdedee17d3d)) - by @ninjamuffin99
 - (debug) No more fullscreening when typing "F" in the flixel debugger console ([29b6763](https://github.com/FunkinCrew/Funkin/commit/29b6763290df05d42039806f3d142740568c80f0)) - by @ninjamuffin99
-- Fix the user song offsets being applied incorrectly ([410cfe9](https://github.com/FunkinCrew/Funkin/commit/410cfe972d6df9de4d4d128375cf8380c4f06d92)) - by @JustKolosaki
-- Fix crash in LatencyState when exiting / cleaning up state data ([39b1a42](https://github.com/FunkinCrew/Funkin/commit/39b1a42cfeafe2b7be8b66e2fe529e853d9ae197)) - by @lemz1
-- Add additional classes to Polymod Blacklist ([b0b73c8](https://github.com/FunkinCrew/Funkin/commit/b0b73c83994f33118c6a69550da9ec8ec1c07adc)) - by @EliteMasterEric
-- Stop allowing inputs after selecting a character ([dbf66ac](https://github.com/FunkinCrew/Funkin/commit/dbf66ac250137262866d75f7c1387645b35d88d0)) - by @ACrazyTown
-- Fixed an issue where the player and girlfriend would disappear or overlap themselves in Character Select (community fix by gamerbross)
-- Fixed an issue where the game would show the wrong girlfriend in Character Select (community fix by gamerbross)
-- Fixed an issue where the cursor wouldn't update properly in Character Select (community fix by gamerbross)
-- Fixed an issue where the player would display double after entering character select or when spamming buttons (community fix by gamerbross)
+- Fix crash in LatencyState when exiting / cleaning up state data ([39b1a42](https://github.com/FunkinCrew/Funkin/commit/39b1a42cfeafe2b7be8b66e2fe529e853d9ae197)) - by @lemz1 in [#3493](https://github.com/FunkinCrew/Funkin/pull/3493)
+- Add additional classes to Polymod blacklist for security ([b0b73c8](https://github.com/FunkinCrew/Funkin/commit/b0b73c83994f33118c6a69550da9ec8ec1c07adc)) - by @EliteMasterEric in [#3558](https://github.com/FunkinCrew/Funkin/pull/3558)
+- Stop allowing inputs after selecting a character ([dbf66ac](https://github.com/FunkinCrew/Funkin/commit/dbf66ac250137262866d75f7c1387645b35d88d0)) - by @ACrazyTown in [#3398](https://github.com/FunkinCrew/Funkin/pull/3398)
+- Fix conflict with modded StrumlineNote sprite looping animation ([bc546e8](https://github.com/FunkinCrew/Funkin/commit/bc546e86aa77ffc795b3f079de5f590289a9c583)) - by @DaWaterMalone in [#3577](https://github.com/FunkinCrew/Funkin/pull/3577)
+- Properly format the millisecond counter in the chart editor playbar ([f1b6e6c](https://github.com/FunkinCrew/Funkin/commit/f1b6e6c4e42455e0c2900d738ebc24893f2479a0)) - by @afreetoplaynoob in [#3537](https://github.com/FunkinCrew/Funkin/pull/3537)
+- Fixed an issue where the player and girlfriend would disappear or overlap themselves in Character Select ([community fix by @gamerbross](https://github.com/FunkinCrew/Funkin/pull/3457))
+- Fixed an issue where the game would show the wrong girlfriend in Character Select ([community fix by @gamerbross](https://github.com/FunkinCrew/Funkin/pull/3457))
+- Fixed an issue where the cursor wouldn't update properly in Character Select ([community fix by @gamerbross](https://github.com/FunkinCrew/Funkin/pull/3457))
+- Fixed an issue where the player would display double after entering character select or when spamming buttons ([community fix by @gamerbross](https://github.com/FunkinCrew/Funkin/pull/3457))
 
 ## New Contributors for 0.5.2
+* @JustKolosaki made their first contribution in [#3482](https://github.com/FunkinCrew/Funkin/pull/3482)
 * @Kn1ghtNight made their first contribution in [#2853](https://github.com/FunkinCrew/Funkin/pull/2853)
-* @DaWaterMalone made their first contribution
-* @amyspark-ng made their first contribution
-* @Cartridge-Man made their first contribution
-* @afreetoplaynoob made their first contribution
+* @DaWaterMalone made their first contribution in [#3577](https://github.com/FunkinCrew/Funkin/pull/3577)
+* @amyspark-ng made their first contribution in [#3552](https://github.com/FunkinCrew/Funkin/pull/3552)
+* @Cartridge-Man made their first contribution in [#3082](https://github.com/FunkinCrew/Funkin/pull/3082)
+* @afreetoplaynoob made their first contribution in [#3537](https://github.com/FunkinCrew/Funkin/pull/3537)
 
 
 ## [0.5.1] - 2024-09-30
@@ -74,7 +78,7 @@ This patch resolves a critical issue which could cause user's save data to becom
 - Separated the Perfect and Perfect (Gold) animations in the Playable Character data.
   - Base game just uses the same animation for both, but modders can split the animations up on their custom characters now.
 - Added a bunch of Flash project files from the Weekend 1 and Playable Pico updates to the `Funkin.art` repository.
-- Added the `flipX` and `flipY` parameters to props in the Stage data. (community feature by abnormalpoof)
+- Added the `flipX` and `flipY` parameters to props in the Stage data. ([community feature by AbnormalPoof](https://github.com/FunkinCrew/Funkin/pull/3474))
 ### Changed
 - The game's mod API version check is now more dynamic.
   - The update accepts mods with API version `0.5.0` as well as `0.5.1`.
@@ -123,18 +127,23 @@ This patch resolves a critical issue which could cause user's save data to becom
 - Fixed an issue where Spirit's trail in Week 6 would not display correctly.
 - Fixed an issue where the Input Offsets menu would crash when entering it before playing a song on web builds.
 - Fixed an issue where the Results screen would spam the percentage tick noise instead of playing when the value changes.
-- Fixed an issue where parts of the Chart Editor could not be interacted with. (community fix by KadeDeveloper)
-- Fixed an issue where classic FocusCamera song events could cause the camera to snap in place. (community fix by NebulaZorua)
-- Fixed an issue where achieving the same rank on a song (but a different clear %) would override your clear %, even if it was lower. (community fix by lemz1)
-- Fixed an issue where the FPS counter would display even if Debug Display was turned off. (community fix by Lethrial)
-- Fixed an issue where selecting the area to the left of the Chart Editor would select some of the player's notes (community fix by NotHyper474)
-- Fixed an issue where pixel icons in the Chart Editor would not display correctly. (community fix by Techniktil)
-- Fixed an issue where `Stage.addCharacter` would not properly assign the `characterType`. (community fix by KadeDeveloper)
-- Fixed an issue where players should interact with Character Select during the unlock sequence, causing a crash. (community fix by actualmandm)
-- Fixed an issue where hold notes in Week 6 were not scaled/positioned correctly. (community fix by dombomb64)
-- Fixed an issue where audio offets would not interact with the Chart Editor properly. (community fix by KadeDev)
-- Fixed an issue where fetching Modules during the `onDestroy` event would fail at random. (community fix by cyn0x8)
-- Fixed an issue where `onSubStateOpenEnd` and `onSubStateCloseEnd` script events would not always get called. (community fix by lemz1)
+- Fixed an issue where parts of the Chart Editor could not be interacted with. ([community fix by Kade-github](https://github.com/FunkinCrew/Funkin/pull/3337))
+- Fixed an issue where classic FocusCamera song events could cause the camera to snap in place. ([community fix by nebulazorua](https://github.com/FunkinCrew/Funkin/pull/2331))
+- Fixed an issue where achieving the same rank on a song (but a different clear %) would override your clear %, even if it was lower. ([community fix by lemz1](https://github.com/FunkinCrew/Funkin/pull/3019))
+- Fixed an issue where the FPS counter would display even if Debug Display was turned off. ([community fix by Lethrial](https://github.com/FunkinCrew/Funkin/pull/3356))
+- Fixed an issue where selecting the area to the left of the Chart Editor would select some of the player's notes ([community fix by NotHyper-474](https://github.com/FunkinCrew/Funkin/pull/3093))
+- Fixed an issue where pixel icons in the Chart Editor would not display correctly. ([community fix by Techniktil](https://github.com/FunkinCrew/Funkin/pull/3339))
+- Fixed an issue where `Stage.addCharacter` would not properly assign the `characterType`. ([community fix by Kade-github](https://github.com/FunkinCrew/Funkin/pull/3357))
+- Fixed an issue where players could interact with Character Select during the unlock sequence, causing a crash. ([community fix by ActualMandM](https://github.com/FunkinCrew/Funkin/pull/3355))
+- Fixed an issue where hold notes in Week 6 were not scaled/positioned correctly. ([community fix by dombomb64](https://github.com/FunkinCrew/Funkin/pull/3351))
+- Fixed an issue where audio offets would not interact with the Chart Editor properly. ([community fix by Kade-github](https://github.com/FunkinCrew/Funkin/pull/3384))
+- Fixed an issue where fetching Modules during the `onDestroy` event would fail at random. ([community fix by cyn0x8](https://github.com/FunkinCrew/Funkin/pull/3131))
+- Fixed an issue where `onSubStateOpenEnd` and `onSubStateCloseEnd` script events would not always get called. ([community fix by lemz1](https://github.com/FunkinCrew/Funkin/pull/3138))
+
+## New Contributors for 0.5.1
+* @Lethrial made their first contribution in [#3356](https://github.com/FunkinCrew/Funkin/pull/3356)
+* @dombomb64 made their first contribution in [#3351](https://github.com/FunkinCrew/Funkin/pull/3351)
+
 
 ## [0.5.0] - 2024-09-12
 ### Added
@@ -171,8 +180,8 @@ This patch resolves a critical issue which could cause user's save data to becom
 - Implemented alternate animations and music for Pico in the results screen.
   - These display on Pico remixes, as well as when playing Weekend 1.
 - Implemented support for scripted Note Kinds. You can use HScript define a different note style to display for these notes as well as custom behavior. (community feature by lemz1)
-- Implemented support for Numeric and Selector options in the Options menu. (community feature by FlooferLand)
-- Implemented new animations for Tankman and Pico
+- Implemented support for Numeric and Selector options in the Options menu. ([community feature by FlooferLand](https://github.com/FunkinCrew/Funkin/pull/2942))
+- Implemented new animations for Tankman and Pico.
 ## Changed
 - Girlfriend and Nene now perform previously unused animations when you achieve a large combo, or drop a large combo.
 - The pixel character icons in the Freeplay menu now display an animation!
@@ -180,40 +189,51 @@ This patch resolves a critical issue which could cause user's save data to becom
 - Character offsets are now independent of the character's scale.
   - This should resolve issues with offsets when porting characters from older mods.
   - Pixel character offsets have been modified to compensate.
-- Note style data can now specify custom combo count graphics, judgement graphics, countdown graphics, and countdown audio. (community feature by anysad)
+- Note style data can now specify custom combo count graphics, judgement graphics, countdown graphics, and countdown audio. ([community feature by anysad](https://github.com/FunkinCrew/Funkin/pull/3020))
   - These were previously using hardcoded values based on whether the stage was `school` or `schoolEvil`.
 - The `danceEvery` property of characters and stage props can now use values with a precision of `0.25`, to play their idle animation up to four times per beat.
 - Reworked the JSON merging system in Polymod; you can now include JSONPatch files under `_merge` in your mod folder to add, modify, or remove values in a JSON without replacing it entirely!
-- Cutscenes now automatically pause when tabbing out (community fix by AbnormalPoof)
-- Characters will now respect the `danceEvery` property (community fix by gamerbross)
-- The F5 function now reloads the current song's chart data from disc (community feature by gamerbross)
-- Refactored the compilation guide and added common troubleshooting steps (community fix by Hundrec)
-- Made several layout improvements and fixes to the Animation Offsets editor in the Debug menu (community fix by gamerbross)
-- Fixed a bug where the Back sound would be not played when leaving the Story menu and Options menu (community fix by AppleHair)
-- Animation offsets no longer directly modify the `x` and `y` position of props, which makes props work better with tweens (community fix by Sword352)
-- The YEAH! events in Tutorial now use chart events rather than being hard-coded (community fix by anysad)
+- Cutscenes now automatically pause when tabbing out ([community fix by AbnormalPoof](https://github.com/FunkinCrew/Funkin/pull/2903))
+- Characters will now respect the `danceEvery` property ([community fix by gamerbross](https://github.com/FunkinCrew/Funkin/pull/2925))
+- The F5 function now reloads the current song's chart data from disc ([community feature by gamerbross](https://github.com/FunkinCrew/Funkin/pull/2990))
+- Refactored the compilation guide and added common troubleshooting steps ([community fix by Hundrec](https://github.com/FunkinCrew/Funkin/pull/2813))
+- Made several layout improvements and fixes to the Animation Offsets editor in the Debug menu ([community fix by gamerbross](https://github.com/FunkinCrew/Funkin/pull/2820))
+- Fixed a bug where the Back sound would be not played when leaving the Story menu and Options menu ([community fix by AppleHair](https://github.com/FunkinCrew/Funkin/pull/2986))
+- Animation offsets no longer directly modify the `x` and `y` position of props, which makes props work better with tweens ([community fix by Sword352](https://github.com/FunkinCrew/Funkin/pull/2310))
+- The YEAH! events in Tutorial now use chart events rather than being hard-coded ([community fix by anysad](https://github.com/FunkinCrew/Funkin/pull/3007))
 - The player's Score now displays commas in it (community fix by loggo)
 ## Fixed
 - Fixed an issue where songs with no notes would crash on the Results screen.
 - Fixed an issue where the old icon easter egg would not work properly on pixel levels.
 - Fixed an issue where you could play notes during the Thorns cutscene.
 - Fixed an issue where the Heart icon when favoriting a song in Freeplay would be malformed.
-- Fixed an issue where Pico's death animation displays a faint blue background (community fix by doggogit)
-- Fixed an issue where mod songs would not play a preview in the Freeplay menu (community fix by KarimAkra)
-- Fixed an issue where the Memory Usage counter could overflow and display a negative number (community fix by KarimAkra)
-- Fixed an issue where pressing the Chart Editor keybind while playtesting a chart would reset the chart editor (community fix by gamerbross)
-- Fixed a crash bug when pressing F5 after seeing the sticker transition (community fix by gamerbross)
-- Fixed an issue where the Story Mode menu couldn't be scrolled with a mouse (community fix by JVNpixels)
-- Fixed an issue causing the song to majorly desync sometimes (community fix by Burgerballs)
-- Fixed an issue where the Freeplay song preview would not respect the instrumental ID specified in the song metadata (community fix by AppleHair)
-- Fixed an issue where Tankman's icon wouldn't display in the Chart Editor (community fix by hundrec)
-- Fixed an issue where pausing the game during a camera zoom would zoom the pause menu. (community fix by gamerbros)
-- Fixed an issue where certain UI elements would not flash at a consistent rate (community fix by cyn0x8)
-- Fixed an issue where the game would not use the placeholder health icon as a fallback (community fix by gamerbross)
-- Fixed an issue where the chart editor could get stuck creating a hold note when using Live Inputs (community fix by gamerbross)
-- Fixed an issue where character graphics could not be placed in week folders (community fix by 7oltan)
-- Fixed a crash issue when a Freeplay song has no `Normal` difficulty (community fix by Applehair and gamerbross)
-- Fixed an issue in Story Mode where a song that isn't valid for the current variation could be selected (community fix by Applehair)
+- Fixed an issue where Pico's death animation displays a faint blue background ([community fix by doggogit](https://github.com/FunkinCrew/funkin.assets/pull/1))
+- Fixed an issue where mod songs would not play a preview in the Freeplay menu ([community fix by KarimAkra](https://github.com/FunkinCrew/Funkin/pull/2724))
+- Fixed an issue where the Memory Usage counter could overflow and display a negative number ([community fix by KarimAkra](https://github.com/FunkinCrew/Funkin/pull/2713))
+- Fixed an issue where pressing the Chart Editor keybind while playtesting a chart would reset the chart editor ([community fix by gamerbross](https://github.com/FunkinCrew/Funkin/pull/2739))
+- Fixed a crash bug when pressing F5 after seeing the sticker transition ([community fix by gamerbross](https://github.com/FunkinCrew/Funkin/pull/2863))
+- Fixed an issue where the Story Mode menu couldn't be scrolled with a mouse ([community fix by JVNpixels](https://github.com/FunkinCrew/Funkin/pull/2873))
+- Fixed an issue causing the song to majorly desync sometimes ([community fix by Burgerballs](https://github.com/FunkinCrew/Funkin/pull/3058))
+- Fixed an issue where the Freeplay song preview would not respect the instrumental ID specified in the song metadata ([community fix by AppleHair](https://github.com/FunkinCrew/Funkin/pull/2742))
+- Fixed an issue where Tankman's icon wouldn't display in the Chart Editor ([community fix by Hundrec](https://github.com/FunkinCrew/Funkin/pull/2912))
+- Fixed an issue where pausing the game during a camera zoom would zoom the pause menu. ([community fix by gamerbross](https://github.com/FunkinCrew/Funkin/pull/2567))
+- Fixed an issue where certain UI elements would not flash at a consistent rate ([community fix by cyn0x8](https://github.com/FunkinCrew/Funkin/pull/2494))
+- Fixed an issue where the game would not use the placeholder health icon as a fallback ([community fix by gamerbross](https://github.com/FunkinCrew/Funkin/pull/3005))
+- Fixed an issue where the chart editor could get stuck creating a hold note when using Live Inputs ([community fix by gamerbross](https://github.com/FunkinCrew/Funkin/pull/2992))
+- Fixed an issue where character graphics could not be placed in week folders ([community fix by 7oltan](https://github.com/FunkinCrew/Funkin/pull/3035))
+- Fixed a crash issue when a Freeplay song has no `Normal` difficulty ([community fix by AppleHair](https://github.com/FunkinCrew/Funkin/pull/3036) and [gamerbross](https://github.com/FunkinCrew/Funkin/pull/2712))
+- Fixed an issue in Story Mode where a song that isn't valid for the current variation could be selected ([community fix by AppleHair](https://github.com/FunkinCrew/Funkin/pull/3037))
+
+## New Contributors for 0.5.0
+* @Flooferland made their first contribution in [#2942](https://github.com/FunkinCrew/Funkin/pull/2942)
+* @anysad made their first contribution in [#3007](https://github.com/FunkinCrew/Funkin/pull/3007)
+* @Sword352 made their first contribution in [#2310](https://github.com/FunkinCrew/Funkin/pull/2310)
+* @KarimAkra made their first contribution in [#2713](https://github.com/FunkinCrew/Funkin/pull/2713)
+* @JVNpixels made their first contribution in [#2873](https://github.com/FunkinCrew/Funkin/pull/2873)
+* @AppleHair made their first contribution in [#2742](https://github.com/FunkinCrew/Funkin/pull/2742)
+* @7oltan made their first contribution in [#3035](https://github.com/FunkinCrew/Funkin/pull/3035)
+* @cyn0x8 made their first contribution in [#2494](https://github.com/FunkinCrew/Funkin/pull/2494)
+
 
 ## [0.4.1] - 2024-06-12
 ### Added
@@ -222,7 +242,7 @@ This patch resolves a critical issue which could cause user's save data to becom
 ### Changed
 - Highscores and ranks are now saved separately, which fixes the issue where people would overwrite their saves with higher scores,
 which would remove their rank if they had a lower one.
-- A-Bot speaker now reacts to the user's volume preference on desktop (thanks to [M7theguy for the issue report/suggestion](https://github.com/FunkinCrew/Funkin/issues/2744)!)
+- A-Bot speaker now reacts to the user's volume preference on desktop ([thanks to M7theguy for the issue report/suggestion](https://github.com/FunkinCrew/Funkin/issues/2744)!)
 - On Freeplay, heart icons are shifted to the right when you favorite a song that has no rank on it.
 - Only play `scrollMenu` sound effect when there's a real change on the freeplay menu ([thanks gamerbross for the PR!](https://github.com/FunkinCrew/Funkin/pull/2741))
 - Gave antialiasing to the edge of the dad graphic on Freeplay
@@ -230,19 +250,24 @@ which would remove their rank if they had a lower one.
 - Made several chart revisions
   - Re-enabled custom camera events in Roses (Erect/Nightmare)
   - Tweaked the chart for Lit Up (Hard)
-  - Corrected the difficulty ratings for M.I.L.F. (Easy/Normal/Hard)
+  - Corrected the difficulty ratings for M.I.L.F (Easy/Normal/Hard)
 ### Fixed
 - Fixed an issue in the controls menu where some control binds would overlap their names
 - Fixed crash when attempting to exit the gameover screen when also attempting to retry the song ([thanks DMMaster636 for the PR!](https://github.com/FunkinCrew/Funkin/pull/2709))
-- Fix botplay sustain release bug ([thanks Hundrec!](Fix botplay sustain release bug #2683))
+- Fix botplay sustain release bug ([thanks Hundrec!](https://github.com/FunkinCrew/Funkin/pull/2683))
 - Fix for the camera not pausing during a gameplay pause ([thanks gamerbross!](https://github.com/FunkinCrew/Funkin/pull/2684))
-- Fixed issue where Pico's gameplay sprite would unintentionally appear on the gameover screen when dying on 2Hot from an explosion
+- Fixed issue where Pico's gameplay sprite would unintentionally appear on the gameover screen when dying on 2hot from an explosion
 - Freeplay previews properly fade volume during the BF idle animation
-- Fixed bug where Dadbattle incorrectly appeared as Dadbattle Erect when returning to freeplay on Hard
-- Fixed 2Hot not appearing under the "#" category in Freeplay menu
+- Fixed bug where DadBattle incorrectly appeared as DadBattle Erect when returning to freeplay on Hard
+- Fixed 2hot not appearing under the "#" category in Freeplay menu
 - Fixed a bug where the Chart Editor would crash when attempting to select an event with the Event toolbox open
 - Improved offsets for Pico and Tankman opponents so they don't slide around as much.
 - Fixed the black "temp" graphic on freeplay from being incorrectly sized / masked, now it's identical to the dad freeplay graphic
+
+## New Contributors for 0.4.1
+* @DMMaster636 made their first contribution in [#2709](https://github.com/FunkinCrew/Funkin/pull/2709)
+* @Hundrec made their first contribution in [#2683](https://github.com/FunkinCrew/Funkin/pull/2683)
+
 
 ## [0.4.0] - 2024-06-06
 ### Added
@@ -252,14 +277,14 @@ which would remove their rank if they had a lower one.
   - Freeplay now plays a preview of songs when you hover over them.
 - Added a Charter field to the chart format, to allow for crediting the creator of a level's chart.
   - You can see who charted a song from the Pause menu.
-- Added a new Scroll Speed chart event to change the note speed mid-song (thanks burgerballs!)
+- Added a new Scroll Speed chart event to change the note speed mid-song ([thanks Burgerballs!](https://github.com/FunkinCrew/Funkin/pull/2409))
 ### Changed
 - Tweaked the charts for several songs:
   - Tutorial (increased the note speed slightly)
   - Spookeez
   - Monster
   - Winter Horrorland
-  - M.I.L.F.
+  - M.I.L.F
   - Senpai (increased the note speed)
   - Roses
   - Thorns (increased the note speed slightly)
@@ -269,54 +294,74 @@ which would remove their rank if they had a lower one.
 - Favorite songs marked in Freeplay are now stored between sessions.
 - The Freeplay easter eggs are now easier to see.
 - In the event that the game cannot load your save data, it will now perform a backup before clearing it, so that we can try to repair it in the future.
-- Custom note styles are now properly supported for songs; add new notestyles via JSON, then select it for use from the Chart Editor Metadata toolbox. (thanks Keoiki!)
-- Health icons now support a Winning frame without requiring a spritesheet, simply include a third frame in the icon file. (thanks gamerbross!)
+- Custom note styles are now properly supported for songs; add new notestyles via JSON, then select it for use from the Chart Editor Metadata toolbox. ([thanks Keoiki!](https://github.com/FunkinCrew/Funkin/pull/2581))
+- Health icons now support a Winning frame without requiring a spritesheet, simply include a third frame in the icon file. ([thanks gamerbross!](https://github.com/FunkinCrew/Funkin/pull/2593))
   - Remember that for more complex behaviors such as animations or transitions, you should use an XML file to define each frame.
 - Improved the Event Toolbox in the Chart Editor; dropdowns are now bigger, include search field, and display elements in alphabetical order rather than a random order.
 ### Fixed
 - Fixed an issue where Nene's visualizer would not play on Desktop builds
 - Fixed a bug where the game would silently fail to load saves on HTML5
 - Fixed some bugs with the props on the Story Menu not bopping properly
-- Additional fixes to the Loading bar on HTML5 (thanks lemz1!)
-- Fixed several bugs with the TitleState, including missing music when returning from the Main Menu (thanks gamerbross!)
-- Fixed a camera bug in the Main Menu (thanks richTrash21!)
-- Fixed a bug where changing difficulties in Story mode wouldn't update the score (thanks sectorA!)
-- Fixed a crash in Freeplay caused by a level referencing an invalid song (thanks gamerbross!)
-- Fixed a bug where pressing the volume keys would stop the Toy commercial (thanks gamerbross!)
-- Fixed a bug where the Chart Editor Playtest would crash when losing (thanks gamerbross!)
-- Fixed a bug where hold notes would display improperly in the Chart Editor when downscroll was enabled for gameplay (thanks gamerbross!)
-- Fixed a bug where hold notes would be positioned wrong on downscroll (thanks MaybeMaru!)
-- Removed a large number of unused imports to optimize builds (thanks Ethan-makes-music!)
-- Improved debug logging for unscripted stages (thanks gamerbross!)
+- Additional fixes to the Loading bar on HTML5 ([thanks lemz1!](https://github.com/FunkinCrew/Funkin/pull/2553))
+- Fixed several bugs with the TitleState, including missing music when returning from the Main Menu ([thanks gamerbross!](https://github.com/FunkinCrew/Funkin/pull/2539))
+- Fixed a camera bug in the Main Menu ([thanks richTrash21!](https://github.com/FunkinCrew/Funkin/pull/2576))
+- Fixed a bug where changing difficulties in Story mode wouldn't update the score ([thanks sector-a!](https://github.com/FunkinCrew/Funkin/pull/2585))
+- Fixed a crash in Freeplay caused by a level referencing an invalid song ([thanks gamerbross!](https://github.com/FunkinCrew/Funkin/pull/2457))
+- Fixed a bug where pressing the volume keys would stop the Toy commercial ([thanks gamerbross!](https://github.com/FunkinCrew/Funkin/pull/2540))
+- Fixed a bug where the Chart Editor Playtest would crash when losing ([thanks gamerbross!](https://github.com/FunkinCrew/Funkin/pull/2518))
+- Fixed a bug where hold notes would display improperly in the Chart Editor when downscroll was enabled for gameplay ([thanks gamerbross!](https://github.com/FunkinCrew/Funkin/pull/2565))
+- Fixed a bug where hold notes would be positioned wrong on downscroll ([thanks MaybeMaru!](https://github.com/FunkinCrew/Funkin/pull/2488))
+- Removed a large number of unused imports to optimize builds ([thanks Ethan-makes-music!](https://github.com/FunkinCrew/Funkin/pull/2624))
+- Improved debug logging for unscripted stages ([thanks gamerbross!](https://github.com/FunkinCrew/Funkin/pull/2603))
+- Fixed a crash on Linux caused by an old version of hxCodec ([thanks Noobz4Life!](https://github.com/FunkinCrew/Funkin/pull/2472))
+- Optimized animation handling for characters ([thanks richTrash21!](https://github.com/FunkinCrew/Funkin/pull/2493))
 - Made improvements to compiling documentation (thanks gedehari!)
-- Fixed a crash on Linux caused by an old version of hxCodec (thanks Noobz4Life!)
-- Optimized animation handling for characters (thanks richTrash21!)
-- Made improvements to compiling documentation (thanks gedehari!)
-- Fixed an issue where the Chart Editor would use an incorrect instrumental on imported Legacy songs (thanks gamerbross!)
-- Fixed a camera bug in the Main Menu (thanks richTrash21!)
-- Fixed a bug where opening the game from the command line would crash the preloader (thanks NotHyper474!)
-- Fixed a bug where characters would sometimes use the wrong scale value (thanks PurSnake!)
+- Fixed an issue where the Chart Editor would use an incorrect instrumental on imported Legacy songs ([thanks gamerbross!](https://github.com/FunkinCrew/Funkin/pull/2604))
+- Fixed a bug where opening the game from the command line would crash the preloader ([thanks NotHyper-474!](https://github.com/FunkinCrew/Funkin/pull/2629))
+- Fixed a bug where characters would sometimes use the wrong scale value ([thanks PurSnake!](https://github.com/FunkinCrew/Funkin/pull/2610))
 - Additional bug fixes and optimizations.
+
+## New Contributors for 0.4.0
+* @Keoiki made their first contribution in [#2581](https://github.com/FunkinCrew/Funkin/pull/2581)
+* @richTrash21 made their first contribution in [#2493](https://github.com/FunkinCrew/Funkin/pull/2493)
+* @sector-a made their first contribution in [#2585](https://github.com/FunkinCrew/Funkin/pull/2585)
+* @MaybeMaru made their first contribution in [#2488](https://github.com/FunkinCrew/Funkin/pull/2488)
+* @Ethan-makes-music made their first contribution in [#2624](https://github.com/FunkinCrew/Funkin/pull/2624)
+* @Noobz4Life made their first contribution in [#2472](https://github.com/FunkinCrew/Funkin/pull/2472)
+* @NotHyper-474 made their first contribution in [#2629](https://github.com/FunkinCrew/Funkin/pull/2629)
+* @PurSnake made their first contribution in [#2610](https://github.com/FunkinCrew/Funkin/pull/2610)
+
 
 ## [0.3.3] - 2024-05-14
 ### Changed
-- Cleaned up some code in `PlayAnimationSongEvent.hx` (thanks BurgerBalls!)
+- Cleaned up some code in `PlayAnimationSongEvent.hx` ([thanks Burgerballs!](https://github.com/FunkinCrew/Funkin/pull/2308))
 ### Fixed
-- Fixes to the Loading bar on HTML5 (thanks lemz1!)
-- Don't allow any more inputs when exiting freeplay (thanks gamerbros!)
-- Fixed using mouse wheel to scroll on freeplay (thanks JugieNoob!)
-- Fixed the reset's of the health icons, score, and notes when re-entering gameplay from gameover (thanks ImCodist!)
-- Fixed the chart editor character selector's hitbox width (thanks MadBear422!)
-- Fixed camera stutter once a wipe transition to the Main Menu completes (thanks ImCodist!)
-- Fixed an issue where hold note would be invisible for a single frame (thanks ImCodist!)
-- Fix tween accumulation on title screen when pressing Y multiple times (thanks TheGaloXx!)
+- Fixes to the Loading bar on HTML5 ([thanks lemz1!](https://github.com/FunkinCrew/Funkin/pull/2499))
+- Don't allow any more inputs when exiting freeplay ([thanks gamerbross!](https://github.com/FunkinCrew/Funkin/pull/2470))
+- Fixed using mouse wheel to scroll on freeplay ([thanks JugieNoob!](https://github.com/FunkinCrew/Funkin/pull/2466))
+- Fixed the resets of the health icons, score, and notes when re-entering gameplay from gameover ([thanks ImCodist!](https://github.com/FunkinCrew/Funkin/pull/2390))
+- Fixed the chart editor character selector's hitbox width ([thanks MadBear422!](https://github.com/FunkinCrew/Funkin/pull/2370))
+- Fixed camera stutter once a wipe transition to the Main Menu completes ([thanks ImCodist!](https://github.com/FunkinCrew/Funkin/pull/2315))
+- Fixed an issue where hold note would be invisible for a single frame ([thanks ImCodist!](https://github.com/FunkinCrew/Funkin/pull/2309))
+- Fix tween accumulation on title screen when pressing Y multiple times ([thanks TheGaloXx!](https://github.com/FunkinCrew/Funkin/pull/2300))
 - Fix a crash when querying FlxG.state in the crash handler
 - Fix for a game over easter egg so you don't accidentally exit it when viewing
 - Fix an issue where the Freeplay menu never displays 100% clear
 - Fix an issue where Weekend 1 Pico attempted to retrieve a missing asset.
-- Fix an issue where duplicate keybinds would be stoed, potentially causing a crash
-- Chart debug key now properly returns you to the previous chart editor session if you were playtesting a chart (thanks nebulazorua!)
+- Fix an issue where duplicate keybinds would be stored, potentially causing a crash
+- Chart debug key now properly returns you to the previous chart editor session if you were playtesting a chart ([thanks nebulazorua!](https://github.com/FunkinCrew/Funkin/pull/2323))
 - Fix a crash on Freeplay found on AMD graphics cards
+
+## New Contributors for 0.3.3
+* @Burgerballs made their first contribution in [#2308](https://github.com/FunkinCrew/Funkin/pull/2308)
+* @lemz1 made their first contribution in [#2499](https://github.com/FunkinCrew/Funkin/pull/2499)
+* @gamerbross made their first contribution in [#2470](https://github.com/FunkinCrew/Funkin/pull/2470)
+* @JugieNoob made their first contribution in [#2466](https://github.com/FunkinCrew/Funkin/pull/2466)
+* @MadBear422 made their first contribution in [#2370](https://github.com/FunkinCrew/Funkin/pull/2370)
+* @ImCodist made their first contribution in [#2309](https://github.com/FunkinCrew/Funkin/pull/2309)
+* @TheGaloXx made their first contribution in [#2300](https://github.com/FunkinCrew/Funkin/pull/2300)
+* @nebulazorua made their first contribution in [#2323](https://github.com/FunkinCrew/Funkin/pull/2323)
+
 
 ## [0.3.2] - 2024-05-03
 ### Added
@@ -343,6 +388,7 @@ which would remove their rank if they had a lower one.
 ### Removed
 - Removed some unused `.txt` files in the `assets/data` folder.
 
+
 ## [0.3.1] - 2024-05-01
 ### Changed
 - Ensure the Git commit hash always displays in the log files.
@@ -358,6 +404,7 @@ which would remove their rank if they had a lower one.
 - Pico game over confirm plays correctly
 - When exiting from a song into freeplay, main menu no longer takes inputs unintentionally (aka issues with merch links opening up when selecting songs)
 - Fix for arrow keys causing web browser page scroll
+
 
 ## [0.3.0] - 2024-04-30
 ### Added
@@ -392,6 +439,7 @@ which would remove their rank if they had a lower one.
 ### Fixed
 - 17 quadrillion bugs across hundreds of PRs.
 
+
 ## [0.2.8] - 2021-04-18 (note, this one is iffy cuz we slacked wit it lol!)
 ### Added
 - TANKMAN! 3 NEW SONGS BY KAWAISPRITE (UGH, GUNS, STRESS)! Charting help by MtH!
@@ -406,6 +454,7 @@ which would remove their rank if they had a lower one.
 ### Fixed
 - That one random note on Bopeebo
 
+
 ## [0.2.7.1] - 2021-02-14
 ### Added
 - Easter eggs
@@ -416,12 +465,13 @@ which would remove their rank if they had a lower one.
 - Offset of the Newgrounds logo on boot screen.
 - Made the changelog txt so it can be opened easier by normal people who don't have a markdown reader (most normal people);
 ### Fixed
-- Fixed crashes on Week 6 story mode dialogue if spam too fast ([Thanks to Lotusotho for the Pull Request!](https://github.com/ninjamuffin99/Funkin/pull/357))
+- Fixed crashes on Week 6 story mode dialogue if spam too fast ([Thanks to Lotusotho for the Pull Request!](https://github.com/FunkinCrew/Funkin/pull/357))
 - Should show intro credits on desktop versions of the game more consistently
 - Layering on Week 4 songs with GF and the LIMO LOL HOW TF I MISS THIS
-- Chart's and chart editor now support changeBPM, GOD BLESS MTH FOR THIS ONE I BEEN STRUGGLIN WIT THAT SINCE OCTOBER LMAO ([GOD BLESS MTH](https://github.com/ninjamuffin99/Funkin/pull/382))
-- Fixed sustain note trails ALSO THANKS TO MTH U A REAL ONE ([MTH VERY POWERFUL](https://github.com/ninjamuffin99/Funkin/pull/415))
+- Chart's and chart editor now support changeBPM, GOD BLESS MTH FOR THIS ONE I BEEN STRUGGLIN WIT THAT SINCE OCTOBER LMAO ([GOD BLESS MTH](https://github.com/FunkinCrew/Funkin/pull/382))
+- Fixed sustain note trails ALSO THANKS TO MTH U A REAL ONE ([MTH VERY POWERFUL](https://github.com/FunkinCrew/Funkin/pull/415))
 - Antialiasing on the skyscraper lights
+
 
 ## [0.2.7] - 2021-02-02
 ### Added
@@ -434,12 +484,13 @@ which would remove their rank if they had a lower one.
 - Made it so you lose sliiiightly more health when you miss a note.
 - Removed the default HaxeFlixel pause screen when the game window loses focus, can get screenshots of the game easier hehehe
 ### Fixed
-- Idle animation bug with BF christmas and BF hair blow sprites ([Thanks to Injourn for the Pull Request!](https://github.com/ninjamuffin99/Funkin/pull/237))
+- Idle animation bug with BF christmas and BF hair blow sprites ([Thanks to Injourn for the Pull Request!](https://github.com/FunkinCrew/Funkin/pull/237))
+
 
 ## [0.2.6] - 2021-01-20
 ### Added
 - 3 NEW CHRISTMAS SONGS. 2 BY KAWAISPRITE, 1 BY BASSETFILMS!!!!! BF WITH DRIP! SANTA HANGIN OUT!
-- Enemy icons change when they you are winning a lot ([Thanks to pahaze for the Pull Request!](https://github.com/ninjamuffin99/Funkin/pull/138))
+- Enemy icons change when they you are winning a lot ([Thanks to pahaze for the Pull Request!](https://github.com/FunkinCrew/Funkin/pull/138))
 - Holding CTRL in charting editor places notes on both sides
 - Q and E changes sustain lengths in note editor
 - Other charting editor workflow improvements
@@ -451,10 +502,11 @@ which would remove their rank if they had a lower one.
 - Removed APE
 ### Fixed
 - Maybe fixed double notes / jump notes. Need to tweak it for balance, but should open things up for cooler charts in the future.
-- Old Verison popup screen weirdness ([Thanks to gedehari for the Pull Request!](https://github.com/ninjamuffin99/Funkin/pull/155))
-- Song no longer loops when finishing the song. ([Thanks Injourn for the Pull Request!](https://github.com/ninjamuffin99/Funkin/pull/132))
+- Old Verison popup screen weirdness ([Thanks to gedehari for the Pull Request!](https://github.com/FunkinCrew/Funkin/pull/155))
+- Song no longer loops when finishing the song. ([Thanks Injourn for the Pull Request!](https://github.com/FunkinCrew/Funkin/pull/132))
 - Screen wipe being cut off in the limo/mom stage. Should fill the whole screen now.
 - Boyfriend animations on hold notes, and pressing on repeating notes should behave differently
+
 
 ## [0.2.5] - 2020-12-27
 ### Added
@@ -470,8 +522,9 @@ which would remove their rank if they had a lower one.
 - Mouse is now visible in note editor
 ### Fixed
 - Crash when playing Week 3 and then playing a non-week 3 song
-- When pausing music at the start, it doesn't continue the song anyways. ([shoutouts gedehari for the Pull Request!](https://github.com/ninjamuffin99/Funkin/pull/48))
-- IDK i think backing out of song menu should play main menu songs again hehe ([shoutouts gedehari for the Pull Request!](https://github.com/ninjamuffin99/Funkin/pull/48))
+- When pausing music at the start, it doesn't continue the song anyways. ([shoutouts gedehari for the Pull Request!](https://github.com/FunkinCrew/Funkin/pull/48))
+- IDK i think backing out of song menu should play main menu songs again hehe ([shoutouts gedehari for the Pull Request!](https://github.com/FunkinCrew/Funkin/pull/48))
+
 
 ## [0.2.4] - 2020-12-11
 ### Added
@@ -481,17 +534,19 @@ which would remove their rank if they had a lower one.
 ### Changed
 - Made it less punishing to ATTEMPT to hit a note and miss, rather than let it pass you
 ### Fixed
-- Song desync of you paused and unpaused frequently ([shoutouts SonicBlam](https://github.com/ninjamuffin99/Funkin/issues/37))
+- Song desync of you paused and unpaused frequently ([shoutouts SonicBlam](https://github.com/FunkinCrew/Funkin/issues/37))
 - Animation offsets when GF is scared
+
 
 ## [0.2.3] - 2020-12-04
 ### Added
 - More intro texts
 ### Fixed
 - Exploit where you could potentially give yourself a high score via the debug menu
-- Issue/bug where you could spam the confirm button on the story menu ([shoutouts lotusotho for the CODE contribution/pull request!](https://github.com/ninjamuffin99/Funkin/pull/19))
-- Glitch where if you never would lose health if you missed a note on a fast song (shoutouts [MrDulfin](https://github.com/ninjamuffin99/Funkin/issues/10), [HotSauceBurritos](https://github.com/ninjamuffin99/Funkin/issues/13) and [LobsterMango](https://lobstermango.newgrounds.com))
-- Fixed tiny note bleed over thingies (shoutouts [lotusotho](https://github.com/ninjamuffin99/Funkin/pull/24))
+- Issue/bug where you could spam the confirm button on the story menu ([shoutouts lotusotho for the CODE contribution/pull request!](https://github.com/FunkinCrew/Funkin/pull/19))
+- Glitch where if you never would lose health if you missed a note on a fast song (shoutouts [MrDulfin](https://github.com/FunkinCrew/Funkin/issues/10), [HotSauceBurritos](https://github.com/FunkinCrew/Funkin/issues/13) and [LobsterMango](https://lobstermango.newgrounds.com))
+- Fixed tiny note bleed over thingies (shoutouts [lotusotho](https://github.com/FunkinCrew/Funkin/pull/24))
+
 
 ## [0.2.2] - 2020-11-20
 ### Added
@@ -500,16 +555,16 @@ which would remove their rank if they had a lower one.
 - Score now shows mid-song.
 - Menu on pause screen! Can resume, and restart song, or go back to main menu.
 - New music made for pause menu!
-
 ### Changed
 - Moved all the intro texts to its own txt file instead of being hardcoded, this allows for much easier customization. File is in the data folder, called "introText.txt", follow the format in there and you're probably good to go!
 ### Fixed
-- Fixed soft lock when pausing on song finish ([shoutouts gedehari](https://github.com/ninjamuffin99/Funkin/issues/15))
-- Think I fixed issue that led to in-game scores being off by 2 ([shoutouts Mike](https://github.com/ninjamuffin99/Funkin/issues/4))
-- Should have fixed the 1 frame note appearance thing. ([shoutouts Mike](https://github.com/ninjamuffin99/Funkin/issues/6))
+- Fixed soft lock when pausing on song finish ([shoutouts gedehari](https://github.com/FunkinCrew/Funkin/issues/15))
+- Think I fixed issue that led to in-game scores being off by 2 ([shoutouts Mike](https://github.com/FunkinCrew/Funkin/issues/4))
+- Should have fixed the 1 frame note appearance thing. ([shoutouts Mike](https://github.com/FunkinCrew/Funkin/issues/6))
 - Cleaned up some charting on South on hard mode
 - Fixed some animation timings, should feel both better to play, and watch. (shoutouts Dave/Ivan lol)
-- Animation issue where GF would freak out on the title screen if you returned to it([shoutouts MultiXIII](https://github.com/ninjamuffin99/Funkin/issues/12)).
+- Animation issue where GF would freak out on the title screen if you returned to it([shoutouts MultiXIII](https://github.com/FunkinCrew/Funkin/issues/12)).
+
 
 ## [0.2.1.2] - 2020-11-06
 ### Fixed
@@ -517,9 +572,11 @@ which would remove their rank if they had a lower one.
 - Difficulty on storymode and in freeplay scores
 - Hard mode difficulty on campaign levels have been fixed
 
+
 ## [0.2.1.1] - 2020-11-06
 ### Fixed
 - Week 2 not unlocking properly
+
 
 ## [0.2.1] - 2020-11-06
 ### Added
@@ -528,17 +585,17 @@ which would remove their rank if they had a lower one.
 - Lightning effect in Spooky stages
 - Campaign scores, can now compete on scoreboards for campaign!
 - Can now change difficulties in Freeplay mode
-
 ### Changed
-- Balanced out Normal mode for the harder songs(Dadbattle and Spookeez, not South yet). Should be much easier all around.
+- Balanced out Normal mode for the harder songs(DadBattle and Spookeez, not South yet). Should be much easier all around.
 - Put tutorial in it's own 'week', so that if you want to play week 1, you don't have to play the tutorial.
-
 ### Fixed
 - One of the charting bits on South and Spookeez during the intro.
+
 
 ## [0.2.0] - 2020-11-01
 ### Added
 - Uhh Newgrounds release lolol I always lose track of shit.
+
 
 ## [0.1.0] - 2020-10-05
 ### Added

--- a/README.md
+++ b/README.md
@@ -11,11 +11,11 @@ This game was made with love to Newgrounds and its community. Extra love to Tom 
 
 **PLEASE USE THE LINKS ABOVE IF YOU JUST WANT TO PLAY THE GAME**
 
-To learn how to install the necessary dependencies and compile the game from source, please check out our [building the game](/docs/COMPILING.md) guide.
+To learn how to install the necessary dependencies and compile the game from source, please follow our [Compiling Guide](/docs/COMPILING.md).
 
 # Contributing
 
-You can actively participate in the development of Friday Night Funkin' by opening a [bug report](https://github.com/FunkinCrew/Funkin/issues) or submitting a [code contribution](https://github.com/FunkinCrew/Funkin/pulls)!
+Check out our [Contributing Guide](/docs/CONTRIBUTING.md) to learn how you can actively contribute to the development of Friday Night Funkin'!
 
 # Modding
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,0 +1,244 @@
+# Contributing
+Welcome to the Contributing Guide!
+You can contribute to the Funkin' repository by opening issues or pull requests. This guide will cover best practices for each type of contribution.
+
+# Part 1: Etiquette
+- Be respectful to one another. We're here to help each other out!
+- Keep your titles clear and concise. Do not type the whole description into the title.
+- Do not spam by creating unnecessary issues and pull requests.
+- Use common sense!
+
+# Part 2: Issues
+Issues serve many purposes, from reporting bugs to suggesting new features.
+This section provides guidelines to follow when [opening an issue](https://github.com/FunkinCrew/Funkin/issues). 
+
+## Requirements
+Make sure you're playing:
+- the latest version of the game (currently v0.5.3)
+- without any mods
+- on [Newgrounds](https://www.newgrounds.com/portal/view/770371) or downloaded from [itch.io](https://ninja-muffin24.itch.io/funkin)
+
+## Rejected Features
+If you want to **suggest a feature**, make sure it hasn't already been rejected.
+Here's a list of commonly suggested features and the reasons why they won't be added:
+
+| Feature | Reason |
+| ------- | ------- |
+| Combo Break + Accuracy Displays | https://github.com/FunkinCrew/Funkin/pull/2681#issuecomment-2156308982 |
+| Toggleable Ghost Tapping | https://github.com/FunkinCrew/Funkin/pull/2564#issuecomment-2119701802 |
+| Perfectly Centered Strumlines | _same as above^_ |
+| Losing Icons for DD and Parents | https://github.com/FunkinCrew/Funkin/issues/3048#issuecomment-2243491536 |
+| Playable GF / Speaker BF / Speaker Pico | https://github.com/FunkinCrew/Funkin/issues/2953#issuecomment-2216985230 |
+| Adjusted Difficulty Ratings | https://github.com/FunkinCrew/Funkin/issues/2781#issuecomment-2172053144 |
+| Countdown after Unpausing | https://github.com/FunkinCrew/Funkin/issues/2721#issuecomment-2159330106 |
+| Importing Charts from Psych Engine (and other mod content) | https://github.com/FunkinCrew/Funkin/issues/2586#issuecomment-2125733327 |
+| Backwards Compatibility for Modding | https://github.com/FunkinCrew/Funkin/issues/3949#issuecomment-2608391329 |
+| Lua Support | https://github.com/FunkinCrew/Funkin/issues/2643#issuecomment-2143718093 |
+
+## Issue Types
+Choose the issue template that best suits your needs!
+Here's what each template is designed for:
+
+### Bug Report ([view list](https://github.com/FunkinCrew/Funkin/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22type%3A%20minor%20bug%22))
+For minor bugs and general issues with the game. Choose this one if none of the others fit your needs.
+
+### Crash Report ([view list](https://github.com/FunkinCrew/Funkin/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22type%3A%20major%20bug%22))
+For crashes and freezes like the [Null Object Reference](https://github.com/FunkinCrew/Funkin/issues/2209) problem from v0.3.0.
+
+### Charting Issue ([view list](https://github.com/FunkinCrew/Funkin/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22type%3A%20charting%20issue%22))
+For misplaced notes, wonky camera movements, broken song events, and everything related to the game's charts.
+
+### Enhancement ([view list](https://github.com/FunkinCrew/Funkin/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22type%3A%20enhancement%22))
+For suggestions to add new features or improve existing ones. We'd love to hear your ideas!
+
+### Compiling Help (only after reading the [Troubleshooting Guide](https://github.com/FunkinCrew/Funkin/blob/main/docs/TROUBLESHOOTING.md))
+For issues with compiling the game. Legacy versions (before v0.3.0) are not supported.
+
+> [!TIP]
+> If none of the above Issue templates suit your inquiry (e.g. Questions or Coding Help), please [open a discussion](https://github.com/FunkinCrew/Funkin/discussions).
+
+## Before You Submit...
+Complete the Issue Checklist at the top of your template!
+
+> [!IMPORTANT]
+> If you do not complete each step of the Issue Checklist, **your issue may be closed.**
+
+Be sure to use the search bar on the Issues page to check that your issue hasn't already been reported by someone else.
+Duplicate issues make it harder to keep track of important issues with the game.
+
+Also only report one issue or enhancement at a time! If you have multiple bug reports or suggestions, split them up into separate submissions so they can be checked off one by one.
+
+Once you're sure your issue is unique and specific, feel free to submit it.
+
+**Thank you for opening issues!**
+
+# Part 3: Pull Requests
+Community members are welcome to contribute their changes by [opening pull requests](https://github.com/FunkinCrew/Funkin/pulls).
+This section covers guidelines for opening and managing pull requests (PRs).
+
+## Choosing a base branch
+When creating a branch in your fork, base your branch on either the `main` or `develop` branch depending on the types of changes you want to make.
+
+> [!CAUTION]
+> Avoid using your fork's default branch (`main` in this case) for your PR. This is considered an [anti-pattern](https://jmeridth.com/posts/do-not-issue-pull-requests-from-your-master-branch/) by GitHub themselves!
+
+Choose the `main` branch if you modify:
+- Documentation (`.md` files)
+- GitHub files (`.yml` files or anything in the `.github` folder)
+
+Choose the `develop` branch if you modify:
+- Game code (`.hx` files)
+- Any other type of file
+
+> [!TIP]
+> When in doubt, base your branch on the `develop` branch.
+
+Choosing the right base branch helps keep your commit history clean and avoid merge conflicts.
+Once you’re satisfied with the changes you’ve made, open a PR and base it on the same branch you previously chose.
+
+## Merge conflicts and rebasing
+Some game updates introduce significant breaking changes that may create merge conflicts in your PR. To resolve them, you will need to update or rebase your PR.
+
+Most merge conflicts are small and will only require you to modify a few files to resolve them.
+However, some changes are so big that your commit history will look like a mess!
+In this case, you will have to perform a [**rebase**](https://docs.github.com/en/get-started/using-git/about-git-rebase).
+This process reapplies your changes on top of the updated branch and cleanly resolves the merge conflicts.
+
+> [!TIP]
+> If your commit history becomes too long, you can use rebase to `squash` your PR's commits into a single commit.
+
+## Code PRs
+
+> [!IMPORTANT]
+> This guide does not cover compiling. If you have trouble compiling the game, refer to the [Compilation Guide](https://github.com/FunkinCrew/Funkin/blob/main/docs/COMPILING.md).
+
+Code-based PRs make changes such as **fixing bugs** or **implementing new features** in the game.
+This involves modifying one or several of the repository’s `.hx` files, found within the `source/` folder.
+
+### Codestyle
+Before submitting your PR, check that your code follows the [Style Guide](https://github.com/FunkinCrew/Funkin/blob/main/docs/style-guide.md).
+
+Here are some guidelines for writing comments in your code:
+- Leave comments only when you believe a piece of code warrants explanation.
+- Ensure that your comments provide meaningful insight into the function or purpose of the code.
+- Write your comments in a clear and concise manner.
+- Only sign your comments with your name when your changes are complex and may require further explanation.
+
+### Example Comments
+#### DO NOT:
+```haxe
+  /**
+    * jumps around the song
+    * works with bpm changes but skipped notes still hurt
+    * @param sections how many sections to jump, negative = backwards
+    */
+  function changeSection(sections:Int):Void
+  {
+    // Pause the music, as you probably guessed
+    // FlxG.sound.music.pause();
+
+    // Set the target time in steps, I don’t really get how this works though lol - [GitHub username]
+    var targetTimeSteps:Float = Conductor.instance.currentStepTime + (Conductor.instance.stepsPerMeasure * sections);
+    var targetTimeMs:Float = Conductor.instance.getStepTimeInMs(targetTimeSteps);
+
+    // Don't go back in time to before the song started, that would probably break a lot of things and cause a whole bunch of problems!
+    targetTimeMs = Math.max(0, targetTimeMs);
+
+    if (FlxG.sound.music != null) // If the music is not null, set the time to the target time
+    {
+      FlxG.sound.music.time = targetTimeMs;
+    }
+
+    // Handle skipped notes and events and all that jazz
+    handleSkippedNotes();
+    SongEventRegistry.handleSkippedEvents(songEvents, Conductor.instance.songPosition);
+    // regenNoteData(FlxG.sound.music.time);
+
+    Conductor.instance.update(FlxG.sound?.music?.time ?? 0.0);
+
+    // I hate this function - [GitHub username]
+    resyncVocals();
+  }
+```
+
+#### DO:
+```haxe
+  /**
+    * Jumps forward or backward a number of sections in the song.
+    * Accounts for BPM changes, does not prevent death from skipped notes.
+    * @param sections The number of sections to jump, negative to go backwards.
+    */
+  function changeSection(sections:Int):Void
+  {
+    var targetTimeSteps:Float = Conductor.instance.currentStepTime + (Conductor.instance.stepsPerMeasure * sections);
+    var targetTimeMs:Float = Conductor.instance.getStepTimeInMs(targetTimeSteps);
+
+    // Don't go back in time to before the song started.
+    targetTimeMs = Math.max(0, targetTimeMs);
+
+    if (FlxG.sound.music != null)
+    {
+      FlxG.sound.music.time = targetTimeMs;
+    }
+
+    handleSkippedNotes();
+    SongEventRegistry.handleSkippedEvents(songEvents, Conductor.instance.songPosition);
+
+    Conductor.instance.update(FlxG.sound?.music?.time ?? 0.0);
+
+    resyncVocals();
+  }
+```
+
+## Documentation PRs
+Documentation-based PRs make changes such as **fixing typos** or **adding new information** in documentation files. 
+This involves modifying one or several of the repository’s `.md` files, found throughout the repository.
+Make sure your changes are easy to understand and formatted consistently to maximize clarity and readability.
+
+> [!CAUTION]
+> DO NOT TOUCH THE `LICENSE.md` FILE, EVEN TO MAKE SMALL CHANGES!
+
+### Example Documentation PR
+#### DO NOT:
+```
+// The original documentation
+- `F2`: ***OVERLAY***: Enables the Flixel debug overlay, which has partial support for scripting.
+- `F3`: ***SCREENSHOT***: Takes a screenshot of the game and saves it to the local `screenshots` directory. Works outside of debug builds too!
+- `F4`: ***EJECT***: Forcibly switch state to the Main Menu (with no extra transition). Useful if you're stuck in a level and you need to get out!
+- `F5`: ***HOT RELOAD***: Forcibly reload the game's scripts and data files, then restart the current state. If any files in the `assets` folder have been modified, the game should process the changes for you! NOTE: Known bug, this does not reset song charts or song scripts, but it should reset everything else (such as stage layout data and character animation data).
+- `CTRL-SHIFT-L`: ***FORCE CRASH***: Immediately crash the game with a detailed crash log and a stack trace.
+
+// The new PR additions
+- `ctrl alt shift e`: No idea what this does
+- `alt-f4`: closes the game
+```
+
+#### DO:
+```
+// The original documentation
+- `F2`: ***OVERLAY***: Enables the Flixel debug overlay, which has partial support for scripting.
+- `F3`: ***SCREENSHOT***: Takes a screenshot of the game and saves it to the local `screenshots` directory. Works outside of debug builds too!
+- `F4`: ***EJECT***: Forcibly switch state to the Main Menu (with no extra transition). Useful if you're stuck in a level and you need to get out!
+- `F5`: ***HOT RELOAD***: Forcibly reload the game's scripts and data files, then restart the current state. If any files in the `assets` folder have been modified, the game should process the changes for you! NOTE: Known bug, this does not reset song charts or song scripts, but it should reset everything else (such as stage layout data and character animation data).
+- `CTRL-SHIFT-L`: ***FORCE CRASH***: Immediately crash the game with a detailed crash log and a stack trace.
+
+// The new PR additions
+- `CTRL-ALT-SHIFT-E`: ***DUMP SAVE DATA***: Prompts the user to save their save data as a JSON file, so its contents can be viewed. Only available on debug builds.
+- `ALT-F4`: ***CLOSE GAME***: Closes the game forcibly on Windows.
+```
+
+## GitHub PRs
+GitHub-related PRs make changes such as **tweaking Issue Templates** or **updating the repository’s workflows**.
+This involves modifying one or several of the repository’s `.yml` files, or any other file in the `.github` folder.
+Please test these changes on your fork’s main branch to avoid breaking anything in this repository (e.g. GitHub Actions, issue templates, etc.)!
+
+## funkin.assets PRs
+The `assets` submodule has its own repository called [funkin.assets](https://github.com/FunkinCrew/funkin.assets).
+If you only modify files in the `assets` folder, open a PR in the `funkin.assets` repository instead of the main repository.
+If you simultaneously modify files from both repositories, then open two separate PRs and explain the connection in your PR descriptions.
+
+Be sure to choose `main` as the base branch for `funkin.assets` PRs, as no `develop` branch exists for that repository.
+
+# Closing
+Thank you for reading the Contributing Guide.
+We look forward to seeing your contributions to the game!

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -1,11 +1,19 @@
 # Troubleshooting Common Compilation Issues
 
+- Any output containing `WARNING` or `(WDeprecated)`
+  - Will not disrupt compilation and can be safely ignored.
+
+- `This version of hxcpp` ... `Would you like to do this now [y/n]`
+  - Type "y" into the console and press Enter.
+
 - Weird macro error with a very tall call stack: Restart Visual Studio Code
   - NOTE: This is caused by Polymod somewhere, and seems to only occur when there is another compile error somewhere in the program. There is a bounty up for it.
 
-- `Get Thread Context Failed`: Turn off other expensive applications while building
+- `Get Thread Context Failed`
+  - Turn off other expensive applications while building.
 
-- `Type not found: T1`: This is thrown by `json2object`, make sure the data type of `@:default` is correct.
+- `Type not found: T1`
+  - This is thrown by `json2object`, make sure the data type of `@:default` is correct.
   - NOTE: `flixel.util.typeLimit.OneOfTwo` isn't supported.
 
 - `Class lists not properly generated. Try cleaning out your export folder, restarting your IDE, and rebuilding your project.`
@@ -15,7 +23,7 @@
   - This error occurs if the PDB file located in your `export` folder is in use or exceeds 4 GB. Try deleting the `export` folder and building again from scratch.
 
 - `error: RPC failed; curl 92 HTTP/2 stream 0 was not closed cleanly: PROTOCOL_ERROR (err 1)`
-  - This error can happen during cloning as a result of poor network connectivity. A common fix is to run ` git config --global http.postBuffer 4096M` in your terminal.
+  - This error can happen during cloning as a result of poor network connectivity. A common fix is to run `git config --global http.postBuffer 4096M` in your terminal.
 
 - Repository is missing an `assets` folder, or `assets` folder is empty.
   - You did not clone the repository correctly! Copy the path to your `funkin` folder and run `cd the\path\you\copied`. Then follow the compilation guide starting from **Step 4**.

--- a/source/Main.hx
+++ b/source/Main.hx
@@ -107,7 +107,7 @@ class Main extends Sprite
     var game:FlxGame = new FlxGame(gameWidth, gameHeight, initialState, Preferences.framerate, Preferences.framerate, skipSplash, startFullscreen);
 
     // FlxG.game._customSoundTray wants just the class, it calls new from
-    // create() in there, which gets called when it's added to stage
+    // create() in there, which gets called when it's added to the stage
     // which is why it needs to be added before addChild(game) here
     @:privateAccess
     game._customSoundTray = funkin.ui.options.FunkinSoundTray;

--- a/source/funkin/Assets.hx
+++ b/source/funkin/Assets.hx
@@ -144,16 +144,31 @@ class Assets
     return openfl.utils.Assets.list(type);
   }
 
+  /**
+   * Checks if a library with the given name exists.
+   * @param name The name to check.
+   * @return Whether or not the library exists.
+   */
   public static function hasLibrary(name:String):Bool
   {
     return openfl.utils.Assets.hasLibrary(name);
   }
 
+  /**
+   * Retrieves a library with the given name.
+   * @param name The name of the library to get.
+   * @return The library with the given name.
+   */
   public static function getLibrary(name:String):lime.utils.AssetLibrary
   {
     return openfl.utils.Assets.getLibrary(name);
   }
 
+  /**
+   * Loads a library with the given name.
+   * @param name The name of the library to load.
+   * @return An `AssetLibary` object.
+   */
   public static function loadLibrary(name:String):Future<openfl.utils.AssetLibrary>
   {
     return openfl.utils.Assets.loadLibrary(name);

--- a/source/funkin/InitState.hx
+++ b/source/funkin/InitState.hx
@@ -187,6 +187,8 @@ class InitState extends FlxState
     ModuleHandler.loadModuleCache();
     ModuleHandler.callOnCreate();
 
+    funkin.input.Cursor.hide();
+
     trace('Parsing game data took: ${TimerUtil.ms(perfStart)}');
   }
 

--- a/source/funkin/Preferences.hx
+++ b/source/funkin/Preferences.hx
@@ -157,6 +157,25 @@ class Preferences
     return value;
   }
 
+  /**
+   * If enabled, the game will automatically launch in fullscreen on startup.
+   * @default `true`
+   */
+  public static var autoFullscreen(get, set):Bool;
+
+  static function get_autoFullscreen():Bool
+  {
+    return Save?.instance?.options?.autoFullscreen ?? true;
+  }
+
+  static function set_autoFullscreen(value:Bool):Bool
+  {
+    var save:Save = Save.instance;
+    save.options.autoFullscreen = value;
+    save.flush();
+    return value;
+  }
+
   public static var unlockedFramerate(get, set):Bool;
 
   static function get_unlockedFramerate():Bool
@@ -211,6 +230,8 @@ class Preferences
     #if web
     toggleFramerateCap(Preferences.unlockedFramerate);
     #end
+    // Apply the autoFullscreen setting (launches the game in fullscreen automatically)
+    FlxG.fullscreen = Preferences.autoFullscreen;
   }
 
   static function toggleFramerateCap(unlocked:Bool):Void

--- a/source/funkin/data/freeplay/album/AlbumData.hx
+++ b/source/funkin/data/freeplay/album/AlbumData.hx
@@ -37,6 +37,13 @@ typedef AlbumData =
   public var albumTitleAsset:String;
 
   /**
+   * Offsets for the album title.
+   */
+  @:optional
+  @:default([0, 0])
+  public var albumTitleOffsets:Null<Array<Float>>;
+
+  /**
    * An optional array of animations for the album title.
    */
   @:optional

--- a/source/funkin/data/song/SongRegistry.hx
+++ b/source/funkin/data/song/SongRegistry.hx
@@ -508,8 +508,32 @@ class SongRegistry extends BaseRegistry<Song, SongMetadata>
   public function listBaseGameSongIds():Array<String>
   {
     return [
-      "tutorial", "bopeebo", "fresh", "dadbattle", "spookeez", "south", "monster", "pico", "philly-nice", "blammed", "satin-panties", "high", "milf", "cocoa",
-      "eggnog", "winter-horrorland", "senpai", "roses", "thorns", "ugh", "guns", "stress", "darnell", "lit-up", "2hot", "blazin"
+      "tutorial",
+      "bopeebo",
+      "fresh",
+      "dadbattle",
+      "spookeez",
+      "south",
+      "monster",
+      "pico",
+      "philly-nice",
+      "blammed",
+      "satin-panties",
+      "high",
+      "milf",
+      "cocoa",
+      "eggnog",
+      "winter-horrorland",
+      "senpai",
+      "roses",
+      "thorns",
+      "ugh",
+      "guns",
+      "stress",
+      "darnell",
+      "lit-up",
+      "2hot",
+      "blazin"
     ];
   }
 

--- a/source/funkin/data/stage/StageData.hx
+++ b/source/funkin/data/stage/StageData.hx
@@ -171,7 +171,7 @@ typedef StageDataProp =
    * How much the prop scrolls relative to the camera. Used to create a parallax effect.
    * Represented as an [x, y] array of two floats.
    * [1, 1] means the prop moves 1:1 with the camera.
-   * [0.5, 0.5] means the prop half as much as the camera.
+   * [0.5, 0.5] means the prop moves half as much as the camera.
    * [0, 0] means the prop is not moved.
    * @default [0, 0]
    */
@@ -261,4 +261,24 @@ typedef StageDataCharacter =
    */
   @:optional
   var cameraOffsets:Array<Float>;
+
+  /**
+   * How much the character scrolls relative to the camera. Used to create a parallax effect.
+   * Represented as an [x, y] array of two floats.
+   * [1, 1] means the character moves 1:1 with the camera.
+   * [0.5, 0.5] means the character moves half as much as the camera.
+   * [0, 0] means the character is not moved.
+   * @default [0, 0]
+   */
+  @:optional
+  @:default([0, 0])
+  var scroll:Array<Float>;
+
+  /**
+   * The alpha of the character, as a float.
+   * @default 1.0
+   */
+  @:optional
+  @:default(1.0)
+  var alpha:Float;
 };

--- a/source/funkin/data/stage/StageData.hx
+++ b/source/funkin/data/stage/StageData.hx
@@ -281,4 +281,12 @@ typedef StageDataCharacter =
   @:optional
   @:default(1.0)
   var alpha:Float;
+
+  /**
+   * The angle of the character, as a float.
+   * @default 1.0
+   */
+  @:optional
+  @:default(0.0)
+  var angle:Float;
 };

--- a/source/funkin/data/stage/StageData.hx
+++ b/source/funkin/data/stage/StageData.hx
@@ -268,10 +268,10 @@ typedef StageDataCharacter =
    * [1, 1] means the character moves 1:1 with the camera.
    * [0.5, 0.5] means the character moves half as much as the camera.
    * [0, 0] means the character is not moved.
-   * @default [0, 0]
+   * @default [1, 1]
    */
   @:optional
-  @:default([0, 0])
+  @:default([1, 1])
   var scroll:Array<Float>;
 
   /**

--- a/source/funkin/data/stage/StageRegistry.hx
+++ b/source/funkin/data/stage/StageRegistry.hx
@@ -93,8 +93,22 @@ class StageRegistry extends BaseRegistry<Stage, StageData>
   public function listBaseGameStageIds():Array<String>
   {
     return [
-      "mainStage", "mainStageErect", "spookyMansion", "phillyTrain", "phillyTrainErect", "limoRide", "limoRideErect", "mallXmas", "mallXmasErect", "mallEvil",
-      "school", "schoolEvil", "tankmanBattlefield", "phillyStreets", "phillyStreetsErect", "phillyBlazin",
+      "mainStage",
+      "mainStageErect",
+      "spookyMansion",
+      "phillyTrain",
+      "phillyTrainErect",
+      "limoRide",
+      "limoRideErect",
+      "mallXmas",
+      "mallXmasErect",
+      "mallEvil",
+      "school",
+      "schoolEvil",
+      "tankmanBattlefield",
+      "phillyStreets",
+      "phillyStreetsErect",
+      "phillyBlazin",
     ];
   }
 

--- a/source/funkin/input/Controls.hx
+++ b/source/funkin/input/Controls.hx
@@ -67,6 +67,8 @@ class Controls extends FlxActionSet
   var _freeplay_left = new FunkinAction(Action.FREEPLAY_LEFT);
   var _freeplay_right = new FunkinAction(Action.FREEPLAY_RIGHT);
   var _freeplay_char_select = new FunkinAction(Action.FREEPLAY_CHAR_SELECT);
+  var _freeplay_top_scroll = new FunkinAction(Action.FREEPLAY_TOP_SCROLL);
+  var _freeplay_bottom_scroll = new FunkinAction(Action.FREEPLAY_BOTTOM_SCROLL);
   var _cutscene_advance = new FunkinAction(Action.CUTSCENE_ADVANCE);
   var _debug_menu = new FunkinAction(Action.DEBUG_MENU);
   #if FEATURE_CHART_EDITOR
@@ -276,6 +278,16 @@ class Controls extends FlxActionSet
   inline function get_FREEPLAY_CHAR_SELECT()
     return _freeplay_char_select.check();
 
+  public var FREEPLAY_BOTTOM_SCROLL(get, never):Bool;
+
+  inline function get_FREEPLAY_BOTTOM_SCROLL()
+    return _freeplay_bottom_scroll.check();
+
+  public var FREEPLAY_TOP_SCROLL(get, never):Bool;
+
+  inline function get_FREEPLAY_TOP_SCROLL()
+    return _freeplay_top_scroll.check();
+
   public var CUTSCENE_ADVANCE(get, never):Bool;
 
   inline function get_CUTSCENE_ADVANCE()
@@ -337,6 +349,8 @@ class Controls extends FlxActionSet
     add(_freeplay_left);
     add(_freeplay_right);
     add(_freeplay_char_select);
+    add(_freeplay_bottom_scroll);
+    add(_freeplay_top_scroll);
     add(_cutscene_advance);
     add(_debug_menu);
     #if FEATURE_CHART_EDITOR add(_debug_chart); #end
@@ -462,6 +476,8 @@ class Controls extends FlxActionSet
       case FREEPLAY_LEFT: _freeplay_left;
       case FREEPLAY_RIGHT: _freeplay_right;
       case FREEPLAY_CHAR_SELECT: _freeplay_char_select;
+      case FREEPLAY_BOTTOM_SCROLL: _freeplay_bottom_scroll;
+      case FREEPLAY_TOP_SCROLL: _freeplay_top_scroll;
       case CUTSCENE_ADVANCE: _cutscene_advance;
       case DEBUG_MENU: _debug_menu;
       #if FEATURE_CHART_EDITOR case DEBUG_CHART: _debug_chart; #end
@@ -542,6 +558,10 @@ class Controls extends FlxActionSet
         func(_freeplay_right, JUST_PRESSED);
       case FREEPLAY_CHAR_SELECT:
         func(_freeplay_char_select, JUST_PRESSED);
+      case FREEPLAY_BOTTOM_SCROLL:
+        func(_freeplay_bottom_scroll, JUST_PRESSED);
+      case FREEPLAY_TOP_SCROLL:
+        func(_freeplay_top_scroll, JUST_PRESSED);
       case CUTSCENE_ADVANCE:
         func(_cutscene_advance, JUST_PRESSED);
       case DEBUG_MENU:
@@ -770,6 +790,8 @@ class Controls extends FlxActionSet
     bindKeys(Control.FREEPLAY_LEFT, getDefaultKeybinds(scheme, Control.FREEPLAY_LEFT));
     bindKeys(Control.FREEPLAY_RIGHT, getDefaultKeybinds(scheme, Control.FREEPLAY_RIGHT));
     bindKeys(Control.FREEPLAY_CHAR_SELECT, getDefaultKeybinds(scheme, Control.FREEPLAY_CHAR_SELECT));
+    bindKeys(Control.FREEPLAY_BOTTOM_SCROLL, getDefaultKeybinds(scheme, Control.FREEPLAY_BOTTOM_SCROLL));
+    bindKeys(Control.FREEPLAY_TOP_SCROLL, getDefaultKeybinds(scheme, Control.FREEPLAY_TOP_SCROLL));
     bindKeys(Control.CUTSCENE_ADVANCE, getDefaultKeybinds(scheme, Control.CUTSCENE_ADVANCE));
     bindKeys(Control.DEBUG_MENU, getDefaultKeybinds(scheme, Control.DEBUG_MENU));
     #if FEATURE_CHART_EDITOR
@@ -810,6 +832,8 @@ class Controls extends FlxActionSet
           case Control.FREEPLAY_LEFT: return [Q]; // Switch tabs on the menu
           case Control.FREEPLAY_RIGHT: return [E]; // Switch tabs on the menu
           case Control.FREEPLAY_CHAR_SELECT: return [TAB];
+          case Control.FREEPLAY_BOTTOM_SCROLL: return [END];
+          case Control.FREEPLAY_TOP_SCROLL: return [HOME];
           case Control.CUTSCENE_ADVANCE: return [Z, ENTER];
           case Control.DEBUG_MENU: return [GRAVEACCENT];
           #if FEATURE_CHART_EDITOR case Control.DEBUG_CHART: return []; #end
@@ -839,6 +863,8 @@ class Controls extends FlxActionSet
           case Control.FREEPLAY_LEFT: return [Q]; // Switch tabs on the menu
           case Control.FREEPLAY_RIGHT: return [E]; // Switch tabs on the menu
           case Control.FREEPLAY_CHAR_SELECT: return [TAB];
+          case Control.FREEPLAY_BOTTOM_SCROLL: return [END];
+          case Control.FREEPLAY_TOP_SCROLL: return [HOME];
           case Control.CUTSCENE_ADVANCE: return [G, Z];
           case Control.DEBUG_MENU: return [GRAVEACCENT];
           #if FEATURE_CHART_EDITOR case Control.DEBUG_CHART: return []; #end
@@ -868,6 +894,8 @@ class Controls extends FlxActionSet
           case Control.FREEPLAY_LEFT: return [];
           case Control.FREEPLAY_RIGHT: return [];
           case Control.FREEPLAY_CHAR_SELECT: return [];
+          case Control.FREEPLAY_BOTTOM_SCROLL: return [];
+          case Control.FREEPLAY_TOP_SCROLL: return [];
           case Control.CUTSCENE_ADVANCE: return [ENTER];
           case Control.DEBUG_MENU: return [];
           #if FEATURE_CHART_EDITOR case Control.DEBUG_CHART: return []; #end
@@ -984,6 +1012,8 @@ class Controls extends FlxActionSet
       Control.FREEPLAY_LEFT => getDefaultGamepadBinds(Control.FREEPLAY_LEFT),
       Control.FREEPLAY_RIGHT => getDefaultGamepadBinds(Control.FREEPLAY_RIGHT),
       Control.FREEPLAY_CHAR_SELECT => getDefaultGamepadBinds(Control.FREEPLAY_CHAR_SELECT),
+      Control.FREEPLAY_BOTTOM_SCROLL => getDefaultGamepadBinds(Control.FREEPLAY_BOTTOM_SCROLL),
+      Control.FREEPLAY_TOP_SCROLL => getDefaultGamepadBinds(Control.FREEPLAY_TOP_SCROLL),
       Control.VOLUME_UP => getDefaultGamepadBinds(Control.VOLUME_UP),
       Control.VOLUME_DOWN => getDefaultGamepadBinds(Control.VOLUME_DOWN),
       Control.VOLUME_MUTE => getDefaultGamepadBinds(Control.VOLUME_MUTE),
@@ -1041,6 +1071,10 @@ class Controls extends FlxActionSet
         return [RIGHT_SHOULDER];
       case Control.FREEPLAY_CHAR_SELECT:
         return [X];
+      case Control.FREEPLAY_BOTTOM_SCROLL:
+        return [];
+      case Control.FREEPLAY_TOP_SCROLL:
+        return [];
       case Control.VOLUME_UP:
         [];
       case Control.VOLUME_DOWN:
@@ -1620,6 +1654,8 @@ enum Control
   FREEPLAY_LEFT;
   FREEPLAY_RIGHT;
   FREEPLAY_CHAR_SELECT;
+  FREEPLAY_BOTTOM_SCROLL;
+  FREEPLAY_TOP_SCROLL;
   // WINDOW
   #if FEATURE_SCREENSHOTS WINDOW_SCREENSHOT; #end
   WINDOW_FULLSCREEN;
@@ -1677,6 +1713,8 @@ enum abstract Action(String) to String from String
   var FREEPLAY_LEFT = "freeplay_left";
   var FREEPLAY_RIGHT = "freeplay_right";
   var FREEPLAY_CHAR_SELECT = "freeplay_char_select";
+  var FREEPLAY_BOTTOM_SCROLL = "freeplay_bottom_scroll";
+  var FREEPLAY_TOP_SCROLL = "freeplay_top_scroll";
   // VOLUME
   var VOLUME_UP = "volume_up";
   var VOLUME_DOWN = "volume_down";

--- a/source/funkin/input/Controls.hx
+++ b/source/funkin/input/Controls.hx
@@ -983,6 +983,7 @@ class Controls extends FlxActionSet
       Control.FREEPLAY_FAVORITE => getDefaultGamepadBinds(Control.FREEPLAY_FAVORITE),
       Control.FREEPLAY_LEFT => getDefaultGamepadBinds(Control.FREEPLAY_LEFT),
       Control.FREEPLAY_RIGHT => getDefaultGamepadBinds(Control.FREEPLAY_RIGHT),
+      Control.FREEPLAY_CHAR_SELECT => getDefaultGamepadBinds(Control.FREEPLAY_CHAR_SELECT),
       Control.VOLUME_UP => getDefaultGamepadBinds(Control.VOLUME_UP),
       Control.VOLUME_DOWN => getDefaultGamepadBinds(Control.VOLUME_DOWN),
       Control.VOLUME_MUTE => getDefaultGamepadBinds(Control.VOLUME_MUTE),
@@ -1033,11 +1034,13 @@ class Controls extends FlxActionSet
       case Control.CUTSCENE_ADVANCE:
         return [A];
       case Control.FREEPLAY_FAVORITE:
-        [FlxGamepadInputID.BACK]; // Back (i.e. Select)
+        return [Y]; // Back (i.e. Select)
       case Control.FREEPLAY_LEFT:
-        [LEFT_SHOULDER];
+        return [LEFT_SHOULDER];
       case Control.FREEPLAY_RIGHT:
-        [RIGHT_SHOULDER];
+        return [RIGHT_SHOULDER];
+      case Control.FREEPLAY_CHAR_SELECT:
+        return [X];
       case Control.VOLUME_UP:
         [];
       case Control.VOLUME_DOWN:

--- a/source/funkin/input/Controls.hx
+++ b/source/funkin/input/Controls.hx
@@ -1605,10 +1605,10 @@ enum Control
   NOTE_UP;
   NOTE_RIGHT;
   // UI
-  UI_UP;
   UI_LEFT;
-  UI_RIGHT;
   UI_DOWN;
+  UI_UP;
+  UI_RIGHT;
   RESET;
   ACCEPT;
   BACK;

--- a/source/funkin/input/Controls.hx
+++ b/source/funkin/input/Controls.hx
@@ -67,8 +67,8 @@ class Controls extends FlxActionSet
   var _freeplay_left = new FunkinAction(Action.FREEPLAY_LEFT);
   var _freeplay_right = new FunkinAction(Action.FREEPLAY_RIGHT);
   var _freeplay_char_select = new FunkinAction(Action.FREEPLAY_CHAR_SELECT);
-  var _freeplay_top_scroll = new FunkinAction(Action.FREEPLAY_TOP_SCROLL);
-  var _freeplay_bottom_scroll = new FunkinAction(Action.FREEPLAY_BOTTOM_SCROLL);
+  var _freeplay_jump_to_top = new FunkinAction(Action.FREEPLAY_JUMP_TO_TOP);
+  var _freeplay_jump_to_bottom = new FunkinAction(Action.FREEPLAY_JUMP_TO_BOTTOM);
   var _cutscene_advance = new FunkinAction(Action.CUTSCENE_ADVANCE);
   var _debug_menu = new FunkinAction(Action.DEBUG_MENU);
   #if FEATURE_CHART_EDITOR
@@ -278,15 +278,15 @@ class Controls extends FlxActionSet
   inline function get_FREEPLAY_CHAR_SELECT()
     return _freeplay_char_select.check();
 
-  public var FREEPLAY_BOTTOM_SCROLL(get, never):Bool;
+  public var FREEPLAY_JUMP_TO_TOP(get, never):Bool;
 
-  inline function get_FREEPLAY_BOTTOM_SCROLL()
-    return _freeplay_bottom_scroll.check();
+  inline function get_FREEPLAY_JUMP_TO_TOP()
+    return _freeplay_jump_to_top.check();
 
-  public var FREEPLAY_TOP_SCROLL(get, never):Bool;
+  public var FREEPLAY_JUMP_TO_BOTTOM(get, never):Bool;
 
-  inline function get_FREEPLAY_TOP_SCROLL()
-    return _freeplay_top_scroll.check();
+  inline function get_FREEPLAY_JUMP_TO_BOTTOM()
+    return _freeplay_jump_to_bottom.check();
 
   public var CUTSCENE_ADVANCE(get, never):Bool;
 
@@ -349,8 +349,8 @@ class Controls extends FlxActionSet
     add(_freeplay_left);
     add(_freeplay_right);
     add(_freeplay_char_select);
-    add(_freeplay_bottom_scroll);
-    add(_freeplay_top_scroll);
+    add(_freeplay_jump_to_top);
+    add(_freeplay_jump_to_bottom);
     add(_cutscene_advance);
     add(_debug_menu);
     #if FEATURE_CHART_EDITOR add(_debug_chart); #end
@@ -476,8 +476,8 @@ class Controls extends FlxActionSet
       case FREEPLAY_LEFT: _freeplay_left;
       case FREEPLAY_RIGHT: _freeplay_right;
       case FREEPLAY_CHAR_SELECT: _freeplay_char_select;
-      case FREEPLAY_BOTTOM_SCROLL: _freeplay_bottom_scroll;
-      case FREEPLAY_TOP_SCROLL: _freeplay_top_scroll;
+      case FREEPLAY_JUMP_TO_TOP: _freeplay_jump_to_top;
+      case FREEPLAY_JUMP_TO_BOTTOM: _freeplay_jump_to_bottom;
       case CUTSCENE_ADVANCE: _cutscene_advance;
       case DEBUG_MENU: _debug_menu;
       #if FEATURE_CHART_EDITOR case DEBUG_CHART: _debug_chart; #end
@@ -558,10 +558,10 @@ class Controls extends FlxActionSet
         func(_freeplay_right, JUST_PRESSED);
       case FREEPLAY_CHAR_SELECT:
         func(_freeplay_char_select, JUST_PRESSED);
-      case FREEPLAY_BOTTOM_SCROLL:
-        func(_freeplay_bottom_scroll, JUST_PRESSED);
-      case FREEPLAY_TOP_SCROLL:
-        func(_freeplay_top_scroll, JUST_PRESSED);
+      case FREEPLAY_JUMP_TO_TOP:
+        func(_freeplay_jump_to_top, JUST_PRESSED);
+      case FREEPLAY_JUMP_TO_BOTTOM:
+        func(_freeplay_jump_to_bottom, JUST_PRESSED);
       case CUTSCENE_ADVANCE:
         func(_cutscene_advance, JUST_PRESSED);
       case DEBUG_MENU:
@@ -790,8 +790,8 @@ class Controls extends FlxActionSet
     bindKeys(Control.FREEPLAY_LEFT, getDefaultKeybinds(scheme, Control.FREEPLAY_LEFT));
     bindKeys(Control.FREEPLAY_RIGHT, getDefaultKeybinds(scheme, Control.FREEPLAY_RIGHT));
     bindKeys(Control.FREEPLAY_CHAR_SELECT, getDefaultKeybinds(scheme, Control.FREEPLAY_CHAR_SELECT));
-    bindKeys(Control.FREEPLAY_BOTTOM_SCROLL, getDefaultKeybinds(scheme, Control.FREEPLAY_BOTTOM_SCROLL));
-    bindKeys(Control.FREEPLAY_TOP_SCROLL, getDefaultKeybinds(scheme, Control.FREEPLAY_TOP_SCROLL));
+    bindKeys(Control.FREEPLAY_JUMP_TO_TOP, getDefaultKeybinds(scheme, Control.FREEPLAY_JUMP_TO_TOP));
+    bindKeys(Control.FREEPLAY_JUMP_TO_BOTTOM, getDefaultKeybinds(scheme, Control.FREEPLAY_JUMP_TO_BOTTOM));
     bindKeys(Control.CUTSCENE_ADVANCE, getDefaultKeybinds(scheme, Control.CUTSCENE_ADVANCE));
     bindKeys(Control.DEBUG_MENU, getDefaultKeybinds(scheme, Control.DEBUG_MENU));
     #if FEATURE_CHART_EDITOR
@@ -832,8 +832,8 @@ class Controls extends FlxActionSet
           case Control.FREEPLAY_LEFT: return [Q]; // Switch tabs on the menu
           case Control.FREEPLAY_RIGHT: return [E]; // Switch tabs on the menu
           case Control.FREEPLAY_CHAR_SELECT: return [TAB];
-          case Control.FREEPLAY_BOTTOM_SCROLL: return [END];
-          case Control.FREEPLAY_TOP_SCROLL: return [HOME];
+          case Control.FREEPLAY_JUMP_TO_TOP: return [HOME];
+          case Control.FREEPLAY_JUMP_TO_BOTTOM: return [END];
           case Control.CUTSCENE_ADVANCE: return [Z, ENTER];
           case Control.DEBUG_MENU: return [GRAVEACCENT];
           #if FEATURE_CHART_EDITOR case Control.DEBUG_CHART: return []; #end
@@ -863,8 +863,8 @@ class Controls extends FlxActionSet
           case Control.FREEPLAY_LEFT: return [Q]; // Switch tabs on the menu
           case Control.FREEPLAY_RIGHT: return [E]; // Switch tabs on the menu
           case Control.FREEPLAY_CHAR_SELECT: return [TAB];
-          case Control.FREEPLAY_BOTTOM_SCROLL: return [END];
-          case Control.FREEPLAY_TOP_SCROLL: return [HOME];
+          case Control.FREEPLAY_JUMP_TO_TOP: return [HOME];
+          case Control.FREEPLAY_JUMP_TO_BOTTOM: return [END];
           case Control.CUTSCENE_ADVANCE: return [G, Z];
           case Control.DEBUG_MENU: return [GRAVEACCENT];
           #if FEATURE_CHART_EDITOR case Control.DEBUG_CHART: return []; #end
@@ -894,8 +894,8 @@ class Controls extends FlxActionSet
           case Control.FREEPLAY_LEFT: return [];
           case Control.FREEPLAY_RIGHT: return [];
           case Control.FREEPLAY_CHAR_SELECT: return [];
-          case Control.FREEPLAY_BOTTOM_SCROLL: return [];
-          case Control.FREEPLAY_TOP_SCROLL: return [];
+          case Control.FREEPLAY_JUMP_TO_TOP: return [];
+          case Control.FREEPLAY_JUMP_TO_BOTTOM: return [];
           case Control.CUTSCENE_ADVANCE: return [ENTER];
           case Control.DEBUG_MENU: return [];
           #if FEATURE_CHART_EDITOR case Control.DEBUG_CHART: return []; #end
@@ -1012,8 +1012,8 @@ class Controls extends FlxActionSet
       Control.FREEPLAY_LEFT => getDefaultGamepadBinds(Control.FREEPLAY_LEFT),
       Control.FREEPLAY_RIGHT => getDefaultGamepadBinds(Control.FREEPLAY_RIGHT),
       Control.FREEPLAY_CHAR_SELECT => getDefaultGamepadBinds(Control.FREEPLAY_CHAR_SELECT),
-      Control.FREEPLAY_BOTTOM_SCROLL => getDefaultGamepadBinds(Control.FREEPLAY_BOTTOM_SCROLL),
-      Control.FREEPLAY_TOP_SCROLL => getDefaultGamepadBinds(Control.FREEPLAY_TOP_SCROLL),
+      Control.FREEPLAY_JUMP_TO_TOP => getDefaultGamepadBinds(Control.FREEPLAY_JUMP_TO_TOP),
+      Control.FREEPLAY_JUMP_TO_BOTTOM => getDefaultGamepadBinds(Control.FREEPLAY_JUMP_TO_BOTTOM),
       Control.VOLUME_UP => getDefaultGamepadBinds(Control.VOLUME_UP),
       Control.VOLUME_DOWN => getDefaultGamepadBinds(Control.VOLUME_DOWN),
       Control.VOLUME_MUTE => getDefaultGamepadBinds(Control.VOLUME_MUTE),
@@ -1071,9 +1071,9 @@ class Controls extends FlxActionSet
         return [RIGHT_SHOULDER];
       case Control.FREEPLAY_CHAR_SELECT:
         return [X];
-      case Control.FREEPLAY_BOTTOM_SCROLL:
+      case Control.FREEPLAY_JUMP_TO_TOP:
         return [];
-      case Control.FREEPLAY_TOP_SCROLL:
+      case Control.FREEPLAY_JUMP_TO_BOTTOM:
         return [];
       case Control.VOLUME_UP:
         [];
@@ -1654,8 +1654,8 @@ enum Control
   FREEPLAY_LEFT;
   FREEPLAY_RIGHT;
   FREEPLAY_CHAR_SELECT;
-  FREEPLAY_BOTTOM_SCROLL;
-  FREEPLAY_TOP_SCROLL;
+  FREEPLAY_JUMP_TO_TOP;
+  FREEPLAY_JUMP_TO_BOTTOM;
   // WINDOW
   #if FEATURE_SCREENSHOTS WINDOW_SCREENSHOT; #end
   WINDOW_FULLSCREEN;
@@ -1713,8 +1713,8 @@ enum abstract Action(String) to String from String
   var FREEPLAY_LEFT = "freeplay_left";
   var FREEPLAY_RIGHT = "freeplay_right";
   var FREEPLAY_CHAR_SELECT = "freeplay_char_select";
-  var FREEPLAY_BOTTOM_SCROLL = "freeplay_bottom_scroll";
-  var FREEPLAY_TOP_SCROLL = "freeplay_top_scroll";
+  var FREEPLAY_JUMP_TO_TOP = "freeplay_jump_to_top";
+  var FREEPLAY_JUMP_TO_BOTTOM = "freeplay_jump_to_bottom";
   // VOLUME
   var VOLUME_UP = "volume_up";
   var VOLUME_DOWN = "volume_down";

--- a/source/funkin/modding/IScriptedClass.hx
+++ b/source/funkin/modding/IScriptedClass.hx
@@ -37,6 +37,9 @@ interface IStateChangingScriptedClass extends IScriptedClass
   public function onSubStateOpenEnd(event:SubStateScriptEvent):Void;
   public function onSubStateCloseBegin(event:SubStateScriptEvent):Void;
   public function onSubStateCloseEnd(event:SubStateScriptEvent):Void;
+
+  public function onFocusLost(event:FocusScriptEvent):Void;
+  public function onFocusGained(event:FocusScriptEvent):Void;
 }
 
 /**

--- a/source/funkin/modding/IScriptedClass.hx
+++ b/source/funkin/modding/IScriptedClass.hx
@@ -143,7 +143,7 @@ interface IPlayStateScriptedClass extends INoteScriptedClass extends IBPMSyncedS
   /**
    * Called when the player restarts the song, either via pause menu or restarting after a game over.
    */
-  public function onSongRetry(event:ScriptEvent):Void;
+  public function onSongRetry(event:SongRetryEvent):Void;
 
   /**
    * Called when the player presses a key when no note is on the strumline.

--- a/source/funkin/modding/PolymodHandler.hx
+++ b/source/funkin/modding/PolymodHandler.hx
@@ -290,7 +290,6 @@ class PolymodHandler
     Polymod.blacklistImport('openfl.utils.Assets');
     Polymod.blacklistImport('openfl.Lib');
     Polymod.blacklistImport('openfl.system.ApplicationDomain');
-    Polymod.blacklistImport('funkin.util.FunkinTypeResolver');
 
     // `openfl.desktop.NativeProcess`
     // Can load native processes on the host operating system.

--- a/source/funkin/modding/PolymodHandler.hx
+++ b/source/funkin/modding/PolymodHandler.hx
@@ -290,6 +290,7 @@ class PolymodHandler
     Polymod.blacklistImport('openfl.utils.Assets');
     Polymod.blacklistImport('openfl.Lib');
     Polymod.blacklistImport('openfl.system.ApplicationDomain');
+    Polymod.blacklistImport('openfl.net.SharedObject');
 
     // `openfl.desktop.NativeProcess`
     // Can load native processes on the host operating system.

--- a/source/funkin/modding/PolymodHandler.hx
+++ b/source/funkin/modding/PolymodHandler.hx
@@ -335,8 +335,19 @@ class PolymodHandler
   {
     return {
       assetLibraryPaths: [
-        'default' => 'preload', 'shared' => 'shared', 'songs' => 'songs', 'videos' => 'videos', 'tutorial' => 'tutorial', 'week1' => 'week1',
-        'week2' => 'week2', 'week3' => 'week3', 'week4' => 'week4', 'week5' => 'week5', 'week6' => 'week6', 'week7' => 'week7', 'weekend1' => 'weekend1',
+        'default' => 'preload',
+        'shared' => 'shared',
+        'songs' => 'songs',
+        'videos' => 'videos',
+        'tutorial' => 'tutorial',
+        'week1' => 'week1',
+        'week2' => 'week2',
+        'week3' => 'week3',
+        'week4' => 'week4',
+        'week5' => 'week5',
+        'week6' => 'week6',
+        'week7' => 'week7',
+        'weekend1' => 'weekend1',
       ],
       coreAssetRedirect: CORE_FOLDER,
     }

--- a/source/funkin/modding/events/ScriptEvent.hx
+++ b/source/funkin/modding/events/ScriptEvent.hx
@@ -437,6 +437,22 @@ class StateChangeScriptEvent extends ScriptEvent
 }
 
 /**
+ * An event that is fired when the game loses or gains focus.
+ */
+class FocusScriptEvent extends ScriptEvent
+{
+  public function new(type:ScriptEventType):Void
+  {
+    super(type, false);
+  }
+
+  public override function toString():String
+  {
+    return 'FocusScriptEvent(type=' + type + ')';
+  }
+}
+
+/**
  * An event that is fired when moving out of or into an FlxSubState.
  */
 class SubStateScriptEvent extends ScriptEvent

--- a/source/funkin/modding/events/ScriptEvent.hx
+++ b/source/funkin/modding/events/ScriptEvent.hx
@@ -415,6 +415,28 @@ class SongLoadScriptEvent extends ScriptEvent
 }
 
 /**
+ * AAn event that is fired when the player retries the song.
+ */
+class SongRetryEvent extends ScriptEvent
+{
+  /**
+   * The new difficulty of the song.
+   */
+  public var difficulty(default, null):String;
+
+  public function new(difficulty:String):Void
+  {
+    super(SONG_RETRY, false);
+    this.difficulty = difficulty;
+  }
+
+  public override function toString():String
+  {
+    return 'SongRetryEvent(difficulty=$difficulty)';
+  }
+}
+
+/**
  * An event that is fired when moving out of or into an FlxState.
  */
 class StateChangeScriptEvent extends ScriptEvent

--- a/source/funkin/modding/events/ScriptEventDispatcher.hx
+++ b/source/funkin/modding/events/ScriptEventDispatcher.hx
@@ -177,6 +177,12 @@ class ScriptEventDispatcher
         case SUBSTATE_CLOSE_END:
           t.onSubStateCloseEnd(cast event);
           return;
+        case FOCUS_LOST:
+          t.onFocusLost(cast event);
+          return;
+        case FOCUS_GAINED:
+          t.onFocusGained(cast event);
+          return;
         default: // Continue;
       }
     }

--- a/source/funkin/modding/events/ScriptEventDispatcher.hx
+++ b/source/funkin/modding/events/ScriptEventDispatcher.hx
@@ -124,7 +124,7 @@ class ScriptEventDispatcher
           t.onSongEnd(event);
           return;
         case SONG_RETRY:
-          t.onSongRetry(event);
+          t.onSongRetry(cast event);
           return;
         case GAME_OVER:
           t.onGameOver(event);

--- a/source/funkin/modding/events/ScriptEventType.hx
+++ b/source/funkin/modding/events/ScriptEventType.hx
@@ -224,6 +224,20 @@ enum abstract ScriptEventType(String) from String to String
   var SUBSTATE_CLOSE_END = 'SUBSTATE_CLOSE_END';
 
   /**
+   * Called when the game regains focus.
+   *
+   * This event is not cancelable.
+   */
+  var FOCUS_GAINED = 'FOCUS_GAINED';
+
+  /**
+   * Called when the game loses focus.
+   *
+   * This event is not cancelable.
+   */
+  var FOCUS_LOST = 'FOCUS_LOST';
+
+  /**
    * Called when the game starts a conversation.
    *
    * This event is not cancelable.

--- a/source/funkin/modding/module/Module.hx
+++ b/source/funkin/modding/module/Module.hx
@@ -109,6 +109,10 @@ class Module implements IPlayStateScriptedClass implements IStateChangingScripte
 
   public function onStateChangeEnd(event:StateChangeScriptEvent) {}
 
+  public function onFocusGained(event:FocusScriptEvent) {}
+
+  public function onFocusLost(event:FocusScriptEvent) {}
+
   public function onSubStateOpenBegin(event:SubStateScriptEvent) {}
 
   public function onSubStateOpenEnd(event:SubStateScriptEvent) {}

--- a/source/funkin/modding/module/Module.hx
+++ b/source/funkin/modding/module/Module.hx
@@ -121,5 +121,5 @@ class Module implements IPlayStateScriptedClass implements IStateChangingScripte
 
   public function onSubStateCloseEnd(event:SubStateScriptEvent) {}
 
-  public function onSongRetry(event:ScriptEvent) {}
+  public function onSongRetry(event:SongRetryEvent) {}
 }

--- a/source/funkin/play/PauseSubState.hx
+++ b/source/funkin/play/PauseSubState.hx
@@ -649,6 +649,7 @@ class PauseSubState extends MusicBeatSubState
     // So if you switch difficulty on the last song of a week you get a really low overall score.
     PlayStatePlaylist.campaignScore = 0;
     PlayStatePlaylist.campaignDifficulty = difficulty;
+    PlayState.instance.previousDifficulty = PlayState.instance.currentDifficulty;
     PlayState.instance.currentDifficulty = PlayStatePlaylist.campaignDifficulty;
 
     FreeplayState.rememberedDifficulty = difficulty;

--- a/source/funkin/play/PlayState.hx
+++ b/source/funkin/play/PlayState.hx
@@ -332,6 +332,11 @@ class PlayState extends MusicBeatSubState
    */
   public var disableKeys:Bool = false;
 
+  /**
+   * The previous difficulty the player was playing on.
+   */
+  public var previousDifficulty:String = Constants.DEFAULT_DIFFICULTY;
+
   public var isSubState(get, never):Bool;
 
   function get_isSubState():Bool
@@ -603,6 +608,7 @@ class PlayState extends MusicBeatSubState
     // Apply parameters.
     currentSong = params.targetSong;
     if (params.targetDifficulty != null) currentDifficulty = params.targetDifficulty;
+    previousDifficulty = currentDifficulty;
     if (params.targetVariation != null) currentVariation = params.targetVariation;
     if (params.targetInstrumental != null) currentInstrumental = params.targetInstrumental;
     isPracticeMode = params.practiceMode ?? false;
@@ -813,7 +819,11 @@ class PlayState extends MusicBeatSubState
 
       prevScrollTargets = [];
 
-      dispatchEvent(new ScriptEvent(SONG_RETRY));
+      var retryEvent = new SongRetryEvent(currentDifficulty);
+
+      previousDifficulty = currentDifficulty;
+
+      dispatchEvent(retryEvent);
 
       resetCamera();
 

--- a/source/funkin/play/PlayState.hx
+++ b/source/funkin/play/PlayState.hx
@@ -906,7 +906,7 @@ class PlayState extends MusicBeatSubState
         Conductor.instance.formatOffset = 0.0;
       }
 
-      Conductor.instance.update(); // Normal conductor update.
+      Conductor.instance.update(Conductor.instance.songPosition + elapsed * 1000, false); // Normal conductor update.
     }
 
     var androidPause:Bool = false;
@@ -1447,7 +1447,9 @@ class PlayState extends MusicBeatSubState
       }
 
       if (!startingSong
-        && (Math.abs(FlxG.sound.music.time - correctSync) > 5 || Math.abs(playerVoicesError) > 5 || Math.abs(opponentVoicesError) > 5))
+        && (Math.abs(FlxG.sound.music.time - correctSync) > 100
+          || Math.abs(playerVoicesError) > 100
+          || Math.abs(opponentVoicesError) > 100))
       {
         trace("VOCALS NEED RESYNC");
         if (vocals != null)

--- a/source/funkin/play/PlayState.hx
+++ b/source/funkin/play/PlayState.hx
@@ -2546,7 +2546,7 @@ class PlayState extends MusicBeatSubState
 
     Highscore.tallies.totalNotesHit++;
     // Display the hit on the strums
-    playerStrumline.hitNote(note, !isComboBreak);
+    playerStrumline.hitNote(note, !event.isComboBreak);
     if (event.doesNotesplash) playerStrumline.playNoteSplash(note.noteData.getDirection());
     if (note.isHoldNote && note.holdNoteSprite != null) playerStrumline.playNoteHoldCover(note.holdNoteSprite);
     vocals.playerVolume = 1;

--- a/source/funkin/play/ResultScore.hx
+++ b/source/funkin/play/ResultScore.hx
@@ -50,12 +50,12 @@ class ResultScore extends FlxTypedSpriteGroup<ScoreNum>
 
   public function animateNumbers():Void
   {
-    for (i in group.members.length-scoreStart...group.members.length)
+    for (i in group.members.length - scoreStart...group.members.length)
     {
-     // if(i.finalDigit == 10) continue;
+      // if(i.finalDigit == 10) continue;
 
-      new FlxTimer().start((i-1)/24, _ -> {
-        group.members[i].finalDelay = scoreStart - (i-1);
+      new FlxTimer().start((i - 1) / 24, _ -> {
+        group.members[i].finalDelay = scoreStart - (i - 1);
         group.members[i].playAnim();
         group.members[i].shuffle();
       });
@@ -97,10 +97,13 @@ class ScoreNum extends FlxSprite
   {
     if (val >= 0 && animation.curAnim != null && animation.curAnim.name != numToString[val])
     {
-      if(glow){
+      if (glow)
+      {
         animation.play(numToString[val], true, false, 0);
         glow = false;
-      }else{
+      }
+      else
+      {
         animation.play(numToString[val], true, false, 4);
       }
       updateHitbox();
@@ -108,18 +111,18 @@ class ScoreNum extends FlxSprite
       switch (val)
       {
         case 1:
-        // offset.x -= 15;
+          // offset.x -= 15;
         case 5:
-        // set offsets
-        // offset.x += 0;
-        // offset.y += 10;
+          // set offsets
+          // offset.x += 0;
+          // offset.y += 10;
 
         case 7:
-        // offset.y += 6;
+          // offset.y += 6;
         case 4:
-        // offset.y += 5;
+          // offset.y += 5;
         case 9:
-        // offset.y += 5;
+          // offset.y += 5;
         default:
           centerOffsets(false);
       }
@@ -144,44 +147,45 @@ class ScoreNum extends FlxSprite
     "ZERO", "ONE", "TWO", "THREE", "FOUR", "FIVE", "SIX", "SEVEN", "EIGHT", "NINE", "DISABLED"
   ];
 
-  function finishShuffleTween():Void{
-
+  function finishShuffleTween():Void
+  {
     var tweenFunction = function(x) {
       var digitRounded = Math.floor(x);
-      //if(digitRounded == finalDigit) glow = true;
+      // if(digitRounded == finalDigit) glow = true;
       digit = digitRounded;
     };
 
-    finalTween = FlxTween.num(0.0, finalDigit, 23/24, {
-      ease: FlxEase.quadOut,
-      onComplete: function (input) {
-        new FlxTimer().start((finalDelay)/24, _ -> {
-          animation.play(animation.curAnim.name, true, false, 0);
-        });
-        // fuck
-      }
-    }, tweenFunction);
+    finalTween = FlxTween.num(0.0, finalDigit, 23 / 24,
+      {
+        ease: FlxEase.quadOut,
+        onComplete: function(input) {
+          new FlxTimer().start((finalDelay) / 24, _ -> {
+            animation.play(animation.curAnim.name, true, false, 0);
+          });
+          // fuck
+        }
+      }, tweenFunction);
   }
-
 
   function shuffleProgress(shuffleTimer:FlxTimer):Void
   {
     var tempDigit:Int = digit;
     tempDigit += 1;
-    if(tempDigit > 9) tempDigit = 0;
-    if(tempDigit < 0) tempDigit = 0;
+    if (tempDigit > 9) tempDigit = 0;
+    if (tempDigit < 0) tempDigit = 0;
     digit = tempDigit;
 
     if (shuffleTimer.loops > 0 && shuffleTimer.loopsLeft == 0)
     {
-      //digit = finalDigit;
+      // digit = finalDigit;
       finishShuffleTween();
     }
   }
 
-  public function shuffle():Void{
-    var duration:Float = 41/24;
-    var interval:Float = 1/24;
+  public function shuffle():Void
+  {
+    var duration:Float = 41 / 24;
+    var interval:Float = 1 / 24;
     shuffleTimer = new FlxTimer().start(interval, shuffleProgress, Std.int(duration / interval));
   }
 

--- a/source/funkin/play/ResultState.hx
+++ b/source/funkin/play/ResultState.hx
@@ -730,19 +730,22 @@ class ResultState extends MusicBeatSubState
 
     if (controls.PAUSE)
     {
-      if (introMusicAudio != null) {
+      if (introMusicAudio != null)
+      {
         @:nullSafety(Off)
         introMusicAudio.onComplete = null;
 
-        FlxTween.tween(introMusicAudio, {volume: 0}, 0.8, {
-          onComplete: _ -> {
-            if (introMusicAudio != null) {
-              introMusicAudio.stop();
-              introMusicAudio.destroy();
-              introMusicAudio = null;
+        FlxTween.tween(introMusicAudio, {volume: 0}, 0.8,
+          {
+            onComplete: _ -> {
+              if (introMusicAudio != null)
+              {
+                introMusicAudio.stop();
+                introMusicAudio.destroy();
+                introMusicAudio = null;
+              }
             }
-          }
-        });
+          });
         FlxTween.tween(introMusicAudio, {pitch: 3}, 0.1,
           {
             onComplete: _ -> {
@@ -752,12 +755,13 @@ class ResultState extends MusicBeatSubState
       }
       else if (FlxG.sound.music != null)
       {
-        FlxTween.tween(FlxG.sound.music, {volume: 0}, 0.8, {
-          onComplete: _ -> {
-            FlxG.sound.music.stop();
-            FlxG.sound.music.destroy();
-          }
-        });
+        FlxTween.tween(FlxG.sound.music, {volume: 0}, 0.8,
+          {
+            onComplete: _ -> {
+              FlxG.sound.music.stop();
+              FlxG.sound.music.destroy();
+            }
+          });
         FlxTween.tween(FlxG.sound.music, {pitch: 3}, 0.1,
           {
             onComplete: _ -> {

--- a/source/funkin/play/ResultState.hx
+++ b/source/funkin/play/ResultState.hx
@@ -278,8 +278,7 @@ class ResultState extends MusicBeatSubState
     songName.shader = maskShaderSongName;
     difficulty.shader = maskShaderDifficulty;
 
-    // maskShaderSongName.swagMaskX = difficulty.x - 15;
-    maskShaderDifficulty.swagMaskX = difficulty.x - 15;
+    maskShaderDifficulty.swagMaskX = difficulty.x - 30;
 
     var blackTopBar:FlxSprite = new FlxSprite().loadGraphic(Paths.image("resultScreen/topBarBlack"));
     blackTopBar.y = -blackTopBar.height;

--- a/source/funkin/play/notes/Strumline.hx
+++ b/source/funkin/play/notes/Strumline.hx
@@ -36,10 +36,30 @@ class Strumline extends FlxSpriteGroup
 
   static var RENDER_DISTANCE_MS(get, never):Float;
 
+  /**
+   * The custom render distance for the strumline.
+   * This should be in miliseconds only! Not pixels.
+   */
+  public static var CUSTOM_RENDER_DISTANCE_MS:Float = 0.0;
+
+  /**
+   * Whether to use the custom render distance.
+   * If false, the render distance will be calculated based on the screen height.
+   */
+  public static var USE_CUSTOM_RENDER_DISTANCE:Bool = false;
+
   static function get_RENDER_DISTANCE_MS():Float
   {
+    if (USE_CUSTOM_RENDER_DISTANCE) return CUSTOM_RENDER_DISTANCE_MS;
     return FlxG.height / Constants.PIXELS_PER_MS;
   }
+
+  /**
+   * Whether to play note splashes or not
+   * TODO: Make this a setting!
+   * IE: Settings.noSplash
+   */
+  public var showNotesplash:Bool = true;
 
   /**
    * Whether this strumline is controlled by the player's inputs.
@@ -73,6 +93,11 @@ class Strumline extends FlxSpriteGroup
   {
     return _conductorInUse = value;
   }
+
+  /**
+   * Whether the game should auto position notes.
+   */
+  public var customPositionData:Bool = false;
 
   /**
    * The notes currently being rendered on the strumline.
@@ -376,7 +401,7 @@ class Strumline extends FlxSpriteGroup
 
       var vwoosh:Bool = note.holdNoteSprite == null;
       // Set the note's position.
-      note.y = this.y - INITIAL_OFFSET + calculateNoteYPos(note.strumTime, vwoosh);
+      if (!customPositionData) note.y = this.y - INITIAL_OFFSET + calculateNoteYPos(note.strumTime, vwoosh);
 
       // If the note is miss
       var isOffscreen = Preferences.downscroll ? note.y > FlxG.height : note.y < -note.height;
@@ -446,13 +471,16 @@ class Strumline extends FlxSpriteGroup
 
         var vwoosh:Bool = false;
 
-        if (Preferences.downscroll)
+        if (!customPositionData)
         {
-          holdNote.y = this.y - INITIAL_OFFSET + calculateNoteYPos(holdNote.strumTime, vwoosh) - holdNote.height + STRUMLINE_SIZE / 2;
-        }
-        else
-        {
-          holdNote.y = this.y - INITIAL_OFFSET + calculateNoteYPos(holdNote.strumTime, vwoosh) + yOffset + STRUMLINE_SIZE / 2;
+          if (Preferences.downscroll)
+          {
+            holdNote.y = this.y - INITIAL_OFFSET + calculateNoteYPos(holdNote.strumTime, vwoosh) - holdNote.height + STRUMLINE_SIZE / 2;
+          }
+          else
+          {
+            holdNote.y = this.y - INITIAL_OFFSET + calculateNoteYPos(holdNote.strumTime, vwoosh) + yOffset + STRUMLINE_SIZE / 2;
+          }
         }
 
         // Clean up the cover.
@@ -475,13 +503,16 @@ class Strumline extends FlxSpriteGroup
           holdNote.visible = false;
         }
 
-        if (Preferences.downscroll)
+        if (!customPositionData)
         {
-          holdNote.y = this.y - INITIAL_OFFSET - holdNote.height + STRUMLINE_SIZE / 2;
-        }
-        else
-        {
-          holdNote.y = this.y - INITIAL_OFFSET + STRUMLINE_SIZE / 2;
+          if (Preferences.downscroll)
+          {
+            holdNote.y = this.y - INITIAL_OFFSET - holdNote.height + STRUMLINE_SIZE / 2;
+          }
+          else
+          {
+            holdNote.y = this.y - INITIAL_OFFSET + STRUMLINE_SIZE / 2;
+          }
         }
       }
       else
@@ -490,13 +521,16 @@ class Strumline extends FlxSpriteGroup
         holdNote.visible = true;
         var vwoosh:Bool = false;
 
-        if (Preferences.downscroll)
+        if (!customPositionData)
         {
-          holdNote.y = this.y - INITIAL_OFFSET + calculateNoteYPos(holdNote.strumTime, vwoosh) - holdNote.height + STRUMLINE_SIZE / 2;
-        }
-        else
-        {
-          holdNote.y = this.y - INITIAL_OFFSET + calculateNoteYPos(holdNote.strumTime, vwoosh) + STRUMLINE_SIZE / 2;
+          if (Preferences.downscroll)
+          {
+            holdNote.y = this.y - INITIAL_OFFSET + calculateNoteYPos(holdNote.strumTime, vwoosh) - holdNote.height + STRUMLINE_SIZE / 2;
+          }
+          else
+          {
+            holdNote.y = this.y - INITIAL_OFFSET + calculateNoteYPos(holdNote.strumTime, vwoosh) + STRUMLINE_SIZE / 2;
+          }
         }
       }
     }
@@ -708,8 +742,7 @@ class Strumline extends FlxSpriteGroup
 
   public function playNoteSplash(direction:NoteDirection):Void
   {
-    // TODO: Add a setting to disable note splashes.
-    // if (Settings.noSplash) return;
+    if (!showNotesplash) return;
     if (!noteStyle.isNoteSplashEnabled()) return;
 
     var splash:NoteSplash = this.constructNoteSplash();
@@ -729,8 +762,7 @@ class Strumline extends FlxSpriteGroup
 
   public function playNoteHoldCover(holdNote:SustainTrail):Void
   {
-    // TODO: Add a setting to disable note splashes.
-    // if (Settings.noSplash) return;
+    if (!showNotesplash) return;
     if (!noteStyle.isHoldNoteCoverEnabled()) return;
 
     var cover:NoteHoldCover = this.constructNoteHoldCover();

--- a/source/funkin/play/notes/SustainTrail.hx
+++ b/source/funkin/play/notes/SustainTrail.hx
@@ -86,6 +86,11 @@ class SustainTrail extends FlxSprite
    */
   public var bottomClip:Float = 0.9;
 
+  /**
+   * Whether the note will recieve custom vertex data
+   */
+  public var customVertexData:Bool = false;
+  
   public var isPixel:Bool;
   public var noteStyleOffsets:Array<Float>;
 
@@ -110,11 +115,68 @@ class SustainTrail extends FlxSprite
     setupHoldNoteGraphic(noteStyle);
     noteStyleOffsets = noteStyle.getHoldNoteOffsets();
 
-    indices = new DrawData<Int>(12, true, TRIANGLE_VERTEX_INDICES);
+    setIndices(TRIANGLE_VERTEX_INDICES);
 
     this.active = true; // This NEEDS to be true for the note to be drawn!
   }
 
+  /**
+   * Sets the indices for the triangles.
+   * @param indices The indices to set.
+   */
+  public function setIndices(indices:Array<Int>):Void
+  {
+    if (this.indices.length == indices.length)
+    {
+      for (i in 0...indices.length)
+      {
+        this.indices[i] = indices[i];
+      }
+    }
+    else
+    {
+      this.indices = new DrawData<Int>(indices.length, false, indices);
+    }
+  }
+
+  /**
+   * Sets the vertices for the triangles.
+   * @param vertices The vertices to set.
+   */
+  public function setVertices(vertices:Array<Float>):Void
+  {
+    if (this.vertices.length == vertices.length)
+    {
+      for (i in 0...vertices.length)
+      {
+        this.vertices[i] = vertices[i];
+      }
+    }
+    else
+    {
+      this.vertices = new DrawData<Float>(vertices.length, false, vertices);
+    }
+  }
+
+  /**
+   * Sets the UV data for the triangles.
+   * @param uvtData The UV data to set.
+   */
+  public function setUVTData(uvtData:Array<Float>):Void
+  {
+    if (this.uvtData.length == uvtData.length)
+    {
+      for (i in 0...uvtData.length)
+      {
+        this.uvtData[i] = uvtData[i];
+      }
+    }
+    else
+    {
+      this.uvtData = new DrawData<Float>(uvtData.length, false, uvtData);
+    }
+  }
+  
   /**
    * Creates hold note graphic and applies correct zooming
    * @param noteStyle The note style
@@ -214,7 +276,7 @@ class SustainTrail extends FlxSprite
    */
   public function updateClipping(songTime:Float = 0):Void
   {
-    if (graphic == null)
+    if (graphic == null || customVertexData)
     {
       return;
     }

--- a/source/funkin/play/notes/SustainTrail.hx
+++ b/source/funkin/play/notes/SustainTrail.hx
@@ -90,7 +90,7 @@ class SustainTrail extends FlxSprite
    * Whether the note will recieve custom vertex data
    */
   public var customVertexData:Bool = false;
-  
+
   public var isPixel:Bool;
   public var noteStyleOffsets:Array<Float>;
 
@@ -176,7 +176,7 @@ class SustainTrail extends FlxSprite
       this.uvtData = new DrawData<Float>(uvtData.length, false, uvtData);
     }
   }
-  
+
   /**
    * Creates hold note graphic and applies correct zooming
    * @param noteStyle The note style

--- a/source/funkin/play/notes/notestyle/NoteStyle.hx
+++ b/source/funkin/play/notes/notestyle/NoteStyle.hx
@@ -36,7 +36,8 @@ class NoteStyle implements IRegistryEntry<NoteStyleData>
    */
   var fallback(get, never):Null<NoteStyle>;
 
-  function get_fallback():Null<NoteStyle> {
+  function get_fallback():Null<NoteStyle>
+  {
     if (_data == null || _data.fallback == null) return null;
     return NoteStyleRegistry.instance.fetchEntry(_data.fallback);
   }

--- a/source/funkin/play/song/Song.hx
+++ b/source/funkin/play/song/Song.hx
@@ -955,12 +955,14 @@ class SongDifficulty
     // Add player vocals.
     for (playerVoice in playerVoiceList)
     {
+      if (!Assets.exists(playerVoice)) continue;
       result.addPlayerVoice(FunkinSound.load(playerVoice));
     }
 
     // Add opponent vocals.
     for (opponentVoice in opponentVoiceList)
     {
+      if (!Assets.exists(opponentVoice)) continue;
       result.addOpponentVoice(FunkinSound.load(opponentVoice));
     }
 

--- a/source/funkin/play/song/Song.hx
+++ b/source/funkin/play/song/Song.hx
@@ -643,11 +643,11 @@ class Song implements IPlayStateScriptedClass implements IRegistryEntry<SongMeta
 
   public function onGameOver(event:ScriptEvent):Void {};
 
-  public function onSongRetry(event:ScriptEvent):Void {};
+  public function onSongRetry(event:SongRetryEvent):Void {};
 
-  public function onNoteIncoming(event:NoteScriptEvent) {}
+  public function onNoteIncoming(event:NoteScriptEvent) {};
 
-  public function onNoteHit(event:HitNoteScriptEvent) {}
+  public function onNoteHit(event:HitNoteScriptEvent) {};
 
   public function onNoteMiss(event:NoteScriptEvent):Void {};
 

--- a/source/funkin/play/stage/Bopper.hx
+++ b/source/funkin/play/stage/Bopper.hx
@@ -389,5 +389,5 @@ class Bopper extends StageProp implements IPlayStateScriptedClass
 
   public function onSongLoaded(event:SongLoadScriptEvent) {}
 
-  public function onSongRetry(event:ScriptEvent) {}
+  public function onSongRetry(event:SongRetryEvent) {}
 }

--- a/source/funkin/play/stage/Stage.hx
+++ b/source/funkin/play/stage/Stage.hx
@@ -458,6 +458,7 @@ class Stage extends FlxSpriteGroup implements IPlayStateScriptedClass implements
       character.scrollFactor.y += stageCharData.scroll[1];
 
       character.alpha = stageCharData.alpha;
+      character.angle = stageCharData.angle;
 
       #if FEATURE_DEBUG_FUNCTIONS
       // Draw the debug icon at the character's feet.

--- a/source/funkin/play/stage/Stage.hx
+++ b/source/funkin/play/stage/Stage.hx
@@ -454,6 +454,11 @@ class Stage extends FlxSpriteGroup implements IPlayStateScriptedClass implements
       character.cameraFocusPoint.x += stageCharData.cameraOffsets[0];
       character.cameraFocusPoint.y += stageCharData.cameraOffsets[1];
 
+      character.scrollFactor.x += stageCharData.scroll[0];
+      character.scrollFactor.y += stageCharData.scroll[1];
+
+      character.alpha = stageCharData.alpha;
+
       #if FEATURE_DEBUG_FUNCTIONS
       // Draw the debug icon at the character's feet.
       if (charType == BF || charType == DAD)

--- a/source/funkin/play/stage/Stage.hx
+++ b/source/funkin/play/stage/Stage.hx
@@ -454,8 +454,8 @@ class Stage extends FlxSpriteGroup implements IPlayStateScriptedClass implements
       character.cameraFocusPoint.x += stageCharData.cameraOffsets[0];
       character.cameraFocusPoint.y += stageCharData.cameraOffsets[1];
 
-      character.scrollFactor.x += stageCharData.scroll[0];
-      character.scrollFactor.y += stageCharData.scroll[1];
+      character.scrollFactor.x = stageCharData.scroll[0];
+      character.scrollFactor.y = stageCharData.scroll[1];
 
       character.alpha = stageCharData.alpha;
       character.angle = stageCharData.angle;

--- a/source/funkin/play/stage/Stage.hx
+++ b/source/funkin/play/stage/Stage.hx
@@ -901,5 +901,5 @@ class Stage extends FlxSpriteGroup implements IPlayStateScriptedClass implements
 
   public function onSongLoaded(event:SongLoadScriptEvent) {}
 
-  public function onSongRetry(event:ScriptEvent) {}
+  public function onSongRetry(event:SongRetryEvent) {}
 }

--- a/source/funkin/play/stage/Stage.hx
+++ b/source/funkin/play/stage/Stage.hx
@@ -31,7 +31,7 @@ typedef StagePropGroup = FlxTypedSpriteGroup<StageProp>;
 /**
  * A Stage is a group of objects rendered in the PlayState.
  *
- * A Stage is comprised of one or more props, each of which is a FlxSprite.
+ * A Stage is comprised of one or more props, each of which is an FlxSprite.
  */
 class Stage extends FlxSpriteGroup implements IPlayStateScriptedClass implements IRegistryEntry<StageData>
 {

--- a/source/funkin/save/Save.hx
+++ b/source/funkin/save/Save.hx
@@ -623,7 +623,7 @@ class Save
         else
         {
           // Level has score data, but the score is 0.
-          return false;
+          continue;
         }
       }
     }
@@ -818,7 +818,7 @@ class Save
         else
         {
           // Level has score data, but the score is 0.
-          return false;
+          continue;
         }
       }
     }

--- a/source/funkin/save/Save.hx
+++ b/source/funkin/save/Save.hx
@@ -97,6 +97,7 @@ class Save
           zoomCamera: true,
           debugDisplay: false,
           autoPause: true,
+          autoFullscreen: false,
           inputOffset: 0,
           audioVisualOffset: 0,
           unlockedFramerate: false,
@@ -1338,6 +1339,12 @@ typedef SaveDataOptions =
    * @default `true`
    */
   var autoPause:Bool;
+
+  /**
+   * If enabled, the game will automatically launch in fullscreen on startup.
+   * @default `true`
+   */
+  var autoFullscreen:Bool;
 
   /**
    * Offset the user's inputs by this many ms.

--- a/source/funkin/ui/MusicBeatState.hx
+++ b/source/funkin/ui/MusicBeatState.hx
@@ -87,6 +87,20 @@ class MusicBeatState extends FlxTransitionableState implements IEventHandler
     dispatchEvent(new UpdateScriptEvent(elapsed));
   }
 
+  override function onFocus():Void
+  {
+    super.onFocus();
+
+    dispatchEvent(new FocusScriptEvent(FOCUS_GAINED));
+  }
+
+  override function onFocusLost():Void
+  {
+    super.onFocusLost();
+
+    dispatchEvent(new FocusScriptEvent(FOCUS_LOST));
+  }
+
   function createWatermarkText()
   {
     // Both have an xPos of 0, but a width equal to the full screen.

--- a/source/funkin/ui/MusicBeatSubState.hx
+++ b/source/funkin/ui/MusicBeatSubState.hx
@@ -89,6 +89,20 @@ class MusicBeatSubState extends FlxSubState implements IEventHandler
     dispatchEvent(new UpdateScriptEvent(elapsed));
   }
 
+  override function onFocus():Void
+  {
+    super.onFocus();
+
+    dispatchEvent(new FocusScriptEvent(FOCUS_GAINED));
+  }
+
+  override function onFocusLost():Void
+  {
+    super.onFocusLost();
+
+    dispatchEvent(new FocusScriptEvent(FOCUS_LOST));
+  }
+
   public function initConsoleHelpers():Void {}
 
   function reloadAssets()

--- a/source/funkin/ui/charSelect/CharSelectSubState.hx
+++ b/source/funkin/ui/charSelect/CharSelectSubState.hx
@@ -474,7 +474,10 @@ class CharSelectSubState extends MusicBeatSubState
       }
       else
       {
-        if (availableChars.exists(i)) nonLocks.push(i);
+        var playableCharacterId:String = availableChars.get(i);
+        var player:Null<PlayableCharacter> = PlayerRegistry.instance.fetchEntry(playableCharacterId);
+        var isPlayerUnlocked:Bool = player?.isUnlocked() ?? false;
+        if (availableChars.exists(i) && isPlayerUnlocked) nonLocks.push(i);
 
         var temp:Lock = new Lock(0, 0, i);
         temp.ID = 1;

--- a/source/funkin/ui/debug/anim/DebugBoundingState.hx
+++ b/source/funkin/ui/debug/anim/DebugBoundingState.hx
@@ -403,6 +403,11 @@ class DebugBoundingState extends FlxState
       onionSkinChar.visible = !onionSkinChar.visible;
     }
 
+    if (FlxG.keys.justPressed.G)
+    {
+      swagChar.flipX = !swagChar.flipX;
+    }
+
     // Plays the idle animation
     if (FlxG.keys.justPressed.SPACE)
     {

--- a/source/funkin/ui/freeplay/Album.hx
+++ b/source/funkin/ui/freeplay/Album.hx
@@ -76,6 +76,14 @@ class Album implements IRegistryEntry<AlbumData>
     return _data.albumTitleAsset;
   }
 
+  /**
+   * Get the offsets for the album title.
+   */
+  public function getAlbumTitleOffsets():Null<Array<Float>>
+  {
+    return _data.albumTitleOffsets;
+  }
+
   public function hasAlbumTitleAnimations()
   {
     return _data.albumTitleAnimations.length > 0;

--- a/source/funkin/ui/freeplay/AlbumRoll.hx
+++ b/source/funkin/ui/freeplay/AlbumRoll.hx
@@ -112,7 +112,7 @@ class AlbumRoll extends FlxSpriteGroup
     var albumGraphic = Paths.image(albumData.getAlbumArtAssetKey());
     newAlbumArt.replaceFrameGraphic(0, albumGraphic);
 
-    buildAlbumTitle(albumData.getAlbumTitleAssetKey());
+    buildAlbumTitle(albumData.getAlbumTitleAssetKey(), albumData.getAlbumTitleOffsets());
 
     applyExitMovers();
 
@@ -198,12 +198,17 @@ class AlbumRoll extends FlxSpriteGroup
     albumTitle.visible = true;
   }
 
-  public function buildAlbumTitle(assetKey:String):Void
+  public function buildAlbumTitle(assetKey:String, ?titleOffsets:Null<Array<Float>>):Void
   {
     if (albumTitle != null)
     {
       remove(albumTitle);
       albumTitle = null;
+    }
+
+    if (titleOffsets == null)
+    {
+      titleOffsets = [0, 0];
     }
 
     albumTitle = FunkinSprite.createSparrow(925, 500, assetKey);
@@ -218,6 +223,9 @@ class AlbumRoll extends FlxSpriteGroup
     albumTitle.animation.play('idle');
 
     albumTitle.zIndex = 1000;
+
+    albumTitle.x += titleOffsets[0];
+    albumTitle.y += titleOffsets[1];
 
     if (_exitMovers != null) _exitMovers.set([albumTitle],
       {

--- a/source/funkin/ui/freeplay/CapsuleOptionsMenu.hx
+++ b/source/funkin/ui/freeplay/CapsuleOptionsMenu.hx
@@ -22,6 +22,8 @@ class CapsuleOptionsMenu extends FlxSpriteGroup
 
   var currentInstrumental:FlxText;
 
+  var busy:Bool = false;
+
   public function new(parent:FreeplayState, x:Float = 0, y:Float = 0, instIds:Array<String>):Void
   {
     super(x, y);
@@ -66,35 +68,40 @@ class CapsuleOptionsMenu extends FlxSpriteGroup
       destroy();
       return;
     }
-    @:privateAccess
-    if (parent.controls.BACK)
+    var changedInst = false;
+
+    if (!busy)
     {
-      close();
-      return;
+      @:privateAccess
+      if (parent.controls.BACK)
+      {
+        close();
+        return;
+      }
+
+      if (parent.getControls().UI_LEFT_P)
+      {
+        currentInstrumentalIndex = (currentInstrumentalIndex + 1) % instrumentalIds.length;
+        changedInst = true;
+      }
+      if (parent.getControls().UI_RIGHT_P)
+      {
+        currentInstrumentalIndex = (currentInstrumentalIndex - 1 + instrumentalIds.length) % instrumentalIds.length;
+        changedInst = true;
+      }
+      if (parent.getControls().ACCEPT)
+      {
+        busy = true;
+        onConfirm(instrumentalIds[currentInstrumentalIndex] ?? '');
+      }
     }
 
-    var changedInst = false;
-    if (parent.getControls().UI_LEFT_P)
-    {
-      currentInstrumentalIndex = (currentInstrumentalIndex + 1) % instrumentalIds.length;
-      changedInst = true;
-    }
-    if (parent.getControls().UI_RIGHT_P)
-    {
-      currentInstrumentalIndex = (currentInstrumentalIndex - 1 + instrumentalIds.length) % instrumentalIds.length;
-      changedInst = true;
-    }
     if (!changedInst && currentInstrumental.text == '') changedInst = true;
 
     if (changedInst)
     {
       currentInstrumental.text = instrumentalIds[currentInstrumentalIndex].toTitleCase() ?? '';
       if (currentInstrumental.text == '') currentInstrumental.text = 'Default';
-    }
-
-    if (parent.getControls().ACCEPT)
-    {
-      onConfirm(instrumentalIds[currentInstrumentalIndex] ?? '');
     }
   }
 

--- a/source/funkin/ui/freeplay/FreeplayState.hx
+++ b/source/funkin/ui/freeplay/FreeplayState.hx
@@ -1400,6 +1400,16 @@ class FreeplayState extends MusicBeatSubState
       }
     }
 
+    if (controls.FREEPLAY_BOTTOM_SCROLL && !busy)
+    {
+      changeSelection(grpCapsules.countLiving() - curSelected - 1);
+    }
+
+    if (controls.FREEPLAY_TOP_SCROLL && !busy)
+    {
+      changeSelection(-curSelected);
+    }
+
     lerpScore = MathUtil.smoothLerp(lerpScore, intendedScore, elapsed, 0.5);
     lerpCompletion = MathUtil.smoothLerp(lerpCompletion, intendedCompletion, elapsed, 0.5);
 

--- a/source/funkin/ui/freeplay/FreeplayState.hx
+++ b/source/funkin/ui/freeplay/FreeplayState.hx
@@ -1400,14 +1400,14 @@ class FreeplayState extends MusicBeatSubState
       }
     }
 
-    if (controls.FREEPLAY_BOTTOM_SCROLL && !busy)
-    {
-      changeSelection(grpCapsules.countLiving() - curSelected - 1);
-    }
-
-    if (controls.FREEPLAY_TOP_SCROLL && !busy)
+    if (controls.FREEPLAY_JUMP_TO_TOP && !busy)
     {
       changeSelection(-curSelected);
+    }
+
+    if (controls.FREEPLAY_JUMP_TO_BOTTOM && !busy)
+    {
+      changeSelection(grpCapsules.countLiving() - curSelected - 1);
     }
 
     lerpScore = MathUtil.smoothLerp(lerpScore, intendedScore, elapsed, 0.5);

--- a/source/funkin/ui/mainmenu/MainMenuState.hx
+++ b/source/funkin/ui/mainmenu/MainMenuState.hx
@@ -105,6 +105,7 @@ class MainMenuState extends MusicBeatState
     createMenuItem('freeplay', 'mainmenu/freeplay', function() {
       persistentDraw = true;
       persistentUpdate = false;
+      rememberedSelectedIndex = menuItems.selectedIndex;
       // Freeplay has its own custom transition
       FlxTransitionableState.skipNextTransIn = true;
       FlxTransitionableState.skipNextTransOut = true;

--- a/source/funkin/ui/options/ControlsMenu.hx
+++ b/source/funkin/ui/options/ControlsMenu.hx
@@ -50,6 +50,10 @@ class ControlsMenu extends funkin.ui.options.OptionsState.Page
   var currentDevice:Device = Keys;
   var deviceListSelected:Bool = false;
 
+  static final CONTROL_BASE_X = 50;
+  static final CONTROL_MARGIN_X = 700;
+  static final CONTROL_SPACING_X = 300;
+
   public function new()
   {
     super();
@@ -142,10 +146,10 @@ class ControlsMenu extends funkin.ui.options.OptionsState.Page
       if (currentHeader != null && name.indexOf(currentHeader) == 0) name = name.substr(currentHeader.length);
 
       var formatName = name.replace('_', ' ');
-      var label = labels.add(new AtlasText(100, y, formatName, AtlasFont.BOLD));
+      var label = labels.add(new AtlasText(CONTROL_BASE_X, y, formatName, AtlasFont.BOLD));
       label.alpha = 0.6;
       for (i in 0...COLUMNS)
-        createItem(label.x + 550 + i * 400, y, control, i);
+        createItem(label.x + CONTROL_MARGIN_X + i * CONTROL_SPACING_X, y, control, i);
 
       y += spacer;
     }

--- a/source/funkin/ui/options/PreferencesMenu.hx
+++ b/source/funkin/ui/options/PreferencesMenu.hx
@@ -3,10 +3,13 @@ package funkin.ui.options;
 import flixel.FlxCamera;
 import flixel.FlxObject;
 import flixel.FlxSprite;
+import flixel.text.FlxText;
+import flixel.util.FlxColor;
 import flixel.group.FlxSpriteGroup.FlxTypedSpriteGroup;
 import funkin.ui.AtlasText.AtlasFont;
 import funkin.ui.options.OptionsState.Page;
 import funkin.graphics.FunkinCamera;
+import funkin.graphics.FunkinSprite;
 import funkin.ui.TextMenuList.TextMenuItem;
 import funkin.audio.FunkinSound;
 import funkin.ui.options.MenuItemEnums;
@@ -18,8 +21,12 @@ class PreferencesMenu extends Page
 {
   var items:TextMenuList;
   var preferenceItems:FlxTypedSpriteGroup<FlxSprite>;
+  var preferenceDesc:Array<String> = [];
+  var itemDesc:FlxText;
+  var itemDescBox:FunkinSprite;
 
   var menuCamera:FlxCamera;
+  var hudCamera:FlxCamera;
   var camFollow:FlxObject;
 
   public function new()
@@ -29,24 +36,58 @@ class PreferencesMenu extends Page
     menuCamera = new FunkinCamera('prefMenu');
     FlxG.cameras.add(menuCamera, false);
     menuCamera.bgColor = 0x0;
+
+    hudCamera = new FlxCamera();
+    FlxG.cameras.add(hudCamera, false);
+    hudCamera.bgColor = 0x0;
+
     camera = menuCamera;
 
     add(items = new TextMenuList());
     add(preferenceItems = new FlxTypedSpriteGroup<FlxSprite>());
 
+    add(itemDescBox = new FunkinSprite());
+    itemDescBox.cameras = [hudCamera];
+
+    add(itemDesc = new FlxText(0, 0, 1180, null, 32));
+    itemDesc.cameras = [hudCamera];
+
     createPrefItems();
+    createPrefDescription();
 
     camFollow = new FlxObject(FlxG.width / 2, 0, 140, 70);
     if (items != null) camFollow.y = items.selectedItem.y;
 
-    menuCamera.follow(camFollow, null, 0.06);
+    menuCamera.follow(camFollow, null, 0.085);
     var margin = 160;
-    menuCamera.deadzone.set(0, margin, menuCamera.width, 40);
+    menuCamera.deadzone.set(0, margin, menuCamera.width, menuCamera.height - margin * 2);
     menuCamera.minScrollY = 0;
 
     items.onChange.add(function(selected) {
       camFollow.y = selected.y;
+      itemDesc.text = preferenceDesc[items.selectedIndex];
     });
+  }
+
+  /**
+   * Create the description for preferences.
+   */
+  function createPrefDescription():Void
+  {
+    itemDescBox.makeSolidColor(1, 1, FlxColor.BLACK);
+    itemDescBox.alpha = 0.6;
+    itemDesc.setFormat(Paths.font('vcr.ttf'), 32, FlxColor.WHITE, FlxTextAlign.CENTER, FlxTextBorderStyle.OUTLINE, FlxColor.BLACK);
+    itemDesc.borderSize = 3;
+
+    // Update the text.
+    itemDesc.text = preferenceDesc[items.selectedIndex];
+    itemDesc.screenCenter();
+    itemDesc.y += 270;
+
+    // Create the box around the text.
+    itemDescBox.setPosition(itemDesc.x - 10, itemDesc.y - 10);
+    itemDescBox.setGraphicSize(Std.int(itemDesc.width + 20), Std.int(itemDesc.height + 25));
+    itemDescBox.updateHitbox();
   }
 
   /**
@@ -54,22 +95,22 @@ class PreferencesMenu extends Page
    */
   function createPrefItems():Void
   {
-    createPrefItemCheckbox('Naughtyness', 'Toggle displaying raunchy content', function(value:Bool):Void {
+    createPrefItemCheckbox('Naughtyness', 'If enabled, raunchy content (such as swearing, etc.) will be displayed.', function(value:Bool):Void {
       Preferences.naughtyness = value;
     }, Preferences.naughtyness);
-    createPrefItemCheckbox('Downscroll', 'Enable to make notes move downwards', function(value:Bool):Void {
+    createPrefItemCheckbox('Downscroll', 'If enabled, this will make the notes move downwards.', function(value:Bool):Void {
       Preferences.downscroll = value;
     }, Preferences.downscroll);
-    createPrefItemCheckbox('Flashing Lights', 'Disable to dampen flashing effects', function(value:Bool):Void {
+    createPrefItemCheckbox('Flashing Lights', 'If disabled, it will dampen flashing effects. Useful for people with photosensitive epilepsy.', function(value:Bool):Void {
       Preferences.flashingLights = value;
     }, Preferences.flashingLights);
-    createPrefItemCheckbox('Camera Zooming on Beat', 'Disable to stop the camera bouncing to the song', function(value:Bool):Void {
+    createPrefItemCheckbox('Camera Zooms', 'If disabled, camera stops bouncing to the song.', function(value:Bool):Void {
       Preferences.zoomCamera = value;
     }, Preferences.zoomCamera);
-    createPrefItemCheckbox('Debug Display', 'Enable to show FPS and other debug stats', function(value:Bool):Void {
+    createPrefItemCheckbox('Debug Display', 'If enabled, FPS and other debug stats will be displayed.', function(value:Bool):Void {
       Preferences.debugDisplay = value;
     }, Preferences.debugDisplay);
-    createPrefItemCheckbox('Auto Pause', 'Automatically pause the game when it loses focus', function(value:Bool):Void {
+    createPrefItemCheckbox('Auto Pause', 'If enabled, game automatically pauses when it loses focus.', function(value:Bool):Void {
       Preferences.autoPause = value;
     }, Preferences.autoPause);
 
@@ -134,6 +175,7 @@ class PreferencesMenu extends Page
     });
 
     preferenceItems.add(checkbox);
+    preferenceDesc.push(prefDesc);
   }
 
   /**
@@ -152,6 +194,7 @@ class PreferencesMenu extends Page
     var item = new NumberPreferenceItem(0, (120 * items.length) + 30, prefName, defaultValue, min, max, step, precision, onChange, valueFormatter);
     items.addItem(prefName, item);
     preferenceItems.add(item.lefthandText);
+    preferenceDesc.push(prefDesc);
   }
 
   /**
@@ -172,6 +215,7 @@ class PreferencesMenu extends Page
     var item = new NumberPreferenceItem(0, (120 * items.length) + 30, prefName, defaultValue, min, max, 10, 0, newCallback, formatter);
     items.addItem(prefName, item);
     preferenceItems.add(item.lefthandText);
+    preferenceDesc.push(prefDesc);
   }
 
   /**
@@ -185,5 +229,6 @@ class PreferencesMenu extends Page
     var item = new EnumPreferenceItem(0, (120 * items.length) + 30, prefName, values, defaultValue, onChange);
     items.addItem(prefName, item);
     preferenceItems.add(item.lefthandText);
+    preferenceDesc.push(prefDesc);
   }
 }

--- a/source/funkin/ui/options/PreferencesMenu.hx
+++ b/source/funkin/ui/options/PreferencesMenu.hx
@@ -101,9 +101,10 @@ class PreferencesMenu extends Page
     createPrefItemCheckbox('Downscroll', 'If enabled, this will make the notes move downwards.', function(value:Bool):Void {
       Preferences.downscroll = value;
     }, Preferences.downscroll);
-    createPrefItemCheckbox('Flashing Lights', 'If disabled, it will dampen flashing effects. Useful for people with photosensitive epilepsy.', function(value:Bool):Void {
-      Preferences.flashingLights = value;
-    }, Preferences.flashingLights);
+    createPrefItemCheckbox('Flashing Lights', 'If disabled, it will dampen flashing effects. Useful for people with photosensitive epilepsy.',
+      function(value:Bool):Void {
+        Preferences.flashingLights = value;
+      }, Preferences.flashingLights);
     createPrefItemCheckbox('Camera Zooms', 'If disabled, camera stops bouncing to the song.', function(value:Bool):Void {
       Preferences.zoomCamera = value;
     }, Preferences.zoomCamera);

--- a/source/funkin/ui/options/PreferencesMenu.hx
+++ b/source/funkin/ui/options/PreferencesMenu.hx
@@ -124,6 +124,10 @@ class PreferencesMenu extends Page
       Preferences.framerate = Std.int(value);
     }, null, Preferences.framerate, 30, 300, 5, 0);
     #end
+
+    createPrefItemCheckbox('Launch in Fullscreen', 'Automatically launch the game in fullscreen on startup', function(value:Bool):Void {
+      Preferences.autoFullscreen = value;
+    }, Preferences.autoFullscreen);
   }
 
   override function update(elapsed:Float):Void

--- a/source/funkin/ui/options/PreferencesMenu.hx
+++ b/source/funkin/ui/options/PreferencesMenu.hx
@@ -114,6 +114,9 @@ class PreferencesMenu extends Page
     createPrefItemCheckbox('Auto Pause', 'If enabled, game automatically pauses when it loses focus.', function(value:Bool):Void {
       Preferences.autoPause = value;
     }, Preferences.autoPause);
+    createPrefItemCheckbox('Launch in Fullscreen', 'Automatically launch the game in fullscreen on startup', function(value:Bool):Void {
+      Preferences.autoFullscreen = value;
+    }, Preferences.autoFullscreen);
 
     #if web
     createPrefItemCheckbox('Unlocked Framerate', 'Enable to unlock the framerate', function(value:Bool):Void {
@@ -124,10 +127,6 @@ class PreferencesMenu extends Page
       Preferences.framerate = Std.int(value);
     }, null, Preferences.framerate, 30, 300, 5, 0);
     #end
-
-    createPrefItemCheckbox('Launch in Fullscreen', 'Automatically launch the game in fullscreen on startup', function(value:Bool):Void {
-      Preferences.autoFullscreen = value;
-    }, Preferences.autoFullscreen);
   }
 
   override function update(elapsed:Float):Void

--- a/source/funkin/ui/story/LevelTitle.hx
+++ b/source/funkin/ui/story/LevelTitle.hx
@@ -44,6 +44,7 @@ class LevelTitle extends FlxSpriteGroup
   }
 
   public var isFlashing:Bool = false;
+
   var flashTick:Float = 0;
   final flashFramerate:Float = 20;
 

--- a/source/funkin/ui/title/TitleState.hx
+++ b/source/funkin/ui/title/TitleState.hx
@@ -28,8 +28,6 @@ import funkin.ui.mainmenu.MainMenuState;
 import openfl.events.MouseEvent;
 import openfl.events.NetStatusEvent;
 import funkin.ui.freeplay.FreeplayState;
-import openfl.media.Video;
-import openfl.net.NetStream;
 import funkin.api.newgrounds.NGio;
 import openfl.display.BlendMode;
 import funkin.save.Save;
@@ -52,10 +50,6 @@ class TitleState extends MusicBeatState
   var lastBeat:Int = 0;
   var swagShader:ColorSwap;
 
-  var video:Video;
-  var netStream:NetStream;
-  var overlay:Sprite;
-
   override public function create():Void
   {
     super.create();
@@ -67,48 +61,11 @@ class TitleState extends MusicBeatState
 
     // DEBUG BULLSHIT
 
-    // netConnection.addEventListener(MouseEvent.MOUSE_DOWN, overlay_onMouseDown);
     if (!initialized) new FlxTimer().start(1, function(tmr:FlxTimer) {
       startIntro();
     });
     else
       startIntro();
-  }
-
-  function client_onMetaData(metaData:Dynamic)
-  {
-    video.attachNetStream(netStream);
-
-    video.width = video.videoWidth;
-    video.height = video.videoHeight;
-    // video.
-  }
-
-  function netStream_onAsyncError(event:AsyncErrorEvent):Void
-  {
-    trace("Error loading video");
-  }
-
-  function netConnection_onNetStatus(event:NetStatusEvent):Void
-  {
-    if (event.info.code == 'NetStream.Play.Complete')
-    {
-      // netStream.dispose();
-      // FlxG.stage.removeChild(video);
-
-      startIntro();
-    }
-
-    trace(event.toString());
-  }
-
-  function overlay_onMouseDown(event:MouseEvent):Void
-  {
-    netStream.soundTransform.volume = 0.2;
-    netStream.soundTransform.pan = -1;
-    // netStream.play(Paths.file('music/kickstarterTrailer.mp4'));
-
-    FlxG.stage.removeChild(overlay);
   }
 
   var logoBl:FlxSprite;
@@ -324,7 +281,6 @@ class TitleState extends MusicBeatState
     if (pressedEnter && !transitioning && skippedIntro)
     {
       if (FlxG.sound.music != null) FlxG.sound.music.onComplete = null;
-      // netStream.play(Paths.file('music/kickstarterTrailer.mp4'));
       NGio.unlockMedal(60960);
       // If it's Friday according to da clock
       if (Date.now().getDay() == 5) NGio.unlockMedal(61034);

--- a/source/funkin/util/Constants.hx
+++ b/source/funkin/util/Constants.hx
@@ -56,6 +56,11 @@ class Constants
   #end
 
   /**
+   * Whether or not the game is a debug build.
+   */
+  public static final DEBUG_BUILD:Bool = #if FEATURE_DEBUG_FUNCTIONS true #else false #end;
+
+  /**
    * URL DATA
    */
   // ==============================

--- a/source/funkin/util/ReflectUtil.hx
+++ b/source/funkin/util/ReflectUtil.hx
@@ -44,6 +44,11 @@ class ReflectUtil
     return Reflect.field(obj, name);
   }
 
+  public static function setAnonymousField(obj:Dynamic, name:String, value:Dynamic):Dynamic
+  {
+    return Reflect.setField(obj, name, value);
+  }
+
   public static function hasAnonymousField(obj:Dynamic, name:String):Bool
   {
     return Reflect.hasField(obj, name);

--- a/source/funkin/util/ReflectUtil.hx
+++ b/source/funkin/util/ReflectUtil.hx
@@ -53,4 +53,19 @@ class ReflectUtil
   {
     return Reflect.hasField(obj, name);
   }
+
+  public static function copyAnonymousFieldsOf(obj:Dynamic):Dynamic
+  {
+    return Reflect.copy(obj);
+  }
+
+  public static function deleteAnonymousField(obj:Dynamic, name:String):Bool
+  {
+    return Reflect.deleteField(obj, name);
+  }
+
+  public static function compareValues(valueA:Dynamic, valueB:Dynamic):Int
+  {
+    return Reflect.compare(valueA, valueB);
+  }
 }

--- a/source/funkin/util/ReflectUtil.hx
+++ b/source/funkin/util/ReflectUtil.hx
@@ -68,4 +68,34 @@ class ReflectUtil
   {
     return Reflect.compare(valueA, valueB);
   }
+
+  public static function isObject(value:Dynamic):Bool
+  {
+    return Reflect.isObject(value);
+  }
+
+  public static function isFunction(value:Dynamic):Bool
+  {
+    return Reflect.isFunction(value);
+  }
+
+  public static function isEnumValue(value:Dynamic):Bool
+  {
+    return Reflect.isEnumValue(value);
+  }
+
+  public static function getProperty(obj:Dynamic, name:String):Dynamic
+  {
+    return Reflect.getProperty(obj, name);
+  }
+
+  public static function setProperty(obj:Dynamic, name:String, value:Dynamic):Void
+  {
+    return Reflect.setProperty(obj, name, value);
+  }
+
+  public static function compareMethods(functionA:Dynamic, functionB:Dynamic):Bool
+  {
+    return Reflect.compareMethods(functionA, functionB);
+  }
 }

--- a/source/funkin/util/ReflectUtil.hx
+++ b/source/funkin/util/ReflectUtil.hx
@@ -44,7 +44,7 @@ class ReflectUtil
     return Reflect.field(obj, name);
   }
 
-  public static function setAnonymousField(obj:Dynamic, name:String, value:Dynamic):Dynamic
+  public static function setAnonymousField(obj:Dynamic, name:String, value:Dynamic):Void
   {
     return Reflect.setField(obj, name, value);
   }


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->
## Does this PR close any issues? If so, link them below.
Fixes #4179
## Briefly describe the issue(s) fixed.
Title. It's literally because the freeplay state is opened as a substate and therefore doesn't call startExitState, which updates the rememberedSelectedIndex. 

This PR simply adds that line into the freeplay menu item callback function.
## Include any relevant screenshots or videos.
