### PR TITLE
[ENHANCEMENT] Chart Editor - Snap selection to current note snap

### DIFF
--- a/source/funkin/ui/debug/charting/ChartEditorState.hx
+++ b/source/funkin/ui/debug/charting/ChartEditorState.hx
@@ -1937,6 +1937,11 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
   var menubarItemDelete:MenuItem;
 
   /**
+   * The `Edit -> Snap Selection` menu item.
+   */
+  var menubarItemSnap:MenuItem;
+
+  /**
    * The `Edit -> Delete Stacked Notes` menu item.
    */
   var menubarItemDeleteStacked:MenuItem;
@@ -3307,6 +3312,21 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
       else
       {
         performCommand(new RemoveStackedNotesCommand(currentNoteSelection.length > 0 ? currentNoteSelection : null));
+      }
+    };
+
+    menubarItemSnap.onClick = _ -> {
+      if (currentNoteSelection.length > 0 && currentEventSelection.length > 0)
+      {
+        performCommand(new SnapItemsCommand(currentNoteSelection, currentEventSelection, noteSnapRatio));
+      }
+      else if (currentNoteSelection.length > 0)
+      {
+        performCommand(new SnapNotesCommand(currentNoteSelection, noteSnapRatio));
+      }
+      else if (currentEventSelection.length > 0)
+      {
+        performCommand(new SnapEventsCommand(currentEventSelection, noteSnapRatio));
       }
     };
 
@@ -6148,15 +6168,15 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
     {
       if (currentNoteSelection.length > 0 && currentEventSelection.length > 0)
       {
-        performCommand(new SnapItemsCommand(currentNoteSelection, currentEventSelection));
+        performCommand(new SnapItemsCommand(currentNoteSelection, currentEventSelection, noteSnapRatio));
       }
       else if (currentNoteSelection.length > 0)
       {
-        performCommand(new SnapNotesCommand(currentNoteSelection));
+        performCommand(new SnapNotesCommand(currentNoteSelection, noteSnapRatio));
       }
       else if (currentEventSelection.length > 0)
       {
-        performCommand(new SnapEventsCommand(currentEventSelection));
+        performCommand(new SnapEventsCommand(currentEventSelection, noteSnapRatio));
       }
     }
 

--- a/source/funkin/ui/debug/charting/ChartEditorState.hx
+++ b/source/funkin/ui/debug/charting/ChartEditorState.hx
@@ -64,6 +64,9 @@ import funkin.ui.debug.charting.commands.ExtendNoteLengthCommand;
 import funkin.ui.debug.charting.commands.FlipNotesCommand;
 import funkin.ui.debug.charting.commands.MirrorNotesCommand;
 import funkin.ui.debug.charting.commands.InvertSelectedItemsCommand;
+import funkin.ui.debug.charting.commands.SnapEventsCommand;
+import funkin.ui.debug.charting.commands.SnapItemsCommand;
+import funkin.ui.debug.charting.commands.SnapNotesCommand;
 import funkin.ui.debug.charting.commands.MoveEventsCommand;
 import funkin.ui.debug.charting.commands.MoveItemsCommand;
 import funkin.ui.debug.charting.commands.MoveNotesCommand;
@@ -6138,6 +6141,23 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
         targetSnappedMs;
       }
       performCommand(new PasteItemsCommand(targetMs));
+    }
+
+    // SHIFT + N = Snap
+    if (FlxG.keys.pressed.SHIFT && FlxG.keys.justPressed.N)
+    {
+      if (currentNoteSelection.length > 0 && currentEventSelection.length > 0)
+      {
+        performCommand(new SnapItemsCommand(currentNoteSelection, currentEventSelection));
+      }
+      else if (currentNoteSelection.length > 0)
+      {
+        performCommand(new SnapNotesCommand(currentNoteSelection));
+      }
+      else if (currentEventSelection.length > 0)
+      {
+        performCommand(new SnapEventsCommand(currentEventSelection));
+      }
     }
 
     // DELETE = Delete

--- a/source/funkin/ui/debug/charting/ChartEditorState.hx
+++ b/source/funkin/ui/debug/charting/ChartEditorState.hx
@@ -2092,6 +2092,11 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
   var menubarItemDelete:MenuItem;
 
   /**
+   * The `Edit -> Snap Selection` menu item.
+   */
+  var menubarItemSnap:MenuItem;
+
+  /**
    * The `Edit -> Delete Stacked Notes` menu item.
    */
   var menubarItemDeleteStacked:MenuItem;
