### PR TITLE
Fix the song stuttering when a song resyncs (Read description)

### DIFF
--- a/source/funkin/play/PlayState.hx
+++ b/source/funkin/play/PlayState.hx
@@ -1087,8 +1087,8 @@ class PlayState extends MusicBeatSubState
 
     // If none of the music is null, process the vocal resyncing.
     if (FlxG.sound.music != null && vocals != null) {
-      // If the vocals' time is not `FlxG.sound.music.time`, resync them.
-      if (Math.abs(vocals.time) > FlxG.sound.music.time) resyncVocals();
+      // If the vocals' time is offset from `FlxG.sound.music.time` by 1ms, resync them.
+      if (vocals.time < FlxG.sound.music.time - 100 || vocals.time > FlxG.sound.music.time + 100) resyncVocals();
     }
 
     justUnpaused = false;
@@ -2037,7 +2037,6 @@ class PlayState extends MusicBeatSubState
     vocals.play();
     vocals.volume = 1.0;
     vocals.pitch = playbackRate;
-    vocals.time = FlxG.sound.music.time;
     // trace('${FlxG.sound.music.time}');
     // trace('${vocals.time}');
     resyncVocals();
@@ -2069,11 +2068,16 @@ class PlayState extends MusicBeatSubState
      */
   function resyncVocals():Void
   {
-    // Skip this if there's no vocals, the music is paused (GameOver, Pause menu, start-of-song offset, etc.), or if the vocals are empty.
-    if (vocals == null || !(FlxG.sound.music?.playing ?? false) || vocals.length <= 0) return;
+    // NULL PROTECTION
+    if (vocals == null || FlxG.sound.music == null) return;
+
+    // Skip this if the music is paused, the vocals are paused (GameOver, Pause menu, start-of-song offset, etc.), or if the vocals are empty.
+    if (!FlxG.sound.music.playing || !vocals.playing || vocals.length <= 0) return;
+
+    vocals.pause();
 
     trace('Resyncing vocals to ${FlxG.sound.music.time}');
-    vocals.time = FlxG.sound.music.time; // Resyncs the vocals
+    vocals.play(true, FlxG.sound.music.time); // Resyncs the vocals
   }
 
   /**

--- a/source/funkin/play/PlayState.hx
+++ b/source/funkin/play/PlayState.hx
@@ -1086,7 +1086,8 @@ class PlayState extends MusicBeatSubState
     if (!isInCutscene) processNotes(elapsed);
 
     // If none of the music is null, process the vocal resyncing.
-    if (FlxG.sound.music != null && vocals != null) {
+    if (FlxG.sound.music != null && vocals != null)
+    {
       // If the vocals' time is offset from `FlxG.sound.music.time` by 1ms, resync them.
       if (vocals.time < FlxG.sound.music.time - 100 || vocals.time > FlxG.sound.music.time + 100) resyncVocals();
     }
@@ -1277,9 +1278,9 @@ class PlayState extends MusicBeatSubState
       }
 
       // Re-sync vocals.
-      if (FlxG.sound.music != null && !startingSong && !isInCutscene) {
+      if (FlxG.sound.music != null && !startingSong && !isInCutscene)
+      {
         FlxG.sound.music.play();
-        vocals.play();
 
         resyncVocals();
       }
@@ -2034,7 +2035,6 @@ class PlayState extends MusicBeatSubState
 
     trace('Playing vocals...');
     add(vocals);
-    vocals.play();
     vocals.volume = 1.0;
     vocals.pitch = playbackRate;
     // trace('${FlxG.sound.music.time}');
@@ -2071,8 +2071,14 @@ class PlayState extends MusicBeatSubState
     // NULL PROTECTION
     if (vocals == null || FlxG.sound.music == null) return;
 
-    // Skip this if the music is paused, the vocals are paused (GameOver, Pause menu, start-of-song offset, etc.), or if the vocals are empty.
-    if (!FlxG.sound.music.playing || !vocals.playing || vocals.length <= 0) return;
+    // Skip this if the music is paused (GameOver, Pause menu, start-of-song offset, etc.), or if the vocals are empty.
+    if (!FlxG.sound.music.playing || vocals.length <= 0) return;
+
+    if (!vocals.playing)
+    {
+      trace('Playing vocals at ${FlxG.sound.music.time}');
+      vocals.play(true, FlxG.sound.music.time);
+    }
 
     vocals.pause();
 

--- a/source/funkin/play/PlayState.hx
+++ b/source/funkin/play/PlayState.hx
@@ -1088,7 +1088,7 @@ class PlayState extends MusicBeatSubState
     // If none of the music is null, process the vocal resyncing.
     if (FlxG.sound.music != null && vocals != null) {
       // If the vocals' time is not `FlxG.sound.music.time`, resync them.
-      if (vocals.time != FlxG.sound.music.time) resyncVocals();
+      if (Math.abs(vocals.time) > FlxG.sound.music.time) resyncVocals();
     }
 
     justUnpaused = false;
@@ -2073,7 +2073,7 @@ class PlayState extends MusicBeatSubState
     if (vocals == null || !(FlxG.sound.music?.playing ?? false) || vocals.length <= 0) return;
 
     trace('Resyncing vocals to ${FlxG.sound.music.time}');
-    vocals.time = FlxG.sound.music.time; // Resyncs the vocals with our offset in mind
+    vocals.time = FlxG.sound.music.time; // Resyncs the vocals
   }
 
   /**

--- a/source/funkin/play/PlayState.hx
+++ b/source/funkin/play/PlayState.hx
@@ -830,7 +830,7 @@ class PlayState extends MusicBeatSubState
       // Reset music properly.
       if (FlxG.sound.music != null)
       {
-        FlxG.sound.music.time = startTimestamp - Conductor.instance.combinedOffset;
+        FlxG.sound.music.time = startTimestamp;
         FlxG.sound.music.pitch = playbackRate;
         FlxG.sound.music.pause();
       }
@@ -847,7 +847,7 @@ class PlayState extends MusicBeatSubState
         }
       }
       vocals.pause();
-      vocals.time = 0 - Conductor.instance.combinedOffset;
+      vocals.time = 0;
 
       if (FlxG.sound.music != null) FlxG.sound.music.volume = 1;
       vocals.volume = 1;
@@ -1085,6 +1085,12 @@ class PlayState extends MusicBeatSubState
     // Moving notes into position is now done by Strumline.update().
     if (!isInCutscene) processNotes(elapsed);
 
+    // If none of the music is null, process the vocal resyncing.
+    if (FlxG.sound.music != null && vocals != null) {
+      // If the vocals' time is not `FlxG.sound.music.time`, resync them.
+      if (vocals.time != FlxG.sound.music.time) resyncVocals();
+    }
+
     justUnpaused = false;
   }
 
@@ -1271,7 +1277,12 @@ class PlayState extends MusicBeatSubState
       }
 
       // Re-sync vocals.
-      if (FlxG.sound.music != null && !startingSong && !isInCutscene) resyncVocals();
+      if (FlxG.sound.music != null && !startingSong && !isInCutscene) {
+        FlxG.sound.music.play();
+        vocals.play();
+
+        resyncVocals();
+      }
 
       // Resume the countdown.
       Countdown.resumeCountdown();
@@ -1422,43 +1433,6 @@ class PlayState extends MusicBeatSubState
     {
       // TODO: Sort more efficiently, or less often, to improve performance.
       // activeNotes.sort(SortUtil.byStrumtime, FlxSort.DESCENDING);
-    }
-
-    if (FlxG.sound.music != null)
-    {
-      var correctSync:Float = Math.min(FlxG.sound.music.length, Math.max(0, Conductor.instance.songPosition - Conductor.instance.combinedOffset));
-      var playerVoicesError:Float = 0;
-      var opponentVoicesError:Float = 0;
-
-      if (vocals != null)
-      {
-        @:privateAccess // todo: maybe make the groups public :thinking:
-        {
-          vocals.playerVoices.forEachAlive(function(voice:FunkinSound) {
-            var currentRawVoiceTime:Float = voice.time + vocals.playerVoicesOffset;
-            if (Math.abs(currentRawVoiceTime - correctSync) > Math.abs(playerVoicesError)) playerVoicesError = currentRawVoiceTime - correctSync;
-          });
-
-          vocals.opponentVoices.forEachAlive(function(voice:FunkinSound) {
-            var currentRawVoiceTime:Float = voice.time + vocals.opponentVoicesOffset;
-            if (Math.abs(currentRawVoiceTime - correctSync) > Math.abs(opponentVoicesError)) opponentVoicesError = currentRawVoiceTime - correctSync;
-          });
-        }
-      }
-
-      if (!startingSong
-        && (Math.abs(FlxG.sound.music.time - correctSync) > 5 || Math.abs(playerVoicesError) > 5 || Math.abs(opponentVoicesError) > 5))
-      {
-        trace("VOCALS NEED RESYNC");
-        if (vocals != null)
-        {
-          trace(playerVoicesError);
-          trace(opponentVoicesError);
-        }
-        trace(FlxG.sound.music.time);
-        trace(correctSync);
-        resyncVocals();
-      }
     }
 
     // Only bop camera if zoom level is below 135%
@@ -2051,7 +2025,7 @@ class PlayState extends MusicBeatSubState
     };
     // A negative instrumental offset means the song skips the first few milliseconds of the track.
     // This just gets added into the startTimestamp behavior so we don't need to do anything extra.
-    FlxG.sound.music.play(true, Math.max(0, startTimestamp - Conductor.instance.combinedOffset));
+    FlxG.sound.music.play(true, Math.max(0, startTimestamp));
     FlxG.sound.music.pitch = playbackRate;
 
     // Prevent the volume from being wrong.
@@ -2095,21 +2069,11 @@ class PlayState extends MusicBeatSubState
      */
   function resyncVocals():Void
   {
-    if (vocals == null) return;
+    // Skip this if there's no vocals, the music is paused (GameOver, Pause menu, start-of-song offset, etc.), or if the vocals are empty.
+    if (vocals == null || !(FlxG.sound.music?.playing ?? false) || vocals.length <= 0) return;
 
-    // Skip this if the music is paused (GameOver, Pause menu, start-of-song offset, etc.)
-    if (!(FlxG.sound.music?.playing ?? false)) return;
-
-    var timeToPlayAt:Float = Math.min(FlxG.sound.music.length, Math.max(0, Conductor.instance.songPosition - Conductor.instance.combinedOffset));
-    trace('Resyncing vocals to ${timeToPlayAt}');
-    FlxG.sound.music.pause();
-    vocals.pause();
-
-    FlxG.sound.music.time = timeToPlayAt;
-    FlxG.sound.music.play(false, timeToPlayAt);
-
-    vocals.time = timeToPlayAt;
-    vocals.play(false, timeToPlayAt);
+    trace('Resyncing vocals to ${FlxG.sound.music.time}');
+    vocals.time = FlxG.sound.music.time; // Resyncs the vocals with our offset in mind
   }
 
   /**

--- a/source/funkin/ui/credits/CreditsState.hx
+++ b/source/funkin/ui/credits/CreditsState.hx
@@ -34,13 +34,7 @@ class CreditsState extends MusicBeatState
    * To use a font from the `assets` folder, use `Paths.font(...)`.
    * Choose something that will render Unicode properly.
    */
