### PR TITLE
[ENHANCEMENT] Chart Editor - Random sound pitch

### DIFF
--- a/source/funkin/save/Save.hx
+++ b/source/funkin/save/Save.hx
@@ -195,6 +195,8 @@ class Save implements ConsoleClass implements ISerializable
         playtestAudioSettings: false,
         playtestResultsSettings: false,
         downscroll: false,
+        hitsoundPitchNoteDirection: false,
+        randomPitch: true,
         showNoteKinds: true,
         metronomeVolume: 1.0,
         hitsoundVolumePlayer: 1.0,
@@ -322,6 +324,10 @@ class Save implements ConsoleClass implements ISerializable
   public var chartEditorPlayerVoiceVolume:SaveProperty<Float>;
   @:saveProperty(data.optionsChartEditor.opponentVoiceVolume, 1.0)
   public var chartEditorOpponentVoiceVolume:SaveProperty<Float>;
+  @:saveProperty(data.optionsChartEditor.hitsoundPitchNoteDirection, false)
+  public var chartEditorHitsoundPitchNoteDirection(get, set):SaveProperty<Bool>;
+  @:saveProperty(data.optionsChartEditor.randomPitch, true)
+  public var chartEditorRandomPitch(get, set):SaveProperty<Bool>;
   @:saveProperty(data.optionsChartEditor.themeMusic, true)
   public var chartEditorThemeMusic:SaveProperty<Bool>;
   @:saveProperty(data.optionsChartEditor.playbackSpeed, 0.5)
@@ -1668,10 +1674,16 @@ typedef SaveDataChartEditorOptions =
   var ?showNoteKinds:Bool;
 
   /**
-   * Show Subtitles in the Chart Editor.
+   * Pitch the hitsound by note direction in the Chart editor.
+   * @default `false`
+   */
+  var ?hitsoundPitchNoteDirection:Bool;
+
+  /**
+   * Random pitch for sounds in the Chart Editor.
    * @default `true`
    */
-  var ?showSubtitles:Bool;
+  var ?randomPitch:Bool;
 
   /**
    * Metronome volume in the Chart Editor.

--- a/source/funkin/save/Save.hx
+++ b/source/funkin/save/Save.hx
@@ -164,6 +164,8 @@ class Save implements ConsoleClass
         playtestAudioSettings: false,
         playtestResultsSettings: false,
         downscroll: false,
+        hitsoundPitchNoteDirection: false,
+        randomPitch: true,
         showNoteKinds: true,
         metronomeVolume: 1.0,
         hitsoundVolumePlayer: 1.0,
@@ -282,6 +284,10 @@ class Save implements ConsoleClass
   public var chartEditorPlayerVoiceVolume:SaveProperty<Float>;
   @:saveProperty(data.optionsChartEditor.opponentVoiceVolume, 1.0)
   public var chartEditorOpponentVoiceVolume:SaveProperty<Float>;
+  @:saveProperty(data.optionsChartEditor.hitsoundPitchNoteDirection, false)
+  public var chartEditorHitsoundPitchNoteDirection(get, set):SaveProperty<Bool>;
+  @:saveProperty(data.optionsChartEditor.randomPitch, true)
+  public var chartEditorRandomPitch(get, set):SaveProperty<Bool>;
   @:saveProperty(data.optionsChartEditor.themeMusic, true)
   public var chartEditorThemeMusic:SaveProperty<Bool>;
   @:saveProperty(data.optionsChartEditor.playbackSpeed, 0.5)
@@ -1417,10 +1423,16 @@ typedef SaveDataChartEditorOptions =
   var ?showNoteKinds:Bool;
 
   /**
-   * Show Subtitles in the Chart Editor.
+   * Pitch the hitsound by note direction in the Chart editor.
+   * @default `false`
+   */
+  var ?hitsoundPitchNoteDirection:Bool;
+
+  /**
+   * Random pitch for sounds in the Chart Editor.
    * @default `true`
    */