@@ -3524,6 +3529,21 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
       else
       {
         performCommand(new RemoveStackedNotesCommand(currentNoteSelection.length > 0 ? currentNoteSelection : null));
+      }
+    };
+
+    menubarItemSnap.onClick = _ -> {
+      if (currentNoteSelection.length > 0 && currentEventSelection.length > 0)
+      {
+        performCommand(new SnapItemsCommand(currentNoteSelection, currentEventSelection, noteSnapRatio));
+      }
+      else if (currentNoteSelection.length > 0)
+      {
+        performCommand(new SnapNotesCommand(currentNoteSelection, noteSnapRatio));
+      }
+      else if (currentEventSelection.length > 0)
+      {
+        performCommand(new SnapEventsCommand(currentEventSelection, noteSnapRatio));
       }
     };
 
@@ -6698,15 +6718,15 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
     {
       if (currentNoteSelection.length > 0 && currentEventSelection.length > 0)
       {
-        performCommand(new SnapItemsCommand(currentNoteSelection, currentEventSelection));
+        performCommand(new SnapItemsCommand(currentNoteSelection, currentEventSelection, noteSnapRatio));
       }
       else if (currentNoteSelection.length > 0)
       {
-        performCommand(new SnapNotesCommand(currentNoteSelection));
+        performCommand(new SnapNotesCommand(currentNoteSelection, noteSnapRatio));
       }
       else if (currentEventSelection.length > 0)
       {
-        performCommand(new SnapEventsCommand(currentEventSelection));
+        performCommand(new SnapEventsCommand(currentEventSelection, noteSnapRatio));
       }
     }
 

--- a/source/funkin/ui/debug/charting/ChartEditorState.hx
+++ b/source/funkin/ui/debug/charting/ChartEditorState.hx
@@ -72,6 +72,9 @@ import funkin.ui.debug.charting.commands.ExtendNoteLengthCommand;
 import funkin.ui.debug.charting.commands.FlipNotesCommand;
 import funkin.ui.debug.charting.commands.InvertSelectedItemsCommand;
 import funkin.ui.debug.charting.commands.MirrorNotesCommand;
+import funkin.ui.debug.charting.commands.SnapEventsCommand;
+import funkin.ui.debug.charting.commands.SnapItemsCommand;
+import funkin.ui.debug.charting.commands.SnapNotesCommand;
 import funkin.ui.debug.charting.commands.MoveEventsCommand;
 import funkin.ui.debug.charting.commands.MoveItemsCommand;
 import funkin.ui.debug.charting.commands.MoveNotesCommand;
@@ -6688,6 +6691,23 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
         targetSnappedMs;
       }
       performCommand(new PasteItemsCommand(targetMs));
+    }
+
+    // SHIFT + N = Snap
+    if (FlxG.keys.pressed.SHIFT && FlxG.keys.justPressed.N)
+    {
+      if (currentNoteSelection.length > 0 && currentEventSelection.length > 0)
+      {
+        performCommand(new SnapItemsCommand(currentNoteSelection, currentEventSelection));
+      }
+      else if (currentNoteSelection.length > 0)
+      {
+        performCommand(new SnapNotesCommand(currentNoteSelection));
+      }
+      else if (currentEventSelection.length > 0)
+      {
+        performCommand(new SnapEventsCommand(currentEventSelection));
+      }
     }
 
     // DELETE = Delete

