### PR TITLE
[BUGFIX] Fix CharSelect not playing confirm animation mid-transition

### DIFF
--- a/source/funkin/ui/charSelect/CharSelectGF.hx
+++ b/source/funkin/ui/charSelect/CharSelectGF.hx
@@ -123,9 +123,9 @@ class CharSelectGF extends FunkinSprite implements IBPMSyncedScriptedClass
       enableVisualizer = gfData?.visualizer ?? false;
     }
 
-    if (pressedSelect) anim.play("confirm", true);
-    else
-    anim.play("idle", true);
+    final animName:String = pressedSelect ? "confirm" : "idle";
+    anim.play(animName, true);
+    if (pressedSelect) anim.curAnim.looped = true;
 
     updateHitbox();
   }

--- a/source/funkin/ui/charSelect/CharSelectGF.hx
+++ b/source/funkin/ui/charSelect/CharSelectGF.hx
@@ -85,8 +85,9 @@ class CharSelectGF extends FunkinSprite implements IBPMSyncedScriptedClass
   /**
    * For switching between "GFs" such as gf, nene, etc
    * @param bf Which BF we are selecting, so that we know the accompyaning GF
+   * @param pressedSelect If select was pressed while switching character, play the confirm animation instead
    */
-  public function switchGF(bf:String):Void
+  public function switchGF(bf:String, pressedSelect:Bool = false):Void
   {
     var previousGFPath:String = currentGFPath;
 
@@ -122,6 +123,8 @@ class CharSelectGF extends FunkinSprite implements IBPMSyncedScriptedClass
       enableVisualizer = gfData?.visualizer ?? false;
     }
 
+    if (pressedSelect) anim.play("confirm", true);
+    else
     anim.play("idle", true);
 
     updateHitbox();

--- a/source/funkin/ui/charSelect/CharSelectGF.hx
+++ b/source/funkin/ui/charSelect/CharSelectGF.hx
@@ -124,9 +124,9 @@ class CharSelectGF extends FunkinSprite implements IBPMSyncedScriptedClass
       enableVisualizer = gfData?.visualizer ?? false;
     }
 
-    if (pressedSelect) animation.play("confirm", true);
-    else
-    animation.play('idle', true);
+    final animName:String = pressedSelect ? "confirm" : "idle";
+    animation.play(animName, true);
+    if (pressedSelect) animation.curAnim.looped = true;
 
     updateHitbox();
   }

--- a/source/funkin/ui/charSelect/CharSelectGF.hx
+++ b/source/funkin/ui/charSelect/CharSelectGF.hx
@@ -85,8 +85,9 @@ class CharSelectGF extends FunkinSprite implements IBPMSyncedScriptedClass
   /**
    * For switching between 'GFs' such as GF, Nene, etc
    * @param bf Which BF we are selecting, so that we know the accompanying GF
+   * @param pressedSelect If select was pressed while switching character, play the confirm animation instead
    */
-  public function switchGF(bf:String):Void
+  public function switchGF(bf:String, pressedSelect:Bool = false):Void
   {
     var previousGFPath:String = currentGFPath;
 
@@ -123,6 +124,8 @@ class CharSelectGF extends FunkinSprite implements IBPMSyncedScriptedClass
       enableVisualizer = gfData?.visualizer ?? false;
     }
 
+    if (pressedSelect) animation.play("confirm", true);
+    else
     animation.play('idle', true);
 
     updateHitbox();

--- a/source/funkin/ui/charSelect/CharSelectPlayer.hx
+++ b/source/funkin/ui/charSelect/CharSelectPlayer.hx
@@ -9,6 +9,8 @@ class CharSelectPlayer extends FunkinSprite implements IBPMSyncedScriptedClass
 {
   static final DEFAULT_PATH = "charSelect/bfChill";
 
+  var pressedSelect:Bool = false;
+
   var initialX:Float = 0;
   var initialY:Float = 0;
 
@@ -33,7 +35,14 @@ class CharSelectPlayer extends FunkinSprite implements IBPMSyncedScriptedClass
         case "slidein":
           if (hasAnimation("slidein idle point"))
           {
-            anim.play("slidein idle point", true);
+
+            if (pressedSelect)
+            {
+              anim.play("select");
+              pressedSelect = false;
+            }
+            else
+              anim.play("slidein idle point", true);
           }
           else
           {
@@ -76,7 +85,7 @@ class CharSelectPlayer extends FunkinSprite implements IBPMSyncedScriptedClass
     }
   };
 
-  public function switchChar(str:String, playSlideAnim:Bool = true):Void
+  public function switchChar(str:String, playSlideAnim:Bool = true, pressedSelect:Bool = false):Void
   {
     var texture:Null<animate.FlxAnimateFrames> = CharSelectAtlasHandler.loadAtlas('charSelect/${str}Chill');
 
@@ -89,6 +98,8 @@ class CharSelectPlayer extends FunkinSprite implements IBPMSyncedScriptedClass
       trace('Failed to load character atlas for ${str}');
       return;
     }
+
+    this.pressedSelect = pressedSelect;
 
     final animName:String = playSlideAnim ? "slidein" : "idle";
     anim.play(animName, true);

