### PR TITLE
[ENHANCEMENT] Customizable Freeplay Song Preview Times

### DIFF
--- a/source/funkin/audio/FunkinSound.hx
+++ b/source/funkin/audio/FunkinSound.hx
@@ -366,8 +366,25 @@ class FunkinSound extends FlxSound implements ICloneable<FunkinSound>
 
     if (shouldLoadPartial)
     {
-      var music = FunkinSound.loadPartial(pathToUse, params.partialParams?.start ?? 0.0, params.partialParams?.end ?? 1.0, params?.startingVolume ?? 1.0,
-        params.loop ?? true, false, false, params.onComplete);
+      var partialStart:Float = params.partialParams?.start ?? 0.0;
+      var partialEnd:Float = params.partialParams?.end ?? 1.0;
+
+      // If a raw start or end time is provided, load a sound to serve as a reference to calculate the percentage to be used in partial sound loading.
+      var tempSound:openfl.media.Sound = Assets.getSound(pathToUse);
+
+      if (params.partialParams?.startRaw != null)
+      {
+        partialStart = FlxMath.bound((params.partialParams?.startRaw ?? 0) / tempSound.length, 0, tempSound.length);
+      }
+
+      if (params.partialParams?.endRaw != null)
+      {
+        // The partial sound preview end should come later than the beginning.
+        partialEnd = FlxMath.bound((params.partialParams?.endRaw ?? 15000) / tempSound.length, partialStart, tempSound.length);
+      }
+
+      var music = FunkinSound.loadPartial(pathToUse, partialStart, partialEnd, params?.startingVolume ?? 1.0, params.loop ?? true, false, false,
+        params.onComplete);
 
       if (music != null)
       {
@@ -644,4 +661,6 @@ typedef PartialSoundParams =
   var loadPartial:Bool;
   var start:Float;
   var end:Float;
+  var ?startRaw:Int;
+  var ?endRaw:Int;
 }

--- a/source/funkin/ui/freeplay/FreeplayState.hx
+++ b/source/funkin/ui/freeplay/FreeplayState.hx
@@ -21,6 +21,7 @@ import flixel.util.FlxSpriteUtil;
 import flixel.util.FlxTimer;
 import funkin.audio.FunkinSound;
 import funkin.data.freeplay.player.PlayerRegistry;
+import funkin.data.song.SongData.SongMetadata;
 import funkin.data.song.SongRegistry;
 import funkin.data.story.level.LevelRegistry;
 import funkin.effects.IntervalShake;
@@ -2091,6 +2092,9 @@ class FreeplayState extends MusicBeatSubState
 
       // Check if character-specific difficulty exists
       var songDifficulty:Null<SongDifficulty> = previewSong.getDifficulty(currentDifficulty, currentVariation);
+      var songMetadata:Null<SongMetadata> = null;
+      @:privateAccess
+      songMetadata = previewSong._metadata.get(currentVariation);
 
       var baseInstrumentalId:String = previewSong.getBaseInstrumentalId(currentDifficulty, songDifficulty?.variation ?? Constants.DEFAULT_VARIATION) ?? '';
       var altInstrumentalIds:Array<String> = previewSong.listAltInstrumentalIds(currentDifficulty,
@@ -2116,7 +2120,9 @@ class FreeplayState extends MusicBeatSubState
             {
               loadPartial: true,
               start: 0,
-              end: 0.2
+              end: 0.2,
+              startRaw: songMetadata?.playData?.previewStart ?? 0,
+              endRaw: songMetadata?.playData?.previewEnd ?? 15000
             },
           onLoad: function() {
             FlxG.sound.music.fadeIn(2, 0, 0.4);


### PR DESCRIPTION
## Does this PR close any issues? If so, link them below.
Closes #4290 

## Briefly describe the issue(s) fixed.
Surprisingly not a breaking change - added two optional/nullable fields to PartialSoundParams, `startRaw` and `endRaw`. If one of them is provided, the percentage of the audio file is calculated for start or end time respectively. They also have priority to their percentage counterparts, `start` and `end`, so if the `startRaw` and `start` are provided in partial params, `startRaw` will be used to determine the start

## Include any relevant screenshots or videos.

https://github.com/user-attachments/assets/7ea8557d-dadb-4f6e-800c-92070aa1f6bb