--- a/source/funkin/ui/debug/charting/commands/SnapEventsCommand.hx
+++ b/source/funkin/ui/debug/charting/commands/SnapEventsCommand.hx
@@ -1,0 +1,85 @@
+package funkin.ui.debug.charting.commands;
+
+import funkin.data.song.SongData.SongEventData;
+import funkin.data.song.SongData.SongNoteData;
+import funkin.data.song.SongDataUtils;
+
+/**
+ * Snap the given events to the current note snap in the chart editor.
+ */
+@:nullSafety
+@:access(funkin.ui.debug.charting.ChartEditorState)
+class SnapEventsCommand implements ChartEditorCommand
+{
+  var events:Array<SongEventData>;
+  var snappedEvents:Array<SongEventData>;
+
+  public function new(events:Array<SongEventData>)
+  {
+    // Clone the events to prevent editing from affecting the history.
+    this.events = [for (event in events) event.clone()];
+
+    this.snappedEvents = [];
+  }
+
+  public function execute(state:ChartEditorState):Void
+  {
+    state.currentSongChartEventData = SongDataUtils.subtractEvents(state.currentSongChartEventData, events);
+
+    snappedEvents = [];
+
+
+
+    for (event in events)
+    {
+      // Clone the events to prevent editing from affecting the history.
+      var resultEvent = event.clone();
+
+      var targetStep:Float = Conductor.instance.getTimeInSteps(resultEvent.time);
+      var targetSnappedStep:Float = Math.round(targetStep / state.noteSnapRatio) * state.noteSnapRatio;
+      var targetSnappedMs:Float = Conductor.instance.getStepTimeInMs(targetSnappedStep);
+
+      if (targetSnappedMs != resultEvent.time) resultEvent.time = targetSnappedMs.clamp(0, Conductor.instance.getStepTimeInMs(state.songLengthInSteps));
+
+      snappedEvents.push(resultEvent);
+    }
+
+    state.currentSongChartEventData = SongDataUtils.subtractEvents(state.currentSongChartEventData, events);
+    state.currentSongChartEventData = state.currentSongChartEventData.concat(snappedEvents);
+    state.currentEventSelection = snappedEvents;
+
+    state.playSound(Paths.sound('chartingSounds/noteLay'));
+
+    state.saveDataDirty = true;
+    state.noteDisplayDirty = true;
+    state.notePreviewDirty = true;
+
+    state.sortChartData();
+  }
+
+  public function undo(state:ChartEditorState):Void
+  {
+    state.currentSongChartEventData = SongDataUtils.subtractEvents(state.currentSongChartEventData, snappedEvents);
+    state.currentSongChartEventData = state.currentSongChartEventData.concat(events);
+
+    state.currentEventSelection = events;
+
+    state.saveDataDirty = true;
+    state.noteDisplayDirty = true;
+    state.notePreviewDirty = true;
+
+    state.sortChartData();
+  }
+
+  public function shouldAddToHistory(state:ChartEditorState):Bool
+  {
+    // This command is undoable. Add to the history if we actually performed an action.
+    return (events.length > 0);
+  }
+
+  public function toString():String
+  {
+    var len:Int = events.length;
+    return 'Snap $len Events';
+  }
+}

--- a/source/funkin/ui/debug/charting/commands/SnapEventsCommand.hx
+++ b/source/funkin/ui/debug/charting/commands/SnapEventsCommand.hx
@@ -14,12 +14,15 @@ class SnapEventsCommand implements ChartEditorCommand
   var events:Array<SongEventData>;
   var snappedEvents:Array<SongEventData>;
 
-  public function new(events:Array<SongEventData>)
+  var snapRatio:Float;
+
+  public function new(events:Array<SongEventData>, snapRatio:Float)
   {
     // Clone the events to prevent editing from affecting the history.
     this.events = [for (event in events) event.clone()];
 
     this.snappedEvents = [];
+    this.snapRatio = snapRatio;
   }
 
   public function execute(state:ChartEditorState):Void
@@ -36,7 +39,7 @@ class SnapEventsCommand implements ChartEditorCommand
       var resultEvent = event.clone();
 
       var targetStep:Float = Conductor.instance.getTimeInSteps(resultEvent.time);
-      var targetSnappedStep:Float = Math.round(targetStep / state.noteSnapRatio) * state.noteSnapRatio;
+      var targetSnappedStep:Float = Math.round(targetStep / snapRatio) * snapRatio;
       var targetSnappedMs:Float = Conductor.instance.getStepTimeInMs(targetSnappedStep);
 
       if (targetSnappedMs != resultEvent.time) resultEvent.time = targetSnappedMs.clamp(0, Conductor.instance.getStepTimeInMs(state.songLengthInSteps));

