### PR TITLE
Add missing note kinds

### DIFF
--- a/source/funkin/ui/debug/charting/util/ChartEditorDropdowns.hx
+++ b/source/funkin/ui/debug/charting/util/ChartEditorDropdowns.hx
@@ -159,10 +159,16 @@ class ChartEditorDropdowns
     "" => "Default",
     "~CUSTOM~" => "Custom",
     // Weeks 1-7
+    "censor" => "[UH-OH!] (bf-christmas / pico-playable)",
     "mom" => "Mom Sings (Week 5)",
-    "ugh" => "Ugh (Week 7)",
-    "hehPrettyGood" => "Heh, Pretty Good (Week 7)",
+    "ugh" => "Tankman Ugh (Week 7)",
+    "hehPrettyGood" => "Tankman Heh, Pretty Good (Week 7)",
     // Weekend 1
+    "weekend-1-lightcan" => "Darnell Light Can (2hot)",
+    "weekend-1-kneecan" => "Darnell Knee Can (2hot)",
+    "weekend-1-kickcan" => "Darnell Kick Can (2hot)",
+    "weekend-1-cockgun" => "Pico Cock (2hot)",
+    "weekend-1-firegun" => "Pico Fire Gun (2hot)",
     "weekend-1-punchhigh" => "Punch High (Blazin')",
     "weekend-1-punchhighdodged" => "Punch High (Dodge) (Blazin')",
     "weekend-1-punchhighblocked" => "Punch High (Block) (Blazin')",


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->
## Does this PR close any issues? If so, link them below.
No, but it (hopefully) prevents one from being opened in the future!
## Briefly describe the issue(s) fixed.
Adds the missing note kinds to the `NOTE_KINDS` var in the `ChartEditorDropdowns` Class.

Also clarifies that ugh and pretty good are for tankman only.
## Include any relevant screenshots or videos.
![Screenshot 2025-03-10 115750](https://github.com/user-attachments/assets/3cafee81-567a-417f-b9bb-d4e595ae2dc6)
![Screenshot 2025-03-10 115804](https://github.com/user-attachments/assets/e09f5aee-8a95-4384-b002-e7693311d572)
![Screenshot 2025-03-10 115816](https://github.com/user-attachments/assets/cd915129-e8a8-4b46-8810-65beaad9af45)
