### PR TITLE
Chart editor - Scroll anchor fix

### DIFF
--- a/source/funkin/ui/debug/charting/ChartEditorState.hx
+++ b/source/funkin/ui/debug/charting/ChartEditorState.hx
@@ -3861,7 +3861,7 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
     // Handle scroll anchor
     if (scrollAnchorScreenPos != null)
     {
-      var currentScreenPos = new FlxPoint(FlxG.mouse.viewX, FlxG.mouse.viewX);
+      var currentScreenPos = new FlxPoint(FlxG.mouse.viewX, FlxG.mouse.viewY);
       var distance = currentScreenPos - scrollAnchorScreenPos;
 
       var verticalDistance = distance.y;


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->
## Does this PR close any issues? If so, link them below.
No, but it prevents one from being opened in the future!
## Briefly describe the issue(s) fixed.
The currentScreenPos was a FlxPoint of only the FlxG.mouse.viewX for both the x and y values, so it wasn't quite scrolling the way it should.

I didn't even know this was a feature (and that it was broken sorta by a typo).
## Include any relevant screenshots or videos.
### Before:

https://github.com/user-attachments/assets/4162f5cc-699a-48bb-845e-9fbb47a8b25b

### After:

https://github.com/user-attachments/assets/a74beb99-3539-4fbf-af9e-34d2384be9b7