--- a/source/funkin/ui/debug/charting/commands/SnapItemsCommand.hx
+++ b/source/funkin/ui/debug/charting/commands/SnapItemsCommand.hx
@@ -1,0 +1,108 @@
+package funkin.ui.debug.charting.commands;
+
+import funkin.data.song.SongData.SongEventData;
+import funkin.data.song.SongData.SongNoteData;
+import funkin.data.song.SongDataUtils;
+
+/**
+ * Snap the given items to the current note snap in the chart editor.
+ */
+@:nullSafety
+@:access(funkin.ui.debug.charting.ChartEditorState)
+class SnapItemsCommand implements ChartEditorCommand
+{
+  var notes:Array<SongNoteData>;
+  var snappedNotes:Array<SongNoteData>;
+  var events:Array<SongEventData>;
+  var snappedEvents:Array<SongEventData>;
+
+  public function new(notes:Array<SongNoteData>, events:Array<SongEventData>)
+  {
+    // Clone the notes to prevent editing from affecting the history.
+    this.notes = notes.clone();
+    this.events = events.clone();
+
+    this.snappedNotes = [];
+    this.snappedEvents = [];
+  }
+
+  public function execute(state:ChartEditorState):Void
+  {
+    state.currentSongChartNoteData = SongDataUtils.subtractNotes(state.currentSongChartNoteData, notes);
+    state.currentSongChartEventData = SongDataUtils.subtractEvents(state.currentSongChartEventData, events);
+
+    snappedNotes = [];
+    snappedEvents = [];
+
+    for (note in notes)
+    {
+      // Clone the notes to prevent editing from affecting the history.
+      var resultNote = note.clone();
+
+      var targetStep:Float = Conductor.instance.getTimeInSteps(resultNote.time);
+      var targetSnappedStep:Float = Math.round(targetStep / state.noteSnapRatio) * state.noteSnapRatio;
+      var targetSnappedMs:Float = Conductor.instance.getStepTimeInMs(targetSnappedStep);
+
+      if (targetSnappedMs != resultNote.time) resultNote.time = targetSnappedMs.clamp(0, Conductor.instance.getStepTimeInMs(state.songLengthInSteps));
+
+      snappedNotes.push(resultNote);
+    }
+
+    for (event in events)
+    {
+      // Clone the notes to prevent editing from affecting the history.
+      var resultEvent = event.clone();
+
+      var targetStep:Float = Conductor.instance.getTimeInSteps(resultEvent.time);
+      var targetSnappedStep:Float = Math.round(targetStep / state.noteSnapRatio) * state.noteSnapRatio;
+      var targetSnappedMs:Float = Conductor.instance.getStepTimeInMs(targetSnappedStep);
+
+      if (targetSnappedMs != resultEvent.time) resultEvent.time = targetSnappedMs.clamp(0, Conductor.instance.getStepTimeInMs(state.songLengthInSteps));
+
+      snappedEvents.push(resultEvent);
+    }
+
+    state.currentSongChartNoteData = state.currentSongChartNoteData.concat(snappedNotes);
+    state.currentSongChartEventData = state.currentSongChartEventData.concat(snappedEvents);
+    state.currentNoteSelection = snappedNotes;
+    state.currentEventSelection = snappedEvents;
+
+    state.playSound(Paths.sound('chartingSounds/noteLay'));
+
+    state.saveDataDirty = true;
+    state.noteDisplayDirty = true;
+    state.notePreviewDirty = true;
+
+    state.sortChartData();
+  }
+
+  public function undo(state:ChartEditorState):Void
+  {
+
+    state.currentSongChartNoteData = SongDataUtils.subtractNotes(state.currentSongChartNoteData, snappedNotes);
+    state.currentSongChartEventData = SongDataUtils.subtractEvents(state.currentSongChartEventData, snappedEvents);
+    state.currentSongChartNoteData = state.currentSongChartNoteData.concat(notes);
+    state.currentSongChartEventData = state.currentSongChartEventData.concat(events);
+
+    state.currentNoteSelection = notes;
+    state.currentEventSelection = events;
+
+    state.saveDataDirty = true;
+    state.noteDisplayDirty = true;
+    state.notePreviewDirty = true;
+
+    state.sortChartData();
+  }
+
+  public function shouldAddToHistory(state:ChartEditorState):Bool
+  {
+    // This command is undoable. Add to the history if we actually performed an action.
+    return (notes.length > 0 || events.length > 0);
+  }
+
+  public function toString():String
+  {
+    var len:Int = notes.length + events.length;
+    return 'Snap $len Items';
+  }
+}

--- a/source/funkin/ui/debug/charting/commands/SnapItemsCommand.hx
+++ b/source/funkin/ui/debug/charting/commands/SnapItemsCommand.hx
@@ -16,7 +16,9 @@ class SnapItemsCommand implements ChartEditorCommand
   var events:Array<SongEventData>;
   var snappedEvents:Array<SongEventData>;
 
-  public function new(notes:Array<SongNoteData>, events:Array<SongEventData>)
+  var snapRatio:Float;
+
+  public function new(notes:Array<SongNoteData>, events:Array<SongEventData>, snapRatio:Float)
   {
     // Clone the notes to prevent editing from affecting the history.
     this.notes = notes.clone();
@@ -24,6 +26,7 @@ class SnapItemsCommand implements ChartEditorCommand
 
     this.snappedNotes = [];
     this.snappedEvents = [];
+    this.snapRatio = snapRatio;
   }
 
   public function execute(state:ChartEditorState):Void
@@ -40,7 +43,7 @@ class SnapItemsCommand implements ChartEditorCommand
       var resultNote = note.clone();
 
       var targetStep:Float = Conductor.instance.getTimeInSteps(resultNote.time);
-      var targetSnappedStep:Float = Math.round(targetStep / state.noteSnapRatio) * state.noteSnapRatio;
+      var targetSnappedStep:Float = Math.round(targetStep / snapRatio) * snapRatio;
       var targetSnappedMs:Float = Conductor.instance.getStepTimeInMs(targetSnappedStep);
 
       if (targetSnappedMs != resultNote.time) resultNote.time = targetSnappedMs.clamp(0, Conductor.instance.getStepTimeInMs(state.songLengthInSteps));
