### PR TITLE
[BUGFIX] Prevent pressing Back and Accept keybinds on the same frame in FreeplayState causing a crash

### DIFF
--- a/source/funkin/ui/freeplay/FreeplayState.hx
+++ b/source/funkin/ui/freeplay/FreeplayState.hx
@@ -1670,7 +1670,7 @@ class FreeplayState extends MusicBeatSubState
       });
     }
 
-    if (accepted)
+    if (accepted && !busy)
     {
       grpCapsules.members[curSelected].onConfirm();
     }


### PR DESCRIPTION
## Does this PR close any issues? If so, link them below.
fixes #2944 

## Briefly describe the issue(s) fixed.
Add an additional check before running the onConfirm logic that checks for if the menu is already doing something, i.e is busy, which would be set to true since the exit logic happens before the accept logic. Exit logic already had this check so no idea why accept logic didn't lol
