### PR TITLE
Volume independent visualizer on web

### DIFF
--- a/source/funkin/audio/visualize/ABotVis.hx
+++ b/source/funkin/audio/visualize/ABotVis.hx
@@ -94,9 +94,18 @@ class ABotVis extends FlxTypedSpriteGroup<FlxSprite>
     }
   }
 
+  override public function destroy():Void
+  {
+    analyzer?.cleanup();
+    super.destroy();
+  }
+
   public function initAnalyzer():Void
   {
     if (snd == null) return;
+
+    // cleanup previous instance
+    analyzer?.cleanup();
 
     @:privateAccess
     analyzer = new SpectralAnalyzer(snd._channel.__audioSource, BAR_COUNT, 0.1, 40);
@@ -120,6 +129,8 @@ class ABotVis extends FlxTypedSpriteGroup<FlxSprite>
   public function dumpSound():Void
   {
     snd = null;
+
+    analyzer?.cleanup();
     analyzer = null;
   }
 

--- a/source/funkin/audio/visualize/ABotVis.hx
+++ b/source/funkin/audio/visualize/ABotVis.hx
@@ -60,9 +60,18 @@ class ABotVis extends FlxTypedSpriteGroup<FlxSprite>
     }
   }
 
+  override public function destroy():Void
+  {
+    analyzer?.cleanup();
+    super.destroy();
+  }
+
   public function initAnalyzer():Void
   {
     if (snd == null) return;
+
+    // cleanup previous instance
+    analyzer?.cleanup();
 
     @:privateAccess
     analyzer = new SpectralAnalyzer(snd._channel.__audioSource, BAR_COUNT, 0.1, 40);
@@ -86,6 +95,8 @@ class ABotVis extends FlxTypedSpriteGroup<FlxSprite>
   public function dumpSound():Void
   {
     snd = null;
+
+    analyzer?.cleanup();
     analyzer = null;
   }
 

--- a/source/funkin/ui/charSelect/CharSelectGF.hx
+++ b/source/funkin/ui/charSelect/CharSelectGF.hx
@@ -27,6 +27,12 @@ class CharSelectGF extends FunkinSprite implements IBPMSyncedScriptedClass
     loadAnimations();
   }
 
+  override public function destroy():Void
+  {
+    analyzer?.cleanup();
+    super.destroy();
+  }
+
   public function onStepHit(event:SongTimeScriptEvent):Void
   {
   }

--- a/source/funkin/ui/charSelect/CharSelectGF.hx
+++ b/source/funkin/ui/charSelect/CharSelectGF.hx
@@ -27,6 +27,12 @@ class CharSelectGF extends FunkinSprite implements IBPMSyncedScriptedClass
     switchGF(Constants.DEFAULT_CHARACTER);
   }
 
+  override public function destroy():Void
+  {
+    analyzer?.cleanup();
+    super.destroy();
+  }
+
   public function onStepHit(event:SongTimeScriptEvent):Void
   {
   }


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->
## Does this PR close any issues? If so, link them below.
https://github.com/FunkinCrew/Funkin/issues/3400

## Briefly describe the issue(s) fixed.
In short, makes the audio visualizer on HTML5 independent of the game volume, which seems to be the [wanted behavior](https://github.com/FunkinCrew/Funkin/pull/2994#issuecomment-2322830669)

More detailed info (and also required PR on funkin.vis): https://github.com/FunkinCrew/funkVis/pull/12

## Include any relevant screenshots or videos.

https://github.com/user-attachments/assets/7147626f-d992-46df-9aa2-2d157fc9bfec