@@ -54,7 +57,7 @@ class SnapItemsCommand implements ChartEditorCommand
       var resultEvent = event.clone();
 
       var targetStep:Float = Conductor.instance.getTimeInSteps(resultEvent.time);
-      var targetSnappedStep:Float = Math.round(targetStep / state.noteSnapRatio) * state.noteSnapRatio;
+      var targetSnappedStep:Float = Math.round(targetStep / snapRatio) * snapRatio;
       var targetSnappedMs:Float = Conductor.instance.getStepTimeInMs(targetSnappedStep);
 
       if (targetSnappedMs != resultEvent.time) resultEvent.time = targetSnappedMs.clamp(0, Conductor.instance.getStepTimeInMs(state.songLengthInSteps));

--- a/source/funkin/ui/debug/charting/commands/SnapNotesCommand.hx
+++ b/source/funkin/ui/debug/charting/commands/SnapNotesCommand.hx
@@ -1,0 +1,81 @@
+package funkin.ui.debug.charting.commands;
+
+import funkin.data.song.SongData.SongNoteData;
+import funkin.data.song.SongDataUtils;
+
+/**
+ * Snap the given notes to the current note snap in the chart editor.
+ */
+@:nullSafety
+@:access(funkin.ui.debug.charting.ChartEditorState)
+class SnapNotesCommand implements ChartEditorCommand
+{
+  var notes:Array<SongNoteData>;
+  var snappedNotes:Array<SongNoteData>;
+
+  public function new(notes:Array<SongNoteData>)
+  {
+    // Clone the notes to prevent editing from affecting the history.
+    this.notes = [for (note in notes) note.clone()];
+
+    this.snappedNotes = [];
+  }
+
+  public function execute(state:ChartEditorState):Void
+  {
+    state.currentSongChartNoteData = SongDataUtils.subtractNotes(state.currentSongChartNoteData, notes);
+
+    snappedNotes = [];
+
+    for (note in notes)
+    {
+      // Clone the notes to prevent editing from affecting the history.
+      var resultNote = note.clone();
+
+      var targetStep:Float = Conductor.instance.getTimeInSteps(resultNote.time);
+      var targetSnappedStep:Float = Math.round(targetStep / state.noteSnapRatio) * state.noteSnapRatio;
+      var targetSnappedMs:Float = Conductor.instance.getStepTimeInMs(targetSnappedStep);
+
+      if (targetSnappedMs != resultNote.time) resultNote.time = targetSnappedMs.clamp(0, Conductor.instance.getStepTimeInMs(state.songLengthInSteps));
+
+      snappedNotes.push(resultNote);
+    }
+
+    state.currentSongChartNoteData = state.currentSongChartNoteData.concat(snappedNotes);
+    state.currentNoteSelection = snappedNotes;
+
+    state.playSound(Paths.sound('chartingSounds/noteLay'));
+
+    state.saveDataDirty = true;
+    state.noteDisplayDirty = true;
+    state.notePreviewDirty = true;
+
+    state.sortChartData();
+  }
+
+  public function undo(state:ChartEditorState):Void
+  {
+    state.currentSongChartNoteData = SongDataUtils.subtractNotes(state.currentSongChartNoteData, snappedNotes);
+    state.currentSongChartNoteData = state.currentSongChartNoteData.concat(notes);
+
+    state.currentNoteSelection = notes;
+
+    state.saveDataDirty = true;
+    state.noteDisplayDirty = true;
+    state.notePreviewDirty = true;
+
+    state.sortChartData();
+  }
+
+  public function shouldAddToHistory(state:ChartEditorState):Bool
+  {
+    // This command is undoable. Add to the history if we actually performed an action.
+    return (notes.length > 0);
+  }
+
+  public function toString():String
+  {
+    var len:Int = notes.length;
+    return 'Snap $len Notes';
+  }
+}

--- a/source/funkin/ui/debug/charting/commands/SnapNotesCommand.hx
+++ b/source/funkin/ui/debug/charting/commands/SnapNotesCommand.hx
@@ -13,12 +13,15 @@ class SnapNotesCommand implements ChartEditorCommand
   var notes:Array<SongNoteData>;
   var snappedNotes:Array<SongNoteData>;
 
-  public function new(notes:Array<SongNoteData>)
+  var snapRatio:Float;
+
+  public function new(notes:Array<SongNoteData>, snapRatio:Float)
   {
     // Clone the notes to prevent editing from affecting the history.
     this.notes = [for (note in notes) note.clone()];
 
     this.snappedNotes = [];
+    this.snapRatio = snapRatio;
   }
 
   public function execute(state:ChartEditorState):Void