-  #if windows
-  static final CREDITS_FONT = 'Consolas';
-  #elseif mac
-  static final CREDITS_FONT = 'Menlo';
-  #else
-  static final CREDITS_FONT = "Courier New";
-  #end
+  static final CREDITS_FONT = "5by7";
 
   /**
    * The size of the font.

--- a/source/funkin/ui/credits/CreditsState.hx
+++ b/source/funkin/ui/credits/CreditsState.hx
@@ -34,7 +34,13 @@ class CreditsState extends MusicBeatState
    * To use a font from the `assets` folder, use `Paths.font(...)`.
    * Choose something that will render Unicode properly.
    */
-  static final CREDITS_FONT = "5by7";
+  #if windows
+  static final CREDITS_FONT = 'Consolas';
+  #elseif mac
+  static final CREDITS_FONT = 'Menlo';
+  #else
+  static final CREDITS_FONT = "Courier New";
+  #end
 
   /**
    * The size of the font.


### PR DESCRIPTION
This pull request revamps the way that FNF resyncs a song's vocals.
Before, it would throw off the player, but in this pull request, it only resyncs the vocals to the instrumental to avoid throwing off the player.

```
My problem with song offsets is that if I change the vocal offset, it's not synced with the instrumental

But if I change the instrumental offset, it throws off the player (which is completely unacceptable), soo I decided that I shall hail input offsets and just force songs to be offset in their audio files manually (which everyone does already)

Also Eric, I know you'll probably have fixed the resync issue in 0.6, but please push this onto the main repo for the time being (if you manage to fix the offset thing), but yeah, this issue's been bugging the community for God knows how long, so I'm happy to have finally fixed it
```

I don't know what issues this fixes (Link them below in the replies)