### PR TITLE
[ENHANCMENT] Rework how the Pause Menu handles Cutscenes

### DIFF
--- a/source/funkin/play/PauseSubState.hx
+++ b/source/funkin/play/PauseSubState.hx
@@ -96,28 +96,13 @@ class PauseSubState extends MusicBeatSubState
   ];
 
   /**
-   * Pause menu entries for when the game is paused during a video cutscene.
+   * Pause menu entries for when the game is paused during a cutscene.
+   * `[CUTSCENE]` is replaced with the name of the cutscene type.
    */
-  static final PAUSE_MENU_ENTRIES_VIDEO_CUTSCENE:Array<PauseMenuEntry> = [
+  static final PAUSE_MENU_ENTRIES_CUTSCENE:Array<PauseMenuEntry> = [
     {text: 'Resume', callback: resume},
-    {
-      text: 'Skip Cutscene',
-      callback: skipVideoCutscene
-    },
-    {text: 'Restart Cutscene', callback: restartVideoCutscene},
-    {text: 'Exit to Menu', callback: quitToMenu},
-  ];
-
-  /**
-   * Pause menu entries for when the game is paused during a conversation.
-   */
-  static final PAUSE_MENU_ENTRIES_CONVERSATION:Array<PauseMenuEntry> = [
-    {text: 'Resume', callback: resume},
-    {
-      text: 'Skip Dialogue',
-      callback: skipConversation
-    },
-    {text: 'Restart Dialogue', callback: restartConversation},
+    {text: 'Skip [CUTSCENE]', callback: skipCutscene},
+    {text: 'Restart [CUTSCENE]', callback: restartCutscene},
     {text: 'Exit to Menu', callback: quitToMenu},
   ];
 
@@ -893,10 +878,15 @@ class PauseSubState extends MusicBeatSubState
 
         // Add the back button.
         currentMenuEntries = entries.concat(PAUSE_MENU_ENTRIES_DIFFICULTY.clone());
-      case PauseMode.Conversation:
-        currentMenuEntries = PAUSE_MENU_ENTRIES_CONVERSATION.clone();
-      case PauseMode.Cutscene:
-        currentMenuEntries = PAUSE_MENU_ENTRIES_VIDEO_CUTSCENE.clone();
+      case Cutscene(entryName, pauseName, onResume, onSkip, onRestart):
+        var entries:Array<PauseMenuEntry> = [];
+
+        for (entry in PAUSE_MENU_ENTRIES_CUTSCENE)
+        {
+          entries.push({text: StringTools.replace(entry.text, '[CUTSCENE]', entryName), callback: entry.callback});
+        }
+
+        currentMenuEntries = entries;
     }
   }
 
@@ -997,10 +987,8 @@ class PauseSubState extends MusicBeatSubState
         metadataDeaths.text = '${PlayState.instance?.deathCounter} Blue Balls';
       case Charting:
         metadataDeaths.text = 'Chart Editor Preview';
-      case Conversation:
-        metadataDeaths.text = 'Dialogue Paused';
-      case Cutscene:
-        metadataDeaths.text = 'Video Paused';
+      case Cutscene(entryName, pauseName, onResume, onSkip, onRestart):
+        metadataDeaths.text = '$pauseName Paused';
     }
   }
 
@@ -1014,11 +1002,18 @@ class PauseSubState extends MusicBeatSubState
    */
   static function resume(state:PauseSubState):Void
   {
-    // Resume a paused video if it exists.
-    VideoCutscene.resumeVideo();
     #if FEATURE_MOBILE_ADVERTISEMENTS
     AdMobUtil.removeBanner();
     #end
+    switch (state.currentMode)
+    {
+      case Cutscene(entryName, pauseName, onResume, onSkip, onRestart):
+        if (onResume != null)
+        {
+          onResume();
+        }
+      default:
+    }
     state.close();
   }
 
@@ -1135,58 +1130,40 @@ class PauseSubState extends MusicBeatSubState
   }
 
   /**
-   * Restart the paused video cutscene, then resume the game.
+   * Restart the paused cutscene, then resume the game.
    * @param state The current PauseSubState.
    */
