### PR TITLE
Chart editor - Disable edit buttons if no selection and stuff

### DIFF
--- a/source/funkin/ui/debug/charting/ChartEditorState.hx
+++ b/source/funkin/ui/debug/charting/ChartEditorState.hx
@@ -1068,6 +1068,22 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
   var commandHistoryDirty:Bool = true;
 
   /**
+   * Whether the selection has changed and the edit buttons need to be updated.
+   */
+  var editButtonsDirty:Bool = true;
+
+  /**
+   * Whether the clipboard has changed and the paste buttons need to be updated.
+   */
+  var clipboardDirty:Bool = true;
+
+  /**
+   * Whether the clipboard is valid and contains a json of notes and events.
+   */
+  var clipboardValid:Bool = true;
+
+
+  /**
    * If true, we are currently in the process of quitting the chart editor.
    * Skip any update functions as most of them will call a crash.
    */
@@ -3141,6 +3157,8 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
 
   function copySelection():Void
   {
+    clipboardDirty = true;
+    clipboardValid = true;
     // Doesn't use a command because it's not undoable.
 
     // Calculate a single time offset for all the notes and events.
@@ -6245,6 +6263,50 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
         // Change the label to the last command.
         menubarItemRedo.disabled = false;
         menubarItemRedo.text = 'Redo ${redoHistory[redoHistory.length - 1].toString()}';
+      }
+    }
+    if (clipboardDirty)
+    {
+      clipboardDirty = false;
+
+      if (funkin.util.ClipboardUtil.getClipboard() == null || !clipboardValid)
+      {
+        menubarItemPaste.disabled = true;
+        menubarItemPasteUnsnapped.disabled = true;
+        clipboardValid = false;
+      }
+      else if (clipboardValid)
+      {
+        menubarItemPaste.disabled = false;
+        menubarItemPasteUnsnapped.disabled = false;
+      }
+    }
+
+    if (editButtonsDirty)
+    {
+      editButtonsDirty = false;
+
+      if (currentEventSelection.length > 0 || currentNoteSelection.length > 0)
+      {
+        menubarItemCopy.disabled = false;
+        menubarItemCut.disabled = false;
+        menubarItemDelete.disabled = false;
+        menubarItemSelectNone.disabled = false;
+      }
+      else
+      {
+        menubarItemCopy.disabled = true;
+        menubarItemCut.disabled = true;
+        menubarItemDelete.disabled = true;
+        menubarItemSelectNone.disabled = true;
+      }
+      if (currentNoteSelection.length > 0)
+      {
+        menubarItemFlipNotes.disabled = false;
+      }
+      else
+      {
+        menubarItemFlipNotes.disabled = true;
       }
     }
   }

--- a/source/funkin/ui/debug/charting/commands/AddEventsCommand.hx
+++ b/source/funkin/ui/debug/charting/commands/AddEventsCommand.hx
@@ -41,6 +41,7 @@ class AddEventsCommand implements ChartEditorCommand
     state.saveDataDirty = true;
     state.noteDisplayDirty = true;
     state.notePreviewDirty = true;
+    state.editButtonsDirty = true;
 
     state.sortChartData();
   }
@@ -55,6 +56,7 @@ class AddEventsCommand implements ChartEditorCommand
     state.saveDataDirty = true;
     state.noteDisplayDirty = true;
     state.notePreviewDirty = true;
+    state.editButtonsDirty = true;
 
     state.sortChartData();
   }

--- a/source/funkin/ui/debug/charting/commands/AddNotesCommand.hx
+++ b/source/funkin/ui/debug/charting/commands/AddNotesCommand.hx
@@ -41,6 +41,7 @@ class AddNotesCommand implements ChartEditorCommand
     state.saveDataDirty = true;
     state.noteDisplayDirty = true;
     state.notePreviewDirty = true;
+    state.editButtonsDirty = true;
 
     state.sortChartData();
   }
@@ -55,6 +56,7 @@ class AddNotesCommand implements ChartEditorCommand
     state.saveDataDirty = true;
     state.noteDisplayDirty = true;
     state.notePreviewDirty = true;
+    state.editButtonsDirty = true;
 
     state.sortChartData();
   }

--- a/source/funkin/ui/debug/charting/commands/CopyItemsCommand.hx
+++ b/source/funkin/ui/debug/charting/commands/CopyItemsCommand.hx
@@ -42,6 +42,8 @@ class CopyItemsCommand implements ChartEditorCommand
       });
 
     performVisuals(state);
+    state.clipboardDirty = true;
+    state.clipboardValid = true;
   }
 
   function performVisuals(state:ChartEditorState):Void

--- a/source/funkin/ui/debug/charting/commands/CutItemsCommand.hx
+++ b/source/funkin/ui/debug/charting/commands/CutItemsCommand.hx
@@ -39,6 +39,9 @@ class CutItemsCommand implements ChartEditorCommand
     state.saveDataDirty = true;
     state.noteDisplayDirty = true;
     state.notePreviewDirty = true;
