### PR TITLE
[BUGFIX] Chart Editor - Selection context menu fix

### DIFF
--- a/source/funkin/ui/debug/charting/contextmenus/ChartEditorSelectionContextMenu.hx
+++ b/source/funkin/ui/debug/charting/contextmenus/ChartEditorSelectionContextMenu.hx
@@ -7,6 +7,10 @@ import funkin.ui.debug.charting.commands.CutItemsCommand;
 import funkin.ui.debug.charting.commands.RemoveEventsCommand;
 import funkin.ui.debug.charting.commands.RemoveItemsCommand;
 import funkin.ui.debug.charting.commands.RemoveNotesCommand;
+import funkin.ui.debug.charting.commands.FlipNotesCommand;
+import funkin.ui.debug.charting.commands.SelectAllItemsCommand;
+import funkin.ui.debug.charting.commands.InvertSelectedItemsCommand;
+import funkin.ui.debug.charting.commands.DeselectAllItemsCommand;
 
 @:access(funkin.ui.debug.charting.ChartEditorState)
 @:build(haxe.ui.ComponentBuilder.build("assets/exclude/data/ui/chart-editor/context-menus/selection.xml"))
@@ -36,7 +40,7 @@ class ChartEditorSelectionContextMenu extends ChartEditorBaseContextMenu
     contextmenuCopy.onClick = (_) -> {
       chartEditorState.copySelection();
     };
-    contextmenuFlip.onClick = (_) -> {
+    contextmenuDelete.onClick = (_) -> {
       if (chartEditorState.currentNoteSelection.length > 0 && chartEditorState.currentEventSelection.length > 0)
       {
         chartEditorState.performCommand(new RemoveItemsCommand(chartEditorState.currentNoteSelection, chartEditorState.currentEventSelection));
@@ -54,5 +58,19 @@ class ChartEditorSelectionContextMenu extends ChartEditorBaseContextMenu
         // Do nothing???
       }
     };
+
+    contextmenuFlip.onClick = function(_) {
+      chartEditorState.performCommand(new FlipNotesCommand(chartEditorState.currentNoteSelection));
+    }
+
+    contextmenuSelectAll.onClick = function(_) {
+      chartEditorState.performCommand(new SelectAllItemsCommand(true, false));
+    }
+    contextmenuSelectInverse.onClick = function(_) {
+      chartEditorState.performCommand(new InvertSelectedItemsCommand());
+    }
+    contextmenuSelectNone.onClick = function(_) {
+      chartEditorState.performCommand(new DeselectAllItemsCommand());
+    }
   }
 }


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->
## Does this PR close any issues? If so, link them below.
No, but it prevents one from being opened in the future!
## Briefly describe the issue(s) fixed.
The flip and selection buttons were broken (they aren't set up in the class for the selection context menu). This PR fixes that.

~~Can someone please tell me why there's a button to select everything in the selection context menu????~~
## Include any relevant screenshots or videos.
