### PR TITLE
[BUGFIX] Ensure Rank Display stays after changing variations

### DIFF
--- a/source/funkin/ui/freeplay/FreeplayState.hx
+++ b/source/funkin/ui/freeplay/FreeplayState.hx
@@ -712,8 +712,9 @@ class FreeplayState extends MusicBeatSubState
    * @param filterStuff A filter to apply to the song list (regex, startswith, all, favorite)
    * @param force Whether the capsules should "jump" back in or not using their animation
    * @param onlyIfChanged Only apply the filter if the song list has changed
+   * @param noJumpIn Will not call the jump-in function, used when changing difficulties to update the song list correctly without this happening twice
    */
-  public function generateSongList(filterStuff:Null<SongFilter>, force:Bool = false, onlyIfChanged:Bool = true):Void
+  public function generateSongList(filterStuff:Null<SongFilter>, force:Bool = false, onlyIfChanged:Bool = true, noJumpIn:Bool = false):Void
   {
     var tempSongs:Array<Null<FreeplaySongData>> = songs;
 
@@ -740,8 +741,11 @@ class FreeplayState extends MusicBeatSubState
         // Instead, we just apply the jump-in animation to the existing capsules.
         for (capsule in grpCapsules.members)
         {
-          capsule.initPosition(FlxG.width, 0);
-          capsule.initJumpIn(0, force);
+          if (!noJumpIn)
+          {
+            capsule.initPosition(FlxG.width, 0);
+            capsule.initJumpIn(0, force);
+          }
         }
 
         // Stop processing.
@@ -772,7 +776,7 @@ class FreeplayState extends MusicBeatSubState
       capsuleOnConfirmRandom(randomCapsule);
     };
 
-    if (fromCharSelect) randomCapsule.forcePosition();
+    if (fromCharSelect || noJumpIn) randomCapsule.forcePosition();
     else
     {
       randomCapsule.initJumpIn(0, force);
@@ -801,8 +805,8 @@ class FreeplayState extends MusicBeatSubState
       funnyMenu.hsvShader = hsvShader;
       funnyMenu.newText.animation.curAnim.curFrame = 45 - ((i * 4) % 45);
 
-      // Stop the bounce-in animation when returning to freeplay from the character selection screen.
-      if (fromCharSelect) funnyMenu.forcePosition();
+      // Stop the bounce-in animation when returning to freeplay from the character selection screen, or if noJumpIn is set to true
+      if (fromCharSelect || noJumpIn) funnyMenu.forcePosition();
       else
         funnyMenu.initJumpIn(0, force);
 
@@ -1778,7 +1782,7 @@ class FreeplayState extends MusicBeatSubState
   /**
    * changeDiff is the root of both difficulty and variation changes/management.
    * It will check the difficulty of the current variation, all available variations, and all available difficulties per variation.
-   * It's generally recommended that after calling this you re-sort the song list, however usually it's already on the way to being sorted.
+   * Call generateSongList after this with the right parameters if you want the capsules to do their jump-in animation after changing difficulties.
    * @param change
    * @param force
    */
@@ -1838,6 +1842,7 @@ class FreeplayState extends MusicBeatSubState
       intendedCompletion = songScore == null ? 0.0 : Math.max(0,
         ((songScore.tallies.sick + songScore.tallies.good - songScore.tallies.missed) / songScore.tallies.totalNotes));
       rememberedDifficulty = currentDifficulty;
+      generateSongList(currentFilter, false, true, true);
       grpCapsules.members[curSelected].refreshDisplay((prepForNewRank == true) ? false : true);
     }
     else
@@ -1845,6 +1850,7 @@ class FreeplayState extends MusicBeatSubState
       intendedScore = 0;
       intendedCompletion = 0.0;
       rememberedDifficulty = currentDifficulty;
+      generateSongList(currentFilter, false, true, true);
     }
 
     if (intendedCompletion == Math.POSITIVE_INFINITY || intendedCompletion == Math.NEGATIVE_INFINITY || Math.isNaN(intendedCompletion))


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->
## Does this PR close any issues? If so, link them below.
Fixes #4415
## Briefly describe the issue(s) fixed.
Switching to Erect difficulty and back removes the rank letter display on some songs. This is caused by the song list not being updated correctly when the difficulty is changed, resulting in some of the songs losing their rank display when their capsules are refreshed.

I added in a call to the `generateSongList` function inside the `changeDiff` function to refresh the song list for the currently selected difficulty and variation (if the song list has changed) before all of the capsules are refreshed.

Update: Because of the new changes with the jump-in animation, I added a default parameter to `generateSongList` so this animation doesn't happen twice.

## Include any relevant screenshots or videos.

Before:

https://github.com/user-attachments/assets/674ca32b-1c5f-4568-a935-f897f708af73


https://github.com/user-attachments/assets/332514e5-e64d-402e-8bda-d91cca8ba821

After:


https://github.com/user-attachments/assets/bcef5ae3-b928-4ef1-96c0-e43a634d732e


https://github.com/user-attachments/assets/28f0b1ae-fc0d-4091-84f9-1cd9846743b3
