### PR TITLE
[ENHANCEMENT] `FunkinSprite` overhaul

### DIFF
--- a/source/funkin/effects/FunkTrail.hx
+++ b/source/funkin/effects/FunkTrail.hx
@@ -48,7 +48,8 @@ class FunkTrail extends FlxTrail
     {
       var targ:Bopper = cast target;
       @:privateAccess
-      frameOffset.set((targ.animOffsets[0] - targ.globalOffsets[0]) * targ.scale.x, (targ.animOffsets[1] - targ.globalOffsets[1]) * targ.scale.y);
+      frameOffset.set((targ.currentAnimationOffsets[0] - targ.globalOffsets[0]) * targ.scale.x,
+        (targ.currentAnimationOffsets[1] - targ.globalOffsets[1]) * targ.scale.y);
 
       _recentPositions[0]?.subtract(frameOffset.x, frameOffset.y);
     }

--- a/source/funkin/graphics/FunkinAnimationController.hx
+++ b/source/funkin/graphics/FunkinAnimationController.hx
@@ -1,0 +1,30 @@
+package funkin.graphics;
+
+import funkin.graphics.FunkinSprite;
+import flixel.animation.FlxAnimationController;
+
+/**
+ * A version of `FlxAnimationController` that has custom offsets support.
+ */
+class FunkinAnimationController extends FlxAnimationController
+{
+  /**
+   * The sprite that this animation controller is attached to.
+   */
+  var _parentSprite:FunkinSprite;
+
+  public function new(sprite:FunkinSprite)
+  {
+    super(sprite);
+    _parentSprite = sprite;
+  }
+
+  /**
+   * We override `FlxAnimationController`'s `play` method to account for animation offsets.
+   */
+  public override function play(animName:String, force = false, reversed = false, frame = 0):Void
+  {
+    _parentSprite.applyAnimationOffsets(animName);
+    super.play(animName, force, reversed, frame);
+  }
+}

--- a/source/funkin/graphics/FunkinSprite.hx
+++ b/source/funkin/graphics/FunkinSprite.hx
@@ -10,6 +10,7 @@ import openfl.display.BitmapData;
 import flixel.math.FlxRect;
 import flixel.math.FlxPoint;
 import flixel.graphics.frames.FlxFrame.FlxFrameAngle;
+import funkin.graphics.FunkinAnimationController;
 import flixel.FlxCamera;
 import openfl.system.System;
 import funkin.FunkinMemory;
