### PR TITLE
[BUGFIX] Hide debug cursor when Title Screen starts

### DIFF
--- a/source/funkin/ui/title/TitleState.hx
+++ b/source/funkin/ui/title/TitleState.hx
@@ -231,6 +231,8 @@ class TitleState extends MusicBeatState
 
     Conductor.instance.update();
 
+    funkin.input.Cursor.hide();
+
     /* if (FlxG.onMobile)
           {
       if (gfDance != null)


### PR DESCRIPTION
## Linked Issue
Fixes https://github.com/FunkinCrew/Funkin/issues/4433

## Changes
Hides the debug cursor when the Title Screen starts up using the same line of code as #3881.

## Notes
In 0.6.2, loading into the Title Screen while the game is unfocused keeps the debug cursor visible after clicking back into focus.
#3881 intended to fix this issue, but only ended up removing the debug cursor flickering in the top left for a split second.
Both that change and this one are necessary to make the debug cursor never show up during launch, focused or unfocused.