### PR TITLE
[ENHANCEMENT] Chart Editor - Toggle audio volume hotkeys

### DIFF
--- a/source/funkin/ui/debug/charting/ChartEditorState.hx
+++ b/source/funkin/ui/debug/charting/ChartEditorState.hx
@@ -5879,80 +5879,68 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
       // Changing values of the audio slider directly because it'll update the audio anyway and makes this code much cleaner, though more verbose.
       var oldValue = previousAudioVolumes[0];
       previousAudioVolumes[0] = menubarItemVolumeMetronome.value;
-      if (oldValue > menubarItemVolumeMetronome.value) menubarItemVolumeMetronome.value = oldValue;
-      else
-      {
-        menubarItemVolumeMetronome.value = (menubarItemVolumeMetronome.value == 0) ? 100 : 0;
-      }
+      menubarItemVolumeMetronome.value = (menubarItemVolumeMetronome.value == 0) ? (oldValue > menubarItemVolumeMetronome.value) ? oldValue : 100 : 0;
     }
     // Hitsounds volume toggle
     if (!isHaxeUIFocused && FlxG.keys.pressed.SHIFT && FlxG.keys.justPressed.H)
     {
-      var oldValue = previousAudioVolumes[1];
+      var oldBFValue = previousAudioVolumes[1];
       previousAudioVolumes[1] = menubarItemVolumeHitsoundPlayer.value;
-      if (oldValue > menubarItemVolumeHitsoundPlayer.value) menubarItemVolumeHitsoundPlayer.value = oldValue;
-      else
-      {
-        menubarItemVolumeHitsoundPlayer.value = (menubarItemVolumeHitsoundPlayer.value == 0) ? 100 : 0;
-      }
-      oldValue = previousAudioVolumes[2];
+      var oldDadValue = previousAudioVolumes[2];
       previousAudioVolumes[2] = menubarItemVolumeHitsoundOpponent.value;
-      if (oldValue > menubarItemVolumeHitsoundOpponent.value) menubarItemVolumeHitsoundOpponent.value = oldValue;
+      if (oldBFValue <= menubarItemVolumeHitsoundPlayer.value || oldDadValue <= menubarItemVolumeHitsoundOpponent.value)
+      {
+        if (menubarItemVolumeHitsoundPlayer.value == 0 && menubarItemVolumeHitsoundOpponent.value == 0)
+        {
+          menubarItemVolumeHitsoundPlayer.value = (oldBFValue > menubarItemVolumeHitsoundPlayer.value) ? oldBFValue : 100;
+          menubarItemVolumeHitsoundOpponent.value = (oldDadValue > menubarItemVolumeHitsoundOpponent.value) ? oldDadValue : 100;
+        }
+        else
+        {
+          if (oldBFValue > menubarItemVolumeHitsoundPlayer.value) previousAudioVolumes[1] = oldBFValue;
+          if (oldDadValue > menubarItemVolumeHitsoundOpponent.value) previousAudioVolumes[2] = oldDadValue;
+          menubarItemVolumeHitsoundPlayer.value = 0;
+          menubarItemVolumeHitsoundOpponent.value = 0;
+        }
+      }
       else
       {
-        menubarItemVolumeHitsoundOpponent.value = (menubarItemVolumeHitsoundOpponent.value == 0) ? 100 : 0;
+        menubarItemVolumeHitsoundPlayer.value = (oldBFValue > menubarItemVolumeHitsoundPlayer.value) ? oldBFValue : 100;
+        menubarItemVolumeHitsoundOpponent.value = (oldDadValue > menubarItemVolumeHitsoundOpponent.value) ? oldDadValue : 100;
       }
+      // menubarItemVolumeHitsoundPlayer.value = (menubarItemVolumeHitsoundPlayer.value == 0) ? (oldBFValue > menubarItemVolumeHitsoundPlayer.value) ? oldBFValue : 100 : 0;
+      // menubarItemVolumeHitsoundOpponent.value = (menubarItemVolumeHitsoundOpponent.value == 0) ? (oldDadValue > menubarItemVolumeHitsoundOpponent.value) ? oldDadValue : 100 : 0;
     }
     // Instrumental volume toggle
     if (!isHaxeUIFocused && FlxG.keys.pressed.SHIFT && FlxG.keys.justPressed.I)
     {
       var oldValue = previousAudioVolumes[3];
       previousAudioVolumes[3] = menubarItemVolumeInstrumental.value;
-      if (oldValue > menubarItemVolumeInstrumental.value) menubarItemVolumeInstrumental.value = oldValue;
-      else
-      {
-        menubarItemVolumeInstrumental.value = (menubarItemVolumeInstrumental.value == 0) ? 100 : 0;
-      }
+      menubarItemVolumeInstrumental.value = (menubarItemVolumeInstrumental.value == 0) ? (oldValue > menubarItemVolumeInstrumental.value) ? oldValue : 100 : 0;
     }
     // Vocals volume toggle
     if (!isHaxeUIFocused && FlxG.keys.pressed.SHIFT && FlxG.keys.justPressed.V)
     {
       var oldValue = previousAudioVolumes[4];
       previousAudioVolumes[4] = menubarItemVolumeVocalsPlayer.value;
-      if (oldValue > menubarItemVolumeVocalsPlayer.value) menubarItemVolumeVocalsPlayer.value = oldValue;
-      else
-      {
-        menubarItemVolumeVocalsPlayer.value = (menubarItemVolumeVocalsPlayer.value == 0) ? 100 : 0;
-      }
+      menubarItemVolumeVocalsPlayer.value = (menubarItemVolumeVocalsPlayer.value == 0) ? (oldValue > menubarItemVolumeVocalsPlayer.value) ? oldValue : 100 : 0;
       oldValue = previousAudioVolumes[5];
       previousAudioVolumes[5] = menubarItemVolumeVocalsOpponent.value;
-      if (oldValue > menubarItemVolumeVocalsOpponent.value) menubarItemVolumeVocalsOpponent.value = oldValue;
-      else
-      {
-        menubarItemVolumeVocalsOpponent.value = (menubarItemVolumeVocalsOpponent.value == 0) ? 100 : 0;
-      }
+      menubarItemVolumeVocalsOpponent.value = (menubarItemVolumeVocalsOpponent.value == 0) ? (oldValue > menubarItemVolumeVocalsOpponent.value) ? oldValue : 100 : 0;
     }
     // Boyfriend vocals volume toggle
     if (!isHaxeUIFocused && FlxG.keys.pressed.SHIFT && FlxG.keys.justPressed.B)
     {
       var oldValue = previousAudioVolumes[4];
       previousAudioVolumes[4] = menubarItemVolumeVocalsPlayer.value;
-      if (oldValue > menubarItemVolumeVocalsPlayer.value) menubarItemVolumeVocalsPlayer.value = oldValue;
-      else
-      {
-        menubarItemVolumeVocalsPlayer.value = (menubarItemVolumeVocalsPlayer.value == 0) ? 100 : 0;
-      }
+      menubarItemVolumeVocalsPlayer.value = (menubarItemVolumeVocalsPlayer.value == 0) ? (oldValue > menubarItemVolumeVocalsPlayer.value) ? oldValue : 100 : 0;
     }
     // Dad vocals volume toggle
     if (!isHaxeUIFocused && FlxG.keys.pressed.SHIFT && FlxG.keys.justPressed.D)
     {
       var oldValue = previousAudioVolumes[5];
       previousAudioVolumes[5] = menubarItemVolumeVocalsOpponent.value;
-      if (oldValue > menubarItemVolumeVocalsOpponent.value) menubarItemVolumeVocalsOpponent.value = oldValue;
-      else
-      {
-        menubarItemVolumeVocalsOpponent.value = (menubarItemVolumeVocalsOpponent.value == 0) ? 100 : 0;
-      }
+      menubarItemVolumeVocalsOpponent.value = (menubarItemVolumeVocalsOpponent.value == 0) ? (oldValue > menubarItemVolumeVocalsOpponent.value) ? oldValue : 100 : 0;
     }
   }
 