@@ -25,12 +26,62 @@ using StringTools;
 class FunkinSprite extends FlxSprite
 {
   /**
+   * A map of offsets for each animation.
+   */
+  public var animationOffsets:Map<String, Array<Float>> = new Map<String, Array<Float>>();
+
+  /**
+   * The current animation offset being used.
+   */
+  public var currentAnimationOffsets(default, set):Array<Float> = [0, 0];
+
+  /**
+   * Sets the current animation offset.
+   * Override this in your class if you want to handle animation offsets differently.
+   */
+  function set_currentAnimationOffsets(value:Array<Float>):Array<Float>
+  {
+    if (currentAnimationOffsets == null) currentAnimationOffsets = [0, 0];
+    if (value == null) value = [0, 0];
+    if ((currentAnimationOffsets[0] == value[0]) && (currentAnimationOffsets[1] == value[1])) return value;
+
+    return currentAnimationOffsets = value;
+  }
+
+  /**
+   * The offset of the sprite overall.
+   */
+  public var globalOffsets(default, set):Array<Float> = [0, 0];
+
+  /**
+   * Sets the global offset.
+   * Override this in your class if you want to handle global offsets differently.
+   */
+  function set_globalOffsets(value:Array<Float>):Array<Float>
+  {
+    if (globalOffsets == null) globalOffsets = [0, 0];
+    if (globalOffsets == value) return value;
+
+    return globalOffsets = value;
+  }
+
+  /**
    * @param x Starting X position
    * @param y Starting Y position
    */
   public function new(?x:Float = 0, ?y:Float = 0)
   {
     super(x, y);
+    globalOffsets = [x, y];
+  }
+
+  override function initVars():Void
+  {
+    super.initVars();
+
+    // We replace `FlxSprite`'s default animation controller with our own to handle offsets.
+    animation.destroy();
+    animation = new FunkinAnimationController(this);
   }
 
   /**
@@ -203,42 +254,103 @@ class FunkinSprite extends FlxSprite
     return FlxG.bitmap.get(key) != null;
   }
 
+  /**
+   * Ensures the texture with the given key is cached.
+   * @param key The key of the texture to cache.
+   */
   @:deprecated("Use FunkinMemory.cacheTexture() instead")
   public static function cacheTexture(key:String):Void
   {
     FunkinMemory.cacheTexture(Paths.image(key));
   }
 
+  /**
+   * Ensures the texture with the given key is cached permanently.
+   * @param key The key of the texture to cache.
+   */
   @:deprecated("Use FunkinMemory.permanentCacheTexture() instead")
   public static function permanentCacheTexture(key:String):Void
   {
     @:privateAccess FunkinMemory.permanentCacheTexture(Paths.image(key));
   }
 
+  /**
+   * Ensures the sparrow atlas with the given key is cached.
+   * @param key The key of the sparrow atlas to cache.
+   */
   @:deprecated("Use FunkinMemory.cacheTexture() instead")
   public static function cacheSparrow(key:String):Void
   {
     FunkinMemory.cacheTexture(Paths.image(key));
   }
 
+  /**
+   * Ensures the packer atlas with the given key is cached.
+   * @param key The key of the packer atlas to cache.
+   */
   @:deprecated("Use FunkinMemory.cacheTexture() instead")
   public static function cachePacker(key:String):Void
   {
     FunkinMemory.cacheTexture(Paths.image(key));
   }
 
+  /**
+   * Applies the offsets for a specific animation.
+   * @param animName The animation name.
+   */
+  public function applyAnimationOffsets(animName:String):Void
+  {
+    var offsets = animationOffsets.get(animName);
+    this.currentAnimationOffsets = offsets;
+  }
+
+  /**
+   * Define the animation offsets for a specific animation.
+   * @param name The animation name.
+   * @param xOffset The x offset.
+   * @param yOffset The y offset.
+   */
+  public function setAnimationOffsets(name:String, xOffset:Float, yOffset:Float):Void
+  {
+    animationOffsets.set(name, [xOffset, yOffset]);
+  }
+
+  /**
+   * Set the sprite scale to the appropriate value.
+   * @param scale
+   */
+  public function setScale(scale:Null<Float>):Void
+  {
+    if (scale == null) scale = 1.0;
+    this.scale.x = scale;
+    this.scale.y = scale;
+    this.updateHitbox();
+  }
+
+  /**
+   * Prepares the sprite cache for purging.
+   * Call this, then `cacheTexture` to keep the textures we still need, then `purgeCache` to remove the textures that we won't be using anymore.
+   */
   @:deprecated("Use FunkinMemory.preparePurgeTextureCache() instead")
   public static function preparePurgeCache():Void
   {
     FunkinMemory.preparePurgeTextureCache();
   }
 
+  /**
+   * Purges the old sprite cache.
+   */
   @:deprecated("Use FunkinMemory.purgeCache() instead")
   public static function purgeCache():Void
   {
     FunkinMemory.purgeCache();
   }
 
+  /**
+   * Whether or not the given graphic is cached.
+   * @param graphic The graphic to check.
+   * @return Bool
+   */
   static function isGraphicCached(graphic:FlxGraphic):Bool
   {
     var result = null;
@@ -254,6 +366,7 @@ class FunkinSprite extends FlxSprite
   }
 
   /**
+   * Whether or not the given animation is dynamic (has multiple frames).
    * @param id The animation ID to check.
    * @return Whether the animation is dynamic (has multiple frames). `false` for static, one-frame animations.
    */
@@ -264,6 +377,37 @@ class FunkinSprite extends FlxSprite
     animData = this.animation.getByName(id);
     if (animData == null) return false;
     return animData.numFrames > 1;
+  }
+
+  /**
+   * Checks whether or not the given animation exists for this sprite.
+   * @param id The name of the animation to check for.
+   * @return Whether this sprite posesses the given animation.
+   * Only true if the animation was successfully loaded from the XML.
+   */
+  public function hasAnimation(id:String):Bool
+  {
+    if (this.animation == null) return false;
+
+    return this.animation.getByName(id) != null;
+  }
+
+  /**
+   * Returns the name of the animation that is currently playing.
+   * If no animation is playing (usually this means the sprite is BROKEN!),
+   * returns an empty string to prevent NPEs.
+   */
+  public function getCurrentAnimation():String
+  {
+    return this.animation?.curAnim?.name ?? "";
+  }
+
+  /**
+   * Whether the current animation has finished playing.
+   */
+  public function isAnimationFinished():Bool
+  {
+    return this.animation?.finished ?? false;
   }
 
   /**
@@ -339,6 +483,10 @@ class FunkinSprite extends FlxSprite
     if (camera == null) camera = FlxG.camera;
 
     result.set(x, y);
+
+    result.x -= currentAnimationOffsets[0];
+    result.y -= currentAnimationOffsets[1];
+
     if (pixelPerfectPosition)
     {
       _rect.width = _rect.width / this.scale.x;

--- a/source/funkin/graphics/FunkinSprite.hx
+++ b/source/funkin/graphics/FunkinSprite.hx
@@ -72,7 +72,9 @@ class FunkinSprite extends FlxSprite
   public function new(?x:Float = 0, ?y:Float = 0)
   {
     super(x, y);
-    globalOffsets = [x, y];
+
+    // null-safety is on crack
+    globalOffsets = [x ?? 0, y ?? 0];
   }
 
   override function initVars():Void
@@ -300,8 +302,8 @@ class FunkinSprite extends FlxSprite
    */
   public function applyAnimationOffsets(animName:String):Void
   {
-    var offsets = animationOffsets.get(animName);
-    this.currentAnimationOffsets = offsets;
+    var offsets:Null<Array<Float>> = animationOffsets.get(animName);
+    this.currentAnimationOffsets = offsets ?? [0, 0];
   }
 
   /**

--- a/source/funkin/play/character/BaseCharacter.hx
+++ b/source/funkin/play/character/BaseCharacter.hx
@@ -250,14 +250,10 @@ class BaseCharacter extends Bopper
    * Set the character's sprite scale to the appropriate value.
    * @param scale The desired scale.
    */