+    state.editButtonsDirty = true;
+    state.clipboardDirty = true;
+    state.clipboardValid = true;
     state.sortChartData();
   }
 
@@ -53,6 +56,7 @@ class CutItemsCommand implements ChartEditorCommand
     state.saveDataDirty = true;
     state.noteDisplayDirty = true;
     state.notePreviewDirty = true;
+    state.editButtonsDirty = true;
     state.sortChartData();
   }
 

--- a/source/funkin/ui/debug/charting/commands/DeselectAllItemsCommand.hx
+++ b/source/funkin/ui/debug/charting/commands/DeselectAllItemsCommand.hx
@@ -24,6 +24,7 @@ class DeselectAllItemsCommand implements ChartEditorCommand
     state.currentEventSelection = [];
 
     state.noteDisplayDirty = true;
+    state.editButtonsDirty = true;
   }
 
   public function undo(state:ChartEditorState):Void
@@ -32,6 +33,7 @@ class DeselectAllItemsCommand implements ChartEditorCommand
     state.currentEventSelection = previousEventSelection;
 
     state.noteDisplayDirty = true;
+    state.editButtonsDirty = true;
   }
 
   public function shouldAddToHistory(state:ChartEditorState):Bool

--- a/source/funkin/ui/debug/charting/commands/DeselectItemsCommand.hx
+++ b/source/funkin/ui/debug/charting/commands/DeselectItemsCommand.hx
@@ -27,6 +27,7 @@ class DeselectItemsCommand implements ChartEditorCommand
 
     state.noteDisplayDirty = true;
     state.notePreviewDirty = true;
+    state.editButtonsDirty = true;
   }
 
   public function undo(state:ChartEditorState):Void
@@ -43,6 +44,7 @@ class DeselectItemsCommand implements ChartEditorCommand
 
     state.noteDisplayDirty = true;
     state.notePreviewDirty = true;
+    state.editButtonsDirty = true;
   }
 
   public function shouldAddToHistory(state:ChartEditorState):Bool

--- a/source/funkin/ui/debug/charting/commands/InvertSelectedItemsCommand.hx
+++ b/source/funkin/ui/debug/charting/commands/InvertSelectedItemsCommand.hx
@@ -26,6 +26,7 @@ class InvertSelectedItemsCommand implements ChartEditorCommand
     state.currentEventSelection = SongDataUtils.subtractEvents(state.currentSongChartEventData, previousEventSelection);
 
     state.noteDisplayDirty = true;
+    state.editButtonsDirty = true;
   }
 
   public function undo(state:ChartEditorState):Void
@@ -34,6 +35,7 @@ class InvertSelectedItemsCommand implements ChartEditorCommand
     state.currentEventSelection = previousEventSelection;
 
     state.noteDisplayDirty = true;
+    state.editButtonsDirty = true;
   }
 
   public function shouldAddToHistory(state:ChartEditorState):Bool

--- a/source/funkin/ui/debug/charting/commands/PasteItemsCommand.hx
+++ b/source/funkin/ui/debug/charting/commands/PasteItemsCommand.hx
@@ -17,18 +17,27 @@ class PasteItemsCommand implements ChartEditorCommand
   var addedNotes:Array<SongNoteData> = [];
   var addedEvents:Array<SongEventData> = [];
 
+  var currentClipboard:SongClipboardItems =
+    {
+      valid: false,
+      notes: [],
+      events: []
+    };
+
   public function new(targetTimestamp:Float)
   {
     this.targetTimestamp = targetTimestamp;
+    // Doing this here so that clearing or changing the clipboard doesn't break the redo and string.
+    this.currentClipboard = SongDataUtils.readItemsFromClipboard();
   }
 
   public function execute(state:ChartEditorState):Void
   {
-    var currentClipboard:SongClipboardItems = SongDataUtils.readItemsFromClipboard();
-
     if (currentClipboard.valid != true)
     {
       state.error('Failed to Paste', 'Could not parse clipboard contents.');
+      state.clipboardDirty = true;
+      state.clipboardValid = false;
       return;
     }
 
@@ -49,6 +58,7 @@ class PasteItemsCommand implements ChartEditorCommand
     state.saveDataDirty = true;
     state.noteDisplayDirty = true;
     state.notePreviewDirty = true;
+    state.editButtonsDirty = true;
 
     state.sortChartData();
 
@@ -67,6 +77,7 @@ class PasteItemsCommand implements ChartEditorCommand
     state.saveDataDirty = true;
     state.noteDisplayDirty = true;
     state.notePreviewDirty = true;
+    state.editButtonsDirty = true;
 
     state.sortChartData();
   }
