### PR TITLE
[BUGFIX] Fix the Inst and Vocal files not being played when the Sound Channel Limit gets reached

### DIFF
--- a/source/funkin/audio/FunkinSound.hx
+++ b/source/funkin/audio/FunkinSound.hx
@@ -16,6 +16,7 @@ import funkin.Paths.PathsFunction;
 import openfl.Assets;
 import lime.app.Future;
 import lime.app.Promise;
+import openfl.media.SoundChannel;
 import openfl.media.SoundMixer;
 
 #if (openfl >= "8.0.0")
@@ -433,19 +434,26 @@ class FunkinSound extends FlxSound implements ICloneable<FunkinSound>
    * @param persist         Whether to keep this `FunkinSound` between states, or destroy it.
    * @param onComplete      Called when the sound finished playing.
    * @param onLoad          Called when the sound finished loading.  Called immediately for succesfully loaded embedded sounds.
+   * @param important       If `true` and the sound channel list is full, the first sound will be cleared to make room for this sound.
    * @return A `FunkinSound` object, or `null` if the sound could not be loaded.
    */
   public static function load(embeddedSound:FlxSoundAsset, volume:Float = 1.0, looped:Bool = false, autoDestroy:Bool = false, autoPlay:Bool = false,
-      persist:Bool = false, ?onComplete:Void->Void, ?onLoad:Void->Void):Null<FunkinSound>
+      persist:Bool = false, ?onComplete:Void->Void, ?onLoad:Void->Void, important:Bool = false):Null<FunkinSound>
   {
     @:privateAccess
-    if (SoundMixer.__soundChannels.length >= SoundMixer.MAX_ACTIVE_CHANNELS)
+    if (SoundMixer.__soundChannels.length >= SoundMixer.MAX_ACTIVE_CHANNELS && !important)
     {
       FlxG.log.error('FunkinSound could not play sound, channels exhausted! Found ${SoundMixer.__soundChannels.length} active sound channels.');
       return null;
     }
 
     var sound:FunkinSound = pool.recycle(construct);
+
+    if (important)
+    {
+      importantSoundQueue.push(sound);
+      FunkinSound.clearSoundChannels();
+    }
 
     // Load the sound.
     // Sets `exists = true` as a side effect.
@@ -525,6 +533,7 @@ class FunkinSound extends FlxSound implements ICloneable<FunkinSound>
   @:nullSafety(Off)
   public override function destroy():Void
   {
+    if (importantSoundQueue.contains(this)) importantSoundQueue.remove(this);
     // trace('[FunkinSound] Destroying sound "${this._label}"');
     super.destroy();
     if (fadeTween != null)
@@ -534,6 +543,45 @@ class FunkinSound extends FlxSound implements ICloneable<FunkinSound>
     }
     FlxTween.cancelTweensOf(this);
     this._label = 'unknown';
+  }
+
+  override function startSound(startTime:Float)
+  {
+    FunkinSound.clearSoundChannels();
+    super.startSound(startTime);
+  }
+
+  override function cleanup(destroySound:Bool, resetPosition:Bool = true)
+  {
+    if (importantSoundQueue.contains(this)) importantSoundQueue.remove(this);
+    super.cleanup(destroySound, resetPosition);
+  }
+
+  static var importantSoundQueue:Array<FunkinSound> = [];
+
+  @:access(openfl.media.SoundMixer)
+  @:access(flixel.sound.FlxSound)
+  public static function clearSoundChannels()
+  {
+    // If there are more important sounds than sound channels, we treat them as if they aren't important and clear them.
+    var keepImportants:Bool = (importantSoundQueue.length < SoundMixer.MAX_ACTIVE_CHANNELS);
+    var importantChannels:Array<SoundChannel> = [for (snd in importantSoundQueue) snd?._channel].filterNull();
+
+    while (SoundMixer.__soundChannels.length >= SoundMixer.MAX_ACTIVE_CHANNELS)
+    {
+      var channel:Null<SoundChannel> = SoundMixer.__soundChannels.pop();
+      if (channel == null) continue;
+
+      // If the channel is important, put it back to the array.
+      if (keepImportants && importantChannels.contains(channel))
+      {
+        SoundMixer.__soundChannels.push(channel);
+        continue;
+      }
+
+      // Otherwise, stop it.
+      channel?.stop();
+    }
   }
 
   /**

--- a/source/funkin/play/song/Song.hx
+++ b/source/funkin/play/song/Song.hx
@@ -809,7 +809,7 @@ class SongDifficulty
   {
     var suffix:String = (instId != '') ? '-$instId' : '';
 
-    FlxG.sound.music = FunkinSound.load(Paths.inst(this.song.id, suffix), volume, looped, false, true);
+    FlxG.sound.music = FunkinSound.load(Paths.inst(this.song.id, suffix), volume, looped, false, true, false, null, null, true);
 
     // Workaround for a bug where FlxG.sound.music.update() was being called twice.
     FlxG.sound.list.remove(FlxG.sound.music);
@@ -956,14 +956,14 @@ class SongDifficulty
     for (playerVoice in playerVoiceList)
     {
       if (!Assets.exists(playerVoice)) continue;
-      result.addPlayerVoice(FunkinSound.load(playerVoice));
+      result.addPlayerVoice(FunkinSound.load(playerVoice, 1.0, false, false, false, false, null, null, true));
     }
 
     // Add opponent vocals.
     for (opponentVoice in opponentVoiceList)
     {
       if (!Assets.exists(opponentVoice)) continue;
-      result.addOpponentVoice(FunkinSound.load(opponentVoice));
+      result.addOpponentVoice(FunkinSound.load(opponentVoice, 1.0, false, false, false, false, null, null, true));
     }
 
     result.playerVoicesOffset = offsets.getVocalOffset(characters.player, instId);


### PR DESCRIPTION
## Does this PR close any issues? If so, link them below.
Closes #2732 

## Briefly describe the issue(s) fixed.
Introduced the sound channel priority to `FunkinSound` with the default value `false`. Inst and vocal files have this value set to `true`. 
When enabled, this value adds the sound to a priority list, which means that when the sound channels get cleared (which happens before playing another sound) they remain untouched.

## Include any relevant screenshots or videos.

https://github.com/user-attachments/assets/dab098d0-0a9c-4720-bde2-616c63e6c3aa

(You can kind of see the effect because the "Go!" sound isn't being played (since it doesn't have the priority) however the music remains intact)
