### PR TITLE
[ENHANCEMENT] Backing image automatically changes based on week

### DIFF
--- a/source/funkin/ui/freeplay/FreeplayState.hx
+++ b/source/funkin/ui/freeplay/FreeplayState.hx
@@ -2103,7 +2103,7 @@ class FreeplayState extends MusicBeatSubState
       playCurSongPreview(daSongCapsule);
       grpCapsules.members[curSelected].selected = true;
 
-      // switchBackingImage(daSongCapsule.freeplayData);
+      switchBackingImage(daSongCapsule.freeplayData);
     }
   }
 


### PR DESCRIPTION
[This commit](https://github.com/FunkinCrew/Funkin/commit/d9fd8146457ac6056949f06e1c07bb99aa11db55) removed swapping of the freeplay backing image because it was supposedly broken. 
However, I uncommented the line and it appears to work fine! This PR re-adds it.

https://github.com/user-attachments/assets/1bbbf79f-55ea-4d58-8817-3597de3f63ba