-  var ?showSubtitles:Bool;
+  var ?randomPitch:Bool;
 
   /**
    * Metronome volume in the Chart Editor.

--- a/source/funkin/ui/debug/charting/ChartEditorState.hx
+++ b/source/funkin/ui/debug/charting/ChartEditorState.hx
@@ -4670,8 +4670,8 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
   function handleCursor():Void
   {
     // Mouse sounds
-    if (FlxG.mouse.justPressed) FunkinSound.playOnce(Paths.sound('chartingSounds/ClickDown'));
-    if (FlxG.mouse.justReleased) FunkinSound.playOnce(Paths.sound('chartingSounds/ClickUp'));
+    if (FlxG.mouse.justPressed) this.playSound(Paths.sound('chartingSounds/ClickDown'), 1.0, 1.0, 0.2);
+    if (FlxG.mouse.justReleased) this.playSound(Paths.sound('chartingSounds/ClickUp'), 1.0, 1.0, 0.2);
 
     // Note: If a menu is open in HaxeUI, don't handle cursor behavior.
     var shouldHandleCursor:Bool = !(isHaxeUIFocused || playbarHeadDragging || isHaxeUIDialogOpen)
@@ -5243,10 +5243,10 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
         }
         var dragDistanceColumns:Int = cursorGridPos - noteGridPos;
 
-        if ((dragTargetCurrentColumn != dragDistanceColumns && overlapsGrid) || dragTargetCurrentStep != dragDistanceSteps)
-        {
-          // Play a sound as we drag.
-          this.playSound(Paths.sound('chartingSounds/noteLay'));
+          if (dragTargetCurrentStep != dragDistanceSteps || dragTargetCurrentColumn != dragDistanceColumns)
+          {
+            // Play a sound as we drag.
+            this.playSound(Paths.sound('chartingSounds/noteLay'), 1.0, 1.0, 0.05);
 
           dragTargetCurrentStep = dragDistanceSteps;
           dragTargetCurrentColumn = dragDistanceColumns;
@@ -5292,23 +5292,23 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
         }
       }
 
-      if (FlxG.mouse.justReleased)
-      {
-        if (dragLengthSteps > 0)
+        if (FlxG.mouse.justReleased)
         {
-          this.playSound(Paths.sound('chartingSounds/stretchSNAP_UI'));
-          // Apply the new length.
-          performCommand(new ExtendNoteLengthCommand(currentPlaceNoteData, dragLengthMs));
-        }
-        else
-        {
-          // Apply the new (zero) length if we are changing the length.
-          if (currentPlaceNoteData.length > 0)
+          if (dragLengthSteps > 0)
           {
-            this.playSound(Paths.sound('chartingSounds/stretchSNAP_UI'));
-            performCommand(new ExtendNoteLengthCommand(currentPlaceNoteData, 0));
+            this.playSound(Paths.sound('chartingSounds/stretchSNAP_UI'), 1.0, 1.0, 0.2);
+            // Apply the new length.
+            performCommand(new ExtendNoteLengthCommand(currentPlaceNoteData, dragLengthMs));
           }
-        }
+          else
+          {
+            // Apply the new (zero) length if we are changing the length.
+            if (currentPlaceNoteData.length > 0)
+            {
+              this.playSound(Paths.sound('chartingSounds/stretchSNAP_UI'), 1.0, 1.0, 0.2);
+              performCommand(new ExtendNoteLengthCommand(currentPlaceNoteData, 0));
+            }
+          }
 
         // Finished dragging. Release the note.
         currentPlaceNoteData = null;
@@ -5439,90 +5439,90 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
       {
         // We right clicked on the grid.
 
-        if (highlightedNote != null && highlightedNote.noteData != null)
-        {
-          // TODO: Handle the case of clicking on a sustain piece.
-          if (FlxG.keys.pressed.SHIFT)
+          if (highlightedNote != null && highlightedNote.noteData != null)
           {
-            // Shift + Right click opens the context menu.
-            // If we are clicking a large selection, open the Selection context menu, otherwise open the Note context menu.
-            var isHighlightedNoteSelected:Bool = isNoteSelected(highlightedNote.noteData);
-            var useSingleNoteContextMenu:Bool = (!isHighlightedNoteSelected)
-              || (isHighlightedNoteSelected && currentNoteSelection.length == 1);
-            // Show the context menu connected to the note.
-            if (useSingleNoteContextMenu)
+            // TODO: Handle the case of clicking on a sustain piece.
+            if (FlxG.keys.pressed.SHIFT)
             {
-              // Open the hold note menu instead if the highlighted note has a length value
-              if (highlightedNote.noteData.length > 0) this.openHoldNoteContextMenu(FlxG.mouse.viewX, FlxG.mouse.viewY, highlightedNote.noteData);
+              // Shift + Right click opens the context menu.
+              // If we are clicking a large selection, open the Selection context menu, otherwise open the Note context menu.
+              var isHighlightedNoteSelected:Bool = isNoteSelected(highlightedNote.noteData);
+              var useSingleNoteContextMenu:Bool = (!isHighlightedNoteSelected)
+                || (isHighlightedNoteSelected && currentNoteSelection.length == 1);
+              // Show the context menu connected to the note.
+              if (useSingleNoteContextMenu)
+              {
+                // Open the hold note menu instead if the highlighted note has a length value
+                if (highlightedNote.noteData.length > 0) this.openHoldNoteContextMenu(FlxG.mouse.viewX, FlxG.mouse.viewY, highlightedNote.noteData);
+                else
+                  this.openNoteContextMenu(FlxG.mouse.viewX, FlxG.mouse.viewY, highlightedNote.noteData);
+              }
               else
-                this.openNoteContextMenu(FlxG.mouse.viewX, FlxG.mouse.viewY, highlightedNote.noteData);
+              {
+                this.openSelectionContextMenu(FlxG.mouse.viewX, FlxG.mouse.viewY);
+              }
             }
             else
             {
-              this.openSelectionContextMenu(FlxG.mouse.viewX, FlxG.mouse.viewY);
+              // Right click removes the note.
+              performCommand(new RemoveNotesCommand([highlightedNote.noteData]));
+            }
+          }
+          else if (highlightedEvent != null && highlightedEvent.eventData != null)
+          {
+            if (FlxG.keys.pressed.SHIFT)
+            {
+              // Shift + Right click opens the context menu.
+              // If we are clicking a large selection, open the Selection context menu, otherwise open the Event context menu.
+              var isHighlightedEventSelected:Bool = isEventSelected(highlightedEvent.eventData);
+              var useSingleEventContextMenu:Bool = (!isHighlightedEventSelected)
+                || (isHighlightedEventSelected && currentEventSelection.length == 1);
+              if (useSingleEventContextMenu)
+              {
+                this.openEventContextMenu(FlxG.mouse.viewX, FlxG.mouse.viewY, highlightedEvent.eventData);
+              }
+              else
+              {
+                this.openSelectionContextMenu(FlxG.mouse.viewX, FlxG.mouse.viewY);
+              }
+            }
+            else
+            {
+              // Right click removes the event.
+              performCommand(new RemoveEventsCommand([highlightedEvent.eventData]));
+            }
+          }
+          else if (highlightedHoldNote != null && highlightedHoldNote.noteData != null)
+          {
+            if (FlxG.keys.pressed.SHIFT)
+            {
+              // Shift + Right click opens the context menu.
+              // If we are clicking a large selection, open the Selection context menu, otherwise open the Note context menu.
+              var isHighlightedNoteSelected:Bool = isNoteSelected(highlightedHoldNote.noteData);
+              var useSingleNoteContextMenu:Bool = (!isHighlightedNoteSelected)
+                || (isHighlightedNoteSelected && currentNoteSelection.length == 1);
+              // Show the context menu connected to the note.
+              if (useSingleNoteContextMenu)
+              {
+                this.openHoldNoteContextMenu(FlxG.mouse.viewX, FlxG.mouse.viewY, highlightedHoldNote.noteData);
+              }
+              else
+              {
+                this.openSelectionContextMenu(FlxG.mouse.viewX, FlxG.mouse.viewY);
+              }
+            }
+            else
+            {
+              // Right click removes hold from the note.
+              this.playSound(Paths.sound('chartingSounds/stretchSNAP_UI'), 1.0, 1.0, 0.2);
+              performCommand(new ExtendNoteLengthCommand(highlightedHoldNote.noteData, 0));
             }
           }
           else
           {
-            // Right click removes the note.
-            performCommand(new RemoveNotesCommand([highlightedNote.noteData]));
+            // Right clicked on nothing.
           }
         }
-        else if (highlightedEvent != null && highlightedEvent.eventData != null)
-        {
-          if (FlxG.keys.pressed.SHIFT)
-          {
-            // Shift + Right click opens the context menu.
-            // If we are clicking a large selection, open the Selection context menu, otherwise open the Event context menu.
-            var isHighlightedEventSelected:Bool = isEventSelected(highlightedEvent.eventData);
-            var useSingleEventContextMenu:Bool = (!isHighlightedEventSelected)
-              || (isHighlightedEventSelected && currentEventSelection.length == 1);
-            if (useSingleEventContextMenu)
-            {
-              this.openEventContextMenu(FlxG.mouse.viewX, FlxG.mouse.viewY, highlightedEvent.eventData);
-            }
-            else
-            {
-              this.openSelectionContextMenu(FlxG.mouse.viewX, FlxG.mouse.viewY);
-            }
-          }
-          else
-          {
-            // Right click removes the event.
-            performCommand(new RemoveEventsCommand([highlightedEvent.eventData]));
-          }
-        }
-        else if (highlightedHoldNote != null && highlightedHoldNote.noteData != null)
-        {
-          if (FlxG.keys.pressed.SHIFT)
-          {
-            // Shift + Right click opens the context menu.
-            // If we are clicking a large selection, open the Selection context menu, otherwise open the Note context menu.
-            var isHighlightedNoteSelected:Bool = isNoteSelected(highlightedHoldNote.noteData);
-            var useSingleNoteContextMenu:Bool = (!isHighlightedNoteSelected)
-              || (isHighlightedNoteSelected && currentNoteSelection.length == 1);
-            // Show the context menu connected to the note.
-            if (useSingleNoteContextMenu)
-            {
-              this.openHoldNoteContextMenu(FlxG.mouse.viewX, FlxG.mouse.viewY, highlightedHoldNote.noteData);
-            }
-            else
-            {
-              this.openSelectionContextMenu(FlxG.mouse.viewX, FlxG.mouse.viewY);
-            }
-          }
-          else
-          {
-            // Right click removes hold from the note.
-            this.playSound(Paths.sound('chartingSounds/stretchSNAP_UI'));
-            performCommand(new ExtendNoteLengthCommand(highlightedHoldNote.noteData, 0));
-          }
-        }
-        else
-        {
-          // Right clicked on nothing.
-        }
-      }
 
       var isOrWillSelect = overlapsSelection || dragTargetNote != null || dragTargetEvent != null || overlapsRenderedNotes || overlapsRenderedHoldNotes
         || overlapsRenderedEvents;
@@ -5989,7 +5989,7 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
     {
       // Extend the note to the playhead position.
       trace('Extending note. ${column}');
-      this.playSound(Paths.sound('chartingSounds/stretchSNAP_UI'));
+      this.playSound(Paths.sound('chartingSounds/stretchSNAP_UI'), 1.0, 1.0, 0.2);
       performCommand(new ExtendNoteLengthCommand(currentLiveInputPlaceNoteData[column], newNoteLength));
       currentLiveInputPlaceNoteData[column] = null;
       gridPlayheadGhostHoldNotes[column].noteData = null;
@@ -7295,9 +7295,9 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
       if (hitsoundsEnabled) switch (noteData.getStrumlineIndex())
       {
         case 0: // Player
-          if (hitsoundVolumePlayer > 0) this.playSound(Paths.sound('chartingSounds/hitNotePlayer'), hitsoundVolumePlayer);
+          if (hitsoundVolumePlayer > 0) this.playSound(Paths.sound('chartingSounds/hitNotePlayer'), hitsoundVolumePlayer, 1.0, 0.1);
         case 1: // Opponent
-          if (hitsoundVolumeOpponent > 0) this.playSound(Paths.sound('chartingSounds/hitNoteOpponent'), hitsoundVolumeOpponent);
+          if (hitsoundVolumeOpponent > 0) this.playSound(Paths.sound('chartingSounds/hitNoteOpponent'), hitsoundVolumeOpponent, 1.0, 0.1);
       }
     }
     // Clearing memory before next event call.

--- a/source/funkin/ui/debug/charting/ChartEditorState.hx
+++ b/source/funkin/ui/debug/charting/ChartEditorState.hx
@@ -2623,6 +2623,8 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
     hitsoundVolumePlayer = save.chartEditorHitsoundVolumePlayer.value;
     hitsoundVolumeOpponent = save.chartEditorHitsoundVolumeOpponent.value;
     shouldPlayWelcomeMusic = save.chartEditorThemeMusic.value;
+    menubarItemHitsoundPitchNoteDirection.selected = save.chartEditorHitsoundPitchNoteDirection;
+    menubarItemRandomPitch.selected = save.chartEditorRandomPitch;
 
     menubarItemVolumeInstrumental.value = Std.int(save.chartEditorInstVolume.value * 100);
     menubarItemVolumeVocalsPlayer.value = Std.int(save.chartEditorPlayerVoiceVolume.value * 100);
@@ -2654,6 +2656,8 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
     save.chartEditorHitsoundVolumePlayer.value = hitsoundVolumePlayer;
     save.chartEditorHitsoundVolumeOpponent.value = hitsoundVolumeOpponent;
     save.chartEditorThemeMusic.value = shouldPlayWelcomeMusic;
+    save.chartEditorHitsoundPitchNoteDirection = menubarItemHitsoundPitchNoteDirection.selected;
+    save.chartEditorRandomPitch = menubarItemRandomPitch.selected;
 
     save.chartEditorInstVolume.value = menubarItemVolumeInstrumental.value / 100.0;
     save.chartEditorPlayerVoiceVolume.value = menubarItemVolumeVocalsPlayer.value / 100.0;
@@ -5296,7 +5300,7 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
         {
           if (dragLengthSteps > 0)
           {
-            this.playSound(Paths.sound('chartingSounds/stretchSNAP_UI'), 1.0, 1.0, 0.2);
+            this.playSound(Paths.sound('chartingSounds/stretchSNAP_UI'));
             // Apply the new length.
             performCommand(new ExtendNoteLengthCommand(currentPlaceNoteData, dragLengthMs));
           }
@@ -5305,7 +5309,7 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
             // Apply the new (zero) length if we are changing the length.
             if (currentPlaceNoteData.length > 0)
             {
-              this.playSound(Paths.sound('chartingSounds/stretchSNAP_UI'), 1.0, 1.0, 0.2);
+              this.playSound(Paths.sound('chartingSounds/stretchSNAP_UI'));
               performCommand(new ExtendNoteLengthCommand(currentPlaceNoteData, 0));
             }
           }
@@ -5514,7 +5518,7 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
             else
             {
               // Right click removes hold from the note.
-              this.playSound(Paths.sound('chartingSounds/stretchSNAP_UI'), 1.0, 1.0, 0.2);
+              this.playSound(Paths.sound('chartingSounds/stretchSNAP_UI'));
               performCommand(new ExtendNoteLengthCommand(highlightedHoldNote.noteData, 0));
             }
           }

--- a/source/funkin/ui/debug/charting/ChartEditorState.hx
+++ b/source/funkin/ui/debug/charting/ChartEditorState.hx
@@ -4986,8 +4986,8 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
   function handleCursor():Void
   {
     // Mouse sounds
-    if (FlxG.mouse.justPressed) FunkinSound.playOnce(Paths.sound('ui/editors/chart-editor/charting-sounds/click-down'));
-    if (FlxG.mouse.justReleased) FunkinSound.playOnce(Paths.sound('ui/editors/chart-editor/charting-sounds/click-up'));
+    if (FlxG.mouse.justPressed) this.playSound(Paths.sound('ui/editors/chart-editor/charting-sounds/click-down'), 1.0, 1.0, 0.2);
+    if (FlxG.mouse.justReleased) this.playSound(Paths.sound('ui/editors/chart-editor/charting-sounds/click-up'), 1.0, 1.0, 0.2);
 
     // Note: If a menu is open in HaxeUI, don't handle cursor behavior.
     var shouldHandleCursor:Bool =
@@ -5576,10 +5576,10 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
         }
         var dragDistanceColumns:Int = cursorGridPos - noteGridPos;
 
-        if ((dragTargetCurrentColumn != dragDistanceColumns && overlapsGrid) || dragTargetCurrentStep != dragDistanceSteps)
-        {
-          // Play a sound as we drag.
-          this.playSound(Paths.sound('ui/editors/chart-editor/charting-sounds/note-place'));
+          if (dragTargetCurrentStep != dragDistanceSteps || dragTargetCurrentColumn != dragDistanceColumns)
+          {
+            // Play a sound as we drag.
+            this.playSound(Paths.sound('ui/editors/chart-editor/charting-sounds/note-place'), 1.0, 1.0, 0.05);
 
           dragTargetCurrentStep = dragDistanceSteps;
           dragTargetCurrentColumn = dragDistanceColumns;
@@ -5625,23 +5625,23 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
         }
       }
 
-      if (FlxG.mouse.justReleased)
-      {
-        if (dragLengthSteps > 0)
+        if (FlxG.mouse.justReleased)
         {
-          this.playSound(Paths.sound('ui/editors/chart-editor/charting-sounds/stretch-snap'));
-          // Apply the new length.
-          performCommand(new ExtendNoteLengthCommand(currentPlaceNoteData, dragLengthMs));
-        }
-        else
-        {
-          // Apply the new (zero) length if we are changing the length.
-          if (currentPlaceNoteData.length > 0)
+          if (dragLengthSteps > 0)
           {
-            this.playSound(Paths.sound('ui/editors/chart-editor/charting-sounds/stretch-snap'));
-            performCommand(new ExtendNoteLengthCommand(currentPlaceNoteData, 0));
+            this.playSound(Paths.sound('ui/editors/chart-editor/charting-sounds/stretch-snap'), 1.0, 1.0, 0.2);
+            // Apply the new length.
+            performCommand(new ExtendNoteLengthCommand(currentPlaceNoteData, dragLengthMs));
           }
-        }
+          else
+          {
+            // Apply the new (zero) length if we are changing the length.
+            if (currentPlaceNoteData.length > 0)
+            {
+              this.playSound(Paths.sound('ui/editors/chart-editor/charting-sounds/stretch-snap'), 1.0, 1.0, 0.2);
+              performCommand(new ExtendNoteLengthCommand(currentPlaceNoteData, 0));
+            }
+          }
 
         // Finished dragging. Release the note.
         currentPlaceNoteData = null;
@@ -5853,7 +5853,7 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
           else
           {
             // Right click removes hold from the note.
-            this.playSound(Paths.sound('ui/editors/chart-editor/charting-sounds/stretch-snap'));
+            this.playSound(Paths.sound('ui/editors/chart-editor/charting-sounds/stretch-snap'), 1.0, 1.0, 0.2);
             performCommand(new ExtendNoteLengthCommand(highlightedHoldNote.noteData, 0));
           }
         }
@@ -6345,7 +6345,7 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
     {
       // Extend the note to the playhead position.
       trace('Extending note. ${column}');
-      this.playSound(Paths.sound('ui/editors/chart-editor/charting-sounds/stretch-snap'));
+      this.playSound(Paths.sound('ui/editors/chart-editor/charting-sounds/stretch-snap'), 1.0, 1.0, 0.2);
       performCommand(new ExtendNoteLengthCommand(currentLiveInputPlaceNoteData[column], newNoteLength));
       currentLiveInputPlaceNoteData[column] = null;
       gridPlayheadGhostHoldNotes[column].noteData = null;
@@ -7881,9 +7881,9 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
         switch (noteData.getStrumlineIndex())
         {
           case 0: // Player
-            if (hitsoundVolumePlayer > 0) this.playSound(Paths.sound('ui/editors/chart-editor/charting-sounds/hitsound-player'), hitsoundVolumePlayer);
+            if (hitsoundVolumePlayer > 0) this.playSound(Paths.sound('ui/editors/chart-editor/charting-sounds/hitsound-player'), hitsoundVolumePlayer, 1.0, 0.1);
           case 1: // Opponent
-            if (hitsoundVolumeOpponent > 0) this.playSound(Paths.sound('ui/editors/chart-editor/charting-sounds/hitsound-opponent'), hitsoundVolumeOpponent);
+            if (hitsoundVolumeOpponent > 0) this.playSound(Paths.sound('ui/editors/chart-editor/charting-sounds/hitsound-opponent'), hitsoundVolumeOpponent, 1.0, 0.1);
         }
       }
 

--- a/source/funkin/ui/debug/charting/ChartEditorState.hx
+++ b/source/funkin/ui/debug/charting/ChartEditorState.hx
@@ -2768,6 +2768,8 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
     hitsoundVolumePlayer = save.chartEditorHitsoundVolumePlayer.value;
     hitsoundVolumeOpponent = save.chartEditorHitsoundVolumeOpponent.value;
     shouldPlayWelcomeMusic = save.chartEditorThemeMusic.value;
+    menubarItemHitsoundPitchNoteDirection.selected = save.chartEditorHitsoundPitchNoteDirection;
+    menubarItemRandomPitch.selected = save.chartEditorRandomPitch;
 
     menubarItemVolumeInstrumental.value = Std.int(save.chartEditorInstVolume.value * 100);
     menubarItemVolumeVocalsPlayer.value = Std.int(save.chartEditorPlayerVoiceVolume.value * 100);
@@ -2805,6 +2807,8 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
     save.chartEditorHitsoundVolumePlayer.value = hitsoundVolumePlayer;
     save.chartEditorHitsoundVolumeOpponent.value = hitsoundVolumeOpponent;
     save.chartEditorThemeMusic.value = shouldPlayWelcomeMusic;
+    save.chartEditorHitsoundPitchNoteDirection = menubarItemHitsoundPitchNoteDirection.selected;
+    save.chartEditorRandomPitch = menubarItemRandomPitch.selected;
 
     save.chartEditorInstVolume.value = menubarItemVolumeInstrumental.value / 100.0;
     save.chartEditorPlayerVoiceVolume.value = menubarItemVolumeVocalsPlayer.value / 100.0;
@@ -5629,7 +5633,7 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
         {
           if (dragLengthSteps > 0)
           {
-            this.playSound(Paths.sound('ui/editors/chart-editor/charting-sounds/stretch-snap'), 1.0, 1.0, 0.2);
+            this.playSound(Paths.sound('ui/editors/chart-editor/charting-sounds/stretch-snap'));
             // Apply the new length.
             performCommand(new ExtendNoteLengthCommand(currentPlaceNoteData, dragLengthMs));
           }
@@ -5638,7 +5642,7 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
             // Apply the new (zero) length if we are changing the length.
             if (currentPlaceNoteData.length > 0)
             {
-              this.playSound(Paths.sound('ui/editors/chart-editor/charting-sounds/stretch-snap'), 1.0, 1.0, 0.2);
+              this.playSound(Paths.sound('ui/editors/chart-editor/charting-sounds/stretch-snap'));
               performCommand(new ExtendNoteLengthCommand(currentPlaceNoteData, 0));
             }
           }
@@ -5781,87 +5785,90 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
       {
         // We right clicked on the grid.
 
-        if (highlightedNote != null && highlightedNote.noteData != null)
-        {
-          // TODO: Handle the case of clicking on a sustain piece.
-          if (FlxG.keys.pressed.SHIFT)
+          if (highlightedNote != null && highlightedNote.noteData != null)
           {
-            // Shift + Right click opens the context menu.
-            // If we are clicking a large selection, open the Selection context menu, otherwise open the Note context menu.
-            var isHighlightedNoteSelected:Bool = isNoteSelected(highlightedNote.noteData);
-            var useSingleNoteContextMenu:Bool = (!isHighlightedNoteSelected) || (isHighlightedNoteSelected && currentNoteSelection.length == 1);
-            // Show the context menu connected to the note.
-            if (useSingleNoteContextMenu)
+            // TODO: Handle the case of clicking on a sustain piece.
+            if (FlxG.keys.pressed.SHIFT)
             {
-              // Open the hold note menu instead if the highlighted note has a length value
-              if (highlightedNote.noteData.length > 0) this.openHoldNoteContextMenu(FlxG.mouse.viewX, FlxG.mouse.viewY, highlightedNote.noteData);
+              // Shift + Right click opens the context menu.
+              // If we are clicking a large selection, open the Selection context menu, otherwise open the Note context menu.
+              var isHighlightedNoteSelected:Bool = isNoteSelected(highlightedNote.noteData);
+              var useSingleNoteContextMenu:Bool = (!isHighlightedNoteSelected)
+                || (isHighlightedNoteSelected && currentNoteSelection.length == 1);
+              // Show the context menu connected to the note.
+              if (useSingleNoteContextMenu)
+              {
+                // Open the hold note menu instead if the highlighted note has a length value
+                if (highlightedNote.noteData.length > 0) this.openHoldNoteContextMenu(FlxG.mouse.viewX, FlxG.mouse.viewY, highlightedNote.noteData);
+                else
+                  this.openNoteContextMenu(FlxG.mouse.viewX, FlxG.mouse.viewY, highlightedNote.noteData);
+              }
               else
-                this.openNoteContextMenu(FlxG.mouse.viewX, FlxG.mouse.viewY, highlightedNote.noteData);
+              {
+                this.openSelectionContextMenu(FlxG.mouse.viewX, FlxG.mouse.viewY);
+              }
             }
             else
             {
-              this.openSelectionContextMenu(FlxG.mouse.viewX, FlxG.mouse.viewY);
+              // Right click removes the note.
+              performCommand(new RemoveNotesCommand([highlightedNote.noteData]));
+            }
+          }
+          else if (highlightedEvent != null && highlightedEvent.eventData != null)
+          {
+            if (FlxG.keys.pressed.SHIFT)
+            {
+              // Shift + Right click opens the context menu.
+              // If we are clicking a large selection, open the Selection context menu, otherwise open the Event context menu.
+              var isHighlightedEventSelected:Bool = isEventSelected(highlightedEvent.eventData);
+              var useSingleEventContextMenu:Bool = (!isHighlightedEventSelected)
+                || (isHighlightedEventSelected && currentEventSelection.length == 1);
+              if (useSingleEventContextMenu)
+              {
+                this.openEventContextMenu(FlxG.mouse.viewX, FlxG.mouse.viewY, highlightedEvent.eventData);
+              }
+              else
+              {
+                this.openSelectionContextMenu(FlxG.mouse.viewX, FlxG.mouse.viewY);
+              }
+            }
+            else
+            {
+              // Right click removes the event.
+              performCommand(new RemoveEventsCommand([highlightedEvent.eventData]));
+            }
+          }
+          else if (highlightedHoldNote != null && highlightedHoldNote.noteData != null)
+          {
+            if (FlxG.keys.pressed.SHIFT)
+            {
+              // Shift + Right click opens the context menu.
+              // If we are clicking a large selection, open the Selection context menu, otherwise open the Note context menu.
+              var isHighlightedNoteSelected:Bool = isNoteSelected(highlightedHoldNote.noteData);
+              var useSingleNoteContextMenu:Bool = (!isHighlightedNoteSelected)
+                || (isHighlightedNoteSelected && currentNoteSelection.length == 1);
+              // Show the context menu connected to the note.
+              if (useSingleNoteContextMenu)
+              {
+                this.openHoldNoteContextMenu(FlxG.mouse.viewX, FlxG.mouse.viewY, highlightedHoldNote.noteData);
+              }
+              else
+              {
+                this.openSelectionContextMenu(FlxG.mouse.viewX, FlxG.mouse.viewY);
+              }
+            }
+            else
+            {
+              // Right click removes hold from the note.
+            this.playSound(Paths.sound('ui/editors/chart-editor/charting-sounds/stretch-snap'));
+              performCommand(new ExtendNoteLengthCommand(highlightedHoldNote.noteData, 0));
             }
           }
           else
           {
-            // Right click removes the note.
-            performCommand(new RemoveNotesCommand([highlightedNote.noteData]));
+            // Right clicked on nothing.
           }
         }
-        else if (highlightedEvent != null && highlightedEvent.eventData != null)
-        {
-          if (FlxG.keys.pressed.SHIFT)
-          {
-            // Shift + Right click opens the context menu.
-            // If we are clicking a large selection, open the Selection context menu, otherwise open the Event context menu.
-            var isHighlightedEventSelected:Bool = isEventSelected(highlightedEvent.eventData);
-            var useSingleEventContextMenu:Bool = (!isHighlightedEventSelected) || (isHighlightedEventSelected && currentEventSelection.length == 1);
-            if (useSingleEventContextMenu)
-            {
-              this.openEventContextMenu(FlxG.mouse.viewX, FlxG.mouse.viewY, highlightedEvent.eventData);
-            }
-            else
-            {
-              this.openSelectionContextMenu(FlxG.mouse.viewX, FlxG.mouse.viewY);
-            }
-          }
-          else
-          {
-            // Right click removes the event.
-            performCommand(new RemoveEventsCommand([highlightedEvent.eventData]));
-          }
-        }
-        else if (highlightedHoldNote != null && highlightedHoldNote.noteData != null)
-        {
-          if (FlxG.keys.pressed.SHIFT)
-          {
-            // Shift + Right click opens the context menu.
-            // If we are clicking a large selection, open the Selection context menu, otherwise open the Note context menu.
-            var isHighlightedNoteSelected:Bool = isNoteSelected(highlightedHoldNote.noteData);
-            var useSingleNoteContextMenu:Bool = (!isHighlightedNoteSelected) || (isHighlightedNoteSelected && currentNoteSelection.length == 1);
-            // Show the context menu connected to the note.
-            if (useSingleNoteContextMenu)
-            {
-              this.openHoldNoteContextMenu(FlxG.mouse.viewX, FlxG.mouse.viewY, highlightedHoldNote.noteData);
-            }
-            else
-            {
-              this.openSelectionContextMenu(FlxG.mouse.viewX, FlxG.mouse.viewY);
-            }
-          }
-          else
-          {
-            // Right click removes hold from the note.
-            this.playSound(Paths.sound('ui/editors/chart-editor/charting-sounds/stretch-snap'), 1.0, 1.0, 0.2);
-            performCommand(new ExtendNoteLengthCommand(highlightedHoldNote.noteData, 0));
-          }
-        }
-        else
-        {
-          // Right clicked on nothing.
-        }
-      }
 
       var isOrWillSelect =
         overlapsSelection

--- a/source/funkin/ui/debug/charting/commands/AddEventsCommand.hx
+++ b/source/funkin/ui/debug/charting/commands/AddEventsCommand.hx
@@ -36,7 +36,7 @@ class AddEventsCommand implements ChartEditorCommand
       state.currentEventSelection = events;
     }
 
-    state.playSound(Paths.sound('chartingSounds/noteLay'));
+    state.playSound(Paths.sound('chartingSounds/noteLay'), 1.0, 1.0, 0.1);
 
     state.saveDataDirty = true;
     state.noteDisplayDirty = true;

--- a/source/funkin/ui/debug/charting/commands/AddEventsCommand.hx
+++ b/source/funkin/ui/debug/charting/commands/AddEventsCommand.hx
@@ -45,7 +45,7 @@ class AddEventsCommand implements ChartEditorCommand
       state.currentEventSelection = events;
     }
 
-    state.playSound(Paths.sound('ui/editors/chart-editor/charting-sounds/note-place'));
+    state.playSound(Paths.sound('ui/editors/chart-editor/charting-sounds/note-place'), 1.0, 1.0, 0.1);
 
     state.saveDataDirty = true;
     state.noteDisplayDirty = true;

--- a/source/funkin/ui/debug/charting/commands/AddNotesCommand.hx
+++ b/source/funkin/ui/debug/charting/commands/AddNotesCommand.hx
@@ -45,7 +45,7 @@ class AddNotesCommand implements ChartEditorCommand
       state.currentEventSelection = [];
     }
 
-    state.playSound(Paths.sound('ui/editors/chart-editor/charting-sounds/note-place'));
+    state.playSound(Paths.sound('ui/editors/chart-editor/charting-sounds/note-place'), 1.0, 1.0, 0.1);
 
     state.saveDataDirty = true;
     state.noteDisplayDirty = true;
@@ -65,7 +65,7 @@ class AddNotesCommand implements ChartEditorCommand
     state.currentSongChartNoteData = SongDataUtils.subtractNotes(state.currentSongChartNoteData, notes);
     state.currentNoteSelection = [];
     state.currentEventSelection = [];
-    state.playSound(Paths.sound('ui/editors/chart-editor/charting-sounds/undo'));
+    state.playSound(Paths.sound('ui/editors/chart-editor/charting-sounds/undo'), 1.0, 1.0, 0.1);
 
     state.saveDataDirty = true;
     state.noteDisplayDirty = true;

--- a/source/funkin/ui/debug/charting/commands/AddNotesCommand.hx
+++ b/source/funkin/ui/debug/charting/commands/AddNotesCommand.hx
@@ -36,7 +36,7 @@ class AddNotesCommand implements ChartEditorCommand
       state.currentEventSelection = [];
     }
 
-    state.playSound(Paths.sound('chartingSounds/noteLay'));
+    state.playSound(Paths.sound('chartingSounds/noteLay'), 1.0, 1.0, 0.1);
 
     state.saveDataDirty = true;
     state.noteDisplayDirty = true;
@@ -51,7 +51,7 @@ class AddNotesCommand implements ChartEditorCommand
     state.currentSongChartNoteData = SongDataUtils.subtractNotes(state.currentSongChartNoteData, notes);
     state.currentNoteSelection = [];
     state.currentEventSelection = [];
-    state.playSound(Paths.sound('chartingSounds/undo'));
+    state.playSound(Paths.sound('chartingSounds/undo'), 1.0, 1.0, 0.1);
 
     state.saveDataDirty = true;
     state.noteDisplayDirty = true;

--- a/source/funkin/ui/debug/charting/commands/ExtendNoteLengthCommand.hx
+++ b/source/funkin/ui/debug/charting/commands/ExtendNoteLengthCommand.hx
@@ -42,7 +42,7 @@ class ExtendNoteLengthCommand implements ChartEditorCommand
 
   public function undo(state:ChartEditorState):Void
   {
-    state.playSound(Paths.sound('chartingSounds/undo'));
+    state.playSound(Paths.sound('chartingSounds/undo'), 1.0, 1.0, 0.1);
 
     // Always use milliseconds for undoing
     this.note.length = oldLength;

--- a/source/funkin/ui/debug/charting/commands/ExtendNoteLengthCommand.hx
+++ b/source/funkin/ui/debug/charting/commands/ExtendNoteLengthCommand.hx
@@ -53,7 +53,7 @@ class ExtendNoteLengthCommand implements ChartEditorCommand
    */
   public function undo(state:ChartEditorState):Void
   {
-    state.playSound(Paths.sound('ui/editors/chart-editor/charting-sounds/undo'));
+    state.playSound(Paths.sound('ui/editors/chart-editor/charting-sounds/undo'), 1.0, 1.0, 0.1);
 
     // Always use milliseconds for undoing
     this.note.length = oldLength;

--- a/source/funkin/ui/debug/charting/commands/MoveEventsCommand.hx
+++ b/source/funkin/ui/debug/charting/commands/MoveEventsCommand.hx
@@ -64,7 +64,7 @@ class MoveEventsCommand implements ChartEditorCommand
     state.currentSongChartEventData = state.currentSongChartEventData.concat(movedEvents);
     state.currentEventSelection = movedEvents;
 
-    state.playSound(Paths.sound('ui/editors/chart-editor/charting-sounds/note-place'));
+    state.playSound(Paths.sound('ui/editors/chart-editor/charting-sounds/note-place'), 1.0, 1.0, 0.1);
 
     state.saveDataDirty = true;
     state.noteDisplayDirty = true;

--- a/source/funkin/ui/debug/charting/commands/MoveEventsCommand.hx
+++ b/source/funkin/ui/debug/charting/commands/MoveEventsCommand.hx
@@ -51,7 +51,7 @@ class MoveEventsCommand implements ChartEditorCommand
     state.currentSongChartEventData = state.currentSongChartEventData.concat(movedEvents);
     state.currentEventSelection = movedEvents;
 
-    state.playSound(Paths.sound('chartingSounds/noteLay'));
+    state.playSound(Paths.sound('chartingSounds/noteLay'), 1.0, 1.0, 0.1);
 
     state.saveDataDirty = true;
     state.noteDisplayDirty = true;

--- a/source/funkin/ui/debug/charting/commands/MoveItemsCommand.hx
+++ b/source/funkin/ui/debug/charting/commands/MoveItemsCommand.hx
@@ -77,7 +77,7 @@ class MoveItemsCommand implements ChartEditorCommand
     state.currentNoteSelection = movedNotes;
     state.currentEventSelection = movedEvents;
 
-    state.playSound(Paths.sound('ui/editors/chart-editor/charting-sounds/note-place'));
+    state.playSound(Paths.sound('ui/editors/chart-editor/charting-sounds/note-place'), 1.0, 1.0, 0.1);
 
     state.saveDataDirty = true;
     state.noteDisplayDirty = true;

--- a/source/funkin/ui/debug/charting/commands/MoveItemsCommand.hx
+++ b/source/funkin/ui/debug/charting/commands/MoveItemsCommand.hx
@@ -65,7 +65,7 @@ class MoveItemsCommand implements ChartEditorCommand
     state.currentNoteSelection = movedNotes;
     state.currentEventSelection = movedEvents;
 
-    state.playSound(Paths.sound('chartingSounds/noteLay'));
+    state.playSound(Paths.sound('chartingSounds/noteLay'), 1.0, 1.0, 0.1);
 
     state.saveDataDirty = true;
     state.noteDisplayDirty = true;

--- a/source/funkin/ui/debug/charting/commands/MoveNotesCommand.hx
+++ b/source/funkin/ui/debug/charting/commands/MoveNotesCommand.hx
@@ -69,7 +69,7 @@ class MoveNotesCommand implements ChartEditorCommand
     state.currentSongChartNoteData = state.currentSongChartNoteData.concat(movedNotes);
     state.currentNoteSelection = movedNotes;
 
-    state.playSound(Paths.sound('ui/editors/chart-editor/charting-sounds/note-place'));
+    state.playSound(Paths.sound('ui/editors/chart-editor/charting-sounds/note-place'), 1.0, 1.0, 0.1);
 
     state.saveDataDirty = true;
     state.noteDisplayDirty = true;

--- a/source/funkin/ui/debug/charting/commands/MoveNotesCommand.hx
+++ b/source/funkin/ui/debug/charting/commands/MoveNotesCommand.hx
@@ -53,7 +53,7 @@ class MoveNotesCommand implements ChartEditorCommand
     state.currentSongChartNoteData = state.currentSongChartNoteData.concat(movedNotes);
     state.currentNoteSelection = movedNotes;
 
-    state.playSound(Paths.sound('chartingSounds/noteLay'));
+    state.playSound(Paths.sound('chartingSounds/noteLay'), 1.0, 1.0, 0.1);
 
     state.saveDataDirty = true;
     state.noteDisplayDirty = true;

--- a/source/funkin/ui/debug/charting/commands/PasteItemsCommand.hx
+++ b/source/funkin/ui/debug/charting/commands/PasteItemsCommand.hx
@@ -108,7 +108,7 @@ class PasteItemsCommand implements ChartEditorCommand
    */
   public function undo(state:ChartEditorState):Void
   {
-    state.playSound(Paths.sound('ui/editors/chart-editor/charting-sounds/undo'));
+    state.playSound(Paths.sound('ui/editors/chart-editor/charting-sounds/undo'), 1.0, 1.0, 0.1);
 
     state.currentSongChartNoteData = SongDataUtils.subtractNotes(state.currentSongChartNoteData, addedNotes).concat(removedNotes);
     state.currentSongChartEventData = SongDataUtils.subtractEvents(state.currentSongChartEventData, addedEvents);

--- a/source/funkin/ui/debug/charting/commands/PasteItemsCommand.hx
+++ b/source/funkin/ui/debug/charting/commands/PasteItemsCommand.hx
@@ -90,7 +90,7 @@ class PasteItemsCommand implements ChartEditorCommand
 
   public function undo(state:ChartEditorState):Void
   {
-    state.playSound(Paths.sound('chartingSounds/undo'));
+    state.playSound(Paths.sound('chartingSounds/undo'), 1.0, 1.0, 0.1);
 
     state.currentSongChartNoteData = SongDataUtils.subtractNotes(state.currentSongChartNoteData, addedNotes).concat(removedNotes);
     state.currentSongChartEventData = SongDataUtils.subtractEvents(state.currentSongChartEventData, addedEvents);

--- a/source/funkin/ui/debug/charting/commands/RemoveEventsCommand.hx
+++ b/source/funkin/ui/debug/charting/commands/RemoveEventsCommand.hx
@@ -30,7 +30,7 @@ class RemoveEventsCommand implements ChartEditorCommand
     state.currentSongChartEventData = SongDataUtils.subtractEvents(state.currentSongChartEventData, events);
     state.currentEventSelection = [];
 
-    state.playSound(Paths.sound('ui/editors/chart-editor/charting-sounds/note-erase'));
+    state.playSound(Paths.sound('ui/editors/chart-editor/charting-sounds/note-erase'), 1.0, 1.0, 0.1);
 
     state.saveDataDirty = true;
     state.noteDisplayDirty = true;
@@ -54,7 +54,7 @@ class RemoveEventsCommand implements ChartEditorCommand
       state.currentSongChartEventData.pushUnique(event);
     }
     state.currentEventSelection = events;
-    state.playSound(Paths.sound('ui/editors/chart-editor/charting-sounds/undo'));
+    state.playSound(Paths.sound('ui/editors/chart-editor/charting-sounds/undo'), 1.0, 1.0, 0.1);
 
     state.saveDataDirty = true;
     state.noteDisplayDirty = true;

--- a/source/funkin/ui/debug/charting/commands/RemoveEventsCommand.hx
+++ b/source/funkin/ui/debug/charting/commands/RemoveEventsCommand.hx
@@ -25,7 +25,7 @@ class RemoveEventsCommand implements ChartEditorCommand
     state.currentSongChartEventData = SongDataUtils.subtractEvents(state.currentSongChartEventData, events);
     state.currentEventSelection = [];
 
-    state.playSound(Paths.sound('chartingSounds/noteErase'));
+    state.playSound(Paths.sound('chartingSounds/noteErase'), 1.0, 1.0, 0.1);
 
     state.saveDataDirty = true;
     state.noteDisplayDirty = true;
@@ -44,7 +44,7 @@ class RemoveEventsCommand implements ChartEditorCommand
       state.currentSongChartEventData.push(event);
     }
     state.currentEventSelection = events;
-    state.playSound(Paths.sound('chartingSounds/undo'));
+    state.playSound(Paths.sound('chartingSounds/undo'), 1.0, 1.0, 0.1);
 
     state.saveDataDirty = true;
     state.noteDisplayDirty = true;

--- a/source/funkin/ui/debug/charting/commands/RemoveItemsCommand.hx
+++ b/source/funkin/ui/debug/charting/commands/RemoveItemsCommand.hx
@@ -36,7 +36,7 @@ class RemoveItemsCommand implements ChartEditorCommand
     state.currentNoteSelection = [];
     state.currentEventSelection = [];
 
-    state.playSound(Paths.sound('ui/editors/chart-editor/charting-sounds/note-erase'));
+    state.playSound(Paths.sound('ui/editors/chart-editor/charting-sounds/note-erase'), 1.0, 1.0, 0.1);
 
     state.saveDataDirty = true;
     state.noteDisplayDirty = true;
@@ -68,7 +68,7 @@ class RemoveItemsCommand implements ChartEditorCommand
     state.currentNoteSelection = notes;
     state.currentEventSelection = events;
 
-    state.playSound(Paths.sound('ui/editors/chart-editor/charting-sounds/undo'));
+    state.playSound(Paths.sound('ui/editors/chart-editor/charting-sounds/undo'), 1.0, 1.0, 0.1);
 
     state.saveDataDirty = true;
     state.noteDisplayDirty = true;

--- a/source/funkin/ui/debug/charting/commands/RemoveItemsCommand.hx
+++ b/source/funkin/ui/debug/charting/commands/RemoveItemsCommand.hx
@@ -31,7 +31,7 @@ class RemoveItemsCommand implements ChartEditorCommand
     state.currentNoteSelection = [];
     state.currentEventSelection = [];
 
-    state.playSound(Paths.sound('chartingSounds/noteErase'));
+    state.playSound(Paths.sound('chartingSounds/noteErase'), 1.0, 1.0, 0.1);
 
     state.saveDataDirty = true;
     state.noteDisplayDirty = true;
@@ -58,7 +58,7 @@ class RemoveItemsCommand implements ChartEditorCommand
     state.currentNoteSelection = notes;
     state.currentEventSelection = events;
 
-    state.playSound(Paths.sound('chartingSounds/undo'));
+    state.playSound(Paths.sound('chartingSounds/undo'), 1.0, 1.0, 0.1);
 
     state.saveDataDirty = true;
     state.noteDisplayDirty = true;

--- a/source/funkin/ui/debug/charting/commands/RemoveNotesCommand.hx
+++ b/source/funkin/ui/debug/charting/commands/RemoveNotesCommand.hx
@@ -31,7 +31,7 @@ class RemoveNotesCommand implements ChartEditorCommand
     state.currentNoteSelection = [];
     state.currentEventSelection = [];
 
-    state.playSound(Paths.sound('ui/editors/chart-editor/charting-sounds/note-erase'));
+    state.playSound(Paths.sound('ui/editors/chart-editor/charting-sounds/note-erase'), 1.0, 1.0, 0.1);
 
     state.saveDataDirty = true;
     state.noteDisplayDirty = true;
@@ -56,7 +56,7 @@ class RemoveNotesCommand implements ChartEditorCommand
     }
     state.currentNoteSelection = notes;
     state.currentEventSelection = [];
