### PR TITLE
[BUGFIX] Prevent the song being incompletable if the inst is longer than vocals

### DIFF
--- a/source/funkin/play/PlayState.hx
+++ b/source/funkin/play/PlayState.hx
@@ -917,6 +917,9 @@ class PlayState extends MusicBeatSubState
       }
 
       Conductor.instance.update(Conductor.instance.songPosition + elapsed * 1000, false); // Normal conductor update.
+
+      // Fallback in case music's onComplete function doesn't get called.
+      if (FlxG.sound.music.time >= (FlxG.sound.music.endTime ?? FlxG.sound.music.length) && mayPauseGame) endSong(skipEndingTransition);
     }
 
     var androidPause:Bool = false;
@@ -1440,7 +1443,7 @@ class PlayState extends MusicBeatSubState
       var playerVoicesError:Float = 0;
       var opponentVoicesError:Float = 0;
 
-      if (vocals != null)
+      if (vocals != null && vocals.playing)
       {
         @:privateAccess // todo: maybe make the groups public :thinking:
         {


### PR DESCRIPTION
## Does this PR close any issues? If so, link them below.
Fixes #4304 

## Briefly describe the issue(s) fixed.
Once vocals are done their time gets set to a negative value, which triggers `resyncVocals`. This is especially present when songs bf songs use their pico remix counterparts' instrumentals, which are typically longer than the original instrumental. This PR aims to prevent `resyncVocals` being called upon the aforementioned circumstance by putting a check to see if the time of vocals is negative.

## Include any relevant screenshots or videos.

https://github.com/user-attachments/assets/243e1479-0574-4c1d-b5ce-65accb25babe