-  static function restartVideoCutscene(state:PauseSubState):Void
+  static function restartCutscene(state:PauseSubState):Void
   {
-    VideoCutscene.restartVideo();
-    #if FEATURE_MOBILE_ADVERTISEMENTS
-    AdMobUtil.removeBanner();
-    #end
+    switch (state.currentMode)
+    {
+      case Cutscene(entryName, pauseName, onResume, onSkip, onRestart):
+        if (onRestart != null)
+        {
+          onRestart(); // VideoCutscene.restartVideo(); on videos
+        }
+      default:
+    }
+
     state.close();
   }
 
   /**
-   * Skip the paused video cutscene, then resume the game.
+   * Skip the paused cutscene, then resume the game.
    * @param state The current PauseSubState.
    */
-  static function skipVideoCutscene(state:PauseSubState):Void
+  static function skipCutscene(state:PauseSubState):Void
   {
-    VideoCutscene.finishVideo();
-    #if FEATURE_MOBILE_ADVERTISEMENTS
-    AdMobUtil.removeBanner();
-    #end
-    state.close();
-  }
+    switch (state.currentMode)
+    {
+      case Cutscene(entryName, pauseName, onResume, onSkip, onRestart):
+        if (onSkip != null)
+        {
+          onSkip(); // VideoCutscene.finishVideo(); on videos
+        }
+      default:
+    }
 
-  /**
-   * Restart the paused conversation, then resume the game.
-   * @param state The current PauseSubState.
-   */
-  static function restartConversation(state:PauseSubState):Void
-  {
-    if (PlayState.instance?.currentConversation == null) return;
-
-    PlayState.instance.currentConversation.resetConversation();
-    #if FEATURE_MOBILE_ADVERTISEMENTS
-    AdMobUtil.removeBanner();
-    #end
-    state.close();
-  }
-
-  /**
-   * Skip the paused conversation, then resume the game.
-   * @param state The current PauseSubState.
-   */
-  static function skipConversation(state:PauseSubState):Void
-  {
-    if (PlayState.instance?.currentConversation == null) return;
-
-    PlayState.instance.currentConversation.skipConversation();
-    #if FEATURE_MOBILE_ADVERTISEMENTS
-    AdMobUtil.removeBanner();
-    #end
     state.close();
   }
 
@@ -1272,14 +1249,14 @@ enum PauseMode
   Difficulty;
 
   /**
-   * The menu displayed when the player pauses the game during a conversation.
+   * The menu displayed when the player pauses the game during a cutscene.
+   * @param entryName The name to show in entries.
+   * @param pauseName The name to show on the "Cutscene Paused" text.
+   * @param onResume Gets called when `Resume` is selected.
+   * @param onSkip Gets called when `Skip [entryName]` is selected.
+   * @param onRestart Gets called when `Restart [entryName]` is selected.
    */
-  Conversation;
-
-  /**
-   * The menu displayed when the player pauses the game during a video cutscene.
-   */
-  Cutscene;
+  Cutscene(entryName:String, pauseName:String, onResume:Void->Void, onSkip:Void->Void, onRestart:Void->Void);
 }
 
 /**

--- a/source/funkin/play/PauseSubState.hx
+++ b/source/funkin/play/PauseSubState.hx
@@ -107,42 +107,21 @@ class PauseSubState extends MusicBeatSubState
   ];
 
   /**
-   * Pause menu entries for when the game is paused during a video cutscene.
+   * Pause menu entries for when the game is paused during a cutscene.
+   * `[CUTSCENE]` is replaced with the name of the cutscene type.
    */
