### PR TITLE
Chart Editor - Invalid chart difficulty playstate crash fix

### DIFF
--- a/source/funkin/ui/transition/LoadingState.hx
+++ b/source/funkin/ui/transition/LoadingState.hx
@@ -218,7 +218,7 @@ class LoadingState extends MusicBeatSubState
     var daChart = params.targetSong.getDifficulty(params.targetDifficulty ?? Constants.DEFAULT_DIFFICULTY,
       params.targetVariation ?? Constants.DEFAULT_VARIATION);
 
-    var daStage = funkin.data.stage.StageRegistry.instance.fetchEntry(daChart.stage);
+    var daStage = funkin.data.stage.StageRegistry.instance.fetchEntry(daChart?.stage);
     stageDirectory = daStage?._data?.directory ?? "shared";
     Paths.setCurrentLevel(stageDirectory);
 


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->
## Does this PR close any issues? If so, link them below.
No, but it prevents one from being opened in the future!
## Briefly describe the issue(s) fixed.
Fixes a crash when getDifficulty returns null in the loading state and it tries to get the stage of said null difficulty, when loading the playstate.

This crash can be replicated in 0.5.3 by loading a song template with an erect difficulty, switching to it, then loading a FNFC with an erect difficulty (which it doesn't load properly) and then try playtesting, hence the title as such.
## Include any relevant screenshots or videos.