@@ -33,7 +36,7 @@ class SnapNotesCommand implements ChartEditorCommand
       var resultNote = note.clone();
 
       var targetStep:Float = Conductor.instance.getTimeInSteps(resultNote.time);
-      var targetSnappedStep:Float = Math.round(targetStep / state.noteSnapRatio) * state.noteSnapRatio;
+      var targetSnappedStep:Float = Math.round(targetStep / snapRatio) * snapRatio;
       var targetSnappedMs:Float = Conductor.instance.getStepTimeInMs(targetSnappedStep);
 
       if (targetSnappedMs != resultNote.time) resultNote.time = targetSnappedMs.clamp(0, Conductor.instance.getStepTimeInMs(state.songLengthInSteps));

--- a/source/funkin/ui/debug/charting/contextmenus/ChartEditorEventContextMenu.hx
+++ b/source/funkin/ui/debug/charting/contextmenus/ChartEditorEventContextMenu.hx
@@ -9,6 +9,7 @@ import haxe.ui.core.Screen;
 import haxe.ui.events.UIEvent;
 import funkin.data.song.SongData.SongEventData;
 import funkin.ui.debug.charting.commands.MoveEventsCommand;
+import funkin.ui.debug.charting.commands.SnapEventsCommand;
 import funkin.ui.debug.charting.commands.RemoveEventsCommand;
 
 @:access(funkin.ui.debug.charting.ChartEditorState)
@@ -19,6 +20,7 @@ class ChartEditorEventContextMenu extends ChartEditorBaseContextMenu
   var contextmenuPosition:NumberStepper;
   var contextmenuUnit:DropDown;
   var contextmenuEdit:MenuItem;
+  var contextmenuSnap:MenuItem;
   var contextmenuDelete:MenuItem;
 
   public var selectedUnit:Int;
@@ -138,6 +140,11 @@ class ChartEditorEventContextMenu extends ChartEditorBaseContextMenu
     contextmenuEdit.onClick = function(_)
     {
       chartEditorState.showToolbox(ChartEditorState.CHART_EDITOR_TOOLBOX_EVENT_DATA_LAYOUT);
+    }
+
+    contextmenuSnap.onClick = function(_)
+    {
+      chartEditorState.performCommand(new SnapEventsCommand([data], chartEditorState.noteSnapRatio));
     }
 
     contextmenuDelete.onClick = function(_)

--- a/source/funkin/ui/debug/charting/contextmenus/ChartEditorEventContextMenu.hx
+++ b/source/funkin/ui/debug/charting/contextmenus/ChartEditorEventContextMenu.hx
@@ -9,6 +9,7 @@ import haxe.ui.core.Screen;
 import haxe.ui.events.UIEvent;
 import funkin.data.song.SongData.SongEventData;
 import funkin.ui.debug.charting.commands.MoveEventsCommand;
+import funkin.ui.debug.charting.commands.SnapEventsCommand;
 import funkin.ui.debug.charting.commands.RemoveEventsCommand;
 
 @:access(funkin.ui.debug.charting.ChartEditorState)
@@ -19,6 +20,7 @@ class ChartEditorEventContextMenu extends ChartEditorBaseContextMenu
   var contextmenuPosition:NumberStepper;
   var contextmenuUnit:DropDown;
   var contextmenuEdit:MenuItem;
+  var contextmenuSnap:MenuItem;
   var contextmenuDelete:MenuItem;
 
   public var selectedUnit:Int;
@@ -140,6 +142,11 @@ class ChartEditorEventContextMenu extends ChartEditorBaseContextMenu
     contextmenuEdit.onClick = function(_)
     {
       chartEditorState.showToolbox(ChartEditorState.CHART_EDITOR_TOOLBOX_EVENT_DATA_LAYOUT);
+    }
+
+    contextmenuSnap.onClick = function(_)
+    {
+      chartEditorState.performCommand(new SnapEventsCommand([data], chartEditorState.noteSnapRatio));
     }
 
     contextmenuDelete.onClick = function(_)

--- a/source/funkin/ui/debug/charting/contextmenus/ChartEditorNoteContextMenu.hx
+++ b/source/funkin/ui/debug/charting/contextmenus/ChartEditorNoteContextMenu.hx
@@ -9,6 +9,7 @@ import haxe.ui.core.Screen;
 import haxe.ui.events.UIEvent;
 import funkin.data.song.SongData.SongNoteData;
 import funkin.ui.debug.charting.commands.MoveNotesCommand;
+import funkin.ui.debug.charting.commands.SnapNotesCommand;
 import funkin.ui.debug.charting.commands.FlipNotesCommand;
 import funkin.ui.debug.charting.commands.MirrorNotesCommand;
 import funkin.ui.debug.charting.commands.RemoveNotesCommand;
