### PR TITLE
[ENHANCEMENT] Metadata pixel icons

### DIFF
--- a/source/funkin/data/song/SongData.hx
+++ b/source/funkin/data/song/SongData.hx
@@ -496,6 +496,13 @@ class SongPlayData implements ICloneable<SongPlayData>
   @:default(15000)
   public var previewEnd:Int;
 
+  /**
+   * The pixel icon for the song in Freeplay.
+   * Defaults to the opponent's icon.
+   */
+  @:optional
+  public var freeplayIcon:Null<PixelIconData>;
+
   public function new()
   {
     ratings = new Map<String, Int>();
@@ -514,6 +521,7 @@ class SongPlayData implements ICloneable<SongPlayData>
     result.album = this.album;
     result.previewStart = this.previewStart;
     result.previewEnd = this.previewEnd;
+    result.freeplayIcon = this.freeplayIcon;
 
     return result;
   }
@@ -1264,4 +1272,29 @@ class NoteParamData implements ICloneable<NoteParamData>
   {
     return 'NoteParamData(${this.name}, ${this.value})';
   }
+}
+
+typedef PixelIconData =
+{
+  /**
+   * The ID to use for the icon.
+   */
+  @:optional
+  var id:String;
+
+  /**
+   * The offsets of the icon.
+   * @default [0, 0]
+   */
+  @:optional
+  @:default([0, 0])
+  var ?offsets:Array<Float>;
+
+  /**
+   * Whether to flip the icon horizontally.
+   * @default false
+   */
+  @:optional
+  @:default(false)
+  var ?flipX:Bool;
 }

--- a/source/funkin/play/song/Song.hx
+++ b/source/funkin/play/song/Song.hx
@@ -3,6 +3,7 @@ package funkin.play.song;
 import funkin.audio.VoicesGroup;
 import funkin.audio.FunkinSound;
 import funkin.data.IRegistryEntry;
+import funkin.data.song.SongData.PixelIconData;
 import funkin.data.song.SongData.SongCharacterData;
 import funkin.data.song.SongData.SongChartData;
 import funkin.data.song.SongData.SongEventData;
@@ -326,6 +327,7 @@ class Song implements IPlayStateScriptedClass implements IRegistryEntry<SongMeta
 
         difficulty.difficultyRating = metadata.playData.ratings.get(diffId) ?? 0;
         difficulty.album = metadata.playData.album;
+        difficulty.freeplayIcon = metadata.playData.freeplayIcon;
         difficulty.stickerPack = metadata.playData.stickerPack;
 
         difficulty.stage = metadata.playData.stage;
@@ -741,6 +743,7 @@ class SongDifficulty
 
   public var difficultyRating:Int = 0;
   public var album:Null<String> = null;
+  public var freeplayIcon:Null<PixelIconData> = null;
   public var stickerPack:Null<String> = null;
 
   public function new(song:Song, diffId:String, variation:String)

--- a/source/funkin/ui/PixelatedIcon.hx
+++ b/source/funkin/ui/PixelatedIcon.hx
@@ -17,8 +17,10 @@ class PixelatedIcon extends FlxFilteredSprite
     this.active = false;
   }
 