--- a/source/funkin/ui/debug/charting/ChartEditorState.hx
+++ b/source/funkin/ui/debug/charting/ChartEditorState.hx
@@ -731,6 +731,12 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
   var hitsoundVolumeOpponent:Float = 1.0;
 
   /**
+   * The audio volume before it was toggled to zero.
+   * Metronome, hitsounds (player and enemy), instrumental, vocals (player and enemy)
+   */
+  var previousAudioVolumes:Array<Float> = [1.0, 1.0, 1.0, 1.0, 1.0, 1.0];
+
+  /**
    * Whether hitsounds are enabled for at least one character.
    */
   var hitsoundsEnabled(get, never):Bool;
@@ -3148,6 +3154,7 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
       menubarLabelVolumeMetronome.text = 'Metronome - ${Std.int(event.value)}%';
     };
     menubarItemVolumeMetronome.value = Std.int(metronomeVolume * 100);
+    previousAudioVolumes[0] = Std.int(metronomeVolume * 100);
 
     menubarItemThemeMusic.onChange = event -> {
       this.welcomeMusic.active = event.value;
@@ -3161,6 +3168,7 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
       menubarLabelVolumeHitsoundPlayer.text = 'Player - ${Std.int(event.value)}%';
     };
     menubarItemVolumeHitsoundPlayer.value = Std.int(hitsoundVolumePlayer * 100);
