### PR TITLE
Fix an oversight on Bopper.correctAnimationName

### DIFF
--- a/source/funkin/play/stage/Bopper.hx
+++ b/source/funkin/play/stage/Bopper.hx
@@ -212,38 +212,27 @@ class Bopper extends StageProp implements IPlayStateScriptedClass
    * @param name The animation name to attempt to correct.
    * @param fallback Instead of failing to play, try to play this animation instead.
    */
-  function correctAnimationName(name:String, ?fallback:String):String
+  function correctAnimationName(name:String, fallback:String = 'idle'):Null<String>
   {
     // If the animation exists, we're good.
     if (hasAnimation(name)) return name;
 
     // Attempt to strip a `-alt` suffix, if it exists.
-    if (name.lastIndexOf('-') != -1)
+    final idx = name.lastIndexOf('-');
+    if (idx != -1)
     {
-      var correctName = name.substring(0, name.lastIndexOf('-'));
-      FlxG.log.notice('${this.toString()} tried to play animation "$name" that does not exist, stripping suffixes ($correctName)...');
-      return correctAnimationName(correctName);
+      FlxG.log.notice('${this.toString()} tried to play animation "$name" that does not exist, stripping suffixes...');
+      return correctAnimationName(name.substr(0, idx), fallback);
+    }
+    else if (fallback != name)
+    {
+      FlxG.log.warn('${this.toString()} tried to play animation "$name" that does not exist, fallback to $fallback');
+      return correctAnimationName(fallback);
     }
     else
     {
-      if (fallback != null)
-      {
-        if (fallback == name)
-        {
-          FlxG.log.error('${this.toString()} tried to play animation "$name" that does not exist! This is bad!');
-          return null;
-        }
-        else
-        {
-          FlxG.log.warn('${this.toString()} tried to play animation "$name" that does not exist, fallback to idle...');
-          return correctAnimationName('idle');
-        }
-      }
-      else
-      {
-        FlxG.log.error('${this.toString()} tried to play animation "$name" that does not exist! This is bad!');
-        return null;
-      }
+      FlxG.log.error('${this.toString()} tried to play animation "$name" that does not exist! This is bad!');
+      return null;
     }
   }
 

--- a/source/funkin/play/stage/Bopper.hx
+++ b/source/funkin/play/stage/Bopper.hx
@@ -212,38 +212,27 @@ class Bopper extends StageProp implements IPlayStateScriptedClass
    * @param name The animation name to attempt to correct.
    * @param fallback Instead of failing to play, try to play this animation instead.
    */
-  function correctAnimationName(name:String, ?fallback:String):String
+  function correctAnimationName(name:String, fallback:String = 'idle'):Null<String>
   {
     // If the animation exists, we're good.
     if (hasAnimation(name)) return name;
 
     // Attempt to strip a `-alt` suffix, if it exists.
-    if (name.lastIndexOf('-') != -1)
+    final idx = name.lastIndexOf('-');
+    if (idx != -1)
     {
-      var correctName = name.substring(0, name.lastIndexOf('-'));
-      FlxG.log.notice('Bopper tried to play animation "$name" that does not exist, stripping suffixes ($correctName)...');
-      return correctAnimationName(correctName);
+      FlxG.log.notice('Bopper tried to play animation "$name" that does not exist, stripping suffixes...');
+      return correctAnimationName(name.substr(0, idx), fallback);
+    }
+    else if (fallback != name)
+    {
+      FlxG.log.warn('Bopper tried to play animation "$name" that does not exist, fallback to $fallback');
+      return correctAnimationName(fallback);
     }
     else
     {
-      if (fallback != null)
-      {
-        if (fallback == name)
-        {
-          FlxG.log.error('Bopper tried to play animation "$name" that does not exist! This is bad!');
-          return null;
-        }
-        else
-        {
-          FlxG.log.warn('Bopper tried to play animation "$name" that does not exist, fallback to idle...');
-          return correctAnimationName('idle');
-        }
-      }
-      else
-      {
-        FlxG.log.error('Bopper tried to play animation "$name" that does not exist! This is bad!');
-        return null;
-      }
+      FlxG.log.error('Bopper tried to play animation "$name" that does not exist! This is bad!');
+      return null;
     }
   }
 


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->
## Does this PR close any issues? If so, link them below.
None

## Briefly describe the issue(s) fixed.
Fixes
- correctAnimationName never tries the default fallback animation "idle" if fallback argument are not filled.
- stripped suffixes of animation names never tries the passed fallback argument.

## Include any relevant screenshots or videos.

Left is before, Right is after.

https://github.com/user-attachments/assets/f1ea1269-f1e3-4e22-8855-b65a01f69be3

(In video, the sing poses animations for dad and mom are purposely removed to show the purpose of the correctAnimationName, although bf not wearing the christmas variant was a bug in the origin branch at the time recording and have been fixed not long ago)
