### PR TITLE
[ENHANCEMENT] Unmute character vocals for forced animations

### DIFF
--- a/source/funkin/play/PlayState.hx
+++ b/source/funkin/play/PlayState.hx
@@ -3152,7 +3152,7 @@ class PlayState extends MusicBeatSubState
 
     if (playSound)
     {
-      if (vocals != null) vocals.playerVolume = 0;
+      if (vocals != null && currentStage != null && currentStage.getBoyfriend() != null && !currentStage.getBoyfriend().tempVocals) vocals.playerVolume = 0;
       FunkinSound.playOnce(Paths.soundRandom('missnote', 1, 3), FlxG.random.float(0.5, 0.6));
     }
   }
@@ -3193,7 +3193,7 @@ class PlayState extends MusicBeatSubState
 
     if (event.playSound)
     {
-      if (vocals != null) vocals.playerVolume = 0;
+      if (vocals != null && currentStage != null && currentStage.getBoyfriend() != null && !currentStage.getBoyfriend().tempVocals) vocals.playerVolume = 0;
       FunkinSound.playOnce(Paths.soundRandom('missnote', 1, 3), FlxG.random.float(0.1, 0.2));
     }
   }

--- a/source/funkin/play/character/BaseCharacter.hx
+++ b/source/funkin/play/character/BaseCharacter.hx
@@ -77,6 +77,11 @@ class BaseCharacter extends Bopper
   final singTimeSteps:Float;
 
   /**
+   * When set to true, the next animation to play will temporarily force the character's vocals to play.
+   */
+  public var tempVocals:Bool = false;
+
+  /**
    * The offset between the corner of the sprite and the origin of the sprite (at the character's feet).
    * cornerPosition = stageData - characterOrigin
    */
@@ -325,6 +330,20 @@ class BaseCharacter extends Bopper
     {
       // Force the character to play the idle after the animation ends.
       this.dance(true);
+    }
+    if (tempVocals)
+    {
+      // stop the temporary vocals
+      if (characterType == BF && PlayState.instance.vocals.playerVolume == 1)
+      {
+        PlayState.instance.vocals.playerVolume = 0;
+      }
+
+      if (characterType == DAD && PlayState.instance.vocals.opponentVolume == 1)
+      {
+        PlayState.instance.vocals.opponentVolume = 0;
+      }
+      tempVocals = false;
     }
   }
 
@@ -700,6 +719,21 @@ class BaseCharacter extends Bopper
 
   public override function playAnimation(name:String, restart:Bool = false, ignoreOther:Bool = false, reversed:Bool = false):Void
   {
+    if (tempVocals)
+    {
+      // restart the character's vocals for the duration of the animation
+      if (characterType == BF && PlayState.instance.vocals.playerVolume == 0)
+      {
+        PlayState.instance.vocals.playerVolume = 1;
+      }
+      else if (characterType == DAD && PlayState.instance.vocals.opponentVolume == 0)
+      {
+        PlayState.instance.vocals.opponentVolume = 1;
+      }
+      else if (characterType != BF || characterType != DAD)
+        tempVocals = false;
+    }
+
     super.playAnimation(name, restart, ignoreOther, reversed);
   }
 

--- a/source/funkin/play/event/PlayAnimationSongEvent.hx
+++ b/source/funkin/play/event/PlayAnimationSongEvent.hx
@@ -61,6 +61,7 @@ class PlayAnimationSongEvent extends SongEvent
       if (Std.isOfType(target, BaseCharacter))
       {
         var targetChar:BaseCharacter = cast target;
+        targetChar.tempVocals = force;
         targetChar.playAnimation(anim, force, force);
       }
       else


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->
## Does this PR close any issues? If so, link them below.
Closes #4313
## Briefly describe the issue(s) fixed.
Adds a bool to BaseCharacter - tempVocals, and is set to/by the PlayAnimationSongEvent force variable. If the character's vocal volume is currently zero, it'll set it to 1 for the duration of the animation.

## Include any relevant screenshots or videos.

https://github.com/user-attachments/assets/6b603292-b66e-4b68-bb22-eef454e3ba42

yea~h!~

I like how the sound for the animation is now heard, but it's still cut short because it's longer than the animation, so it actually works quite well!
