### PR TITLE
End the funking song I'm going insane

### DIFF
--- a/source/funkin/play/PlayState.hx
+++ b/source/funkin/play/PlayState.hx
@@ -918,8 +918,12 @@ class PlayState extends MusicBeatSubState
 
       Conductor.instance.update(Conductor.instance.songPosition + elapsed * 1000, false); // Normal conductor update.
 
-      // Fallback in case music's onComplete function doesn't get called.
-      if (FlxG.sound.music.time >= (FlxG.sound.music.endTime ?? FlxG.sound.music.length) && mayPauseGame) endSong(skipEndingTransition);
+      // If, after updating the conductor, the instrumental has finished, end the song immediately.
+      // This helps prevent a major bug where the level suddenly loops back to the start or middle.
+      if (Conductor.instance.songPosition >= (FlxG.sound.music.endTime ?? FlxG.sound.music.length))
+      {
+        if (mayPauseGame) endSong(skipEndingTransition);
+      }
     }
 
     var androidPause:Bool = false;
@@ -2062,7 +2066,7 @@ class PlayState extends MusicBeatSubState
     }
 
     FlxG.sound.music.onComplete = function() {
-      endSong(skipEndingTransition);
+      if (mayPauseGame) endSong(skipEndingTransition);
     };
     // A negative instrumental offset means the song skips the first few milliseconds of the track.
     // This just gets added into the startTimestamp behavior so we don't need to do anything extra.


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->
## Does this PR close any issues? If so, link them below.
Fixes #4304, (finally) fixes #3142
## Briefly describe the issue(s) fixed.

https://github.com/FunkinCrew/Funkin/pull/4309#issuecomment-2727275864

> @Hundrec 
>
> Has found _the_ way to replicate the bug - when the song ends, click off the window, then click back into it - what ends up happening is that you bypass music's oncomplete function (because the music still plays even when you've clicked off) and so, the song doesn't end.

This also means that once the music playing when unfocused haxe issue is fixed, it should fix this issue too (but then again, maybe keep this in just in case it's also caused by something else?).

## Include any relevant screenshots or videos.
