### PR TITLE
Results screen plays new rank after practice mode fix

### DIFF
--- a/source/funkin/play/ResultState.hx
+++ b/source/funkin/play/ResultState.hx
@@ -81,18 +81,12 @@ class ResultState extends MusicBeatSubState
   final cameraScroll:FunkinCamera;
   final cameraEverything:FunkinCamera;
 
-  /**
-   * Whether the game is currently in Practice Mode.
-   * If true, player will not lose gain or lose score from notes.
-   */
   var isPracticeMode(get, never):Bool;
 
   function get_isPracticeMode():Bool
   {
     return PlayState.instance.isPracticeMode;
   }
-
-
 
   public function new(params:ResultsStateParams)
   {

--- a/source/funkin/play/ResultState.hx
+++ b/source/funkin/play/ResultState.hx
@@ -808,7 +808,7 @@ class ResultState extends MusicBeatSubState
       }
       else
       {
-        if (rank > Scoring.calculateRank(params?.prevScoreData))
+        if (!isPracticeMode && rank > Scoring.calculateRank(params?.prevScoreData))
         {
           trace('THE RANK IS Higher.....');
 
@@ -823,7 +823,7 @@ class ResultState extends MusicBeatSubState
                     newRank: rank,
                     songId: params.songId,
                     difficultyId: params.difficultyId,
-                    playRankAnim: (isPracticeMode == true) ? false : true
+                    playRankAnim: true
                   }
               }
             });

--- a/source/funkin/play/ResultState.hx
+++ b/source/funkin/play/ResultState.hx
@@ -81,6 +81,19 @@ class ResultState extends MusicBeatSubState
   final cameraScroll:FunkinCamera;
   final cameraEverything:FunkinCamera;
 
+  /**
+   * Whether the game is currently in Practice Mode.
+   * If true, player will not lose gain or lose score from notes.
+   */
+  var isPracticeMode(get, never):Bool;
+
+  function get_isPracticeMode():Bool
+  {
+    return PlayState.instance.isPracticeMode;
+  }
+
+
+
   public function new(params:ResultsStateParams)
   {
     super();
@@ -816,7 +829,7 @@ class ResultState extends MusicBeatSubState
                     newRank: rank,
                     songId: params.songId,
                     difficultyId: params.difficultyId,
-                    playRankAnim: true
+                    playRankAnim: (isPracticeMode == true) ? false : true
                   }
               }
             });


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->
## Does this PR close any issues? If so, link them below.
Fixes #2722
## Briefly describe the issue(s) fixed.
The results screen always plays the new rank animation if the rank is higher, regardless if the song was played in practice mode or not.
## Include any relevant screenshots or videos.

https://github.com/user-attachments/assets/621b851d-081c-44af-ae6a-4e7264cb10ef

