### PR TITLE
Chart editor - Open hold note context menu if note is hold note

### DIFF
--- a/source/funkin/ui/debug/charting/ChartEditorState.hx
+++ b/source/funkin/ui/debug/charting/ChartEditorState.hx
@@ -4814,7 +4814,10 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
               // Show the context menu connected to the note.
               if (useSingleNoteContextMenu)
               {
-                this.openNoteContextMenu(FlxG.mouse.viewX, FlxG.mouse.viewY, highlightedNote.noteData);
+                // Open the hold note menu instead if the highlighted note has a length value
+                if (highlightedNote.noteData.length > 0) this.openHoldNoteContextMenu(FlxG.mouse.viewX, FlxG.mouse.viewY, highlightedNote.noteData);
+                else
+                  this.openNoteContextMenu(FlxG.mouse.viewX, FlxG.mouse.viewY, highlightedNote.noteData);
               }
               else
               {


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->
## Does this PR close any issues? If so, link them below.
No, but it prevents one from being opened in the future!
## Briefly describe the issue(s) fixed.
Opening the context menu on the note of a hold note would open the regular note context menu, rather than the hold note one.

This change pairs very well with my improved context menus.
## Include any relevant screenshots or videos.
Before:

https://github.com/user-attachments/assets/738265eb-b240-4eb8-b254-115521b602d1

After:

https://github.com/user-attachments/assets/9e446f6e-14c6-4364-aaf9-2c93cf110135


