### PR TITLE
[DOCS] Add missing documentation to `Module`

### DIFF
--- a/source/funkin/modding/module/Module.hx
+++ b/source/funkin/modding/module/Module.hx
@@ -57,6 +57,9 @@ class Module implements IPlayStateScriptedClass implements IStateChangingScripte
 
   // TODO: Half of these aren't actually being called!!!!!!!
 
+  /**
+   * Called when ANY script event is dispatched.
+   */
   public function onScriptEvent(event:ScriptEvent) {}
 
   /**
@@ -71,55 +74,138 @@ class Module implements IPlayStateScriptedClass implements IStateChangingScripte
    */
   public function onDestroy(event:ScriptEvent) {}
 
+  /**
+   * Called every frame.
+   */
   public function onUpdate(event:UpdateScriptEvent) {}
 
+  /**
+   * Called when the game is paused.
+   */
   public function onPause(event:PauseScriptEvent) {}
 
+  /**
+   * Called when the game is resumed.
+   */
   public function onResume(event:ScriptEvent) {}
 
+  /**
+   * Called when the song begins.
+   */
   public function onSongStart(event:ScriptEvent) {}
 
+  /**
+   * Called when the song ends.
+   */
   public function onSongEnd(event:ScriptEvent) {}
 
+  /**
+   * Called when the player dies.
+   */
   public function onGameOver(event:ScriptEvent) {}
 
+  /**
+   * Called when a note on the strumline has been rendered and is now onscreen.
+   * This gets dispatched for both the player and opponent strumlines.
+   */
   public function onNoteIncoming(event:NoteScriptEvent) {}
 
+  /**
+   * Called when a note has been hit.
+   * This gets dispatched for both the player and opponent strumlines.
+   */
   public function onNoteHit(event:HitNoteScriptEvent) {}
 
+  /**
+   * Called when a note has been missed.
+   * This gets dispatched for both the player and opponent strumlines.
+   */
   public function onNoteMiss(event:NoteScriptEvent) {}
 
+  /**
+   * Called when the player presses a key without any notes present.
+   */
   public function onNoteGhostMiss(event:GhostMissNoteScriptEvent) {}
 
+  /**
+   * Called when a step is hit in the song.
+   */
   public function onStepHit(event:SongTimeScriptEvent) {}
 
+  /**
+   * Called when a beat is hit in the song.
+   */
   public function onBeatHit(event:SongTimeScriptEvent) {}
 
+  /**
+   * Called when a song event is triggered.
+   */
   public function onSongEvent(event:SongEventScriptEvent) {}
 
+  /**
+   * Called when the countdown begins.
+   */
   public function onCountdownStart(event:CountdownScriptEvent) {}
 
+  /**
+   * Called for every step in the countdown.
+   */
   public function onCountdownStep(event:CountdownScriptEvent) {}
 
+  /**
+   * Called when the countdown ends, but BEFORE the song starts.
+   */
   public function onCountdownEnd(event:CountdownScriptEvent) {}
 
+  /**
+   * Called when the song's chart has been parsed and loaded.
+   */
   public function onSongLoaded(event:SongLoadScriptEvent) {}
 
+  /**
+   * Called when the game is about to switch to a new state.
+   */
   public function onStateChangeBegin(event:StateChangeScriptEvent) {}
 
+  /**
+   * Called after the game has switched to a new state.
+   */
   public function onStateChangeEnd(event:StateChangeScriptEvent) {}
 
+  /**
+   * Called when the game regains focus.
+   * This does not get called if "Auto Pause" is disabled.
+   */
   public function onFocusGained(event:FocusScriptEvent) {}
 
+  /**
+   * Called when the game loses focus.
+   * This does not get called if "Auto Pause" is disabled.
+   */
   public function onFocusLost(event:FocusScriptEvent) {}
 
+  /**
+   * Called when the game is about to open a substate.
+   */
   public function onSubStateOpenBegin(event:SubStateScriptEvent) {}
 
+  /**
+   * Called when a substate has been opened.
+   */
   public function onSubStateOpenEnd(event:SubStateScriptEvent) {}
 
+  /**
+   * Called when the game is about to close a substate.
+   */
   public function onSubStateCloseBegin(event:SubStateScriptEvent) {}
 
+  /**
+   * Called when a substate has been closed.
+   */
   public function onSubStateCloseEnd(event:SubStateScriptEvent) {}
 
+  /**
+   * Called when the song has been restarted.
+   */
   public function onSongRetry(event:SongRetryEvent) {}
 }


### PR DESCRIPTION
I noticed only 2 of the event functions had documentation while the rest didn't, this PR adds documentation for the rest of the functions.