### PR TITLE
[ENHANCEMENT] `playSingAnimation` bool in noteSprite

### DIFF
--- a/source/funkin/play/character/BaseCharacter.hx
+++ b/source/funkin/play/character/BaseCharacter.hx
@@ -519,13 +519,13 @@ class BaseCharacter extends Bopper
     if (event.note.noteData.getMustHitNote() && characterType == BF)
     {
       // If the note is from the same strumline, play the sing animation.
-      this.playSingAnimation(event.note.noteData.getDirection(), false);
+      if (event.note.playSingAnimation) this.playSingAnimation(event.note.noteData.getDirection(), false);
       holdTimer = 0;
     }
     else if (!event.note.noteData.getMustHitNote() && characterType == DAD)
     {
       // If the note is from the same strumline, play the sing animation.
-      this.playSingAnimation(event.note.noteData.getDirection(), false);
+      if (event.note.playSingAnimation) this.playSingAnimation(event.note.noteData.getDirection(), false);
       holdTimer = 0;
     }
     else if (characterType == GF && event.note.noteData.getMustHitNote())
@@ -554,12 +554,12 @@ class BaseCharacter extends Bopper
     if (event.note.noteData.getMustHitNote() && characterType == BF)
     {
       // If the note is from the same strumline, play the miss animation.
-      this.playSingAnimation(event.note.noteData.getDirection(), true);
+      if (event.note.playSingAnimation) this.playSingAnimation(event.note.noteData.getDirection(), true);
     }
     else if (!event.note.noteData.getMustHitNote() && characterType == DAD)
     {
       // If the note is from the same strumline, play the miss animation.
-      this.playSingAnimation(event.note.noteData.getDirection(), true);
+      if (event.note.playSingAnimation) this.playSingAnimation(event.note.noteData.getDirection(), true);
     }
     else if (event.note.noteData.getMustHitNote() && characterType == GF)
     {

--- a/source/funkin/play/notes/NoteSprite.hx
+++ b/source/funkin/play/notes/NoteSprite.hx
@@ -165,6 +165,11 @@ class NoteSprite extends FunkinSprite
    */
   public var handledMiss:Bool;
 
+  /**
+   * Whether hitting or missing this note causes the sing animation for the character to play.
+   */
+  public var playSingAnimation:Bool = true;
+
   public function new(noteStyle:NoteStyle, direction:Int = 0)
   {
     super(0, -9999);


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->
## Does this PR close any issues? If so, link them below.
Closes #3966
## Briefly describe the issue(s) fixed.

Added a `playSingAnimation` bool in the noteSprite class.

I also made a demonstration with a scripted note kind: https://github.com/FunkinCrew/funkin.assets/pull/140

## Include any relevant screenshots or videos.

https://github.com/user-attachments/assets/1297ccd6-39b7-4ab0-b82f-968aa5647704

~~They're 2lazy to sing~~


