### PR TITLE
[ENHANCEMENT] Pixel Icon Metadata in Character Metadata

### DIFF
--- a/source/funkin/play/character/CharacterData.hx
+++ b/source/funkin/play/character/CharacterData.hx
@@ -12,6 +12,7 @@ import funkin.util.assets.DataAssets;
 import funkin.util.VersionUtil;
 import haxe.Json;
 import flixel.graphics.frames.FlxFrame;
+import openfl.utils.Assets;
 
 class CharacterDataParser
 {
@@ -281,40 +282,73 @@ class CharacterDataParser
   }
 
   /**
+   * Fetches the character's pixel icon data.
+   * @param char The character to load.
+   * @return The pixel icon data, or null if validation failed.
+   */
+  public static function getCharPixelIconData(char:String):Null<PixelIconData>
+  {
+    if (char == null || char == '' || !characterCache.exists(char))
+    {
+      trace('Failed to fetch pixel icon, character not found in cache: ${char}');
+      return null;
+    }
+
+    var charData:CharacterData = characterCache.get(char);
+
+    if (charData != null && charData.pixelIcon != null)
+    {
+      return charData.pixelIcon;
+    }
+    else
+    {
+      trace('Pixel icon data not found for character: ${char}');
+      return null;
+    }
+  }
+
+  /**
    * Returns the idle frame of a character.
    */
   public static function getCharPixelIconAsset(char:String):FlxFrame
   {
-    var charPath:String = "freeplay/icons/";
+    if (char == null || char == '' || !characterCache.exists(char))
+    {
+      trace('Failed to fetch pixel icon, character not found in cache: ${char}');
+      return null;
+    }
+
+    var charData:CharacterData = characterCache.get(char);
+    var charPath:String = "freeplay/icons/" + charData.pixelIcon.id + "pixel";
 
     // FunkinCrew please dont skin me alive for copying pixelated icon and changing it a tiny bit
-    switch (char)
-    {
-      case "bf-christmas" | "bf-car" | "bf-pixel" | "bf-holding-gf" | "bf-dark":
-        charPath += "bfpixel";
-      case "monster-christmas":
-        charPath += "monsterpixel";
-      case "mom" | "mom-car":
-        charPath += "mommypixel";
-      case "pico-blazin" | "pico-playable" | "pico-speaker":
-        charPath += "picopixel";
-      case "gf-christmas" | "gf-car" | "gf-pixel" | "gf-tankmen" | "gf-dark":
-        charPath += "gfpixel";
-      case "dad":
-        charPath += "dadpixel";
-      case "darnell-blazin":
-        charPath += "darnellpixel";
-      case "senpai-angry":
-        charPath += "senpaipixel";
-      case "spooky-dark":
-        charPath += "spookypixel";
-      case "tankman-atlas":
-        charPath += "tankmanpixel";
-      case "pico-christmas" | "pico-dark":
-        charPath += "picopixel";
-      default:
-        charPath += '${char}pixel';
-    }
+    // switch (char)
+    // {
+    //   case "bf-christmas" | "bf-car" | "bf-pixel" | "bf-holding-gf" | "bf-dark":
+    //     charPath += "bfpixel";
+    //   case "monster-christmas":
+    //     charPath += "monsterpixel";
+    //   case "mom" | "mom-car":
+    //     charPath += "mommypixel";
+    //   case "pico-blazin" | "pico-playable" | "pico-speaker":
+    //     charPath += "picopixel";
+    //   case "gf-christmas" | "gf-car" | "gf-pixel" | "gf-tankmen" | "gf-dark":
+    //     charPath += "gfpixel";
+    //   case "dad":
+    //     charPath += "dadpixel";
+    //   case "darnell-blazin":
+    //     charPath += "darnellpixel";
+    //   case "senpai-angry":
+    //     charPath += "senpaipixel";
+    //   case "spooky-dark":
+    //     charPath += "spookypixel";
+    //   case "tankman-atlas":
+    //     charPath += "tankmanpixel";
+    //   case "pico-christmas" | "pico-dark":
+    //     charPath += "picopixel";
+    //   default:
+    //     charPath += '${char}pixel';
+    // }
 
     if (!Assets.exists(Paths.image(charPath)))
     {
@@ -433,6 +467,7 @@ class CharacterDataParser
   public static final DEFAULT_NAME:String = 'Untitled Character';
   public static final DEFAULT_OFFSETS:Array<Float> = [0, 0];
   public static final DEFAULT_HEALTHICON_OFFSETS:Array<Int> = [0, 25];
+  public static final DEFAULT_PIXELICON_ORIGIN_OFFSETS:Array<Int> = [0, 0];
   public static final DEFAULT_RENDERTYPE:CharacterRenderType = CharacterRenderType.Sparrow;
   public static final DEFAULT_SCALE:Float = 1;
   public static final DEFAULT_SCROLL:Array<Float> = [0, 0];
@@ -522,6 +557,31 @@ class CharacterDataParser
     if (input.healthIcon.offsets == null)
     {
       input.healthIcon.offsets = DEFAULT_OFFSETS;
+    }
+
+    if (input.pixelIcon == null)
+    {
+      input.pixelIcon =
+        {
+          id: null,
+          flipX: null,
+          originOffsets: null
+        };
+    }
+
+    if (input.pixelIcon.id == null)
+    {
+      input.pixelIcon.id = id;
+    }
+
+    if (input.pixelIcon.flipX == null)
+    {
+      input.pixelIcon.flipX = DEFAULT_FLIPX;
+    }
+
+    if (input.pixelIcon.originOffsets == null)
+    {
+      input.pixelIcon.originOffsets = DEFAULT_PIXELICON_ORIGIN_OFFSETS;
     }
 
     if (input.startingAnimation == null)
@@ -680,6 +740,11 @@ typedef CharacterData =
    */
   var healthIcon:Null<HealthIconData>;
 
+  /**
+   * Optional data about the pixel icon for the character.
+   */
+  var pixelIcon:Null<PixelIconData>;
+
   var death:Null<DeathData>;
 
   /**
@@ -775,6 +840,30 @@ typedef HealthIconData =
    * @default [0, 25]
    */
   var offsets:Null<Array<Float>>;
+}
+
+/**
+ * The JSON data schema used to define the pixel icon for a character.
+ */
+typedef PixelIconData =
+{
+  /**
+   * The ID to use for the pixel icon.
+   * @default The character's ID
+   */
+  var id:Null<String>;
+
+  /**
+   * Whether to flip the pixel icon horizontally.
+   * @default false
+   */
+  var flipX:Null<Bool>;
+
+  /**
+   * The origin offsets of the pixel icon, in pixels.
+   * @default [0, 0]
+   */
+  var originOffsets:Null<Array<Int>>;
 }
 
 typedef DeathData =

--- a/source/funkin/ui/PixelatedIcon.hx
+++ b/source/funkin/ui/PixelatedIcon.hx
@@ -2,6 +2,8 @@ package funkin.ui;
 
 import flixel.FlxSprite;
 import funkin.graphics.FlxFilteredSprite;
+import funkin.play.character.CharacterData;
+import funkin.play.character.CharacterData.CharacterDataParser;
 
 /**
  * The icon that gets used for Freeplay capsules and char select
@@ -12,6 +14,7 @@ class PixelatedIcon extends FlxFilteredSprite
   public function new(x:Float, y:Float)
   {
     super(x, y);
+
     this.makeGraphic(32, 32, 0x00000000);
     this.antialiasing = false;
     this.active = false;
@@ -20,32 +23,15 @@ class PixelatedIcon extends FlxFilteredSprite
   public function setCharacter(char:String):Void
   {
     var charPath:String = "freeplay/icons/";
+    var charPixelIconData = CharacterDataParser.getCharPixelIconData(char);
 
-    switch (char)
+    if (charPixelIconData == null)
     {
-      case "bf-christmas" | "bf-car" | "bf-pixel" | "bf-holding-gf":
-        charPath += "bfpixel";
-      case "monster-christmas":
-        charPath += "monsterpixel";
-      case "mom" | "mom-car":
-        charPath += "mommypixel";
-      case "pico-blazin" | "pico-playable" | "pico-speaker":
-        charPath += "picopixel";
-      case "gf-christmas" | "gf-car" | "gf-pixel" | "gf-tankmen":
-        charPath += "gfpixel";
-      case "dad":
-        charPath += "dadpixel";
-      case "darnell-blazin":
-        charPath += "darnellpixel";
-      case "senpai-angry":
-        charPath += "senpaipixel";
-      case "spooky-dark":
-        charPath += "spookypixel";
-      case "tankman-atlas":
-        charPath += "tankmanpixel";
-      default:
-        charPath += '${char}pixel';
+      trace('[WARN] Character ${char} has no pixel icon data.');
+      return;
     }
+
+    charPath += '${charPixelIconData.id}pixel';
 
     if (!openfl.utils.Assets.exists(Paths.image(charPath)))
     {
@@ -71,13 +57,14 @@ class PixelatedIcon extends FlxFilteredSprite
 
     this.scale.x = this.scale.y = 2;
 
-    switch (char)
-    {
-      case 'parents-christmas':
-        this.origin.x = 140;
-      default:
-        this.origin.x = 100;
-    }
+    // Set to 100 for default position
+    this.origin.x = 100;
+
+    // Add the pixel icon origin with offsets for position adjustments
+    this.origin.x += charPixelIconData.originOffsets[0];
+    this.origin.y += charPixelIconData.originOffsets[1];
+    // Set whether or not to flip the pixel icon
+    this.flipX = charPixelIconData.flipX;
 
     if (isAnimated)
     {

--- a/source/funkin/ui/freeplay/SongMenuItem.hx
+++ b/source/funkin/ui/freeplay/SongMenuItem.hx
@@ -5,6 +5,8 @@ import funkin.graphics.shaders.HSVShader;
 import funkin.graphics.shaders.GaussianBlurShader;
 import flixel.group.FlxGroup;
 import flixel.FlxSprite;
+import funkin.play.character.CharacterData;
+import funkin.play.character.CharacterData.CharacterDataParser;
 import flixel.graphics.frames.FlxAtlasFrames;
 import flixel.group.FlxSpriteGroup.FlxTypedSpriteGroup;
 import flixel.group.FlxSpriteGroup;


### PR DESCRIPTION
* Had to make a new PR for this for clean up. Works with the latest version of the develop branch. Apologies for the inconvenience.

Freeplay and the chart editor now read from character metadata instead of hard-coding assigned character pixel icons. Existing character metadata files have updated with respective icons previously assigned in the source code . Additionally, the ability to flip the icons horizontally and adjusting the origin offset is now included via the metadata.
No issues found after testing.

Situation:
For the modders who have multiple versions of some character and would like to use the same character icon, it was previously not possible simply due to the fact that prior to this change, the pixel icon is determined by the character's id name rather than a specified pixel ID. In this case, I have a characters labeled as "hugenate-opponent" and "hugenate-playable". I also have an icon file named "hugenate", and I want both of these characters to use the same icon. However, neither will work since they would have to be the same name as the freeplay icon file.
![image](https://github.com/FunkinCrew/Funkin/assets/22872042/8f585463-930e-4352-a0ab-bbfd5f80a772)
Now with this change, it corrects the issue and allows for me to individually assign the icon id to the players in their metadata. NOTE: If the id is left as null, the game will automatically set it to the same name as their character id.
![image](https://github.com/FunkinCrew/Funkin/assets/22872042/56400258-20fb-49da-aa51-7f7067f33fca)
After modifying it with this data, this is the new result!
![image](https://github.com/FunkinCrew/Funkin/assets/22872042/d594679f-b525-4af2-b121-b9a8a01d3a82)
New parameters such as flipX and origin are also included to adjust icons if they overlap the text:
![image](https://github.com/FunkinCrew/Funkin/assets/22872042/dd0824ab-da42-4240-96a8-32a5a576d8c8)
Before:
![image](https://github.com/FunkinCrew/Funkin/assets/22872042/34860a8f-550e-480f-bcaa-88bdfa86ce04)
After:
![image](https://github.com/FunkinCrew/Funkin/assets/22872042/71620eb9-0bd4-4bc6-a9c1-4a96b5a7f9e7)
