### PR TITLE
Change order of Restart and Skip in Dialogue pause menu

### DIFF
--- a/source/funkin/play/PauseSubState.hx
+++ b/source/funkin/play/PauseSubState.hx
@@ -86,8 +86,8 @@ class PauseSubState extends MusicBeatSubState
    */
   static final PAUSE_MENU_ENTRIES_CONVERSATION:Array<PauseMenuEntry> = [
     {text: 'Resume', callback: resume},
-    {text: 'Restart Dialogue', callback: restartConversation},
     {text: 'Skip Dialogue', callback: skipConversation},
+    {text: 'Restart Dialogue', callback: restartConversation},
     {text: 'Exit to Menu', callback: quitToMenu},
   ];
 


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->
## Does this PR close any issues? If so, link them below.
Closes #4552
## Briefly describe the issue(s) fixed.
Swaps the positions of "Restart Dialogue" and "Skip Dialogue" in the pause menu to be consistent with the order for cutscenes.
## Include any relevant screenshots or videos.

Before:

![screenshot-2025-04-04-14-32-56](https://github.com/user-attachments/assets/421c6568-076b-4aa9-ac93-ab6e825e5f33)

After:

![screenshot-2025-04-04-14-40-25](https://github.com/user-attachments/assets/333810d9-10ef-454a-9818-7e906df3353f)