### PR TITLE
[BUGFIX] Prevent the Game from crashing when resetting Save Data

### DIFF
--- a/source/funkin/util/plugins/ScreenshotPlugin.hx
+++ b/source/funkin/util/plugins/ScreenshotPlugin.hx
@@ -663,7 +663,7 @@ class ScreenshotPlugin extends FlxBasic
 
     @:privateAccess
     for (parent in [flashSprite, previewSprite])
-      for (child in parent.__children)
+      for (child in (parent?.__children ?? []))
         parent.removeChild(child);
 
     flashSprite = null;


### PR DESCRIPTION
## Does this PR close any issues? If so, link them below.
Closes https://github.com/FunkinCrew/Funkin/issues/4465

## Briefly describe the issue(s) fixed.
Added null-safe field access to one part of the `ScreenshotPlugin` because I guess flashSprite and previewSprite get set to `null` when they are removed from `FlxG.stage`.

Will get to fixing merge conflicts in a bit, wanted to get this out of the way first lol
## Include any relevant screenshots or videos.

https://github.com/user-attachments/assets/32bbab99-dbe2-4f3b-bc84-5f38f56b7f10
