### PR TITLE
[BUGFIX] Fix Chart Editor playbar millisecond display

### DIFF
--- a/source/funkin/ui/debug/charting/ChartEditorState.hx
+++ b/source/funkin/ui/debug/charting/ChartEditorState.hx
@@ -5107,7 +5107,7 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
     playbarHeadLayout.y = FlxG.height - 48 - 8;
 
     var songPos:Float = Conductor.instance.songPosition + Conductor.instance.instrumentalOffset;
-    var songPosMilliseconds:String = Std.string(Math.floor(Math.abs(songPos) % 1000)).lpad('0', 2).substr(0, 2);
+    var songPosMilliseconds:String = Std.string(Math.floor(Math.abs(songPos) % 1000)).lpad('0', 3).substr(0, 2);
     var songPosSeconds:String = Std.string(Math.floor((Math.abs(songPos) / 1000) % 60)).lpad('0', 2);
     var songPosMinutes:String = Std.string(Math.floor((Math.abs(songPos) / 1000) / 60)).lpad('0', 2);
     if (songPos < 0) songPosMinutes = '-' + songPosMinutes;


### PR DESCRIPTION
## Does this PR close any issues? If so, link them below.
Fixes #4256

## Briefly describe the issue(s) fixed.
The Chart Editor playbar timer will now display the correct number of milliseconds when below 100 ms.

## Include any relevant screenshots or videos.
https://github.com/user-attachments/assets/4c6ae17a-2c2a-4234-bfe5-12bcf8f318bf