### PR TITLE
Fix Freeplay Rank Animation when switching songs

### DIFF
--- a/source/funkin/ui/freeplay/FreeplayState.hx
+++ b/source/funkin/ui/freeplay/FreeplayState.hx
@@ -1695,8 +1695,9 @@ class FreeplayState extends MusicBeatSubState
    * It's generally recommended that after calling this you re-sort the song list, however usually it's already on the way to being sorted.
    * @param change
    * @param force
+   * @param updateRank
    */
-  function changeDiff(change:Int = 0, force:Bool = false):Void
+  function changeDiff(change:Int = 0, force:Bool = false, updateRank:Bool = true):Void
   {
     touchTimer = 0;
     var previousVariation:String = currentVariation;
@@ -1744,7 +1745,7 @@ class FreeplayState extends MusicBeatSubState
       intendedScore = songScore?.score ?? 0;
       intendedCompletion = songScore == null ? 0.0 : ((songScore.tallies.sick + songScore.tallies.good) / songScore.tallies.totalNotes);
       rememberedDifficulty = currentDifficulty;
-      grpCapsules.members[curSelected].refreshDisplay();
+      grpCapsules.members[curSelected].refreshDisplay(updateRank);
     }
     else
     {
@@ -2040,8 +2041,8 @@ class FreeplayState extends MusicBeatSubState
       intendedScore = songScore?.score ?? 0;
       intendedCompletion = songScore == null ? 0.0 : ((songScore.tallies.sick + songScore.tallies.good) / songScore.tallies.totalNotes);
       rememberedSongId = daSongCapsule.freeplayData.data.id;
-      changeDiff();
-      daSongCapsule.refreshDisplay();
+      changeDiff(0, false, false);
+      daSongCapsule.refreshDisplay(false);
     }
     else
     {

--- a/source/funkin/ui/freeplay/SongMenuItem.hx
+++ b/source/funkin/ui/freeplay/SongMenuItem.hx
@@ -422,7 +422,7 @@ class SongMenuItem extends FlxSpriteGroup
     return evilTrail.color;
   }
 
-  public function refreshDisplay():Void
+  public function refreshDisplay(updateRank:Bool = true):Void
   {
     if (freeplayData == null)
     {
@@ -441,7 +441,7 @@ class SongMenuItem extends FlxSpriteGroup
       pixelIcon.visible = true;
       updateBPM(Std.int(freeplayData.songStartingBpm) ?? 0);
       updateDifficultyRating(freeplayData.difficultyRating ?? 0);
-      updateScoringRank(freeplayData.scoringRank);
+      if (updateRank) updateScoringRank(freeplayData.scoringRank);
       newText.visible = freeplayData.isNew;
       favIcon.visible = freeplayData.isFav;
       favIconBlurred.visible = freeplayData.isFav;


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->
## Does this PR close any issues? If so, link them below.
Fixes #4530
## Briefly describe the issue(s) fixed.

The rank animation in freeplay plays whenever you switch songs. This PR fixes this by adding a default argument to `refreshDisplay` in `SongMenuItem.hx` to check whether the rank should be updated.

Then, the call to `refreshDisplay` in `changeSelection` passes in a value of `false` over the default `true`.

I also made a similar change to the `changeDiff` function to allow me to pass in a value of `false` in its call to `refreshDisplay` when `changeDiff` is being called in `changeSelection`.

## Include any relevant screenshots or videos.

Before changes:

https://github.com/user-attachments/assets/1035ca21-bdf9-4639-8d0e-f6688069b874

After changes:

https://github.com/user-attachments/assets/c73b8d82-363e-497a-8ea3-3bc58819f5e9