### PR TITLE
[OPTIMIZATION] Optimize `FreeplayDJ`'s `onFinishAnim`

### DIFF
--- a/source/funkin/ui/freeplay/FreeplayDJ.hx
+++ b/source/funkin/ui/freeplay/FreeplayDJ.hx
@@ -236,71 +236,39 @@ class FreeplayDJ extends FlxAtlasSprite
 
   function onFinishAnim(name:String):Void
   {
-    // var name = anim.curSymbol.name;
-
-    if (name == playableCharData.getAnimationPrefix('intro'))
+    switch (currentState)
     {
-      if (PlayerRegistry.instance.hasNewCharacter())
-      {
-        currentState = NewUnlock;
-      }
-      else
-      {
+      case Intro:
+        if (PlayerRegistry.instance.hasNewCharacter())
+        {
+          currentState = NewUnlock;
+        }
+        else
+        {
+          currentState = Idle;
+        }
+        onIntroDone.dispatch();
+      case FistPump:
         currentState = Idle;
-      }
-      onIntroDone.dispatch();
-    }
-    else if (name == playableCharData.getAnimationPrefix('idle'))
-    {
-      // trace('Finished idle');
-    }
-    else if (name == playableCharData.getAnimationPrefix('confirm'))
-    {
-      // trace('Finished confirm');
-    }
-    else if (name == playableCharData.getAnimationPrefix('fistPump'))
-    {
-      // trace('Finished fist pump');
-      currentState = Idle;
-    }
-    else if (name == playableCharData.getAnimationPrefix('idleEasterEgg'))
-    {
-      // trace('Finished spook');
-      currentState = Idle;
-    }
-    else if (name == playableCharData.getAnimationPrefix('loss'))
-    {
-      // trace('Finished loss reaction');
-      currentState = Idle;
-    }
-    else if (name == playableCharData.getAnimationPrefix('cartoon'))
-    {
-      // trace('Finished cartoon');
+      case IdleEasterEgg:
+        currentState = Idle;
+      case Cartoon:
+        var frame:Int = FlxG.random.bool(33) ? playableCharData.getCartoonLoopBlinkFrame() : playableCharData.getCartoonLoopFrame();
+        var cartoonAnim:String = playableCharData.getAnimationPrefix('cartoon');
 
-      var frame:Int = FlxG.random.bool(33) ? playableCharData.getCartoonLoopBlinkFrame() : playableCharData.getCartoonLoopFrame();
-
-      // Character switches channels when the video ends, or at a 10% chance each time his idle loops.
-      if (FlxG.random.bool(5))
-      {
-        frame = playableCharData.getCartoonChannelChangeFrame();
-        // boyfriend switches channel code?
-        // runTvLogic();
-      }
-      trace('Replay idle: ${frame}');
-      playFlashAnimation(playableCharData.getAnimationPrefix('cartoon'), true, false, false, frame);
-      // trace('Finished confirm');
-    }
-    else if (name == playableCharData.getAnimationPrefix('newUnlock'))
-    {
-      // Animation should loop.
-    }
-    else if (name == playableCharData.getAnimationPrefix('charSelect'))
-    {
-      onCharSelectComplete();
-    }
-    else
-    {
-      trace('Finished ${name}');
+        // Character switches channels when the video ends, or at a 10% chance each time his idle loops.
+        if (FlxG.random.bool(5))
+        {
+          frame = playableCharData.getCartoonChannelChangeFrame();
+          // boyfriend switches channel code?
+          // runTvLogic();
+        }
+        trace('Replay idle: ${frame}');
+        playFlashAnimation(cartoonAnim, true, false, false, frame);
+      case CharSelect:
+        onCharSelectComplete();
+      default:
+        // Nothing!
     }
   }
 


### PR DESCRIPTION
Replaces the messy if/else block in `onFinishAnim` with a switch statement. This also changes the function to check `currentState` instead of the DJ's animation prefixes. This should have no effect on functionality!

(Made with help by @Lasercar lol)