### PR TITLE
Fix Lit Up being impossible to submit score into

### DIFF
--- a/source/funkin/api/newgrounds/Leaderboards.hx
+++ b/source/funkin/api/newgrounds/Leaderboards.hx
@@ -285,7 +285,7 @@ enum abstract Leaderboard(Int)
         {
           case "darnell":
             return DarnellBFMix;
-          case "litup":
+          case "lit-up":
             return LitUpBFMix;
           default:
             return Unknown;
@@ -379,7 +379,7 @@ enum abstract Leaderboard(Int)
             return Stress;
           case "darnell":
             return Darnell;
-          case "litup":
+          case "lit-up":
             return LitUp;
           case "2hot":
             return TwoHot;


### PR DESCRIPTION
Changes expected song id at Leaderboards API to match with the assets song id

<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->
## Does this PR close any issues? If so, link them below.
Closes https://github.com/FunkinCrew/Funkin/issues/4527

## Briefly describe the issue(s) fixed.
Changes the expected song id to match with the assets Lit Up Songs (BF Mix included)

## Include any relevant screenshots or videos.
https://github.com/user-attachments/assets/9b9de769-1fbb-43ab-825a-e115c3f06a53