-    state.playSound(Paths.sound('ui/editors/chart-editor/charting-sounds/undo'));
+    state.playSound(Paths.sound('ui/editors/chart-editor/charting-sounds/undo'), 1.0, 1.0, 0.1);
 
     state.saveDataDirty = true;
     state.noteDisplayDirty = true;

--- a/source/funkin/ui/debug/charting/commands/RemoveNotesCommand.hx
+++ b/source/funkin/ui/debug/charting/commands/RemoveNotesCommand.hx
@@ -26,7 +26,7 @@ class RemoveNotesCommand implements ChartEditorCommand
     state.currentNoteSelection = [];
     state.currentEventSelection = [];
 
-    state.playSound(Paths.sound('chartingSounds/noteErase'));
+    state.playSound(Paths.sound('chartingSounds/noteErase'), 1.0, 1.0, 0.1);
 
     state.saveDataDirty = true;
     state.noteDisplayDirty = true;
@@ -46,7 +46,7 @@ class RemoveNotesCommand implements ChartEditorCommand
     }
     state.currentNoteSelection = notes;
     state.currentEventSelection = [];
-    state.playSound(Paths.sound('chartingSounds/undo'));
+    state.playSound(Paths.sound('chartingSounds/undo'), 1.0, 1.0, 0.1);
 
     state.saveDataDirty = true;
     state.noteDisplayDirty = true;

