### PR TITLE
Hit window offset fix

### DIFF
--- a/source/funkin/play/PlayState.hx
+++ b/source/funkin/play/PlayState.hx
@@ -891,34 +891,6 @@ class PlayState extends MusicBeatSubState
       needsReset = false;
     }
 
-    // Update the conductor.
-    if (startingSong)
-    {
-      if (isInCountdown)
-      {
-        // Do NOT apply offsets at this point, because they already got applied the previous frame!
-        Conductor.instance.update(Conductor.instance.songPosition + elapsed * 1000, false);
-        if (Conductor.instance.songPosition >= (startTimestamp + Conductor.instance.combinedOffset))
-        {
-          trace("started song at " + Conductor.instance.songPosition);
-          startSong();
-        }
-      }
-    }
-    else
-    {
-      if (Constants.EXT_SOUND == 'mp3')
-      {
-        Conductor.instance.formatOffset = Constants.MP3_DELAY_MS;
-      }
-      else
-      {
-        Conductor.instance.formatOffset = 0.0;
-      }
-
-      Conductor.instance.update(Conductor.instance.songPosition + elapsed * 1000, false); // Normal conductor update.
-    }
-
     var androidPause:Bool = false;
 
     #if android
@@ -1096,6 +1068,33 @@ class PlayState extends MusicBeatSubState
     if (!isInCutscene) processNotes(elapsed);
 
     justUnpaused = false;
+    // Update the conductor last.
+    if (startingSong)
+    {
+      if (isInCountdown)
+      {
+        // Do NOT apply offsets at this point, because they already got applied the previous frame!
+        Conductor.instance.update(Conductor.instance.songPosition + elapsed * 1000, false);
+        if (Conductor.instance.songPosition >= (startTimestamp + Conductor.instance.combinedOffset))
+        {
+          trace("started song at " + Conductor.instance.songPosition);
+          startSong();
+        }
+      }
+    }
+    else
+    {
+      if (Constants.EXT_SOUND == 'mp3')
+      {
+        Conductor.instance.formatOffset = Constants.MP3_DELAY_MS;
+      }
+      else
+      {
+        Conductor.instance.formatOffset = 0.0;
+      }
+
+      Conductor.instance.update(Conductor.instance.songPosition + elapsed * 1000, false); // Normal conductor update.
+    }
   }
 
   function moveToGameOver():Void
@@ -2525,7 +2524,10 @@ class PlayState extends MusicBeatSubState
 
     // Get the offset and compensate for input latency.
     // Round inward (trim remainder) for consistency.
-    var noteDiff:Int = Std.int(Conductor.instance.songPosition - note.noteData.time - inputLatencyMs);
+    var noteDiff:Int = Std.int(Conductor.instance.songPosition - note.noteData.time);
+    // Correctly apply the input latency
+    if (noteDiff > 0) noteDiff -= Std.int(inputLatencyMs);
+    else if (noteDiff < 0) noteDiff += Std.int(inputLatencyMs);
 
     var score = Scoring.scoreNote(noteDiff, PBOT1);
     var daRating = Scoring.judgeNote(noteDiff, PBOT1);

--- a/source/funkin/play/notes/Strumline.hx
+++ b/source/funkin/play/notes/Strumline.hx
@@ -784,7 +784,7 @@ class Strumline extends FlxSpriteGroup
       cover.y = this.y;
       cover.y += INITIAL_OFFSET;
       cover.y += STRUMLINE_SIZE / 2;
-      cover.y += -96; // Manual tweaking because fuck.
+      cover.y += -87; // Manual tweaking because fuck.
     }
   }
 


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->
## Does this PR close any issues? If so, link them below.
Fixes #2969, closes #2877
## Briefly describe the issue(s) fixed.
The hit window appeared to be offset, these changes ensure that is no longer the case.

Requires this assets change: https://github.com/FunkinCrew/funkin.assets/pull/142 (otherwise it'll still be offset, lol)
## Include any relevant screenshots or videos.

https://github.com/user-attachments/assets/d6b86630-f2be-4d70-b3fd-8149d89cb803

My first perfect gold too, just goes to show that the changes really work! 

I've since fixed the hold notes and hold cover from being offset from the new y offset as seen in the video, too.

A "perfect" hit before the change (aka `Conductor.instance.songPosition > hitWindowCenter`):
![Screenshot 2025-03-14 203126](https://github.com/user-attachments/assets/5f799285-06c3-4015-a725-d50e34b8e0cb)

After the change:
![Screenshot 2025-03-14 203732](https://github.com/user-attachments/assets/dec88c56-b720-4e90-8c2a-c7c4263da911)
![Screenshot 2025-03-14 203748](https://github.com/user-attachments/assets/68d1f2a4-5b52-4900-9576-072a745fba37)
![Screenshot 2025-03-14 203824](https://github.com/user-attachments/assets/d376113a-1e46-46f1-8f4d-45874f9bb5ed)
![Screenshot 2025-03-14 203833](https://github.com/user-attachments/assets/2e50e2c3-0e1c-4497-a17d-d24aa6551f71)

I'd imagine this: https://github.com/FunkinCrew/Funkin/pull/3544 would fix those first two still appearing slightly off though.