### PR TITLE
[BUGFIX] Prevent chart editor from loading invalid variation

### DIFF
--- a/source/funkin/ui/debug/charting/handlers/ChartEditorImportExportHandler.hx
+++ b/source/funkin/ui/debug/charting/handlers/ChartEditorImportExportHandler.hx
@@ -119,6 +119,11 @@ class ChartEditorImportExportHandler
     state.songChartData = newSongChartData;
     state.selectedDifficulty = state.availableDifficulties[0];
 
+    if (!newSongMetadata.exists(state.selectedVariation))
+    {
+      state.selectedVariation = Constants.DEFAULT_VARIATION;
+    }
+
     Conductor.instance.forceBPM(null); // Disable the forced BPM.
     Conductor.instance.instrumentalOffset = state.currentInstrumentalOffset; // Loads from the metadata.
     Conductor.instance.mapTimeChanges(state.currentSongMetadata.timeChanges);


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->
## Does this PR close any issues? If so, link them below.
Fixes #2468 
## Briefly describe the issue(s) fixed.
When accessing the current chart's song metadata it creates a blank variation if the currently selected one doesn't exist. This could cause a crash when accessing that variation's sound data.
This makes it so it checks if the current selected variation exists before trying to load the song, and sets it to the default one if it doesn't exist. Though I think a proper fix would be for the aforementioned behavior to not happen, but this will work for now.
## Include any relevant screenshots or videos.

https://github.com/user-attachments/assets/65ae2c8c-6c1f-4ab8-995a-36643b8f7ea4