@@ -22,6 +23,7 @@ class ChartEditorNoteContextMenu extends ChartEditorBaseContextMenu
   var contextmenuPosition:NumberStepper;
   var contextmenuUnit:DropDown;
   var contextmenuEdit:MenuItem;
+  var contextmenuSnap:MenuItem;
   var contextmenuFlip:MenuItem;
   var contextmenuMirrorX:MenuItem;
   var contextmenuDelete:MenuItem;
@@ -158,6 +160,11 @@ class ChartEditorNoteContextMenu extends ChartEditorBaseContextMenu
     contextmenuEdit.onClick = function(_)
     {
       chartEditorState.showToolbox(ChartEditorState.CHART_EDITOR_TOOLBOX_NOTE_DATA_LAYOUT);
+    }
+
+    contextmenuSnap.onClick = function(_)
+    {
+      chartEditorState.performCommand(new SnapNotesCommand([data], chartEditorState.noteSnapRatio));
     }
 
     contextmenuFlip.onClick = function(_)

--- a/source/funkin/ui/debug/charting/contextmenus/ChartEditorNoteContextMenu.hx
+++ b/source/funkin/ui/debug/charting/contextmenus/ChartEditorNoteContextMenu.hx
@@ -9,6 +9,7 @@ import haxe.ui.core.Screen;
 import haxe.ui.events.UIEvent;
 import funkin.data.song.SongData.SongNoteData;
 import funkin.ui.debug.charting.commands.MoveNotesCommand;
+import funkin.ui.debug.charting.commands.SnapNotesCommand;
 import funkin.ui.debug.charting.commands.FlipNotesCommand;
 import funkin.ui.debug.charting.commands.MirrorNotesCommand;
 import funkin.ui.debug.charting.commands.RemoveNotesCommand;
@@ -22,6 +23,7 @@ class ChartEditorNoteContextMenu extends ChartEditorBaseContextMenu
   var contextmenuPosition:NumberStepper;
   var contextmenuUnit:DropDown;
   var contextmenuEdit:MenuItem;
+  var contextmenuSnap:MenuItem;
   var contextmenuFlip:MenuItem;
   var contextmenuMirrorX:MenuItem;
   var contextmenuDelete:MenuItem;
@@ -160,6 +162,11 @@ class ChartEditorNoteContextMenu extends ChartEditorBaseContextMenu
     contextmenuEdit.onClick = function(_)
     {
       chartEditorState.showToolbox(ChartEditorState.CHART_EDITOR_TOOLBOX_NOTE_DATA_LAYOUT);
+    }
+
+    contextmenuSnap.onClick = function(_)
+    {
+      chartEditorState.performCommand(new SnapNotesCommand([data], chartEditorState.noteSnapRatio));
     }
 
     contextmenuFlip.onClick = function(_)

--- a/source/funkin/ui/debug/charting/contextmenus/ChartEditorSelectionContextMenu.hx
+++ b/source/funkin/ui/debug/charting/contextmenus/ChartEditorSelectionContextMenu.hx
@@ -12,6 +12,9 @@ import funkin.ui.debug.charting.commands.CutItemsCommand;
 import funkin.ui.debug.charting.commands.RemoveEventsCommand;
 import funkin.ui.debug.charting.commands.RemoveItemsCommand;
 import funkin.ui.debug.charting.commands.RemoveNotesCommand;
+import funkin.ui.debug.charting.commands.SnapEventsCommand;
+import funkin.ui.debug.charting.commands.SnapItemsCommand;
+import funkin.ui.debug.charting.commands.SnapNotesCommand;
 import funkin.ui.debug.charting.commands.FlipNotesCommand;
 import funkin.ui.debug.charting.commands.MirrorNotesCommand;
 import funkin.ui.debug.charting.commands.SelectAllItemsCommand;
@@ -29,6 +32,7 @@ class ChartEditorSelectionContextMenu extends ChartEditorBaseContextMenu
   var contextmenuCut:MenuItem;
   var contextmenuCopy:MenuItem;
   var contextmenuDelete:MenuItem;
+  var contextmenuSnap:MenuItem;
   var contextmenuFlip:MenuItem;
   var contextmenuMirrorX:MenuItem;
   var contextmenuMirrorY:MenuItem;
@@ -156,6 +160,23 @@ class ChartEditorSelectionContextMenu extends ChartEditorBaseContextMenu
         // Do nothing???
       }
     };