-  public function setScale(scale:Null<Float>):Void
+  public override function setScale(scale:Null<Float>):Void
   {
-    if (scale == null) scale = 1.0;
-
+    super.setScale(scale);
     var feetPos:FlxPoint = feetPosition;
-    this.scale.x = scale;
-    this.scale.y = scale;
-    this.updateHitbox();
     // Reposition with newly scaled sprite.
     this.x = feetPos.x - characterOrigin.x + globalOffsets[0];
     this.y = feetPos.y - characterOrigin.y + globalOffsets[1];

--- a/source/funkin/play/character/MultiSparrowCharacter.hx
+++ b/source/funkin/play/character/MultiSparrowCharacter.hx
@@ -115,7 +115,7 @@ class MultiSparrowCharacter extends BaseCharacter
 
       if (anim.offsets == null)
       {
-        setAnimationOffsets(anim.name, 0, 0);
+        setAnimationOffsets(anim.name, 0.0, 0.0);
       }
       else
       {

--- a/source/funkin/play/character/SparrowCharacter.hx
+++ b/source/funkin/play/character/SparrowCharacter.hx
@@ -71,7 +71,7 @@ class SparrowCharacter extends BaseCharacter
     {
       if (anim.offsets == null)
       {
-        setAnimationOffsets(anim.name, 0, 0);
+        setAnimationOffsets(anim.name, 0.0, 0.0);
       }
       else
       {

--- a/source/funkin/play/components/HealthIcon.hx
+++ b/source/funkin/play/components/HealthIcon.hx
@@ -453,35 +453,6 @@ class HealthIcon extends FunkinSprite
   }
 
   /**
-   * @return Name of the current animation being played by this health icon.
-   */
-  public function getCurrentAnimation():String
-  {
-    if (this.animation == null || this.animation.curAnim == null) return "";
-    return this.animation.curAnim.name;
-  }
-
-  /**
-   * @param id The name of the animation to check for.
-   * @return Whether this sprite posesses the given animation.
-   *   Only true if the animation was successfully loaded from the XML.
-   */
-  public function hasAnimation(id:String):Bool
-  {
-    if (this.animation == null) return false;
-
-    return this.animation.getByName(id) != null;
-  }
-
-  /**
-   * @return Whether the current animation is in the finished state.
-   */
-  public function isAnimationFinished():Bool
-  {
-    return this.animation.finished;
-  }
-
-  /**
    * Plays the animation with the given name.
    * @param name The name of the animation to play.
    * @param fallback The fallback animation to play if the given animation is not found.

--- a/source/funkin/play/cutscene/dialogue/DialogueBox.hx
+++ b/source/funkin/play/cutscene/dialogue/DialogueBox.hx
@@ -139,7 +139,7 @@ class DialogueBox extends FlxSpriteGroup implements IDialogueScriptedClass imple
       this.boxSprite = null;
     }
 
-    this.boxSprite = new FunkinSprite(0, 0);
+    this.boxSprite = new FlxSprite(0, 0);
 
     trace('[DIALOGUE BOX] Loading spritesheet ${_data.assetPath} for ${id}');
 

--- a/source/funkin/play/cutscene/dialogue/Speaker.hx
+++ b/source/funkin/play/cutscene/dialogue/Speaker.hx
@@ -1,6 +1,6 @@
 package funkin.play.cutscene.dialogue;
 
-import flixel.FlxSprite;
+import funkin.graphics.FunkinSprite;
 import funkin.data.IRegistryEntry;
 import funkin.modding.events.ScriptEvent;
 import flixel.graphics.frames.FlxFramesCollection;
@@ -15,7 +15,7 @@ import funkin.ui.FullScreenScaleMode;
  *
  * Most conversations have two speakers, with one being flipped.
  */
-class Speaker extends FlxSprite implements IDialogueScriptedClass implements IRegistryEntry<SpeakerData>
+class Speaker extends FunkinSprite implements IDialogueScriptedClass implements IRegistryEntry<SpeakerData>
 {
   /**
    * A readable name for this speaker.
@@ -27,36 +27,21 @@ class Speaker extends FlxSprite implements IDialogueScriptedClass implements IRe
     return _data.name;
   }
 
-  /**
-   * Offset the speaker's sprite by this much when playing each animation.
-   */
-  var animationOffsets:Map<String, Array<Float>> = new Map<String, Array<Float>>();
-
-  /**
-   * The current animation offset being used.
-   */
-  var animOffsets(default, set):Array<Float> = [0, 0];
-
-  function set_animOffsets(value:Array<Float>):Array<Float>
+  override function set_currentAnimationOffsets(value:Array<Float>):Array<Float>
   {
-    if (animOffsets == null) animOffsets = [0, 0];
-    if ((animOffsets[0] == value[0]) && (animOffsets[1] == value[1])) return value;
+    if (currentAnimationOffsets == null) currentAnimationOffsets = [0, 0];
+    if ((currentAnimationOffsets[0] == value[0]) && (currentAnimationOffsets[1] == value[1])) return value;
 
-    var xDiff:Float = value[0] - animOffsets[0];
-    var yDiff:Float = value[1] - animOffsets[1];
+    var xDiff:Float = value[0] - currentAnimationOffsets[0];
+    var yDiff:Float = value[1] - currentAnimationOffsets[1];
 
     this.x += xDiff;
     this.y += yDiff;
 
-    return animOffsets = value;
+    return currentAnimationOffsets = value;
   }
 
-  /**
-   * The offset of the speaker overall.
-   */
-  public var globalOffsets(default, set):Array<Float> = [0, 0];
-
-  function set_globalOffsets(value:Array<Float>):Array<Float>
+  override function set_globalOffsets(value:Array<Float>):Array<Float>
   {
     if (globalOffsets == null) globalOffsets = [0, 0];
     if (globalOffsets == value) return value;
@@ -166,7 +151,7 @@ class Speaker extends FlxSprite implements IDialogueScriptedClass implements IRe
    * Set the sprite scale to the appropriate value.
    * @param scale
    */
-  public function setScale(scale:Null<Float>):Void
+  public override function setScale(scale:Null<Float>):Void
   {
     if (scale == null) scale = 1.0;
 
@@ -190,7 +175,7 @@ class Speaker extends FlxSprite implements IDialogueScriptedClass implements IRe
     {
       if (anim.offsets == null)
       {
-        setAnimationOffsets(anim.name, 0, 0);
+        setAnimationOffsets(anim.name, 0.0, 0.0);
       }
       else
       {
@@ -212,14 +197,6 @@ class Speaker extends FlxSprite implements IDialogueScriptedClass implements IRe
     if (correctName == null) return;
 
     this.animation.play(correctName, restart, false, 0);
-
-    applyAnimationOffsets(correctName);
-  }
-
-  public function getCurrentAnimation():String
-  {
-    if (this.animation == null || this.animation.curAnim == null) return "";
-    return this.animation.curAnim.name;
   }
 
   /**
@@ -253,37 +230,6 @@ class Speaker extends FlxSprite implements IDialogueScriptedClass implements IRe
         FlxG.log.error('Speaker tried to play animation "idle" that does not exist! This is bad!');
         return null;
       }
-    }
-  }
-
-  public function hasAnimation(id:String):Bool
-  {
-    if (this.animation == null) return false;
-
-    return this.animation.getByName(id) != null;
-  }
-
-  /**
-   * Define the animation offsets for a specific animation.
-   */
-  public function setAnimationOffsets(name:String, xOffset:Float, yOffset:Float):Void
-  {
-    animationOffsets.set(name, [xOffset, yOffset]);
-  }
-
-  /**
-   * Retrieve an apply the animation offsets for a specific animation.
-   */
-  function applyAnimationOffsets(name:String):Void
-  {
-    var offsets:Array<Float> = animationOffsets.get(name);
-    if (offsets != null && !(offsets[0] == 0 && offsets[1] == 0))
-    {
-      this.animOffsets = offsets;
-    }
-    else
-    {
-      this.animOffsets = [0, 0];
     }
   }
 

--- a/source/funkin/play/notes/StrumlineNote.hx
+++ b/source/funkin/play/notes/StrumlineNote.hx
@@ -172,22 +172,6 @@ class StrumlineNote extends FunkinSprite
     }
   }
 
-  /**
-   * Returns the name of the animation that is currently playing.
-   * If no animation is playing (usually this means the sprite is BROKEN!),
-   *   returns an empty string to prevent NPEs.
-   */
-  public function getCurrentAnimation():String
-  {
-    if (this.animation == null || this.animation.curAnim == null) return "";
-    return this.animation.curAnim.name;
-  }
-
-  public function isAnimationFinished():Bool
-  {
-    return this.animation.finished;
-  }
-
   static final DEFAULT_OFFSET:Int = 13;
 
   /**

--- a/source/funkin/ui/debug/anim/DebugBoundingState.hx
+++ b/source/funkin/ui/debug/anim/DebugBoundingState.hx
@@ -215,18 +215,18 @@ class DebugBoundingState extends FlxState
       if (FlxG.mouse.justPressed && !haxeUIFocused)
       {
         movingCharacter = true;
-        mouseOffset.set(FlxG.mouse.x - -swagChar.animOffsets[0], FlxG.mouse.y - -swagChar.animOffsets[1]);
+        mouseOffset.set(FlxG.mouse.x - -swagChar.currentAnimationOffsets[0], FlxG.mouse.y - -swagChar.currentAnimationOffsets[1]);
       }
 
       if (!movingCharacter) return;
 
       if (FlxG.mouse.pressed)
       {
-        swagChar.animOffsets = [(FlxG.mouse.x - mouseOffset.x) * -1, (FlxG.mouse.y - mouseOffset.y) * -1];
+        swagChar.currentAnimationOffsets = [(FlxG.mouse.x - mouseOffset.x) * -1, (FlxG.mouse.y - mouseOffset.y) * -1];
 
-        swagChar.animationOffsets.set(offsetAnimationDropdown.value.id, swagChar.animOffsets);
+        swagChar.animationOffsets.set(offsetAnimationDropdown.value.id, swagChar.currentAnimationOffsets);
 
-        txtOffsetShit.text = 'Offset: ' + swagChar.animOffsets;
+        txtOffsetShit.text = 'Offset: ' + swagChar.currentAnimationOffsets;
         txtOffsetShit.y = FlxG.height - 20 - txtOffsetShit.height;
       }
 
@@ -536,7 +536,7 @@ class DebugBoundingState extends FlxState
       }
     }
 
-    txtOffsetShit.text = 'Offset: ' + swagChar.animOffsets;
+    txtOffsetShit.text = 'Offset: ' + swagChar.currentAnimationOffsets;
     txtOffsetShit.y = FlxG.height - 20 - txtOffsetShit.height;
     dropDownSetup = true;
   }
@@ -559,7 +559,7 @@ class DebugBoundingState extends FlxState
     swagChar.playAnimation(animName, true); // trace();
     trace(swagChar.animationOffsets.get(animName));
 
-    txtOffsetShit.text = 'Offset: ' + swagChar.animOffsets;
+    txtOffsetShit.text = 'Offset: ' + swagChar.currentAnimationOffsets;
     txtOffsetShit.y = FlxG.height - 20 - txtOffsetShit.height;
   }
 

--- a/source/funkin/ui/haxeui/components/CharacterPlayer.hx
+++ b/source/funkin/ui/haxeui/components/CharacterPlayer.hx
@@ -177,10 +177,10 @@ class CharacterPlayer extends Box
     character.y = this.cachedScreenY;
 
     // Apply animation offsets, so the character is positioned correctly based on the animation.
-    @:privateAccess var animOffsets:Array<Float> = character.animOffsets;
+    @:privateAccess var currentAnimationOffsets:Array<Float> = character.currentAnimationOffsets;
 
-    character.x -= animOffsets[0] * targetScale * (flip ? -1 : 1);
-    character.y -= animOffsets[1] * targetScale;
+    character.x -= currentAnimationOffsets[0] * targetScale * (flip ? -1 : 1);
+    character.y -= currentAnimationOffsets[1] * targetScale;
   }
 
   /**

--- a/source/funkin/ui/options/PreferencesMenu.hx
+++ b/source/funkin/ui/options/PreferencesMenu.hx
@@ -248,7 +248,7 @@ class PreferencesMenu extends Page<OptionsState.OptionsMenuPageName>
    */
   function createPrefItemCheckbox(prefName:String, prefDesc:String, onChange:Bool->Void, defaultValue:Bool, available:Bool = true):Void
   {
-    var checkbox:CheckboxPreferenceItem = new CheckboxPreferenceItem(funkin.ui.FullScreenScaleMode.gameNotchSize.x, 120 * (items.length - 1 + 1),
+    var checkbox:CheckboxPreferenceItem = new CheckboxPreferenceItem(25 + funkin.ui.FullScreenScaleMode.gameNotchSize.x, (120 * (items.length - 1 + 1) + 35),
       defaultValue, available);
 
     items.createItem(0, (120 * items.length) + 30, prefName, AtlasFont.BOLD, function() {

--- a/source/funkin/ui/options/items/CheckboxPreferenceItem.hx
+++ b/source/funkin/ui/options/items/CheckboxPreferenceItem.hx
@@ -1,8 +1,8 @@
 package funkin.ui.options.items;
 
-import flixel.FlxSprite.FlxSprite;
+import funkin.graphics.FunkinSprite;
 
-class CheckboxPreferenceItem extends FlxSprite
+class CheckboxPreferenceItem extends FunkinSprite
 {
   public var currentValue(default, set):Bool;
 
@@ -10,9 +10,10 @@ class CheckboxPreferenceItem extends FlxSprite
   {
     super(x, y);
 
-    frames = Paths.getSparrowAtlas('checkboxThingie');
+    loadSparrow('checkboxThingie');
     animation.addByPrefix('static', 'Check Box unselected', 24, false);
     animation.addByPrefix('checked', 'Check Box selecting animation', 24, false);
+    setAnimationOffsets('checked', 17, 70);
 
     setGraphicSize(Std.int(width * 0.7));
     updateHitbox();
@@ -20,19 +21,6 @@ class CheckboxPreferenceItem extends FlxSprite
     if (!available) this.alpha = 0.5;
 
     this.currentValue = defaultValue;
-  }
-
-  override function update(elapsed:Float):Void
-  {
-    super.update(elapsed);
-
-    switch (animation.curAnim.name)
-    {
-      case 'static':
-        offset.set();
-      case 'checked':
-        offset.set(17, 70);
-    }
   }
 
   function set_currentValue(value:Bool):Bool


### PR DESCRIPTION
## Description
This PR overhauls `FunkinSprite`, combining different changes into one PR.

## Changes
- Refactored the way animation offsets are handled.
	- All `FunkinSprite`-based classes now depend on `FunkinSprite` for handling animation offsets rather than managing them independently.
		- We use a custom `FunkinAnimationController` to do this!
		- This also allows scripted `FunkinSprite`'s to add offsets to their animations with ease:
			```haxe
			loadSparrow('checkboxThingie');
			animation.addByPrefix('static', 'Check Box unselected', 24, false);
			animation.addByPrefix('checked', 'Check Box selecting animation', 24, false);
			setAnimationOffsets('checked', 17, 70);
			```
		- `animOffsets` has been renamed to `currentAnimationOffsets` to avoid confusion.
- Commonly used functions (`getCurrentAnimation`, `isAnimationFinished`, etc.) have been moved to `FunkinSprite`.
- Documentation to some `FunkinSprite` functions have been added.
## Some things to note
- Any class that extends `FlxSpriteGroup` (FlxTypedSpriteGroup<FlxSprite>) was left untouched since `FlxSpriteGroup` extends `FlxSprite`. Updating these classes would require basically making a clone of `FlxSpriteGroup`.
- While most sprites will work fine with these changes, some sprites may require position updates (ex. `CheckboxPreferenceItem`)
- This will be a breaking change for mods that access `animOffsets`.