-  static final PAUSE_MENU_ENTRIES_VIDEO_CUTSCENE:Array<PauseMenuEntry> = [
+  static final PAUSE_MENU_ENTRIES_CUTSCENE:Array<PauseMenuEntry> = [
     {
       text: 'Resume',
       callback: resume
     },
     {
-      text: 'Skip Cutscene',
-      callback: skipVideoCutscene
+      text: 'Skip [CUTSCENE]',
+      callback: skipCutscene
     },
     {
-      text: 'Restart Cutscene',
-      callback: restartVideoCutscene
-    },
-    {
-      text: 'Exit to Menu',
-      callback: quitToMenu
-    },
-  ];
-
-  /**
-   * Pause menu entries for when the game is paused during a conversation.
-   */
-  static final PAUSE_MENU_ENTRIES_CONVERSATION:Array<PauseMenuEntry> = [
-    {
-      text: 'Resume',
-      callback: resume
-    },
-    {
-      text: 'Skip Dialogue',
-      callback: skipConversation
-    },
-    {
-      text: 'Restart Dialogue',
-      callback: restartConversation
+      text: 'Restart [CUTSCENE]',
+      callback: restartCutscene
     },
     {
       text: 'Exit to Menu',
@@ -990,10 +969,18 @@ class PauseSubState extends MusicBeatSubState
 
         // Add the back button.
         currentMenuEntries = entries.concat(PAUSE_MENU_ENTRIES_DIFFICULTY.clone());
-      case PauseMode.Conversation:
-        currentMenuEntries = PAUSE_MENU_ENTRIES_CONVERSATION.clone();
-      case PauseMode.Cutscene:
-        currentMenuEntries = PAUSE_MENU_ENTRIES_VIDEO_CUTSCENE.clone();
+      case Cutscene(entryName, pauseName, onResume, onSkip, onRestart):
+        var entries:Array<PauseMenuEntry> = [];
+
+        for (entry in PAUSE_MENU_ENTRIES_CUTSCENE)
+        {
+          entries.push({
+            text: StringTools.replace(entry.text, '[CUTSCENE]', entryName),
+            callback: entry.callback
+          });
+        }
+
+        currentMenuEntries = entries;
     }
   }
 
@@ -1098,10 +1085,8 @@ class PauseSubState extends MusicBeatSubState
         metadataDeaths.text = '${PlayState.instance?.deathCounter} Blue Balls';
       case Charting:
         metadataDeaths.text = 'Chart Editor Preview';
-      case Conversation:
-        metadataDeaths.text = 'Dialogue Paused';
-      case Cutscene:
-        metadataDeaths.text = 'Video Paused';
+      case Cutscene(entryName, pauseName, onResume, onSkip, onRestart):
+        metadataDeaths.text = '$pauseName Paused';
     }
   }
 
@@ -1115,11 +1100,18 @@ class PauseSubState extends MusicBeatSubState
    */
   static function resume(state:PauseSubState):Void
   {
-    // Resume a paused video if it exists.
-    VideoCutscene.resumeVideo();
     #if FEATURE_MOBILE_ADVERTISEMENTS
     AdMobUtil.removeBanner();
     #end
+    switch (state.currentMode)
+    {
+      case Cutscene(entryName, pauseName, onResume, onSkip, onRestart):
+        if (onResume != null)
+        {
+          onResume();
+        }
+      default:
+    }
     state.close();
   }
 
@@ -1237,58 +1229,40 @@ class PauseSubState extends MusicBeatSubState
   }
 
   /**
-   * Restart the paused video cutscene, then resume the game.
+   * Restart the paused cutscene, then resume the game.
    * @param state The current PauseSubState.
    */
-  static function restartVideoCutscene(state:PauseSubState):Void
+  static function restartCutscene(state:PauseSubState):Void
   {
-    VideoCutscene.restartVideo();
-    #if FEATURE_MOBILE_ADVERTISEMENTS
-    AdMobUtil.removeBanner();
-    #end
+    switch (state.currentMode)
+    {
+      case Cutscene(entryName, pauseName, onResume, onSkip, onRestart):
+        if (onRestart != null)
+        {
+          onRestart(); // VideoCutscene.restartVideo(); on videos
+        }
+      default:
+    }
+
     state.close();
   }
 
   /**
-   * Skip the paused video cutscene, then resume the game.
+   * Skip the paused cutscene, then resume the game.
    * @param state The current PauseSubState.
    */
-  static function skipVideoCutscene(state:PauseSubState):Void
+  static function skipCutscene(state:PauseSubState):Void
   {
-    VideoCutscene.finishVideo();
-    #if FEATURE_MOBILE_ADVERTISEMENTS
-    AdMobUtil.removeBanner();
-    #end
-    state.close();
-  }
+    switch (state.currentMode)
+    {
+      case Cutscene(entryName, pauseName, onResume, onSkip, onRestart):
+        if (onSkip != null)
+        {
+          onSkip(); // VideoCutscene.finishVideo(); on videos
+        }
+      default:
+    }
 
