### PR TITLE
New highscore plays twice fix

### DIFF
--- a/source/funkin/play/ResultState.hx
+++ b/source/funkin/play/ResultState.hx
@@ -563,16 +563,6 @@ class ResultState extends MusicBeatSubState
         // scorePopin.animation.play("score");
 
         // scorePopin.visible = true;
-
-        if (params.isNewHighscore ?? false)
-        {
-          highscoreNew.visible = true;
-          highscoreNew.animation.play("new");
-        }
-        else
-        {
-          highscoreNew.visible = false;
-        }
       };
     }
 


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->
## Does this PR close any issues? If so, link them below.
Fixes #2851
## Briefly describe the issue(s) fixed.
When the ratings finish popping in, it plays the new highscore animation, even though it's already played by a timer when the state is created.
## Include any relevant screenshots or videos.
I can't be bothered, it's such a tiny issue and I know this fixes it.