### PR TITLE
[BUGFIX] Funkin sound restarting music fix

### DIFF
--- a/source/funkin/audio/FunkinSound.hx
+++ b/source/funkin/audio/FunkinSound.hx
@@ -545,7 +545,8 @@ class FunkinSound extends FlxSound implements ICloneable<FunkinSound>
 
       soundRequest.future.onComplete(function(partialSound)
       {
-        var snd = FunkinSound.load(partialSound, volume, looped, autoDestroy, autoPlay, false, onComplete, onLoad);
+        var snd:Null<FunkinSound> = FunkinSound.load(partialSound, volume, looped, autoDestroy, autoPlay, false, onComplete, onLoad);
+        if (snd != null) snd._label = path;
         promise.complete(snd);
       });
     }

--- a/source/funkin/audio/FunkinSound.hx
+++ b/source/funkin/audio/FunkinSound.hx
@@ -288,13 +288,25 @@ class FunkinSound extends FlxSound implements ICloneable<FunkinSound>
   {
     if (!(params.overrideExisting ?? false) && (FlxG.sound.music?.exists ?? false) && FlxG.sound.music.playing) return false;
 
+    var pathsFunction = params.pathsFunction ?? MUSIC;
+    var suffix = params.suffix ?? '';
+    var pathToUse = switch (pathsFunction)
+    {
+      case MUSIC:
+        Paths.music('$key/$key');
+      case INST:
+        Paths.inst('$key', suffix);
+      default:
+        Paths.music('$key/$key');
+    }
+
     if (!(params.restartTrack ?? false) && FlxG.sound.music?.playing)
     {
       if (FlxG.sound.music != null && Std.isOfType(FlxG.sound.music, FunkinSound))
       {
         var existingSound:FunkinSound = cast FlxG.sound.music;
         // Stop here if we would play a matching music track.
-        if (existingSound._label == Paths.music('$key/$key'))
+        if (existingSound._label == pathToUse)
         {
           return false;
         }
@@ -322,17 +334,6 @@ class FunkinSound extends FlxSound implements ICloneable<FunkinSound>
       {
         FlxG.log.warn('Tried and failed to find music metadata for $key');
       }
-    }
-    var pathsFunction = params.pathsFunction ?? MUSIC;
-    var suffix = params.suffix ?? '';
-    var pathToUse = switch (pathsFunction)
-    {
-      case MUSIC:
-        Paths.music('$key/$key');
-      case INST:
-        Paths.inst('$key', suffix);
-      default:
-        Paths.music('$key/$key');
     }
 
     var shouldLoadPartial = params.partialParams?.loadPartial ?? false;
@@ -506,7 +507,8 @@ class FunkinSound extends FlxSound implements ICloneable<FunkinSound>
 
       soundRequest.future.onComplete(function(partialSound)
       {
-        var snd = FunkinSound.load(partialSound, volume, looped, autoDestroy, autoPlay, false, onComplete, onLoad);
+        var snd:Null<FunkinSound> = FunkinSound.load(partialSound, volume, looped, autoDestroy, autoPlay, false, onComplete, onLoad);
+        if (snd != null) snd._label = path;
         promise.complete(snd);
       });
     }


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->
## Does this PR close any issues? If so, link them below.
Fixes #3656, fixes #4821
## Briefly describe the issue(s) fixed.
The funkin sound play music function does not check against music suffixes, leading to it restarting the current music if one was passed when the function is called.

That, and the load partial doesn't set the label to the path given afterwards, so the label ends up being 'unknown' and causes the preview to still be reset.
## Include any relevant screenshots or videos.