-  /**
-   * Restart the paused conversation, then resume the game.
-   * @param state The current PauseSubState.
-   */
-  static function restartConversation(state:PauseSubState):Void
-  {
-    if (PlayState.instance?.currentConversation == null) return;
-
-    PlayState.instance.currentConversation.resetConversation();
-    #if FEATURE_MOBILE_ADVERTISEMENTS
-    AdMobUtil.removeBanner();
-    #end
-    state.close();
-  }
-
-  /**
-   * Skip the paused conversation, then resume the game.
-   * @param state The current PauseSubState.
-   */
-  static function skipConversation(state:PauseSubState):Void
-  {
-    if (PlayState.instance?.currentConversation == null) return;
-
-    PlayState.instance.currentConversation.skipConversation();
-    #if FEATURE_MOBILE_ADVERTISEMENTS
-    AdMobUtil.removeBanner();
-    #end
     state.close();
   }
 
@@ -1378,14 +1352,14 @@ enum PauseMode
   Difficulty;
 
   /**
-   * The menu displayed when the player pauses the game during a conversation.
+   * The menu displayed when the player pauses the game during a cutscene.
+   * @param entryName The name to show in entries.
+   * @param pauseName The name to show on the "Cutscene Paused" text.
+   * @param onResume Gets called when `Resume` is selected.
+   * @param onSkip Gets called when `Skip [entryName]` is selected.
+   * @param onRestart Gets called when `Restart [entryName]` is selected.
    */
-  Conversation;
-
-  /**
-   * The menu displayed when the player pauses the game during a video cutscene.
-   */
-  Cutscene;
+  Cutscene(entryName:String, pauseName:String, onResume:Void->Void, onSkip:Void->Void, onRestart:Void->Void);
 }
 
 /**

--- a/source/funkin/play/PlayState.hx
+++ b/source/funkin/play/PlayState.hx
@@ -1346,28 +1346,21 @@ class PlayState extends MusicBeatSubState
      * Pause the game.
      * @param mode Which set of pause menu options to display (distinguishes between standard, charting, and cutscene)
      * @param lostFocus Whether the game paused because the window lost focus
+     * @param onPause Callback to run when finished initializing.
      */
-  function pause(mode:PauseMode = Standard, lostFocus:Bool = false):Void
+  function pause(mode:PauseMode = Standard, lostFocus:Bool = false, ?onPause:Void->Void):Void
   {
     if (!mayPauseGame || justUnpaused || isGamePaused || isPlayerDying || isSongEnd) return;
 
     switch (mode)
     {
-      case Conversation:
+      case Cutscene(entryName, pauseName, onResume, onSkip, onRestart):
         preparePauseUI();
 
         final event = new PauseScriptEvent(false);
         dispatchEvent(event);
 
-        if (!event.eventCanceled) openPauseSubState(Conversation, camPause, lostFocus, () -> currentConversation?.pause());
-
-      case Cutscene:
-        preparePauseUI();
-
-        final event = new PauseScriptEvent(false);
-        dispatchEvent(event);
-
-        if (!event.eventCanceled) openPauseSubState(Cutscene, camPause, lostFocus, () -> VideoCutscene.pauseVideo());
+        if (!event.eventCanceled) openPauseSubState(mode, camPause, lostFocus, onPause);
 
       default: // also known as standard
         if (!isInCountdown || isInCutscene) return;
@@ -1796,11 +1789,13 @@ class PlayState extends MusicBeatSubState
     {
       if (currentConversation != null)
       {
-        pause(Conversation, true);
+        pause(Cutscene('Conversation', 'Conversation', null, currentConversation?.skipConversation, currentConversation?.resetConversation), true,
+          currentConversation.pauseMusic);
       }
       else if (VideoCutscene.isPlaying())
       {
-        pause(Cutscene, true);
+        pause(Cutscene('Cutscene', 'Video', VideoCutscene.resumeVideo, VideoCutscene.finishVideo.bind(null), VideoCutscene.restartVideo), true,
+          VideoCutscene.pauseVideo);
       }
       else
       {
@@ -3418,7 +3413,8 @@ class PlayState extends MusicBeatSubState
       }
       else if ((controls.PAUSE_P || androidPause || pauseButtonCheck) && !justUnpaused)
       {
-        pause(Conversation);
+        pause(Cutscene('Conversation', 'Conversation', null, currentConversation?.skipConversation, currentConversation?.resetConversation),
+          currentConversation.pauseMusic);
       }
     }
     else if (VideoCutscene.isPlaying())
@@ -3426,7 +3422,8 @@ class PlayState extends MusicBeatSubState
       // This is a video cutscene.
       if ((controls.PAUSE_P || androidPause || pauseButtonCheck) && !justUnpaused)
       {
-        pause(Cutscene);
+        pause(Cutscene('Cutscene', 'Video', VideoCutscene.resumeVideo, VideoCutscene.finishVideo.bind(null), VideoCutscene.restartVideo),
+          VideoCutscene.pauseVideo);
       }
     }
   }

