### PR TITLE
[BUGFIX] Destroy the volume plugin when wiping save data

### DIFF
--- a/source/funkin/util/plugins/VolumePlugin.hx
+++ b/source/funkin/util/plugins/VolumePlugin.hx
@@ -31,4 +31,11 @@ class VolumePlugin extends FlxBasic
       else if (PlayerSettings.player1.controls.VOLUME_DOWN) FlxG.sound.changeVolume(-0.1);
     }
   }
+
+  override public function destroy():Void
+  {
+    if (FlxG.plugins.list.contains(this)) FlxG.plugins.remove(this);
+
+    super.destroy();
+  }
 }


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->
## Does this PR close any issues? If so, link them below.
Fixes #4616
## Briefly describe the issue(s) fixed.
The volume plugin doesn't have a destroy function.
## Include any relevant screenshots or videos.
No