--- a/source/funkin/ui/debug/charting/handlers/ChartEditorAudioHandler.hx
+++ b/source/funkin/ui/debug/charting/handlers/ChartEditorAudioHandler.hx
@@ -276,7 +276,7 @@ class ChartEditorAudioHandler
   public static function playSound(_state:ChartEditorState, path:String, volume:Float = 1.0, pitch:Float = 1.0, pitchRandom:Float = 0):Void
   {
     if (volume == 0) return;
-    if (pitchRandom != 0)
+    if (_state.menubarItemRandomPitch.selected && pitchRandom != 0)
     {
       pitch = FlxG.random.float(pitch - pitchRandom / 2, pitch + pitchRandom / 2);
     }

--- a/source/funkin/ui/debug/charting/handlers/ChartEditorAudioHandler.hx
+++ b/source/funkin/ui/debug/charting/handlers/ChartEditorAudioHandler.hx
@@ -269,9 +269,17 @@ class ChartEditorAudioHandler
    * Play a sound effect.
    * Automatically cleans up after itself and recycles previous FlxSound instances if available, for performance.
    * @param path The path to the sound effect. Use `Paths` to build this.
+   * @param volume The volume of the sound effect.
+   * @param pitch The pitch and speed the sound effect is played at.
+   * @param pitchRandom The total random variation of the pitch.
    */
-  public static function playSound(_state:ChartEditorState, path:String, volume:Float = 1.0):Void
+  public static function playSound(_state:ChartEditorState, path:String, volume:Float = 1.0, pitch:Float = 1.0, pitchRandom:Float = 0):Void
   {
+    if (volume == 0) return;
+    if (pitchRandom != 0)
+    {
+      pitch = FlxG.random.float(pitch - pitchRandom / 2, pitch + pitchRandom / 2);
+    }
     var asset:Null<FlxSoundAsset> = FlxG.sound.cache(path);
     if (asset == null)
     {
@@ -283,6 +291,9 @@ class ChartEditorAudioHandler
     snd.autoDestroy = true;
     snd.play(true);
     snd.volume = volume;
+    #if FLX_PITCH
+    snd.pitch = pitch;
+    #end
   }
 
   /**

--- a/source/funkin/ui/debug/charting/handlers/ChartEditorAudioHandler.hx
+++ b/source/funkin/ui/debug/charting/handlers/ChartEditorAudioHandler.hx
@@ -291,9 +291,17 @@ class ChartEditorAudioHandler
    * Play a sound effect.
    * Automatically cleans up after itself and recycles previous FlxSound instances if available, for performance.
    * @param path The path to the sound effect. Use `Paths` to build this.
+   * @param volume The volume of the sound effect.
+   * @param pitch The pitch and speed the sound effect is played at.
+   * @param pitchRandom The total random variation of the pitch.
    */
-  public static function playSound(_state:ChartEditorState, path:String, volume:Float = 1.0):Void
+  public static function playSound(_state:ChartEditorState, path:String, volume:Float = 1.0, pitch:Float = 1.0, pitchRandom:Float = 0):Void
   {
+    if (volume == 0) return;
+    if (pitchRandom != 0)
+    {
+      pitch = FlxG.random.float(pitch - pitchRandom / 2, pitch + pitchRandom / 2);
+    }
     var asset:Null<FlxSoundAsset> = FlxG.sound.cache(path);
     if (asset == null)
     {
@@ -305,6 +313,9 @@ class ChartEditorAudioHandler
     snd.autoDestroy = true;
     snd.play(true);
     snd.volume = volume;
+    #if FLX_PITCH
+    snd.pitch = pitch;
+    #end
   }
 
   /**

--- a/source/funkin/ui/debug/charting/handlers/ChartEditorAudioHandler.hx
+++ b/source/funkin/ui/debug/charting/handlers/ChartEditorAudioHandler.hx
@@ -298,7 +298,7 @@ class ChartEditorAudioHandler
   public static function playSound(_state:ChartEditorState, path:String, volume:Float = 1.0, pitch:Float = 1.0, pitchRandom:Float = 0):Void
   {
     if (volume == 0) return;
-    if (pitchRandom != 0)
+    if (_state.menubarItemRandomPitch.selected && pitchRandom != 0)
     {
       pitch = FlxG.random.float(pitch - pitchRandom / 2, pitch + pitchRandom / 2);
     }

--- a/source/funkin/ui/debug/charting/handlers/ChartEditorToolboxHandler.hx
+++ b/source/funkin/ui/debug/charting/handlers/ChartEditorToolboxHandler.hx
@@ -44,7 +44,7 @@ class ChartEditorToolboxHandler
     {
       toolbox.showDialog(false);
 
-      state.playSound(Paths.sound('chartingSounds/openWindow'));
+      state.playSound(Paths.sound('chartingSounds/openWindow'), 1.0, 1.0, 0.1);
 
       switch (id)
       {
@@ -88,7 +88,7 @@ class ChartEditorToolboxHandler
     {
       toolbox.hideDialog(DialogButton.CANCEL);
 
-      state.playSound(Paths.sound('chartingSounds/exitWindow'));
+      state.playSound(Paths.sound('chartingSounds/exitWindow'), 1.0, 1.0, 0.1);
 
       switch (id)
       {

--- a/source/funkin/ui/debug/charting/handlers/ChartEditorToolboxHandler.hx
+++ b/source/funkin/ui/debug/charting/handlers/ChartEditorToolboxHandler.hx
@@ -55,7 +55,7 @@ class ChartEditorToolboxHandler
       toolbox.showDialog(false);
       clearHaxeUIFocus();
 
-      state.playSound(Paths.sound('ui/editors/chart-editor/charting-sounds/window-open'));
+      state.playSound(Paths.sound('ui/editors/chart-editor/charting-sounds/window-open'), 1.0, 1.0, 0.1);
 
       switch (id)
       {
@@ -100,7 +100,7 @@ class ChartEditorToolboxHandler
       clearHaxeUIFocus();
       toolbox.hideDialog(DialogButton.CANCEL);
 
-      state.playSound(Paths.sound('ui/editors/chart-editor/charting-sounds/window-exit'));
+      state.playSound(Paths.sound('ui/editors/chart-editor/charting-sounds/window-exit'), 1.0, 1.0, 0.1);
 
       switch (id)
       {


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->
## Does this PR close any issues? If so, link them below.
Closes #2435
## Briefly describe the issue(s) fixed.
Random sound pitch for the chart editor sfxs so that you don't go crazy hearing the exact same funkin click sound over and over and over and over.................

Randomly pitches the click and stretch sfxs by 0.2, and note lay, note erase, undo, hitsounds and window sfxs by 0.1. The note lay sound played for dragging notes only has a 0.05 variation.

Also adds an option to play hitsounds at a different pitch for each note direction:
Left: 0.75
Down: 0.65
Up: 1
Right: 0.85

Lemme know if I should change the pitches above to something different! 
For example, maybe I should instead set them to:
Left: 0.95 
Down: 0.8 
Up: 1.25 
Right: 1.1

>[!IMPORTANT]
> Requires this https://github.com/FunkinCrew/funkin.assets/pull/336 assets PR.

## Include any relevant screenshots or videos.

<details>

<summary>first version/video</summary>

https://github.com/user-attachments/assets/2b39cb22-32f8-49eb-85fb-a343e8638f37

</details>

https://github.com/user-attachments/assets/96ac7179-cf10-4387-8fba-4936716007b4

Hitsounds pitch variation:

https://github.com/user-attachments/assets/5f70cd39-0caf-4f95-94ac-e700deed05d3

Hitsounds pitch variation + note direction pitch:

https://github.com/user-attachments/assets/6b2c6fd5-8c61-406c-8a49-42e19a1d7812