--- a/source/funkin/play/PlayState.hx
+++ b/source/funkin/play/PlayState.hx
@@ -1363,30 +1363,22 @@ class PlayState extends MusicBeatSubState
    * Pause the game.
    * @param mode Which set of pause menu options to display (distinguishes between standard, charting, and cutscene)
    * @param lostFocus Whether the game paused because the window lost focus
+   * @param onPause Callback to run when finished initializing.
    */
-  function pause(mode:PauseMode = Standard, lostFocus:Bool = false):Void
+  function pause(mode:PauseMode = Standard, lostFocus:Bool = false, ?onPause:Void->Void):Void
   {
     if (!mayPauseGame || justUnpaused || isGamePaused || isPlayerDying || isSongEnd) return;
 
     switch (mode)
     {
-      case Conversation:
+      case Cutscene(entryName, pauseName, onResume, onSkip, onRestart):
         preparePauseUI();
 
         final event = PauseScriptEvent.get(false);
         dispatchEvent(event);
         event.put();
 
-        if (!event.eventCanceled) openPauseSubState(Conversation, camPause, lostFocus, () -> currentConversation?.pauseMusic());
-
-      case Cutscene:
-        preparePauseUI();
-
-        final event = PauseScriptEvent.get(false);
-        dispatchEvent(event);
-        event.put();
-
-        if (!event.eventCanceled) openPauseSubState(Cutscene, camPause, lostFocus, () -> VideoCutscene.pauseVideo());
+        if (!event.eventCanceled) openPauseSubState(mode, camPause, lostFocus, onPause);
 
       default: // also known as standard
         if (!isInCountdown || isInCutscene) return;
@@ -1790,11 +1782,19 @@ class PlayState extends MusicBeatSubState
     {
       if (currentConversation != null)
       {
-        pause(Conversation, true);
+        pause(
+          Cutscene('Conversation', 'Conversation', null, currentConversation?.skipConversation, currentConversation?.resetConversation),
+          true,
+          currentConversation.pauseMusic
+        );
       }
       else if (VideoCutscene.isPlaying())
       {
-        pause(Cutscene, true);
+        pause(
+          Cutscene('Cutscene', 'Video', VideoCutscene.resumeVideo, VideoCutscene.finishVideo.bind(null), VideoCutscene.restartVideo),
+          true,
+          VideoCutscene.pauseVideo
+        );
       }
       else
       {
@@ -3473,7 +3473,10 @@ class PlayState extends MusicBeatSubState
       }
       else if ((controls.PAUSE_P || androidPause || pauseButtonCheck) && !justUnpaused)
       {
-        pause(Conversation);
+        pause(
+          Cutscene('Conversation', 'Conversation', null, currentConversation?.skipConversation, currentConversation?.resetConversation),
+          currentConversation.pauseMusic
+        );
       }
     }
     else if (VideoCutscene.isPlaying())
@@ -3481,7 +3484,10 @@ class PlayState extends MusicBeatSubState
       // This is a video cutscene.
       if ((controls.PAUSE_P || androidPause || pauseButtonCheck) && !justUnpaused)
       {
-        pause(Cutscene);
+        pause(
+          Cutscene('Cutscene', 'Video', VideoCutscene.resumeVideo, VideoCutscene.finishVideo.bind(null), VideoCutscene.restartVideo),
+          VideoCutscene.pauseVideo
+        );
       }
     }
   }


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->
## Does this PR close any issues? If so, link them below.

## Briefly describe the issue(s) fixed.
This PR reworks how the Pause Menu handles Cutscenes, by merging the Conversation and Cutscene enums into one general one, which takes parameters.

This doesn't change anything, but makes it easier for making different types of cutscenes.