### PR TITLE
Replace Deprecated State Switching

### DIFF
--- a/source/funkin/ui/debug/DebugMenuSubState.hx
+++ b/source/funkin/ui/debug/DebugMenuSubState.hx
@@ -112,7 +112,7 @@ class DebugMenuSubState extends MusicBeatSubState
 
   function openCharSelect()
   {
-    FlxG.switchState(new funkin.ui.charSelect.CharSelectSubState());
+    FlxG.switchState(() -> new funkin.ui.charSelect.CharSelectSubState());
   }
 
   function openAnimationEditor()

--- a/source/funkin/ui/freeplay/FreeplayState.hx
+++ b/source/funkin/ui/freeplay/FreeplayState.hx
@@ -1158,7 +1158,7 @@ class FreeplayState extends MusicBeatSubState
     fadeShader.fade(1.0, 0.0, 0.8, {ease: FlxEase.quadIn});
     FlxG.sound.music?.fadeOut(0.9, 0);
     new FlxTimer().start(0.9, _ -> {
-      FlxG.switchState(new funkin.ui.charSelect.CharSelectSubState());
+      FlxG.switchState(() -> new funkin.ui.charSelect.CharSelectSubState());
     });
     for (grpSpr in exitMoversCharSel.keys())
     {


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->
## Does this PR close any issues? If so, link them below.
No
## Briefly describe the issue(s) fixed.
The way of switching states with Flixel has changed, resulting in the old way being deprecated. Many instances of state switching in the code were changed to the new way in [this commit](https://github.com/FunkinCrew/Funkin/commit/e5fb1de4ba74412e7f3e6673a7223e8dbe373d37#diff-d735da8a36bf5a753af53c828f8a2213a4cd5bf5bad648e262c3391f9fb8f442). There are still two instances of using the old way to switch states in the code. This PR replaces these last two instances with the new way.
## Include any relevant screenshots or videos.

![Screenshot 2025-04-06 075823](https://github.com/user-attachments/assets/61557369-9b64-4462-945f-cb4bd3c491f6)
