### PR TITLE
Use System.totalMemoryNumber in MemoryUtil

### DIFF
--- a/source/funkin/modding/PolymodHandler.hx
+++ b/source/funkin/modding/PolymodHandler.hx
@@ -557,11 +557,9 @@ class PolymodHandler
     Polymod.clearScripts();
 
     // Forcibly reload Polymod so it finds any new files.
+    // This will also register all scripts.
     // TODO: Replace this with loadEnabledMods().
     funkin.modding.PolymodHandler.loadAllMods();
-
-    // Reload scripted classes so stages and modules will update.
-    Polymod.registerAllScriptClasses();
 
     // Reload everything that is cached.
     // Currently this freezes the game for a second but I guess that's tolerable?

--- a/source/funkin/ui/debug/stageeditor/components/WelcomeDialog.hx
+++ b/source/funkin/ui/debug/stageeditor/components/WelcomeDialog.hx
@@ -57,7 +57,7 @@ class WelcomeDialog extends Dialog
 
     boxDrag.onClick = function(_) FileUtil.browseForSaveFile([FileUtil.FILE_FILTER_FNFS], loadFromFilePath, null, null, "Open Stage Data");
 
-    var defaultStages:Array<String> = StageRegistry.instance.listBaseGameEntryIds();
+    var defaultStages:Array<String> = StageRegistry.instance.listEntryIds();
     defaultStages.sort(funkin.util.SortUtil.alphabetically);
 
     for (stage in defaultStages)

--- a/source/funkin/util/MemoryUtil.hx
+++ b/source/funkin/util/MemoryUtil.hx
@@ -47,16 +47,11 @@ class MemoryUtil
 
   /**
    * Calculate the total memory usage of the program, in bytes.
-   * @return Int
+   * @return Float
    */
-  public static function getMemoryUsed():#if cpp Float #else Int #end
+  public static function getMemoryUsed():Float
   {
-    #if cpp
-    // There is also Gc.MEM_INFO_RESERVED, MEM_INFO_CURRENT, and MEM_INFO_LARGE.
-    return cpp.vm.Gc.memInfo64(cpp.vm.Gc.MEM_INFO_USAGE);
-    #else
-    return openfl.system.System.totalMemory;
-    #end
+    return openfl.system.System.totalMemoryNumber;
   }
 
   /**


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->
## Does this PR close any issues? If so, link them below.
Probably not

## Briefly describe the issue(s) fixed.
Simple lil' PR, since OpenFL was updated we can use the new [`System.totalMemoryNumber`](https://api.openfl.org/openfl/system/System.html#totalMemoryNumber) field to get a higher range memory usage value where possible directly from OpenFL without Funkin' needing to intervene

## Include any relevant screenshots or videos.
N/A