--- a/source/funkin/ui/charSelect/CharSelectPlayer.hx
+++ b/source/funkin/ui/charSelect/CharSelectPlayer.hx
@@ -9,8 +9,6 @@ class CharSelectPlayer extends FunkinSprite implements IBPMSyncedScriptedClass
 {
   static final DEFAULT_PATH = "charSelect/bfChill";
 
-  var pressedSelect:Bool = false;
-
   var initialX:Float = 0;
   var initialY:Float = 0;
 
@@ -35,14 +33,7 @@ class CharSelectPlayer extends FunkinSprite implements IBPMSyncedScriptedClass
         case "slidein":
           if (hasAnimation("slidein idle point"))
           {
-
-            if (pressedSelect)
-            {
-              anim.play("select");
-              pressedSelect = false;
-            }
-            else
-              anim.play("slidein idle point", true);
+            anim.play("slidein idle point", true);
           }
           else
           {
@@ -99,9 +90,8 @@ class CharSelectPlayer extends FunkinSprite implements IBPMSyncedScriptedClass
       return;
     }
 
-    this.pressedSelect = pressedSelect;
-
-    final animName:String = playSlideAnim ? "slidein" : "idle";
+    // If select was pressed while switching character, play the confirm animation instead
+    final animName:String = pressedSelect ? "select" : (playSlideAnim ? "slidein" : "idle");
     anim.play(animName, true);
 
     updateHitbox();

--- a/source/funkin/ui/charSelect/CharSelectPlayer.hx
+++ b/source/funkin/ui/charSelect/CharSelectPlayer.hx
@@ -37,14 +37,7 @@ class CharSelectPlayer extends FunkinSprite implements IBPMSyncedScriptedClass
         case 'slideIn':
           if (hasAnimation('slideInPoint'))
           {
-
-            if (pressedSelect)
-            {
-              animation.play("select");
-              pressedSelect = false;
-            }
-            else
-              animation.play('slideInPoint', true);
+            animation.play('slideInPoint', true);
           }
           else
           {
@@ -85,9 +78,8 @@ class CharSelectPlayer extends FunkinSprite implements IBPMSyncedScriptedClass
       return;
     }
 
-    this.pressedSelect = pressedSelect;
-
-    final animName:String = playSlideAnim ? 'slideIn' : 'idle';
+    // If select was pressed while switching character, play the confirm animation instead
+    final animName:String = pressedSelect ? "select" : (playSlideAnim ? "slidein" : "idle");
     animation.play(animName, true);
 
     updateHitbox();

--- a/source/funkin/ui/charSelect/CharSelectPlayer.hx
+++ b/source/funkin/ui/charSelect/CharSelectPlayer.hx
@@ -10,6 +10,8 @@ class CharSelectPlayer extends FunkinSprite implements IBPMSyncedScriptedClass
 {
   static final DEFAULT_PATH = 'ui/character-select/characters/bf';
 
+  var pressedSelect:Bool = false;
+
   var initialX:Float = 0;
   var initialY:Float = 0;
   var currentBFPath:Null<String>;
@@ -35,7 +37,14 @@ class CharSelectPlayer extends FunkinSprite implements IBPMSyncedScriptedClass
         case 'slideIn':
           if (hasAnimation('slideInPoint'))
           {
-            animation.play('slideInPoint', true);
+
+            if (pressedSelect)
+            {
+              animation.play("select");
+              pressedSelect = false;
+            }
+            else
+              animation.play('slideInPoint', true);
           }
           else
           {
@@ -61,7 +70,7 @@ class CharSelectPlayer extends FunkinSprite implements IBPMSyncedScriptedClass
     }
   };
 
-  public function switchChar(str:String, playSlideAnim:Bool = true):Void
+  public function switchChar(str:String, playSlideAnim:Bool = true, pressedSelect:Bool = false):Void
   {
     var texture:Null<animate.FlxAnimateFrames> = CharSelectAtlasHandler.loadAtlas('ui/character-select/characters/${str}');
 
@@ -75,6 +84,8 @@ class CharSelectPlayer extends FunkinSprite implements IBPMSyncedScriptedClass
       trace('Failed to load character atlas for ${str}');
       return;
     }
+
+    this.pressedSelect = pressedSelect;
 
     final animName:String = playSlideAnim ? 'slideIn' : 'idle';
     animation.play(animName, true);

--- a/source/funkin/ui/charSelect/CharSelectSubState.hx
+++ b/source/funkin/ui/charSelect/CharSelectSubState.hx
@@ -1181,8 +1181,8 @@ class CharSelectSubState extends MusicBeatSubState
       if (!playerChill.visible)
       {
         playerChill.visible = true;
-        playerChill.switchChar(value);
-        gfChill.switchGF(value);
+        playerChill.switchChar(value, true, pressedSelect);
+        gfChill.switchGF(value, pressedSelect);
         gfChill.visible = true;
       }
     });

--- a/source/funkin/ui/charSelect/CharSelectSubState.hx
+++ b/source/funkin/ui/charSelect/CharSelectSubState.hx
@@ -1191,8 +1191,8 @@ class CharSelectSubState extends MusicBeatSubState
       if (!playerChill.visible)
       {
         playerChill.visible = true;
-        playerChill.switchChar(value);
-        gfChill.switchGF(value);
+        playerChill.switchChar(value, true, pressedSelect);
+        gfChill.switchGF(value, pressedSelect);
         gfChill.visible = true;
       }
     });


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->
## Does this PR close any issues? If so, link them below.
Fixes #3730
## Briefly describe the issue(s) fixed.
Characters do not play confirm animation if selected mid transition. The pressed Selected bool is now passed when they're switched and plays the confirm animations instead if it's true.

## Include any relevant screenshots or videos.

[See trayfellow's video below](https://github.com/FunkinCrew/Funkin/pull/4272#issuecomment-4122867719)