### PR TITLE
Character icon clickable in playstate fix

### DIFF
--- a/source/funkin/ui/debug/charting/ChartEditorState.hx
+++ b/source/funkin/ui/debug/charting/ChartEditorState.hx
@@ -2761,18 +2761,19 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
 
     // Setup character dropdowns.
     FlxMouseEvent.add(healthIconDad, function(_) {
-      if (!isCursorOverHaxeUI)
+      if (!isCursorOverHaxeUI && persistentDraw && persistentUpdate)
       {
         this.openCharacterDropdown(CharacterType.DAD, true);
       }
     });
 
     FlxMouseEvent.add(healthIconBF, function(_) {
-      if (!isCursorOverHaxeUI)
+      if (!isCursorOverHaxeUI && persistentDraw && persistentUpdate)
       {
         this.openCharacterDropdown(CharacterType.BF, true);
       }
     });
+
 
     buttonSelectOpponent = new Button();
     buttonSelectOpponent.allowFocus = false;


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->
## Does this PR close any issues? If so, link them below.
No, but it prevents one from being opened in the future!
## Briefly describe the issue(s) fixed.
The character icon in the chart editor was still clickable in while playstate - it wasn't checking if the chart editor state was actually currently active or not.
## Include any relevant screenshots or videos.
