### PR TITLE
Fix memory overflow in crash log

### DIFF
--- a/source/funkin/util/MemoryUtil.hx
+++ b/source/funkin/util/MemoryUtil.hx
@@ -17,10 +17,10 @@ class MemoryUtil
   {
     #if cpp
     var result:String = 'HXCPP-Immix:';
-    result += '\n- Memory Used: ${cpp.vm.Gc.memInfo(cpp.vm.Gc.MEM_INFO_USAGE)} bytes';
-    result += '\n- Memory Reserved: ${cpp.vm.Gc.memInfo(cpp.vm.Gc.MEM_INFO_RESERVED)} bytes';
-    result += '\n- Memory Current Pool: ${cpp.vm.Gc.memInfo(cpp.vm.Gc.MEM_INFO_CURRENT)} bytes';
-    result += '\n- Memory Large Pool: ${cpp.vm.Gc.memInfo(cpp.vm.Gc.MEM_INFO_LARGE)} bytes';
+    result += '\n- Memory Used: ${cpp.vm.Gc.memInfo64(cpp.vm.Gc.MEM_INFO_USAGE)} bytes';
+    result += '\n- Memory Reserved: ${cpp.vm.Gc.memInfo64(cpp.vm.Gc.MEM_INFO_RESERVED)} bytes';
+    result += '\n- Memory Current Pool: ${cpp.vm.Gc.memInfo64(cpp.vm.Gc.MEM_INFO_CURRENT)} bytes';
+    result += '\n- Memory Large Pool: ${cpp.vm.Gc.memInfo64(cpp.vm.Gc.MEM_INFO_LARGE)} bytes';
     result += '\n- HXCPP Debugger: ${#if HXCPP_DEBUGGER 'Enabled' #else 'Disabled' #end}';
     result += '\n- HXCPP Exp Generational Mode: ${#if HXCPP_GC_GENERATIONAL 'Enabled' #else 'Disabled' #end}';
     result += '\n- HXCPP Exp Moving GC: ${#if HXCPP_GC_MOVING 'Enabled' #else 'Disabled' #end}';


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->
## Does this PR close any issues? If so, link them below.
No

## Briefly describe the issue(s) fixed.
Previously when generating the crash log, `cpp.vm.Gc.memInfo()` was used which returns a 32bit integer that overflows after ~2.14GB. Ez fix by just using `memInfo64` instead

## Include any relevant screenshots or videos.

Before, memory overflows after ~2.14GB
![Screenshot 2025-04-06 001451 2](https://github.com/user-attachments/assets/dd740707-39da-4633-86e2-e33c2faa11a9)

After, no overflow! Memory can grow as much as it wants! Hooray!
![Screenshot 2025-04-06 001741 2](https://github.com/user-attachments/assets/a9088a6c-8f31-4c5f-a0c1-759d365127ff)
