### PR TITLE
[BUGFIX] Chart Editor - Note rendering broken after bpm change fix

### DIFF
--- a/source/funkin/ui/debug/charting/commands/AddNewTimeChangeCommand.hx
+++ b/source/funkin/ui/debug/charting/commands/AddNewTimeChangeCommand.hx
@@ -3,6 +3,7 @@ package funkin.ui.debug.charting.commands;
 #if FEATURE_CHART_EDITOR
 import funkin.data.song.SongData.SongTimeChange;
 import funkin.ui.debug.charting.toolboxes.ChartEditorMetadataToolbox;
+import funkin.data.song.SongDataUtils;
 
 /**
  * A command which adds a new timechange to the current song's timechanges, after the index value given, at the given timestamp.
@@ -43,9 +44,6 @@ class AddNewTimeChangeCommand implements ChartEditorCommand
 
     state.currentSongMetadata.timeChanges = timeChanges;
 
-    state.noteDisplayDirty = true;
-    state.notePreviewDirty = true;
-    state.notePreviewViewportBoundsDirty = true;
     state.scrollPositionInPixels = 0;
 
     var metadataToolbox:ChartEditorMetadataToolbox = cast state.getToolbox(ChartEditorState.CHART_EDITOR_TOOLBOX_METADATA_LAYOUT);
@@ -57,6 +55,8 @@ class AddNewTimeChangeCommand implements ChartEditorCommand
     state.updateSongTime(); // basically will update the time signature for the editor if necessary.
     state.updateGridHeight();
     state.updateTimeSignature();
+    state.currentSongChartNoteData = SongDataUtils.offsetSongNoteData(state.currentSongChartNoteData, 0);
+    state.currentSongChartEventData = SongDataUtils.offsetSongEventData(state.currentSongChartEventData, 0);
   }
 
   public function undo(state:ChartEditorState):Void
@@ -68,9 +68,6 @@ class AddNewTimeChangeCommand implements ChartEditorCommand
 
     state.currentSongMetadata.timeChanges = previousTimeChanges;
 
-    state.noteDisplayDirty = true;
-    state.notePreviewDirty = true;
-    state.notePreviewViewportBoundsDirty = true;
     state.scrollPositionInPixels = 0;
 
     var metadataToolbox:ChartEditorMetadataToolbox = cast state.getToolbox(ChartEditorState.CHART_EDITOR_TOOLBOX_METADATA_LAYOUT);
@@ -82,6 +79,8 @@ class AddNewTimeChangeCommand implements ChartEditorCommand
     state.updateSongTime();
     state.updateGridHeight();
     state.updateTimeSignature();
+    state.currentSongChartNoteData = SongDataUtils.offsetSongNoteData(state.currentSongChartNoteData, 0);
+    state.currentSongChartEventData = SongDataUtils.offsetSongEventData(state.currentSongChartEventData, 0);
   }
 
   public function shouldAddToHistory(state:ChartEditorState):Bool

--- a/source/funkin/ui/debug/charting/commands/AddNewTimeChangeCommand.hx
+++ b/source/funkin/ui/debug/charting/commands/AddNewTimeChangeCommand.hx
@@ -3,6 +3,7 @@ package funkin.ui.debug.charting.commands;
 #if FEATURE_CHART_EDITOR
 import funkin.data.song.SongData.SongTimeChange;
 import funkin.ui.debug.charting.toolboxes.ChartEditorMetadataToolbox;
+import funkin.data.song.SongDataUtils;
 
 /**
  * Represents a reversible action to add a new time change.
@@ -52,9 +53,6 @@ class AddNewTimeChangeCommand implements ChartEditorCommand
 
     state.currentSongMetadata.timeChanges = timeChanges;
 
-    state.noteDisplayDirty = true;
-    state.notePreviewDirty = true;
-    state.notePreviewViewportBoundsDirty = true;
     state.scrollPositionInPixels = 0;
 
     var metadataToolbox:ChartEditorMetadataToolbox = cast state.getToolbox(ChartEditorState.CHART_EDITOR_TOOLBOX_METADATA_LAYOUT);
@@ -66,6 +64,8 @@ class AddNewTimeChangeCommand implements ChartEditorCommand
     state.updateSongTime(); // basically will update the time signature for the editor if necessary.
     state.updateGridHeight();
     state.updateTimeSignature();
+    state.currentSongChartNoteData = SongDataUtils.offsetSongNoteData(state.currentSongChartNoteData, 0);
+    state.currentSongChartEventData = SongDataUtils.offsetSongEventData(state.currentSongChartEventData, 0);
   }
 
   /**
@@ -82,9 +82,6 @@ class AddNewTimeChangeCommand implements ChartEditorCommand
 
     state.currentSongMetadata.timeChanges = previousTimeChanges;
 
-    state.noteDisplayDirty = true;
-    state.notePreviewDirty = true;
-    state.notePreviewViewportBoundsDirty = true;
     state.scrollPositionInPixels = 0;
 
     var metadataToolbox:ChartEditorMetadataToolbox = cast state.getToolbox(ChartEditorState.CHART_EDITOR_TOOLBOX_METADATA_LAYOUT);
@@ -96,6 +93,8 @@ class AddNewTimeChangeCommand implements ChartEditorCommand
     state.updateSongTime();
     state.updateGridHeight();
     state.updateTimeSignature();
+    state.currentSongChartNoteData = SongDataUtils.offsetSongNoteData(state.currentSongChartNoteData, 0);
+    state.currentSongChartEventData = SongDataUtils.offsetSongEventData(state.currentSongChartEventData, 0);
   }
 
   /**

--- a/source/funkin/ui/debug/charting/commands/ModifyTimeChangeCommand.hx
+++ b/source/funkin/ui/debug/charting/commands/ModifyTimeChangeCommand.hx
@@ -3,6 +3,7 @@ package funkin.ui.debug.charting.commands;
 #if FEATURE_CHART_EDITOR
 import funkin.data.song.SongData.SongTimeChange;
 import funkin.ui.debug.charting.toolboxes.ChartEditorMetadataToolbox;
+import funkin.data.song.SongDataUtils;
 
 /**
  * A command which modifies the give time change in the current song's time changes.
@@ -61,9 +62,6 @@ class ModifyTimeChangeCommand implements ChartEditorCommand
 
     state.currentSongMetadata.timeChanges = timeChanges;
 
-    state.noteDisplayDirty = true;
-    state.notePreviewDirty = true;
-    state.notePreviewViewportBoundsDirty = true;
     state.scrollPositionInPixels = 0;
 
     var metadataToolbox:ChartEditorMetadataToolbox = cast state.getToolbox(ChartEditorState.CHART_EDITOR_TOOLBOX_METADATA_LAYOUT);
@@ -75,6 +73,11 @@ class ModifyTimeChangeCommand implements ChartEditorCommand
     state.updateSongTime();
     state.updateGridHeight();
     state.updateTimeSignature();
+    // Fix the positions of the notes and events (don't ask me how this works, I have no clue). It just works!
+    // I considered putting this in updateGridHeight() but I've noticed it gets updated in a lot of places, so I won't.
+
+    state.currentSongChartNoteData = SongDataUtils.offsetSongNoteData(state.currentSongChartNoteData, 0);
+    state.currentSongChartEventData = SongDataUtils.offsetSongEventData(state.currentSongChartEventData, 0);
   }
 
   public function undo(state:ChartEditorState):Void
@@ -94,9 +97,6 @@ class ModifyTimeChangeCommand implements ChartEditorCommand
 
     state.currentSongMetadata.timeChanges = timeChanges;
 
-    state.noteDisplayDirty = true;
-    state.notePreviewDirty = true;
-    state.notePreviewViewportBoundsDirty = true;
     state.scrollPositionInPixels = 0;
 
     var metadataToolbox:ChartEditorMetadataToolbox = cast state.getToolbox(ChartEditorState.CHART_EDITOR_TOOLBOX_METADATA_LAYOUT);
@@ -108,6 +108,8 @@ class ModifyTimeChangeCommand implements ChartEditorCommand
     state.updateSongTime();
     state.updateGridHeight();
     state.updateTimeSignature();
+    state.currentSongChartNoteData = SongDataUtils.offsetSongNoteData(state.currentSongChartNoteData, 0);
+    state.currentSongChartEventData = SongDataUtils.offsetSongEventData(state.currentSongChartEventData, 0);
   }
 
   public function shouldAddToHistory(state:ChartEditorState):Bool

--- a/source/funkin/ui/debug/charting/commands/ModifyTimeChangeCommand.hx
+++ b/source/funkin/ui/debug/charting/commands/ModifyTimeChangeCommand.hx
@@ -3,6 +3,7 @@ package funkin.ui.debug.charting.commands;
 #if FEATURE_CHART_EDITOR
 import funkin.data.song.SongData.SongTimeChange;
 import funkin.ui.debug.charting.toolboxes.ChartEditorMetadataToolbox;
+import funkin.data.song.SongDataUtils;
 
 /**
  * Represents a reversible action to modify a time change in a song.
@@ -60,9 +61,6 @@ class ModifyTimeChangeCommand implements ChartEditorCommand
 
     state.currentSongMetadata.timeChanges = timeChanges;
 
-    state.noteDisplayDirty = true;
-    state.notePreviewDirty = true;
-    state.notePreviewViewportBoundsDirty = true;
     state.scrollPositionInPixels = 0;
 
     var metadataToolbox:ChartEditorMetadataToolbox = cast state.getToolbox(ChartEditorState.CHART_EDITOR_TOOLBOX_METADATA_LAYOUT);
@@ -74,6 +72,11 @@ class ModifyTimeChangeCommand implements ChartEditorCommand
     state.updateSongTime();
     state.updateGridHeight();
     state.updateTimeSignature();
+    // Fix the positions of the notes and events (don't ask me how this works, I have no clue). It just works!
+    // I considered putting this in updateGridHeight() but I've noticed it gets updated in a lot of places, so I won't.
+
+    state.currentSongChartNoteData = SongDataUtils.offsetSongNoteData(state.currentSongChartNoteData, 0);
+    state.currentSongChartEventData = SongDataUtils.offsetSongEventData(state.currentSongChartEventData, 0);
   }
 
   /**
@@ -98,9 +101,6 @@ class ModifyTimeChangeCommand implements ChartEditorCommand
 
     state.currentSongMetadata.timeChanges = timeChanges;
 
-    state.noteDisplayDirty = true;
-    state.notePreviewDirty = true;
-    state.notePreviewViewportBoundsDirty = true;
     state.scrollPositionInPixels = 0;
 
     var metadataToolbox:ChartEditorMetadataToolbox = cast state.getToolbox(ChartEditorState.CHART_EDITOR_TOOLBOX_METADATA_LAYOUT);
@@ -112,6 +112,8 @@ class ModifyTimeChangeCommand implements ChartEditorCommand
     state.updateSongTime();
     state.updateGridHeight();
     state.updateTimeSignature();
+    state.currentSongChartNoteData = SongDataUtils.offsetSongNoteData(state.currentSongChartNoteData, 0);
+    state.currentSongChartEventData = SongDataUtils.offsetSongEventData(state.currentSongChartEventData, 0);
   }
 
   /**

--- a/source/funkin/ui/debug/charting/commands/RemoveTimeChangeCommand.hx
+++ b/source/funkin/ui/debug/charting/commands/RemoveTimeChangeCommand.hx
@@ -3,6 +3,7 @@ package funkin.ui.debug.charting.commands;
 #if FEATURE_CHART_EDITOR
 import funkin.data.song.SongData.SongTimeChange;
 import funkin.ui.debug.charting.toolboxes.ChartEditorMetadataToolbox;
+import funkin.data.song.SongDataUtils;
 
 /**
  * A command which removes the given timechange from the current song's timechanges.
@@ -37,9 +38,7 @@ class RemoveTimeChangeCommand implements ChartEditorCommand
 
     state.currentSongMetadata.timeChanges = timeChanges;
 
-    state.noteDisplayDirty = true;
-    state.notePreviewDirty = true;
-    state.notePreviewViewportBoundsDirty = true;
+    state.scrollPositionInPixels = 0;
 
     var metadataToolbox:ChartEditorMetadataToolbox = cast state.getToolbox(ChartEditorState.CHART_EDITOR_TOOLBOX_METADATA_LAYOUT);
 
@@ -50,6 +49,8 @@ class RemoveTimeChangeCommand implements ChartEditorCommand
     state.updateSongTime();
     state.updateGridHeight();
     state.updateTimeSignature();
+    state.currentSongChartNoteData = SongDataUtils.offsetSongNoteData(state.currentSongChartNoteData, 0);
+    state.currentSongChartEventData = SongDataUtils.offsetSongEventData(state.currentSongChartEventData, 0);
   }
 
   public function undo(state:ChartEditorState):Void
@@ -61,9 +62,7 @@ class RemoveTimeChangeCommand implements ChartEditorCommand
 
     state.currentSongMetadata.timeChanges = previousTimeChanges;
 
-    state.noteDisplayDirty = true;
-    state.notePreviewDirty = true;
-    state.notePreviewViewportBoundsDirty = true;
+    state.scrollPositionInPixels = 0;
 
     var metadataToolbox:ChartEditorMetadataToolbox = cast state.getToolbox(ChartEditorState.CHART_EDITOR_TOOLBOX_METADATA_LAYOUT);
 
@@ -74,6 +73,8 @@ class RemoveTimeChangeCommand implements ChartEditorCommand
     state.updateSongTime();
     state.updateGridHeight();
     state.updateTimeSignature();
+    state.currentSongChartNoteData = SongDataUtils.offsetSongNoteData(state.currentSongChartNoteData, 0);
+    state.currentSongChartEventData = SongDataUtils.offsetSongEventData(state.currentSongChartEventData, 0);
   }
 
   public function shouldAddToHistory(state:ChartEditorState):Bool

--- a/source/funkin/ui/debug/charting/commands/RemoveTimeChangeCommand.hx
+++ b/source/funkin/ui/debug/charting/commands/RemoveTimeChangeCommand.hx
@@ -3,6 +3,7 @@ package funkin.ui.debug.charting.commands;
 #if FEATURE_CHART_EDITOR
 import funkin.data.song.SongData.SongTimeChange;
 import funkin.ui.debug.charting.toolboxes.ChartEditorMetadataToolbox;
+import funkin.data.song.SongDataUtils;
 
 /**
  * Represents a reversible action to remove a time change from the current chart.
@@ -40,9 +41,7 @@ class RemoveTimeChangeCommand implements ChartEditorCommand
 
     state.currentSongMetadata.timeChanges = timeChanges;
 
-    state.noteDisplayDirty = true;
-    state.notePreviewDirty = true;
-    state.notePreviewViewportBoundsDirty = true;
+    state.scrollPositionInPixels = 0;
 
     var metadataToolbox:ChartEditorMetadataToolbox = cast state.getToolbox(ChartEditorState.CHART_EDITOR_TOOLBOX_METADATA_LAYOUT);
 
@@ -53,6 +52,8 @@ class RemoveTimeChangeCommand implements ChartEditorCommand
     state.updateSongTime();
     state.updateGridHeight();
     state.updateTimeSignature();
+    state.currentSongChartNoteData = SongDataUtils.offsetSongNoteData(state.currentSongChartNoteData, 0);
+    state.currentSongChartEventData = SongDataUtils.offsetSongEventData(state.currentSongChartEventData, 0);
   }
 
   /**
@@ -69,9 +70,7 @@ class RemoveTimeChangeCommand implements ChartEditorCommand
 
     state.currentSongMetadata.timeChanges = previousTimeChanges;
 
-    state.noteDisplayDirty = true;
-    state.notePreviewDirty = true;
-    state.notePreviewViewportBoundsDirty = true;
+    state.scrollPositionInPixels = 0;
 
     var metadataToolbox:ChartEditorMetadataToolbox = cast state.getToolbox(ChartEditorState.CHART_EDITOR_TOOLBOX_METADATA_LAYOUT);
 
@@ -82,6 +81,8 @@ class RemoveTimeChangeCommand implements ChartEditorCommand
     state.updateSongTime();
     state.updateGridHeight();
     state.updateTimeSignature();
+    state.currentSongChartNoteData = SongDataUtils.offsetSongNoteData(state.currentSongChartNoteData, 0);
+    state.currentSongChartEventData = SongDataUtils.offsetSongEventData(state.currentSongChartEventData, 0);
   }
 
   /**


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->
## Does this PR close any issues? If so, link them below.
Fixes #3557
## Briefly describe the issue(s) fixed.

Hi everyone, it's Laserchart, back again with another chart fix!

This time I've fixed rendered notes from breaking after a BPM change. Don't ask me how the fix works, I have no clue. It just works!

## Include any relevant screenshots or videos.

https://github.com/user-attachments/assets/1d9250ca-b1f3-4898-b7a4-298e3ae0089f

The waveforms are just doing their thing, don't mind them.