+    previousAudioVolumes[1] = Std.int(hitsoundVolumePlayer * 100);
 
     menubarItemVolumeHitsoundOpponent.onChange = event -> {
       var volume:Float = event.value.toFloat() / 100.0;
@@ -3168,24 +3176,28 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
       menubarLabelVolumeHitsoundOpponent.text = 'Enemy - ${Std.int(event.value)}%';
     };
     menubarItemVolumeHitsoundOpponent.value = Std.int(hitsoundVolumeOpponent * 100);
+    previousAudioVolumes[2] = Std.int(hitsoundVolumeOpponent * 100);
 
     menubarItemVolumeInstrumental.onChange = event -> {
       var volume:Float = event.value.toFloat() / 100.0;
       if (audioInstTrack != null) audioInstTrack.volume = volume;
       menubarLabelVolumeInstrumental.text = 'Instrumental - ${Std.int(event.value)}%';
     };
+    previousAudioVolumes[3] = menubarLabelVolumeInstrumental.value;
 
     menubarItemVolumeVocalsPlayer.onChange = event -> {
       var volume:Float = event.value.toFloat() / 100.0;
       audioVocalTrackGroup.playerVolume = volume;
       menubarLabelVolumeVocalsPlayer.text = 'Player - ${Std.int(event.value)}%';
     };
+    previousAudioVolumes[4] = menubarLabelVolumeVocalsPlayer.value;
 
     menubarItemVolumeVocalsOpponent.onChange = event -> {
       var volume:Float = event.value.toFloat() / 100.0;
       audioVocalTrackGroup.opponentVolume = volume;
       menubarLabelVolumeVocalsOpponent.text = 'Enemy - ${Std.int(event.value)}%';
     };
