### PR TITLE
[BUGFIX] Chart Editor - Fix resolution breaking after returning from PlayState

### DIFF
--- a/source/funkin/ui/debug/charting/ChartEditorState.hx
+++ b/source/funkin/ui/debug/charting/ChartEditorState.hx
@@ -5838,6 +5838,7 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
   {
     uiCamera.revive();
     FlxG.cameras.reset(uiCamera);
+    uiCamera.onResize();
 
     add(this.root);
   }


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->
## Does this PR close any issues? If so, link them below.
Fixes #2614 
## Briefly describe the issue(s) fixed.
The chart editor would always break after returning from PlayState when either changing window size or going fullscreen. This was caused by the UI camera not updating (probably because it is killed), so this fixes it by simply manually updating it.

~~Not me taking many hours trying to fix something I thought was HaxeUI's fault~~
## Include any relevant screenshots or videos.

https://github.com/user-attachments/assets/47c66298-ae10-4925-bb0d-f484645bde12

