### PR TITLE
[BUGFIX] Fallback when no defined inputs

### DIFF
--- a/source/funkin/input/Controls.hx
+++ b/source/funkin/input/Controls.hx
@@ -423,6 +423,7 @@ class Controls extends FlxActionSet
 
   public function getDialogueName(action:FlxActionDigital, ?ignoreSurrounding:Bool = false):String
   {
+    if (action.inputs.length == 0) return 'N/A';
     var input = action.inputs[0];
     if (ignoreSurrounding == false)
     {


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->
## Does this PR close any issues? If so, link them below.
Fixes #4354 
## Briefly describe the issue(s) fixed.
When attempting to retrieve for a button name it could try to access a non-existent value from an empty set of inputs, causing a `Null Object Reference` error.
This changes so it falls back to `N/A` when there's no inputs available.
## Include any relevant screenshots or videos.
![image](https://github.com/user-attachments/assets/b7a3f532-6557-4c87-9c86-b5ef0a3f3c58)