+
+    contextmenuSnap.onClick = function(_)
+    {
+      if (chartEditorState.currentNoteSelection.length > 0 && chartEditorState.currentEventSelection.length > 0)
+      {
+        chartEditorState.performCommand(new SnapItemsCommand(chartEditorState.currentNoteSelection, chartEditorState.currentEventSelection,
+          chartEditorState.noteSnapRatio));
+      }
+      else if (chartEditorState.currentNoteSelection.length > 0)
+      {
+        chartEditorState.performCommand(new SnapNotesCommand(chartEditorState.currentNoteSelection, chartEditorState.noteSnapRatio));
+      }
+      else if (chartEditorState.currentEventSelection.length > 0)
+      {
+        chartEditorState.performCommand(new SnapEventsCommand(chartEditorState.currentEventSelection, chartEditorState.noteSnapRatio));
+      }
+    }
 
     contextmenuFlip.onClick = function(_)
     {

--- a/source/funkin/ui/debug/charting/contextmenus/ChartEditorSelectionContextMenu.hx
+++ b/source/funkin/ui/debug/charting/contextmenus/ChartEditorSelectionContextMenu.hx
@@ -12,6 +12,9 @@ import funkin.ui.debug.charting.commands.CutItemsCommand;
 import funkin.ui.debug.charting.commands.RemoveEventsCommand;
 import funkin.ui.debug.charting.commands.RemoveItemsCommand;
 import funkin.ui.debug.charting.commands.RemoveNotesCommand;
+import funkin.ui.debug.charting.commands.SnapEventsCommand;
+import funkin.ui.debug.charting.commands.SnapItemsCommand;
+import funkin.ui.debug.charting.commands.SnapNotesCommand;
 import funkin.ui.debug.charting.commands.FlipNotesCommand;
 import funkin.ui.debug.charting.commands.MirrorNotesCommand;
 import funkin.ui.debug.charting.commands.SelectAllItemsCommand;
@@ -29,6 +32,7 @@ class ChartEditorSelectionContextMenu extends ChartEditorBaseContextMenu
   var contextmenuCopy:MenuItem;
   var contextmenuPaste:MenuItem;
   var contextmenuDelete:MenuItem;
+  var contextmenuSnap:MenuItem;
   var contextmenuFlip:MenuItem;
   var contextmenuMirrorX:MenuItem;
   var contextmenuMirrorY:MenuItem;
@@ -148,6 +152,23 @@ class ChartEditorSelectionContextMenu extends ChartEditorBaseContextMenu
         // Do nothing???
       }
     };
+
+    contextmenuSnap.onClick = function(_)
+    {
+      if (chartEditorState.currentNoteSelection.length > 0 && chartEditorState.currentEventSelection.length > 0)
+      {
+        chartEditorState.performCommand(new SnapItemsCommand(chartEditorState.currentNoteSelection, chartEditorState.currentEventSelection,
+          chartEditorState.noteSnapRatio));
+      }
+      else if (chartEditorState.currentNoteSelection.length > 0)
+      {
+        chartEditorState.performCommand(new SnapNotesCommand(chartEditorState.currentNoteSelection, chartEditorState.noteSnapRatio));
+      }
+      else if (chartEditorState.currentEventSelection.length > 0)
+      {
+        chartEditorState.performCommand(new SnapEventsCommand(chartEditorState.currentEventSelection, chartEditorState.noteSnapRatio));
+      }
+    }
 
     contextmenuFlip.onClick = function(_)
     {

--- a/source/funkin/ui/debug/charting/handlers/ChartEditorShortcutHandler.hx
+++ b/source/funkin/ui/debug/charting/handlers/ChartEditorShortcutHandler.hx
@@ -23,6 +23,9 @@ class ChartEditorShortcutHandler
     state.menubarItemCopy.shortcutText = ctrlOrCmd('C');
     state.menubarItemPaste.shortcutText = ctrlOrCmd('V');
 
+    state.menubarItemSnap.shortcutText = shift('N');
+    state.menubarItemFlipNotes.shortcutText = ctrlOrCmd('F');
+
     state.menubarItemMirrorX.shortcutText = ctrlOrCmd(shift('M'));
     state.menubarItemMirrorY.shortcutText = ctrlOrCmd(alt('M'));
     state.menubarItemMirrorXY.shortcutText = ctrlOrCmd(shift(alt('M')));


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->
## Does this PR close any issues? If so, link them below.
Closes #4122
## Briefly describe the issue(s) fixed.
Adds a command and hotkey (Shift + N) to snap the current selection to the current note snap. 

>[!IMPORTANT]
> Requires https://github.com/FunkinCrew/funkin.assets/issues/335

Now with Buttons!

## Include any relevant screenshots or videos.

https://github.com/user-attachments/assets/3992a99c-0277-4bae-8d23-bef8a832f15e

