### PR TITLE
[ENHANCEMENT + BUGFIX] ReflectUtil overhaul

### DIFF
--- a/source/funkin/util/ReflectUtil.hx
+++ b/source/funkin/util/ReflectUtil.hx
@@ -1,101 +1,340 @@
 package funkin.util;
 
 import Type;
+import polymod.hscript._internal.PolymodScriptClass;
+import thx.Types;
 
 class ReflectUtil
 {
-  public static function getClassFields(cls:Class<Dynamic>):Array<String>
-  {
-    return Type.getClassFields(cls);
-  }
-
-  public static function getClassFieldsOf(obj:Dynamic):Array<String>
-  {
-    return Type.getClassFields(Type.getClass(obj));
-  }
-
-  public static function getInstanceFields(cls:Class<Dynamic>):Array<String>
-  {
-    return Type.getInstanceFields(cls);
-  }
-
-  public static function getInstanceFieldsOf(obj:Dynamic):Array<String>
-  {
-    return Type.getInstanceFields(Type.getClass(obj));
-  }
-
+  /**
+   * Get the class name of a class type.
+   * 
+   * @param cls The class type.
+   * @return The class name.
+   */
   public static function getClassName(cls:Class<Dynamic>):String
   {
     return Type.getClassName(cls);
   }
 
+  /**
+   * Get the class name of an object, class instance, or script class instance.
+   * 
+   * @param obj The object instance.
+   * @return The class name, or "null" if the object was not of a class.
+   */
   public static function getClassNameOf(obj:Dynamic):String
   {
-    return Type.getClassName(Type.getClass(obj));
+    @:nullSafety(Loose) @:privateAccess if (obj._asc is PolymodScriptClass) return obj._asc.get_className();
+    var cls:Class<Dynamic> = Type.getClass(obj);
+    if (cls == null) return "null";
+    return getClassName(cls);
+  }
+  
+  /**
+   * Get a list of static fields of a class.
+   * 
+   * @param cls The class type.
+   * @return An array of field names.
+   */
+  public static function getClassFields(cls:Class<Dynamic>):Array<String>
+  {
+    return Type.getClassFields(cls);
   }
 
-  public static function getAnonymousFieldsOf(obj:Dynamic):Array<String>
+  /**
+   * Get a list of static fields of an object.
+   * 
+   * @param obj The object instance.
+   * @return An array of field names, or `null` if the object was not of a class.
+   */
+  public static function getClassFieldsOf(obj:Dynamic):Null<Array<String>>
   {
-    return Reflect.fields(obj);
+    var cls:Class<Dynamic> = Type.getClass(obj);
+    if (cls == null) return null;
+    return getClassFields(cls);
   }
 
-  public static function getAnonymousField(obj:Dynamic, name:String):Dynamic
+  /**
+   * Get a list of instance fields of a class.
+   * 
+   * @param cls The class type.
+   * @return An array of field names.
+   */
+  public static function getInstanceFields(cls:Class<Dynamic>):Array<String>
   {
-    return Reflect.field(obj, name);
+    return Type.getInstanceFields(cls);
   }
 
-  public static function setAnonymousField(obj:Dynamic, name:String, value:Dynamic):Void
+  /**
+   * Get instance fields of an object or class instance.
+   * 
+   * @param obj The object instance.
+   * @return An array of field names, or `null` if the object was not an object.
+   */
+  public static function getInstanceFieldsOf(obj:Dynamic):Null<Array<String>>
   {
-    return Reflect.setField(obj, name, value);
+    var cls:Class<Dynamic> = Type.getClass(obj);
+    if (cls == null) return getFieldsOf(obj);
+    return getInstanceFields(cls);
   }
 
-  public static function hasAnonymousField(obj:Dynamic, name:String):Bool
+  /**
+   * Safely attempt to get a field of an object, or a field of a class if the field exists.
+   * 
+   * @param obj The object instance.
+   * @param name The field name.
+   * @return The field value, or `null` if the field does not exist or the object was not an object.
+   */
+  public static function getField(obj:Dynamic, name:String):Null<Dynamic>
   {
+    if (isAnonymousObject(obj) || hasField(obj, name)) return Reflect.field(obj, name);
+    return null;
+  }
+  
+  /**
+   * Get a list of fields of an object or class instance.
+   * 
+   * @param obj The object instance.
+   * @return An array of field names, or `null` if the object was not an object.
+   */
+  public static function getFieldsOf(obj:Dynamic):Null<Array<String>>
+  {
+    if (isObject(obj)) return Reflect.fields(obj);
+    return null;
+  }
+
+  /**
+   * Safely attempt to set a field of an anonymous object, or a field of a class if the field exists.
+   * 
+   * @param obj The object instance.
+   * @param name The field name.
+   * @param value The value to set.
+   * @return The input value, for chaining.
+   */
+  public static function setField(obj:Dynamic, name:String, value:Dynamic):Dynamic
+  {
+    if (isAnonymousObject(obj) || hasField(obj, name)) Reflect.setField(obj, name, value);
+    return value;
+  }
+
+  /**
+   * Check if an object or class instance has a field.
+   * 
+   * @param obj The object instance.
+   * @param name The field name.
+   * @return `true` if the field exists, and `false` otherwise or if the object was not an object.
+   */
+  public static function hasField(obj:Dynamic, name:String):Bool
+  {
+    if (!isObject(obj)) return false;
     return Reflect.hasField(obj, name);
   }
-
-  public static function copyAnonymousFieldsOf(obj:Dynamic):Dynamic
+  
+  /**
+   * Safely attempt to get a property of an object, class instance, or scripted class instance.
+   * 
+   * @param obj The object instance.
+   * @param name The property name.
+   * @return The property value, or `null` if the object was not an object or the property did not exist.
+   */
+  public static function getProperty(obj:Dynamic, name:String):Null<Dynamic>
   {
-    return Reflect.copy(obj);
+    if (!isObject(obj)) return null;
+    if (hasField(obj, name)) return Reflect.getProperty(obj, name);
+    @:nullSafety(Loose) @:privateAccess if (obj._asc is PolymodScriptClass) try return getScriptField(obj, name) catch (e:Dynamic) {}
+    return null;
   }
 
+  /**
+   * Safely attempt to set a property of an object, class instance, or scripted class instance.
+   * 
+   * @param obj The object instance.
+   * @param name The property name.
+   * @param value The value to set.
+   * @return The input value, for chaining.
+   */
+  public static function setProperty(obj:Dynamic, name:String, value:Dynamic):Dynamic
+  {
+    if (!isObject(obj)) return value;
+    if (hasField(obj, name)) Reflect.setProperty(obj, name, value);
+    else @:nullSafety(Loose) @:privateAccess if (obj._asc is PolymodScriptClass) try setScriptField(obj, name, value) catch (e:Dynamic) {}
+    else setField(obj, name, value);
+    return value;
+  }
+  
+  /**
+   * Shallow-copy an anonymous object.
+   * 
+   * @param obj The object instance.
+   * @return A new anonymous object with the same fields, or `null` if the object was not an anonymous object.
+   */
+  public static function copyAnonymousFieldsOf(obj:Dynamic):Null<Dynamic>
+  {
+    if (isAnonymousObject(obj)) return Reflect.copy(obj);
+    return null;
+  }
+
+  /**
+   * Delete a field of an anonymous object.
+   * 
+   * @param obj The object instance.
+   * @param name The field name.
+   * @return `true` if the field existed and was deleted, and `false` otherwise.
+   */
   public static function deleteAnonymousField(obj:Dynamic, name:String):Bool
   {
-    return Reflect.deleteField(obj, name);
+    if (isAnonymousObject(obj) && hasField(obj, name)) return Reflect.deleteField(obj, name);
+    return false;
   }
 
-  public static function compareValues(valueA:Dynamic, valueB:Dynamic):Int
+  /**
+   * Safely attempt to get a script field of a scripted class instance.
+   * 
+   * @param obj The scripted object instance.
+   * @param name The field name.
+   * @return The field value, or `null` if the object was not of a scripted class or the field did not exist.
+   */
+  public static function getScriptField(obj:Dynamic, name:String):Null<Dynamic>
   {
-    return Reflect.compare(valueA, valueB);
+    @:nullSafety(Loose) @:privateAccess if (obj._asc is PolymodScriptClass) try return obj.scriptGet(name) catch (e:Dynamic) {}
+    return null;
+  }
+  
+  /**
+   * Get script fields of a scripted class instance.
+   * 
+   * @param obj The scripted object instance.
+   * @return An array of field names, or `null` if the object was not of a scripted class.
+   */
+  public static function getScriptFieldsOf(obj:Dynamic):Null<Array<String>>
+  {
+    @:nullSafety(Loose) @:privateAccess if (obj._asc is PolymodScriptClass)
+    {
+      var scriptFields:Array<String> = [];
+      var decls:Null<Map<String, hscript.Expr.FieldDecl>> = cast obj._asc._cachedFieldDecls;
+      if (decls != null) for (decl in decls.iterator()) scriptFields.push(decl.name);
+      return scriptFields;
+    }
+    return null;
   }
 
+  /**
+   * Safely attempt to set a script field of a scripted class instance.
+   * 
+   * @param obj The scripted object instance.
+   * @param name The field name.
+   * @param value The value to set.
+   * @return The input value, for chaining.
+   */
+  public static function setScriptField(obj:Dynamic, name:String, value:Dynamic):Dynamic
+  {
+    @:nullSafety(Loose) @:privateAccess if (obj._asc is PolymodScriptClass) try obj.scriptSet(name, value) catch (e:Dynamic) {}
+    return value;
+  }
+
+  /**
+   * Check if a value is an anonymous object.
+   * 
+   * @param value The value.
+   * @return `true` if the object is anonymous, and `false` otherwise.
+   */
+  public static function isAnonymousObject(value:Dynamic):Bool
+  {
+    return Types.isAnonymousObject(value);
+  }
+
+  /**
+   * Check if a value is an object.
+   * 
+   * @param value The value.
+   * @return `true` if the object is an object, and `false` otherwise.
+   */
   public static function isObject(value:Dynamic):Bool
   {
-    return Reflect.isObject(value);
+    return Types.isObject(value);
   }
 
+  /**
+   * Check if a value is a function.
+   * 
+   * @param value The value.
+   * @return `true` if the object is a function, and `false` otherwise.
+   */
   public static function isFunction(value:Dynamic):Bool
   {
     return Reflect.isFunction(value);
   }
 
+  /**
+   * Check if a value is an enum value.
+   * 
+   * @param value The value.
+   * @return `true` if the object is an enum value, and `false` otherwise.
+   */
   public static function isEnumValue(value:Dynamic):Bool
   {
     return Reflect.isEnumValue(value);
   }
 
-  public static function getProperty(obj:Dynamic, name:String):Dynamic
+  /**
+   * Check if a value is a primitive.
+   * 
+   * @param value The value.
+   * @return `true` if the object is a primitive, and `false` otherwise.
+   */
+  public static function isPrimitive(value:Dynamic):Bool
   {
-    return Reflect.getProperty(obj, name);
+    return Types.isPrimitive(value);
   }
 
-  public static function setProperty(obj:Dynamic, name:String, value:Dynamic):Void
+  /**
+   * Compares `valueA` and `valueB`.
+   * 
+   * @see https://api.haxe.org/Reflect.html#compare
+   * 
+   * @param valueA The first value to compare.
+   * @param valueB The second value to compare.
+   */
+  public static function compareValues(valueA:Dynamic, valueB:Dynamic):Int
   {
-    return Reflect.setProperty(obj, name, value);
+    return Reflect.compare(valueA, valueB);
   }
 
+  /**
+   * Compares `functionA` and `functionB`.
+   * 
+   * @see https://api.haxe.org/Reflect.html#compareMethods
+   * 
+   * @param functionA The first function to compare.
+   * @param functionB The second function to compare.
+   */
   public static function compareMethods(functionA:Dynamic, functionB:Dynamic):Bool
   {
     return Reflect.compareMethods(functionA, functionB);
+  }
+
+  @:deprecated("Use `getFieldsOf` instead")
+  public static function getAnonymousFieldsOf(obj:Dynamic):Array<String>
+  {
+    return Reflect.fields(obj);
+  }
+
+  @:deprecated("Use `getField` instead")
+  public static function getAnonymousField(obj:Dynamic, name:String):Dynamic
+  {
+    return Reflect.field(obj, name);
+  }
+
+  @:deprecated("Use `setField` instead")
+  public static function setAnonymousField(obj:Dynamic, name:String, value:Dynamic):Void
+  {
+    Reflect.setField(obj, name, value);
+  }
+
+  @:deprecated("Use `hasField` instead")
+  public static function hasAnonymousField(obj:Dynamic, name:String):Bool
+  {
+    return Reflect.hasField(obj, name);
   }
 }


### PR DESCRIPTION
## Briefly describe the issue(s) fixed.

should be merged alongside https://github.com/larsiusprime/polymod/pull/202

- `getClassNameOf` now gets script class name (useful for checking like `event.targetState` on state change to a scripted state)
- added `getScriptFieldsOf`/`getScriptField`/`setScriptField`/`hasScriptField`
  - safer than `scriptGet`/`scriptSet` as they will not error
- added `getFieldsOf`/`getField`/`setField`/`hasField` (respective anonymous labeled ones are now deprecated)
- added `isAnonymousObject` and `isPrimitive`
- `getProperty`/`setProperty` now attempt to use scripted fields
- added returns to setter functions
- fix all unspecified and/or unintended behavior
- reorganized and added docs to all functions

## Include any relevant screenshots or videos.

<img src="https://github.com/user-attachments/assets/bd5aaad2-3112-4c23-aa22-974d4eab5845" width="40%">
<br>
<img src="https://github.com/user-attachments/assets/2961fc59-cb06-4776-86bc-f7977fed0105" width="70%">
<br>
<img src="https://github.com/user-attachments/assets/958715e4-9d8e-4090-ad9e-8cd240e8133b" width="50%">