### PR TITLE
[BUGFIX] Fix the Atlas Characters not being in place after a Song Reset

### DIFF
--- a/source/funkin/play/character/AnimateAtlasCharacter.hx
+++ b/source/funkin/play/character/AnimateAtlasCharacter.hx
@@ -42,6 +42,7 @@ class AnimateAtlasCharacter extends BaseCharacter
   // BaseCharacter extends FlxSprite but we can't make it also extend FlxAtlasSprite UGH
   // I basically copied the code from FlxSpriteGroup to make the FlxAtlasSprite a "child" of this class
   var mainSprite:FlxAtlasSprite;
+  var originalSizes(default, never):FlxPoint = new FlxPoint();
 
   var _skipTransformChildren:Bool = false;
 
@@ -172,6 +173,8 @@ class AnimateAtlasCharacter extends BaseCharacter
     this.mainSprite.alpha = 0.0001;
     this.mainSprite.draw();
     this.mainSprite.alpha = 1.0;
+
+    originalSizes.set(this.mainSprite.width, this.mainSprite.height);
 
     var feetPos:FlxPoint = feetPosition;
     this.updateHitbox();
@@ -597,7 +600,7 @@ class AnimateAtlasCharacter extends BaseCharacter
   {
     if (this.mainSprite == null) return 0;
 
-    return this.mainSprite.width;
+    return this.originalSizes.x;
   }
 
   /**
@@ -646,7 +649,7 @@ class AnimateAtlasCharacter extends BaseCharacter
   {
     if (this.mainSprite == null) return 0;
 
-    return this.mainSprite.height;
+    return this.originalSizes.y;
   }
 
   /**


### PR DESCRIPTION
## Does this PR close any issues? If so, link them below.
Closes https://github.com/FunkinCrew/Funkin/issues/3168

## Briefly describe the issue(s) fixed.
Lasercar pointed out in the issue's thread that the atlas characters don't have their widths and heights be a fixed value unlike the rest of characters, probably due to all the limbs n shit so I added an `FlxPoint` that gets its values set to the sizes of the atlas sprite right after it's initializied. The values of this FlxPoint override `width` and `height` fields of the FlxSprite object

Imo this would be nice to contribute upstream at some point

## Include any relevant screenshots or videos.

https://github.com/user-attachments/assets/368c3595-365f-4e2a-87db-354f4ad7fcbc