+    previousAudioVolumes[5] = menubarLabelVolumeVocalsOpponent.value;
 
     menubarItemPlaybackSpeed.onChange = event -> {
       var pitch:Float = (event.value.toFloat() * 2.0) / 100.0;
@@ -3436,6 +3448,7 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
     handleViewKeybinds();
     handleTestKeybinds();
     handleHelpKeybinds();
+    handleAudioKeybinds();
 
     #if FEATURE_DEBUG_FUNCTIONS
     handleQuickWatch();
@@ -5852,6 +5865,94 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
     if (FlxG.keys.justPressed.F1 && !isHaxeUIDialogOpen)
     {
       this.openUserGuideDialog();
+    }
+  }
+
+  /**
+   * Handle keybinds for audio playback.
+   */
+  function handleAudioKeybinds():Void
+  {
+    // Metronome volume toggle
+    if (!isHaxeUIFocused && FlxG.keys.pressed.SHIFT && FlxG.keys.justPressed.M)
+    {
+      // Changing values of the audio slider directly because it'll update the audio anyway and makes this code much cleaner, though more verbose.
+      var oldValue = previousAudioVolumes[0];
+      previousAudioVolumes[0] = menubarItemVolumeMetronome.value;
+      if (oldValue > menubarItemVolumeMetronome.value) menubarItemVolumeMetronome.value = oldValue;
+      else
+      {
+        menubarItemVolumeMetronome.value = (menubarItemVolumeMetronome.value == 0) ? 100 : 0;
+      }
+    }
+    // Hitsounds volume toggle
+    if (!isHaxeUIFocused && FlxG.keys.pressed.SHIFT && FlxG.keys.justPressed.H)
+    {
+      var oldValue = previousAudioVolumes[1];
+      previousAudioVolumes[1] = menubarItemVolumeHitsoundPlayer.value;
+      if (oldValue > menubarItemVolumeHitsoundPlayer.value) menubarItemVolumeHitsoundPlayer.value = oldValue;
+      else
+      {
+        menubarItemVolumeHitsoundPlayer.value = (menubarItemVolumeHitsoundPlayer.value == 0) ? 100 : 0;
+      }
+      oldValue = previousAudioVolumes[2];
+      previousAudioVolumes[2] = menubarItemVolumeHitsoundOpponent.value;
+      if (oldValue > menubarItemVolumeHitsoundOpponent.value) menubarItemVolumeHitsoundOpponent.value = oldValue;
+      else
+      {
+        menubarItemVolumeHitsoundOpponent.value = (menubarItemVolumeHitsoundOpponent.value == 0) ? 100 : 0;
+      }
+    }
+    // Instrumental volume toggle
+    if (!isHaxeUIFocused && FlxG.keys.pressed.SHIFT && FlxG.keys.justPressed.I)
+    {
+      var oldValue = previousAudioVolumes[3];
+      previousAudioVolumes[3] = menubarItemVolumeInstrumental.value;
+      if (oldValue > menubarItemVolumeInstrumental.value) menubarItemVolumeInstrumental.value = oldValue;
+      else
+      {
+        menubarItemVolumeInstrumental.value = (menubarItemVolumeInstrumental.value == 0) ? 100 : 0;
+      }
+    }
+    // Vocals volume toggle
+    if (!isHaxeUIFocused && FlxG.keys.pressed.SHIFT && FlxG.keys.justPressed.V)
+    {
+      var oldValue = previousAudioVolumes[4];
+      previousAudioVolumes[4] = menubarItemVolumeVocalsPlayer.value;
+      if (oldValue > menubarItemVolumeVocalsPlayer.value) menubarItemVolumeVocalsPlayer.value = oldValue;
+      else
+      {
+        menubarItemVolumeVocalsPlayer.value = (menubarItemVolumeVocalsPlayer.value == 0) ? 100 : 0;
+      }
+      oldValue = previousAudioVolumes[5];
+      previousAudioVolumes[5] = menubarItemVolumeVocalsOpponent.value;
+      if (oldValue > menubarItemVolumeVocalsOpponent.value) menubarItemVolumeVocalsOpponent.value = oldValue;
+      else
+      {
+        menubarItemVolumeVocalsOpponent.value = (menubarItemVolumeVocalsOpponent.value == 0) ? 100 : 0;
+      }
+    }
+    // Boyfriend vocals volume toggle
+    if (!isHaxeUIFocused && FlxG.keys.pressed.SHIFT && FlxG.keys.justPressed.B)
+    {
+      var oldValue = previousAudioVolumes[4];
+      previousAudioVolumes[4] = menubarItemVolumeVocalsPlayer.value;
+      if (oldValue > menubarItemVolumeVocalsPlayer.value) menubarItemVolumeVocalsPlayer.value = oldValue;
+      else
+      {
+        menubarItemVolumeVocalsPlayer.value = (menubarItemVolumeVocalsPlayer.value == 0) ? 100 : 0;
+      }
+    }
+    // Dad vocals volume toggle
+    if (!isHaxeUIFocused && FlxG.keys.pressed.SHIFT && FlxG.keys.justPressed.D)
+    {
+      var oldValue = previousAudioVolumes[5];
+      previousAudioVolumes[5] = menubarItemVolumeVocalsOpponent.value;
+      if (oldValue > menubarItemVolumeVocalsOpponent.value) menubarItemVolumeVocalsOpponent.value = oldValue;
+      else
+      {
+        menubarItemVolumeVocalsOpponent.value = (menubarItemVolumeVocalsOpponent.value == 0) ? 100 : 0;
+      }
     }
   }
 


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->
## Does this PR close any issues? If so, link them below.
Closes #2731
## Briefly describe the issue(s) fixed.
Adds hotkeys for toggling the volume of everything in the audio menu.

Shift + M for metronome
Shift + H for hitsounds
Shift + I for instrumental
Shift + V for vocals
Shift + B for Boyfriend vocals
Shift + D for Dad vocals
## Include any relevant screenshots or videos.

https://github.com/user-attachments/assets/ebe154ec-efc1-45c8-b762-bdc766cd7609