-  public function setCharacter(char:String):Void
+  public function setCharacter(char:String, ?offsets:Null<Array<Float>>):Void
   {
+    if (offsets == null) offsets = [0, 0];
+
     var charPath:String = "freeplay/icons/";
 
     switch (char)
@@ -71,13 +73,10 @@ class PixelatedIcon extends FlxFilteredSprite
 
     this.scale.x = this.scale.y = 2;
 
-    switch (char)
-    {
-      case 'parents-christmas':
-        this.origin.x = 140;
-      default:
-        this.origin.x = 100;
-    }
+    this.origin.x = 100;
+
+    this.origin.x += offsets[0];
+    this.origin.y += offsets[1];
 
     if (isAnimated)
     {

--- a/source/funkin/ui/freeplay/FreeplayState.hx
+++ b/source/funkin/ui/freeplay/FreeplayState.hx
@@ -18,6 +18,7 @@ import flixel.util.FlxTimer;
 import funkin.audio.FunkinSound;
 import funkin.data.freeplay.player.PlayerRegistry;
 import funkin.data.song.SongRegistry;
+import funkin.data.song.SongData.PixelIconData;
 import funkin.data.story.level.LevelRegistry;
 import funkin.effects.IntervalShake;
 import funkin.graphics.FunkinCamera;
@@ -2336,6 +2337,11 @@ class FreeplaySongData
 
   public var scoringRank(get, never):Null<ScoringRank>;
 
+  /**
+   * The pixel icon for the song.
+   */
+  public var pixelIconData(get, never):Null<PixelIconData>;
+
   public function new(data:Song, levelData:Level)
   {
     this.data = data;
@@ -2410,6 +2416,12 @@ class FreeplaySongData
     var variation:String = data.getFirstValidVariation(FreeplayState.rememberedDifficulty, null, variations);
 
     return Save.instance.getSongRank(data.id, FreeplayState.rememberedDifficulty, variation);
+  }
+
+  function get_pixelIconData():Null<PixelIconData>
+  {
+    var variations:Array<String> = data.getVariationsByCharacterId(FreeplayState.rememberedCharacterId);
+    return data.getDifficulty(FreeplayState.rememberedDifficulty, null, variations)?.freeplayIcon;
   }
 }
 

--- a/source/funkin/ui/freeplay/SongMenuItem.hx
+++ b/source/funkin/ui/freeplay/SongMenuItem.hx
@@ -407,7 +407,11 @@ class SongMenuItem extends FlxSpriteGroup
     else
     {
       songText.text = freeplayData.fullSongName;
-      if (freeplayData.songCharacter != null) pixelIcon.setCharacter(freeplayData.songCharacter);
+      if (freeplayData.songCharacter != null)
+      {
+        pixelIcon.setCharacter(freeplayData.pixelIconData?.id ?? freeplayData.songCharacter, freeplayData.pixelIconData?.offsets);
+        pixelIcon.flipX = freeplayData.pixelIconData?.flipX ?? false;
+      }
       pixelIcon.visible = true;
       updateBPM(Std.int(freeplayData.songStartingBpm) ?? 0);
       updateDifficultyRating(freeplayData.difficultyRating ?? 0);


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->
This PR adds pixel icon data to the metadata, allowing for offsets adjustment and flipping.

This is different from the implementations seen in #2465 and #3042 in the sense that it uses the ***song*** metadata instead of the character metadata, Eric mentioned it here: https://github.com/FunkinCrew/Funkin/pull/3042#issuecomment-2254349610
This allows pixel icons to be configured on a song-by-song basis!

Example:
```json
{
  "version": "2.2.4",
  "songName": "Blazin'",
  "artist": "Kawai Sprite",
  "charter": "fabs + PhantomArcade",
  "playData": {
    "difficulties": ["easy", "normal", "hard"],
    "characters": {
      "player": "pico-blazin",
      "girlfriend": "nene",
      "opponent": "darnell-blazin"
    },
    "stage": "phillyBlazin",
    "noteStyle": "funkin",
    "ratings": { "easy": 3, "normal": 4, "hard": 5 },
    "album": "volume3",
    "previewStart": 0,
    "previewEnd": 15000,
    "freeplayIcon": {
      "id": "mom",
      "offsets": [0, 0],
      "flipX": true
    }
  },
  "generatedBy": "Chart Editor Import (FNF Legacy)",
  "timeFormat": "ms",
  "timeChanges": [
    { "t": 0, "b": 0, "bpm": 180, "n": 4, "d": 4, "bt": [4, 4, 4, 4] }
  ]
}
```
If `freeplayIcon` isn't in the song metadata, it defaults to the opponent's character ID, as it did before.

![screenshot-2025-03-21-20-50-24](https://github.com/user-attachments/assets/8480b973-a0ca-456e-9355-65c29b850a97)

Let me know if there's any issues, I haven't been able to test this *as* much as my other PRs!