@@ -79,8 +90,6 @@ class PasteItemsCommand implements ChartEditorCommand
 
   public function toString():String
   {
-    var currentClipboard:SongClipboardItems = SongDataUtils.readItemsFromClipboard();
-
     var len:Int = currentClipboard.notes.length + currentClipboard.events.length;
 
     if (currentClipboard.notes.length == 0) return 'Paste $len Events';

--- a/source/funkin/ui/debug/charting/commands/RemoveEventsCommand.hx
+++ b/source/funkin/ui/debug/charting/commands/RemoveEventsCommand.hx
@@ -30,6 +30,7 @@ class RemoveEventsCommand implements ChartEditorCommand
     state.saveDataDirty = true;
     state.noteDisplayDirty = true;
     state.notePreviewDirty = true;
+    state.editButtonsDirty = true;
 
     state.sortChartData();
   }
@@ -48,6 +49,7 @@ class RemoveEventsCommand implements ChartEditorCommand
     state.saveDataDirty = true;
     state.noteDisplayDirty = true;
     state.notePreviewDirty = true;
+    state.editButtonsDirty = true;
 
     state.sortChartData();
   }

--- a/source/funkin/ui/debug/charting/commands/RemoveItemsCommand.hx
+++ b/source/funkin/ui/debug/charting/commands/RemoveItemsCommand.hx
@@ -36,6 +36,7 @@ class RemoveItemsCommand implements ChartEditorCommand
     state.saveDataDirty = true;
     state.noteDisplayDirty = true;
     state.notePreviewDirty = true;
+    state.editButtonsDirty = true;
 
     state.sortChartData();
   }
@@ -62,6 +63,7 @@ class RemoveItemsCommand implements ChartEditorCommand
     state.saveDataDirty = true;
     state.noteDisplayDirty = true;
     state.notePreviewDirty = true;
+    state.editButtonsDirty = true;
 
     state.sortChartData();
   }

--- a/source/funkin/ui/debug/charting/commands/RemoveNotesCommand.hx
+++ b/source/funkin/ui/debug/charting/commands/RemoveNotesCommand.hx
@@ -31,6 +31,7 @@ class RemoveNotesCommand implements ChartEditorCommand
     state.saveDataDirty = true;
     state.noteDisplayDirty = true;
     state.notePreviewDirty = true;
+    state.editButtonsDirty = true;
 
     state.sortChartData();
   }
@@ -50,6 +51,7 @@ class RemoveNotesCommand implements ChartEditorCommand
     state.saveDataDirty = true;
     state.noteDisplayDirty = true;
     state.notePreviewDirty = true;
+    state.editButtonsDirty = true;
 
     state.sortChartData();
   }

--- a/source/funkin/ui/debug/charting/commands/SelectAllItemsCommand.hx
+++ b/source/funkin/ui/debug/charting/commands/SelectAllItemsCommand.hx
@@ -31,6 +31,7 @@ class SelectAllItemsCommand implements ChartEditorCommand
     state.currentEventSelection = shouldSelectEvents ? state.currentSongChartEventData : [];
 
     state.noteDisplayDirty = true;
+    state.editButtonsDirty = true;
   }
 
   public function undo(state:ChartEditorState):Void
@@ -39,6 +40,7 @@ class SelectAllItemsCommand implements ChartEditorCommand
     state.currentEventSelection = previousEventSelection;
 
     state.noteDisplayDirty = true;
+    state.editButtonsDirty = true;
   }
 
   public function shouldAddToHistory(state:ChartEditorState):Bool

--- a/source/funkin/ui/debug/charting/commands/SelectItemsCommand.hx
+++ b/source/funkin/ui/debug/charting/commands/SelectItemsCommand.hx
@@ -72,6 +72,7 @@ class SelectItemsCommand implements ChartEditorCommand
 
     state.noteDisplayDirty = true;
     state.notePreviewDirty = true;
+    state.editButtonsDirty = true;
   }
 
   public function undo(state:ChartEditorState):Void
@@ -81,6 +82,7 @@ class SelectItemsCommand implements ChartEditorCommand
 
     state.noteDisplayDirty = true;
     state.notePreviewDirty = true;
+    state.editButtonsDirty = true;
   }
 
   public function shouldAddToHistory(state:ChartEditorState):Bool

--- a/source/funkin/ui/debug/charting/commands/SetItemSelectionCommand.hx
+++ b/source/funkin/ui/debug/charting/commands/SetItemSelectionCommand.hx
@@ -80,6 +80,7 @@ class SetItemSelectionCommand implements ChartEditorCommand
     }
 
     state.noteDisplayDirty = true;
+    state.editButtonsDirty = true;
   }
 
   public function undo(state:ChartEditorState):Void
@@ -88,6 +89,7 @@ class SetItemSelectionCommand implements ChartEditorCommand
     state.currentEventSelection = previousEventSelection;
 
     state.noteDisplayDirty = true;
+    state.editButtonsDirty = true;
   }
 
   public function shouldAddToHistory(state:ChartEditorState):Bool


### PR DESCRIPTION
## Briefly describe the issue(s) fixed.
The edit buttons don't disable if there's no selection or whatever.

Also fixes the paste items command to _not_ use the current clipboard, but rather the clipboard at the time the command was created.
## Include any relevant screenshots or videos.

https://github.com/user-attachments/assets/3a1949e0-90f8-4ba8-bfa4-e3343f912dd6

