### PR TITLE
[BUGFIX] Fix the chance of getting the special pause menu

### DIFF
--- a/source/funkin/play/PlayState.hx
+++ b/source/funkin/play/PlayState.hx
@@ -948,7 +948,7 @@ class PlayState extends MusicBeatSubState
     // Attempt to pause the game.
     if ((controls.PAUSE || androidPause) && isInCountdown && mayPauseGame && !justUnpaused)
     {
-      var event = new PauseScriptEvent(FlxG.random.bool(1 / 1000));
+      var event = new PauseScriptEvent(FlxG.random.bool((1 / 1000) * 100));
 
       dispatchEvent(event);
 


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->
## Does this PR close any issues? If so, link them below.
No, and I don't think anyone would unless they looked at the code to notice this.
## Briefly describe the issue(s) fixed.
According to line 949 in `PlayState.hx`, there is a 1/1000 chance to use a special pause menu. The function used to calculate this chance is `FlxG.random.bool`. This function takes in a number to use as a percent chance for something to happen (ex: passing in 50 would give it a 50% chance to return `true`). 

The number currently passed into this function to determine the chance of getting the special pause menu is 1 / 1000. This wouldn't give you a 1/1000 chance as it was not converted to a percent for the function first. This value would need to be multiplied by 100. You can see that this was done correctly in `GameOverSubState.hx` line 223 for the 1/4096 chance of getting the fakeout death animation:
```
if (boyfriend.hasAnimation('fakeoutDeath') && FlxG.random.bool((1 / 4096) * 100))
```
This PR fixes the chance to get the special pause menu by multiplying the 1 / 1000 by 100 in the same format used above.
