### PR TITLE
[BUGFIX] Fix texture atlas sprites looping infinitely

### DIFF
--- a/source/funkin/graphics/adobeanimate/FlxAtlasSprite.hx
+++ b/source/funkin/graphics/adobeanimate/FlxAtlasSprite.hx
@@ -66,6 +66,8 @@ class FlxAtlasSprite extends FlxAnimate
       throw 'FlxAtlasSprite not initialized properly. Are you sure the path (${path}) exists?';
     }
 
+    onAnimationComplete.add(cleanupAnimation);
+
     // This defaults the sprite to play the first animation in the atlas,
     // then pauses it. This ensures symbols are intialized properly.
     this.anim.play('');

--- a/source/funkin/graphics/adobeanimate/FlxAtlasSprite.hx
+++ b/source/funkin/graphics/adobeanimate/FlxAtlasSprite.hx
@@ -319,7 +319,6 @@ class FlxAtlasSprite extends FlxAnimate
         else if (fr != null && anim.curFrame != anim.length - 1)
         {
           anim.curFrame--;
-          cleanupAnimation(currentAnimation ?? "");
           _onAnimationComplete();
         }
       }


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->
## Does this PR close any issues? If so, link them below.
Fixes #4475, fixes #4472, fixes #4614

## Briefly describe the issue(s) fixed.
It's literally one line.
Credit to @KoloInDaCrib for finding the issue

## Include any relevant screenshots or videos.

https://github.com/user-attachments/assets/97a9ae7b-4227-4e62-851f-2d499c9c5b44

