### PR TITLE
[CLEANUP] Recode Preferences

### DIFF
--- a/source/funkin/ui/options/PreferenceItem.hx
+++ b/source/funkin/ui/options/PreferenceItem.hx
@@ -11,10 +11,6 @@ class PreferenceItem extends MenuTypedItem<FlxTypedSpriteGroup<FlxSprite>>
 {
   /**
    * The type of the preference item.
-   * - Checkbox: A checkbox that can be checked or unchecked.
-   * - Number: A number input that can be adjusted with a slider.
-   * - Percentage: A percentage input that can be adjusted with a slider.
-   * - Enum: A dropdown list that allows the user to select from a list of options.
    */
   public var type:PreferenceType;
 
@@ -42,7 +38,17 @@ class PreferenceItem extends MenuTypedItem<FlxTypedSpriteGroup<FlxSprite>>
 
   public static final SPACING_X:Int = 10;
 
-  public function new(x:Float, y:Float, type:PreferenceType, name:String, description:String, onChange:Null<Dynamic->Void>, defaultValue:Dynamic, ?extraData:PreferenceItemData)
+  /**
+   * Creates a new preference item.
+   * @param type The type of the preference item (checkbox, number, percentage, enum).
+   * @param name The name of the preference item.
+   * @param description The description of the preference item.
+   * @param onChange The function to call when the preference item changes.
+   * @param defaultValue The default value of the preference item.
+   * // make data refer to PreferenceItemData
+   * @param data
+   */
+  public function new(x:Float, y:Float, type:PreferenceType, name:String, description:String, onChange:Null<Dynamic->Void>, defaultValue:Dynamic, ?data:PreferenceItemData)
   {
     group = new FlxTypedSpriteGroup<FlxSprite>();
 
@@ -51,16 +57,17 @@ class PreferenceItem extends MenuTypedItem<FlxTypedSpriteGroup<FlxSprite>>
       case PreferenceType.Checkbox:
         preferenceGraphic = new CheckboxPreferenceItem(x, y, defaultValue, onChange);
       case PreferenceType.Number:
-        preferenceGraphic = new NumberPreferenceItem(x, y, name, defaultValue, extraData?.min, extraData?.max, extraData?.step, extraData?.precision,
-          onChange, extraData?.formatter);
+        preferenceGraphic = new NumberPreferenceItem(x, y, name, defaultValue, data?.min, data?.max, data?.step, data?.precision,
+          onChange, data?.formatter);
       case PreferenceType.Percentage:
-        preferenceGraphic = new NumberPreferenceItem(x, y, name, defaultValue, extraData?.min ?? 0, extraData?.max ?? 100, 10, 0, function(value:Float) {
+        preferenceGraphic = new NumberPreferenceItem(x, y, name, defaultValue, data?.min ?? 0, data?.max ?? 100, 10, 0, function(value:Float) {
           onChange(Std.int(value));
         }, function(value:Float):String {
           return '${value}%';
         });
       case PreferenceType.Enum:
-        preferenceGraphic = new EnumPreferenceItem(x, y, name, extraData.values, defaultValue, onChange);
+        trace(data?.values);
+        preferenceGraphic = new EnumPreferenceItem(x, y, name, data?.values, defaultValue, onChange);
     }
 
     if (preferenceGraphic != null) group.add(preferenceGraphic);
@@ -107,12 +114,12 @@ enum PreferenceType
 }
 
 /**
- * @param min The minimum value of the number preference item.
- * @param max The maximum value of the number preference item.
- * @param step The step value of the number preference item.
- * @param formatter The function to call to format the value of the number preference item.
- * @param precision The precision of the value of the number preference item.
- * @param values The values of the enumpreference item.
+ * @param min Minimum value (example: 0, for a percentage the default value is 0).
+ * @param max Maximum value (example: 10, for a percentage the default value is 100).
+ * @param step The value to increment/decrement by (default = 0.1)
+ * @param formatter Will get called every time the game needs to display the float value; use this to change how the displayed value looks.
+ * @param precision Rounds decimals up to a `precision` amount of digits (ex: 4 -> 0.1234, 2 -> 0.12)
+ * @param values Maps enum values to display strings _(ex: `NoteHitSoundType.PingPong => "Ping pong"`)_
  */
 typedef PreferenceItemData =
 {

--- a/source/funkin/ui/options/PreferenceItem.hx
+++ b/source/funkin/ui/options/PreferenceItem.hx
@@ -4,7 +4,6 @@ import flixel.FlxSprite;
 import funkin.ui.options.items.CheckboxPreferenceItem;
 import funkin.ui.options.items.NumberPreferenceItem;
 import funkin.ui.options.items.EnumPreferenceItem;
-import funkin.ui.TextMenuList.TextMenuItem;
 import funkin.ui.MenuList.MenuTypedItem;
 import flixel.group.FlxSpriteGroup.FlxTypedSpriteGroup;
 
@@ -39,13 +38,13 @@ class PreferenceItem extends MenuTypedItem<FlxTypedSpriteGroup<FlxSprite>>
 
   public var text:AtlasText;
   public var preferenceGraphic:FlxSprite;
+  private var group:FlxTypedSpriteGroup<FlxSprite>;
 
-  static final SPACING_X:Float = 100;
+  public static final SPACING_X:Int = 10;
 
-  public function new(x:Float, y:Float, type:PreferenceType, name:String, description:String, onChange:Null<Dynamic->Void>, defaultValue:Dynamic,
-      ?extraData:PreferenceItemData)
+  public function new(x:Float, y:Float, type:PreferenceType, name:String, description:String, onChange:Null<Dynamic->Void>, defaultValue:Dynamic, ?extraData:PreferenceItemData)
   {
-    var group = new FlxTypedSpriteGroup<FlxSprite>();
+    group = new FlxTypedSpriteGroup<FlxSprite>();
 
     switch (type)
     {
@@ -62,15 +61,12 @@ class PreferenceItem extends MenuTypedItem<FlxTypedSpriteGroup<FlxSprite>>
         });
       case PreferenceType.Enum:
         preferenceGraphic = new EnumPreferenceItem(x, y, name, extraData.values, defaultValue, onChange);
-      default:
-        trace('Unsupported PreferenceType: $type');
-        preferenceGraphic = null; // Explicitly set to null to avoid uninitialized variable issues
     }
 
-    text = new AtlasText(x + (preferenceGraphic != null ? preferenceGraphic.frameWidth : 0), y, name, BOLD);
-    group.add(text);
-
     if (preferenceGraphic != null) group.add(preferenceGraphic);
+
+    text = new AtlasText(x, y, name, BOLD);
+    if (text != null) group.add(text);
 
     super(x, y, group, name, function() {
       if (onChange != null)
@@ -87,6 +83,7 @@ class PreferenceItem extends MenuTypedItem<FlxTypedSpriteGroup<FlxSprite>>
         }
       }
     });
+    setEmptyBackground();
 
     this.type = type;
     this.description = description;
@@ -97,10 +94,6 @@ class PreferenceItem extends MenuTypedItem<FlxTypedSpriteGroup<FlxSprite>>
 
   override function update(elapsed:Float):Void
   {
-    // if (Std.isOfType(this, EnumPreferenceItem)) cast(this, EnumPreferenceItem).update(elapsed);
-    // else if (Std.isOfType(this, NumberPreferenceItem)) cast(this, NumberPreferenceItem).update(elapsed);
-    // else if (Std.isOfType(this, CheckboxPreferenceItem)) cast(this, CheckboxPreferenceItem).update(elapsed);
-
     super.update(elapsed);
   }
 }
@@ -114,11 +107,6 @@ enum PreferenceType
 }
 
 /**
- * @param type The type of the preference item.
- * @param name The name of the preference item.
- * @param description The description of the preference item.
- * @param onChange The function to call when the preference item changes.
- * @param defaultValue The default value of the preference item.
  * @param min The minimum value of the number preference item.
  * @param max The maximum value of the number preference item.
  * @param step The step value of the number preference item.

--- a/source/funkin/ui/options/PreferenceItem.hx
+++ b/source/funkin/ui/options/PreferenceItem.hx
@@ -54,17 +54,17 @@ class PreferenceItem extends MenuTypedItem<FlxTypedSpriteGroup<FlxSprite>>
 
     switch (type)
     {
-      case PreferenceType.Checkbox:
+      case Checkbox:
         preferenceGraphic = new CheckboxPreferenceItem(x, y, defaultValue, onChange);
-      case PreferenceType.Number:
+      case Number:
         preferenceGraphic = new NumberPreferenceItem(x, y, name, defaultValue, data?.min, data?.max, data?.step, data?.precision, onChange, data?.formatter);
-      case PreferenceType.Percentage:
+      case Percentage:
         preferenceGraphic = new NumberPreferenceItem(x, y, name, defaultValue, data?.min ?? 0, data?.max ?? 100, 10, 0, function(value:Float) {
           onChange(Std.int(value));
         }, function(value:Float):String {
           return '${value}%';
         });
-      case PreferenceType.Enum:
+      case Enum:
         preferenceGraphic = new EnumPreferenceItem(x, y, name, data?.values, defaultValue, onChange);
     }
 
@@ -78,7 +78,7 @@ class PreferenceItem extends MenuTypedItem<FlxTypedSpriteGroup<FlxSprite>>
       {
         switch (type)
         {
-          case PreferenceType.Checkbox:
+          case Checkbox:
             var checkbox = cast(preferenceGraphic, CheckboxPreferenceItem);
             var value = !checkbox.currentValue;
             onChange(value);
@@ -95,7 +95,7 @@ class PreferenceItem extends MenuTypedItem<FlxTypedSpriteGroup<FlxSprite>>
     this.description = description;
     this.onChange = onChange;
     this.defaultValue = defaultValue;
-    if (type != PreferenceType.Checkbox) this.fireInstantly = true;
+    if (type != Checkbox) this.fireInstantly = true;
   }
 
   override function update(elapsed:Float):Void
@@ -124,12 +124,12 @@ class PreferenceItem extends MenuTypedItem<FlxTypedSpriteGroup<FlxSprite>>
  * - Percentage: A preference item that allows the user to have a percentage value.
  * - Enum: A list that allows the user to select a value from a list of options.
  */
-enum PreferenceType
+enum abstract PreferenceType(String) from String to String
 {
-  Checkbox;
-  Number;
-  Percentage;
-  Enum;
+  var Checkbox = 'checkbox';
+  var Number = 'number';
+  var Percentage = 'percentage';
+  var Enum = 'enum';
 }
 
 /**

--- a/source/funkin/ui/options/PreferenceItem.hx
+++ b/source/funkin/ui/options/PreferenceItem.hx
@@ -5,6 +5,7 @@ import funkin.ui.options.items.CheckboxPreferenceItem;
 import funkin.ui.options.items.NumberPreferenceItem;
 import funkin.ui.options.items.EnumPreferenceItem;
 import funkin.ui.MenuList.MenuTypedItem;
+import funkin.ui.TextMenuList.TextMenuItem;
 import flixel.group.FlxSpriteGroup.FlxTypedSpriteGroup;
 
 class PreferenceItem extends MenuTypedItem<FlxTypedSpriteGroup<FlxSprite>>
@@ -45,7 +46,6 @@ class PreferenceItem extends MenuTypedItem<FlxTypedSpriteGroup<FlxSprite>>
    * @param description The description of the preference item.
    * @param onChange The function to call when the preference item changes.
    * @param defaultValue The default value of the preference item.
-   * // make data refer to PreferenceItemData
    * @param data
    */
   public function new(x:Float, y:Float, type:PreferenceType, name:String, description:String, onChange:Null<Dynamic->Void>, defaultValue:Dynamic, ?data:PreferenceItemData)
@@ -57,8 +57,7 @@ class PreferenceItem extends MenuTypedItem<FlxTypedSpriteGroup<FlxSprite>>
       case PreferenceType.Checkbox:
         preferenceGraphic = new CheckboxPreferenceItem(x, y, defaultValue, onChange);
       case PreferenceType.Number:
-        preferenceGraphic = new NumberPreferenceItem(x, y, name, defaultValue, data?.min, data?.max, data?.step, data?.precision,
-          onChange, data?.formatter);
+        preferenceGraphic = new NumberPreferenceItem(x, y, name, defaultValue, data?.min, data?.max, data?.step, data?.precision, onChange, data?.formatter);
       case PreferenceType.Percentage:
         preferenceGraphic = new NumberPreferenceItem(x, y, name, defaultValue, data?.min ?? 0, data?.max ?? 100, 10, 0, function(value:Float) {
           onChange(Std.int(value));
@@ -66,7 +65,6 @@ class PreferenceItem extends MenuTypedItem<FlxTypedSpriteGroup<FlxSprite>>
           return '${value}%';
         });
       case PreferenceType.Enum:
-        trace(data?.values);
         preferenceGraphic = new EnumPreferenceItem(x, y, name, data?.values, defaultValue, onChange);
     }
 
@@ -90,6 +88,7 @@ class PreferenceItem extends MenuTypedItem<FlxTypedSpriteGroup<FlxSprite>>
         }
       }
     });
+
     setEmptyBackground();
 
     this.type = type;
@@ -103,8 +102,28 @@ class PreferenceItem extends MenuTypedItem<FlxTypedSpriteGroup<FlxSprite>>
   {
     super.update(elapsed);
   }
+
+  override public function idle()
+  {
+    if (text != null) text.alpha = 0.6;
+    if (preferenceGraphic != null) preferenceGraphic.alpha = 0.6;
+  }
+
+  override public function select()
+  {
+    if (text != null) text.alpha = 1.0;
+    if (preferenceGraphic != null) preferenceGraphic.alpha = 1.0;
+  }
 }
 
+/**
+ * The type of the preference item.
+ * This is used to determine how the preference item should be displayed and how it should behave.
+ * - Checkbox: A checkbox that can be checked or unchecked.
+ * - Number: A preference item that allows the user to have a number value.
+ * - Percentage: A preference item that allows the user to have a percentage value.
+ * - Enum: A list that allows the user to select a value from a list of options.
+ */
 enum PreferenceType
 {
   Checkbox;

--- a/source/funkin/ui/options/PreferenceItem.hx
+++ b/source/funkin/ui/options/PreferenceItem.hx
@@ -1,0 +1,138 @@
+package funkin.ui.options;
+
+import flixel.FlxSprite;
+import funkin.ui.options.items.CheckboxPreferenceItem;
+import funkin.ui.options.items.NumberPreferenceItem;
+import funkin.ui.options.items.EnumPreferenceItem;
+import funkin.ui.TextMenuList.TextMenuItem;
+import funkin.ui.MenuList.MenuTypedItem;
+import flixel.group.FlxSpriteGroup.FlxTypedSpriteGroup;
+
+class PreferenceItem extends MenuTypedItem<FlxTypedSpriteGroup<FlxSprite>>
+{
+  /**
+   * The type of the preference item.
+   * - Checkbox: A checkbox that can be checked or unchecked.
+   * - Number: A number input that can be adjusted with a slider.
+   * - Percentage: A percentage input that can be adjusted with a slider.
+   * - Enum: A dropdown list that allows the user to select from a list of options.
+   */
+  public var type:PreferenceType;
+
+  /**
+   * The description of the preference item.
+   * This is used to display the description of the preference item in the options menu.
+   */
+  public var description:String;
+
+  /**
+   * The function to call when the preference item changes.
+   * This is used to update the preference item when the user interacts with it.
+   */
+  public var onChange:Null<Dynamic->Void>;
+
+  /**
+   * The default value of the preference item.
+   * This is used to set the initial value of the preference item when it is created.
+   */
+  public var defaultValue:Dynamic;
+
+  public var text:AtlasText;
+  public var preferenceGraphic:FlxSprite;
+
+  static final SPACING_X:Float = 100;
+
+  public function new(x:Float, y:Float, type:PreferenceType, name:String, description:String, onChange:Null<Dynamic->Void>, defaultValue:Dynamic,
+      ?extraData:PreferenceItemData)
+  {
+    var group = new FlxTypedSpriteGroup<FlxSprite>();
+
+    switch (type)
+    {
+      case PreferenceType.Checkbox:
+        preferenceGraphic = new CheckboxPreferenceItem(x, y, defaultValue, onChange);
+      case PreferenceType.Number:
+        preferenceGraphic = new NumberPreferenceItem(x, y, name, defaultValue, extraData?.min, extraData?.max, extraData?.step, extraData?.precision,
+          onChange, extraData?.formatter);
+      case PreferenceType.Percentage:
+        preferenceGraphic = new NumberPreferenceItem(x, y, name, defaultValue, extraData?.min ?? 0, extraData?.max ?? 100, 10, 0, function(value:Float) {
+          onChange(Std.int(value));
+        }, function(value:Float):String {
+          return '${value}%';
+        });
+      case PreferenceType.Enum:
+        preferenceGraphic = new EnumPreferenceItem(x, y, name, extraData.values, defaultValue, onChange);
+      default:
+        trace('Unsupported PreferenceType: $type');
+        preferenceGraphic = null; // Explicitly set to null to avoid uninitialized variable issues
+    }
+
+    text = new AtlasText(x + (preferenceGraphic != null ? preferenceGraphic.frameWidth : 0), y, name, BOLD);
+    group.add(text);
+
+    if (preferenceGraphic != null) group.add(preferenceGraphic);
+
+    super(x, y, group, name, function() {
+      if (onChange != null)
+      {
+        switch (type)
+        {
+          case PreferenceType.Checkbox:
+            var checkbox = cast(preferenceGraphic, CheckboxPreferenceItem);
+            var value = !checkbox.currentValue;
+            onChange(value);
+            checkbox.currentValue = value;
+          default:
+            onChange(defaultValue);
+        }
+      }
+    });
+
+    this.type = type;
+    this.description = description;
+    this.onChange = onChange;
+    this.defaultValue = defaultValue;
+    if (type != PreferenceType.Checkbox) this.fireInstantly = true;
+  }
+
+  override function update(elapsed:Float):Void
+  {
+    // if (Std.isOfType(this, EnumPreferenceItem)) cast(this, EnumPreferenceItem).update(elapsed);
+    // else if (Std.isOfType(this, NumberPreferenceItem)) cast(this, NumberPreferenceItem).update(elapsed);
+    // else if (Std.isOfType(this, CheckboxPreferenceItem)) cast(this, CheckboxPreferenceItem).update(elapsed);
+
+    super.update(elapsed);
+  }
+}
+
+enum PreferenceType
+{
+  Checkbox;
+  Number;
+  Percentage;
+  Enum;
+}
+
+/**
+ * @param type The type of the preference item.
+ * @param name The name of the preference item.
+ * @param description The description of the preference item.
+ * @param onChange The function to call when the preference item changes.
+ * @param defaultValue The default value of the preference item.
+ * @param min The minimum value of the number preference item.
+ * @param max The maximum value of the number preference item.
+ * @param step The step value of the number preference item.
+ * @param formatter The function to call to format the value of the number preference item.
+ * @param precision The precision of the value of the number preference item.
+ * @param values The values of the enumpreference item.
+ */
+typedef PreferenceItemData =
+{
+  var ?min:Int;
+  var ?max:Int;
+  var ?step:Float;
+  var ?formatter:Float->String;
+  var ?precision:Int;
+
+  var ?values:Map<String, String>;
+}

--- a/source/funkin/ui/options/PreferencesMenu.hx
+++ b/source/funkin/ui/options/PreferencesMenu.hx
@@ -14,14 +14,19 @@ import funkin.ui.TextMenuList.TextMenuItem;
 import funkin.ui.options.items.CheckboxPreferenceItem;
 import funkin.ui.options.items.NumberPreferenceItem;
 import funkin.ui.options.items.EnumPreferenceItem;
+import funkin.ui.options.PreferenceItem;
+import funkin.ui.options.PreferenceItem.PreferenceItemData;
+import funkin.ui.options.PreferenceItem.PreferenceType;
+import funkin.ui.MenuList.MenuTypedList;
 
 class PreferencesMenu extends Page<OptionsState.OptionsMenuPageName>
 {
-  var items:TextMenuList;
-  var preferenceItems:FlxTypedSpriteGroup<FlxSprite>;
-  var preferenceDesc:Array<String> = [];
-  var itemDesc:FlxText;
-  var itemDescBox:FunkinSprite;
+  var options:MenuTypedList<PreferenceItem>;
+  // var items:TextMenuList;
+  // var preferenceItems:FlxTypedSpriteGroup<FlxSprite>;
+  // var preferenceDesc:Array<String> = [];
+  // var itemDesc:FlxText;
+  // var itemDescBox:FunkinSprite;
 
   var menuCamera:FlxCamera;
   var hudCamera:FlxCamera;
@@ -41,109 +46,121 @@ class PreferencesMenu extends Page<OptionsState.OptionsMenuPageName>
 
     camera = menuCamera;
 
-    add(items = new TextMenuList());
-    add(preferenceItems = new FlxTypedSpriteGroup<FlxSprite>());
+    // add(items = new TextMenuList());
+    // add(preferenceItems = new FlxTypedSpriteGroup<FlxSprite>());
 
-    add(itemDescBox = new FunkinSprite());
-    itemDescBox.cameras = [hudCamera];
+    // add(itemDescBox = new FunkinSprite());
+    // itemDescBox.cameras = [hudCamera];
 
-    add(itemDesc = new FlxText(0, 0, 1180, null, 32));
-    itemDesc.cameras = [hudCamera];
+    // add(itemDesc = new FlxText(0, 0, 1180, null, 32));
+    // itemDesc.cameras = [hudCamera];
+
+    options = new MenuTypedList<PreferenceItem>();
+    add(options);
 
     createPrefItems();
-    createPrefDescription();
+    // createPrefDescription();
 
     camFollow = new FlxObject(FlxG.width / 2, 0, 140, 70);
-    if (items != null) camFollow.y = items.selectedItem.y;
+    if (options != null) camFollow.y = options.selectedItem.y;
 
     menuCamera.follow(camFollow, null, 0.085);
     var margin = 160;
     menuCamera.deadzone.set(0, margin, menuCamera.width, menuCamera.height - margin * 2);
     menuCamera.minScrollY = 0;
 
-    items.onChange.add(function(selected) {
+    options.onChange.add(function(selected) {
       camFollow.y = selected.y;
-      itemDesc.text = preferenceDesc[items.selectedIndex];
+      // itemDesc.text = preferenceDesc[items.selectedIndex];
     });
   }
 
   /**
    * Create the description for preferences.
    */
-  function createPrefDescription():Void
-  {
-    itemDescBox.makeSolidColor(1, 1, FlxColor.BLACK);
-    itemDescBox.alpha = 0.6;
-    itemDesc.setFormat(Paths.font('vcr.ttf'), 32, FlxColor.WHITE, FlxTextAlign.CENTER, FlxTextBorderStyle.OUTLINE, FlxColor.BLACK);
-    itemDesc.borderSize = 3;
+  // function createPrefDescription():Void
+  // {
+  //   itemDescBox.makeSolidColor(1, 1, FlxColor.BLACK);
+  //   itemDescBox.alpha = 0.6;
+  //   itemDesc.setFormat(Paths.font('vcr.ttf'), 32, FlxColor.WHITE, FlxTextAlign.CENTER, FlxTextBorderStyle.OUTLINE, FlxColor.BLACK);
+  //   itemDesc.borderSize = 3;
 
-    // Update the text.
-    itemDesc.text = preferenceDesc[items.selectedIndex];
-    itemDesc.screenCenter();
-    itemDesc.y += 270;
+  //   // Update the text.
+  //   itemDesc.text = preferenceDesc[items.selectedIndex];
+  //   itemDesc.screenCenter();
+  //   itemDesc.y += 270;
 
-    // Create the box around the text.
-    itemDescBox.setPosition(itemDesc.x - 10, itemDesc.y - 10);
-    itemDescBox.setGraphicSize(Std.int(itemDesc.width + 20), Std.int(itemDesc.height + 25));
-    itemDescBox.updateHitbox();
-  }
+  //   // Create the box around the text.
+  //   itemDescBox.setPosition(itemDesc.x - 10, itemDesc.y - 10);
+  //   itemDescBox.setGraphicSize(Std.int(itemDesc.width + 20), Std.int(itemDesc.height + 25));
+  //   itemDescBox.updateHitbox();
+  // }
 
   /**
    * Create the menu items for each of the preferences.
    */
   function createPrefItems():Void
   {
-    createPrefItemCheckbox('Naughtyness', 'If enabled, raunchy content (such as swearing, etc.) will be displayed.', function(value:Bool):Void {
+    addOption(PreferenceType.Checkbox, 'Naughtyness', 'If enabled, raunchy content (such as swearing, etc.) will be displayed.', function(value:Bool):Void {
       Preferences.naughtyness = value;
     }, Preferences.naughtyness);
-    createPrefItemCheckbox('Downscroll', 'If enabled, this will make the notes move downwards.', function(value:Bool):Void {
+    addOption(PreferenceType.Checkbox, 'Downscroll', 'If enabled, this will make the notes move downwards.', function(value:Bool):Void {
       Preferences.downscroll = value;
     }, Preferences.downscroll);
-    createPrefItemPercentage('Strumline Background', 'Give the strumline a semi-transparent background', function(value:Int):Void {
+    addOption(PreferenceType.Percentage, 'Strumline Background', 'Give the strumline a semi-transparent background', function(value:Int):Void {
       Preferences.strumlineBackgroundOpacity = value;
     }, Preferences.strumlineBackgroundOpacity);
-    createPrefItemCheckbox('Flashing Lights', 'If disabled, it will dampen flashing effects. Useful for people with photosensitive epilepsy.',
-      function(value:Bool):Void {
-        Preferences.flashingLights = value;
-      }, Preferences.flashingLights);
-    createPrefItemCheckbox('Camera Zooms', 'If disabled, camera stops bouncing to the song.', function(value:Bool):Void {
+    addOption(PreferenceType.Checkbox, 'Flashing Lights', 'If disabled, it will dampen flashing effects. Useful for people with photosensitive epilepsy.', function(value:Bool):Void {
+      Preferences.flashingLights = value;
+    }, Preferences.flashingLights);
+    addOption(PreferenceType.Checkbox, 'Camera Zooms', 'If disabled, camera stops bouncing to the song.', function(value:Bool):Void {
       Preferences.zoomCamera = value;
     }, Preferences.zoomCamera);
-    createPrefItemCheckbox('Debug Display', 'If enabled, FPS and other debug stats will be displayed.', function(value:Bool):Void {
+    addOption(PreferenceType.Checkbox, 'Debug Display', 'If enabled, FPS and other debug stats will be displayed.', function(value:Bool):Void {
       Preferences.debugDisplay = value;
     }, Preferences.debugDisplay);
-    createPrefItemCheckbox('Pause on Unfocus', 'If enabled, game automatically pauses when it loses focus.', function(value:Bool):Void {
+    addOption(PreferenceType.Checkbox, 'Pause on Unfocus', 'If enabled, game automatically pauses when it loses focus.', function(value:Bool):Void {
       Preferences.autoPause = value;
     }, Preferences.autoPause);
-    createPrefItemCheckbox('Launch in Fullscreen', 'Automatically launch the game in fullscreen on startup', function(value:Bool):Void {
+    addOption(PreferenceType.Checkbox, 'Launch in Fullscreen', 'Automatically launch the game in fullscreen on startup', function(value:Bool):Void {
       Preferences.autoFullscreen = value;
     }, Preferences.autoFullscreen);
 
     #if web
-    createPrefItemCheckbox('Unlocked Framerate', 'If enabled, the framerate will be unlocked.', function(value:Bool):Void {
+    addOption(PreferenceType.Checkbox, 'Unlocked Framerate', 'If enabled, the framerate will be unlocked.', function(value:Bool):Void {
       Preferences.unlockedFramerate = value;
     }, Preferences.unlockedFramerate);
     #else
-    createPrefItemNumber('FPS', 'The maximum framerate that the game targets.', function(value:Float) {
-      Preferences.framerate = Std.int(value);
-    }, null, Preferences.framerate, 30, 300, 5, 0);
+    addOption(PreferenceType.Number, 'FPS', 'The maximum framerate that the game targets.', function(value:Int):Void {
+      Preferences.framerate = value;
+    }, Preferences.framerate, { min: 30, max: 300, step: 5, precision: 0 });
     #end
 
-    createPrefItemCheckbox('Hide Mouse', 'If enabled, the mouse will be hidden when taking a screenshot.', function(value:Bool):Void {
+    addOption(PreferenceType.Checkbox, 'Hide Mouse', 'If enabled, the mouse will be hidden when taking a screenshot.', function(value:Bool):Void {
       Preferences.shouldHideMouse = value;
     }, Preferences.shouldHideMouse);
-    createPrefItemCheckbox('Fancy Preview', 'If enabled, a preview will be shown after taking a screenshot.', function(value:Bool):Void {
+    addOption(PreferenceType.Checkbox, 'Hide Mouse', 'If enabled, the mouse will be hidden when taking a screenshot.', function(value:Bool):Void {
+      Preferences.shouldHideMouse = value;
+    }, Preferences.shouldHideMouse);
+
+    addOption(PreferenceType.Checkbox, 'Fancy Preview', 'If enabled, a preview will be shown after taking a screenshot.', function(value:Bool):Void {
       Preferences.fancyPreview = value;
     }, Preferences.fancyPreview);
-    createPrefItemCheckbox('Preview on save', 'If enabled, the preview will be shown only after a screenshot is saved.', function(value:Bool):Void {
+    addOption(PreferenceType.Checkbox, 'Preview on save', 'If enabled, the preview will be shown only after a screenshot is saved.', function(value:Bool):Void {
       Preferences.previewOnSave = value;
     }, Preferences.previewOnSave);
-    createPrefItemEnum('Save Format', 'Save screenshots to this format.', ['PNG' => 'PNG', 'JPEG' => 'JPEG'], function(value:String):Void {
-      Preferences.saveFormat = value;
-    }, Preferences.saveFormat);
-    createPrefItemNumber('JPEG Quality', 'The quality of JPEG screenshots.', function(value:Float) {
+    // addOption(PreferenceType.Enum, 'Save Format', 'Save screenshots to this format.', function(value:String):Void {
+    //   Preferences.saveFormat = value;
+    // }, Preferences.saveFormat, {values: ['PNG' => 'PNG', 'JPEG' => 'JPEG']});
+    addOption(PreferenceType.Number, 'JPEG Quality', 'The quality of JPEG screenshots.', function(value:Float) {
       Preferences.jpegQuality = Std.int(value);
-    }, null, Preferences.jpegQuality, 0, 100, 5, 0);
+    }, Preferences.jpegQuality, { min: 0, max: 100, step: 5, precision: 0 });
+  }
+
+  function addOption(type:PreferenceType, name:String, description:String, onChange:Null<Dynamic->Void>, defaultValue:Dynamic,?extraData:PreferenceItemData):Void
+  {
+    var item = new PreferenceItem(0, (60 * options.length) + 30, type, name, description, onChange, defaultValue, extraData);
+    options.addItem(name, item);
   }
 
   override function update(elapsed:Float):Void
@@ -151,7 +168,7 @@ class PreferencesMenu extends Page<OptionsState.OptionsMenuPageName>
     super.update(elapsed);
 
     // Indent the selected item.
-    items.forEach(function(daItem:TextMenuItem) {
+    options.forEach(function(daItem:PreferenceItem) {
       var thyOffset:Int = 0;
       // Initializing thy text width (if thou text present)
       var thyTextWidth:Int = 0;
@@ -164,13 +181,13 @@ class PreferencesMenu extends Page<OptionsState.OptionsMenuPageName>
         thyOffset += thyTextWidth - 75;
       }
 
-      if (items.selectedItem == daItem)
+      if (options.selectedItem == daItem)
       {
-        thyOffset += 150;
+        thyOffset += 30;
       }
       else
       {
-        thyOffset += 120;
+        thyOffset += 0;
       }
 
       daItem.x = thyOffset;
@@ -185,19 +202,19 @@ class PreferencesMenu extends Page<OptionsState.OptionsMenuPageName>
    * @param onChange Gets called every time the player changes the value; use this to apply the value
    * @param defaultValue The value that is loaded in when the pref item is created (usually your Preferences.settingVariable)
    */
-  function createPrefItemCheckbox(prefName:String, prefDesc:String, onChange:Bool->Void, defaultValue:Bool):Void
-  {
-    var checkbox:CheckboxPreferenceItem = new CheckboxPreferenceItem(0, 120 * (items.length - 1 + 1), defaultValue);
+  // function createPrefItemCheckbox(prefName:String, prefDesc:String, onChange:Bool->Void, defaultValue:Bool):Void
+  // {
+  //   var checkbox:CheckboxPreferenceItem = new CheckboxPreferenceItem(0, 120 * (items.length - 1 + 1), defaultValue);
 
-    items.createItem(0, (120 * items.length) + 30, prefName, AtlasFont.BOLD, function() {
-      var value = !checkbox.currentValue;
-      onChange(value);
-      checkbox.currentValue = value;
-    });
+  //   items.createItem(0, (120 * items.length) + 30, prefName, AtlasFont.BOLD, function() {
+  //     var value = !checkbox.currentValue;
+  //     onChange(value);
+  //     checkbox.currentValue = value;
+  //   });
 
-    preferenceItems.add(checkbox);
-    preferenceDesc.push(prefDesc);
-  }
+  //   preferenceItems.add(checkbox);
+  //   preferenceDesc.push(prefDesc);
+  // }
 
   /**
    * Creates a pref item that works with general numbers
@@ -209,14 +226,14 @@ class PreferencesMenu extends Page<OptionsState.OptionsMenuPageName>
    * @param step The value to increment/decrement by (default = 0.1)
    * @param precision Rounds decimals up to a `precision` amount of digits (ex: 4 -> 0.1234, 2 -> 0.12)
    */
-  function createPrefItemNumber(prefName:String, prefDesc:String, onChange:Float->Void, ?valueFormatter:Float->String, defaultValue:Int, min:Int, max:Int,
-      step:Float = 0.1, precision:Int):Void
-  {
-    var item = new NumberPreferenceItem(0, (120 * items.length) + 30, prefName, defaultValue, min, max, step, precision, onChange, valueFormatter);
-    items.addItem(prefName, item);
-    preferenceItems.add(item.lefthandText);
-    preferenceDesc.push(prefDesc);
-  }
+  // function createPrefItemNumber(prefName:String, prefDesc:String, onChange:Float->Void, ?valueFormatter:Float->String, defaultValue:Int, min:Int, max:Int,
+  //     step:Float = 0.1, precision:Int):Void
+  // {
+  //   var item = new NumberPreferenceItem(0, (120 * items.length) + 30, prefName, defaultValue, min, max, step, precision, onChange, valueFormatter);
+  //   items.addItem(prefName, item);
+  //   preferenceItems.add(item.lefthandText);
+  //   preferenceDesc.push(prefDesc);
+  // }
 
   /**
    * Creates a pref item that works with number percentages
@@ -225,19 +242,19 @@ class PreferencesMenu extends Page<OptionsState.OptionsMenuPageName>
    * @param min Minimum value (default = 0)
    * @param max Maximum value (default = 100)
    */
-  function createPrefItemPercentage(prefName:String, prefDesc:String, onChange:Int->Void, defaultValue:Int, min:Int = 0, max:Int = 100):Void
-  {
-    var newCallback = function(value:Float) {
-      onChange(Std.int(value));
-    };
-    var formatter = function(value:Float) {
-      return '${value}%';
-    };
-    var item = new NumberPreferenceItem(0, (120 * items.length) + 30, prefName, defaultValue, min, max, 10, 0, newCallback, formatter);
-    items.addItem(prefName, item);
-    preferenceItems.add(item.lefthandText);
-    preferenceDesc.push(prefDesc);
-  }
+  // function createPrefItemPercentage(prefName:String, prefDesc:String, onChange:Int->Void, defaultValue:Int, min:Int = 0, max:Int = 100):Void
+  // {
+  //   var newCallback = function(value:Float) {
+  //     onChange(Std.int(value));
+  //   };
+  //   var formatter = function(value:Float) {
+  //     return '${value}%';
+  //   };
+  //   var item = new NumberPreferenceItem(0, (120 * items.length) + 30, prefName, defaultValue, min, max, 10, 0, newCallback, formatter);
+  //   items.addItem(prefName, item);
+  //   preferenceItems.add(item.lefthandText);
+  //   preferenceDesc.push(prefDesc);
+  // }
 
   /**
    * Creates a pref item that works with enums
@@ -245,11 +262,11 @@ class PreferencesMenu extends Page<OptionsState.OptionsMenuPageName>
    * @param onChange Gets called every time the player changes the value; use this to apply the value
    * @param defaultValue The value that is loaded in when the pref item is created (usually your Preferences.settingVariable)
    */
-  function createPrefItemEnum(prefName:String, prefDesc:String, values:Map<String, String>, onChange:String->Void, defaultValue:String):Void
-  {
-    var item = new EnumPreferenceItem(0, (120 * items.length) + 30, prefName, values, defaultValue, onChange);
-    items.addItem(prefName, item);
-    preferenceItems.add(item.lefthandText);
-    preferenceDesc.push(prefDesc);
-  }
+  // function createPrefItemEnum(prefName:String, prefDesc:String, values:Map<String, String>, onChange:String->Void, defaultValue:String):Void
+  // {
+  //   var item = new EnumPreferenceItem(0, (120 * items.length) + 30, prefName, values, defaultValue, onChange);
+  //   items.addItem(prefName, item);
+  //   preferenceItems.add(item.lefthandText);
+  //   preferenceDesc.push(prefDesc);
+  // }
 }

--- a/source/funkin/ui/options/PreferencesMenu.hx
+++ b/source/funkin/ui/options/PreferencesMenu.hx
@@ -143,22 +143,22 @@ class PreferencesMenu extends Page<OptionsState.OptionsMenuPageName>
     addOption(PreferenceType.Checkbox, 'Fancy Preview', 'If enabled, a preview will be shown after taking a screenshot.', function(value:Bool):Void {
       Preferences.fancyPreview = value;
     }, Preferences.fancyPreview);
-    addOption(PreferenceType.Checkbox, 'Preview on save', 'If enabled, the preview will be shown only after a screenshot is saved.',
-      function(value:Bool):Void {
+    addOption(PreferenceType.Checkbox, 'Preview on save', 'If enabled, the preview will be shown only after a screenshot is saved.', function(value:Bool):Void {
         Preferences.previewOnSave = value;
-      }, Preferences.previewOnSave);
-    // addOption(PreferenceType.Enum, 'Save Format', 'Save screenshots to this format.', function(value:String):Void {
-    //   Preferences.saveFormat = value;
-    // }, Preferences.saveFormat, {values: ['PNG' => 'PNG', 'JPEG' => 'JPEG']});
+    }, Preferences.previewOnSave);
+    addOption(PreferenceType.Enum, 'Save Format', 'Save screenshots to this format.', function(value:String):Void {
+      Preferences.saveFormat = value;
+    }, Preferences.saveFormat, {
+      values: ['PNG' => 'PNG', 'JPEG' => 'JPEG']
+    });
     addOption(PreferenceType.Number, 'JPEG Quality', 'The quality of JPEG screenshots.', function(value:Float) {
       Preferences.jpegQuality = Std.int(value);
     }, Preferences.jpegQuality, { min: 0, max: 100, step: 5, precision: 0 });
   }
 
-  function addOption(type:PreferenceType, name:String, description:String, onChange:Null<Dynamic->Void>, defaultValue:Dynamic,
-      ?extraData:PreferenceItemData):Void
+  function addOption(type:PreferenceType, name:String, description:String, onChange:Null<Dynamic->Void>, defaultValue:Dynamic, ?data:PreferenceItemData):Void
   {
-    var item = new PreferenceItem(0, 60 * (options.length + categories.length) + 15, type, name, description, onChange, defaultValue, extraData);
+    var item = new PreferenceItem(0, 60 * (options.length + categories.length) + 15, type, name, description, onChange, defaultValue, data);
     options.addItem(name, item);
   }
 
@@ -180,13 +180,10 @@ class PreferencesMenu extends Page<OptionsState.OptionsMenuPageName>
 
       switch (daItem.type)
       {
-        // oh my days I'm going feral
-        case PreferenceType.Enum, PreferenceType.Number, PreferenceType.Percentage:
-          trace(Type.typeof(daItem.preferenceGraphic));
-          trace(Type.typeof(daItem));
-          if (Std.is(daItem.preferenceGraphic, AtlasText)) {
-            thyTextWidth = cast(daItem.preferenceGraphic, AtlasText).getWidth();
-          }
+        case PreferenceType.Number, PreferenceType.Percentage:
+          thyTextWidth = cast(daItem.preferenceGraphic, NumberPreferenceItem).label.getWidth();
+        case PreferenceType.Enum:
+          thyTextWidth = cast(daItem.preferenceGraphic, EnumPreferenceItem).label.getWidth();
         case PreferenceType.Checkbox:
           thyTextWidth = Std.int(daItem.preferenceGraphic.width);
       }

--- a/source/funkin/ui/options/PreferencesMenu.hx
+++ b/source/funkin/ui/options/PreferencesMenu.hx
@@ -14,7 +14,6 @@ import funkin.ui.TextMenuList.TextMenuItem;
 import funkin.ui.options.items.CheckboxPreferenceItem;
 import funkin.ui.options.items.NumberPreferenceItem;
 import funkin.ui.options.items.EnumPreferenceItem;
-import funkin.ui.options.PreferenceItem;
 import funkin.ui.options.PreferenceItem.PreferenceItemData;
 import funkin.ui.options.PreferenceItem.PreferenceType;
 import funkin.ui.MenuList.MenuTypedList;
@@ -95,58 +94,58 @@ class PreferencesMenu extends Page<OptionsState.OptionsMenuPageName>
   function createPrefItems():Void
   {
     addCategory('Gameplay');
-    addOption(PreferenceType.Checkbox, 'Naughtyness', 'If enabled, raunchy content (such as swearing, etc.) will be displayed.', function(value:Bool):Void {
+    addOption(Checkbox, 'Naughtyness', 'If enabled, raunchy content (such as swearing, etc.) will be displayed.', function(value:Bool):Void {
       Preferences.naughtyness = value;
     }, Preferences.naughtyness);
-    addOption(PreferenceType.Checkbox, 'Downscroll', 'If enabled, this will make the notes move downwards.', function(value:Bool):Void {
+    addOption(Checkbox, 'Downscroll', 'If enabled, this will make the notes move downwards.', function(value:Bool):Void {
       Preferences.downscroll = value;
     }, Preferences.downscroll);
-    addOption(PreferenceType.Percentage, 'Strumline Background', 'The strumline background\'s transparency percentage.', function(value:Int):Void {
+    addOption(Percentage, 'Strumline Background', 'The strumline background\'s transparency percentage.', function(value:Int):Void {
       Preferences.strumlineBackgroundOpacity = value;
     }, Preferences.strumlineBackgroundOpacity);
-    addOption(PreferenceType.Checkbox, 'Flashing Lights', 'If disabled, it will dampen flashing effects. Useful for people with photosensitive epilepsy.', function(value:Bool):Void {
+    addOption(Checkbox, 'Flashing Lights', 'If disabled, it will dampen flashing effects. Useful for people with photosensitive epilepsy.', function(value:Bool):Void {
       Preferences.flashingLights = value;
     }, Preferences.flashingLights);
 
     addCategory('Additional');
-    addOption(PreferenceType.Checkbox, 'Camera Zooms', 'If disabled, camera stops bouncing to the song.', function(value:Bool):Void {
+    addOption(Checkbox, 'Camera Zooms', 'If disabled, camera stops bouncing to the song.', function(value:Bool):Void {
       Preferences.zoomCamera = value;
     }, Preferences.zoomCamera);
-    addOption(PreferenceType.Checkbox, 'Debug Display', 'If enabled, FPS and other debug stats will be displayed.', function(value:Bool):Void {
+    addOption(Checkbox, 'Debug Display', 'If enabled, FPS and other debug stats will be displayed.', function(value:Bool):Void {
       Preferences.debugDisplay = value;
     }, Preferences.debugDisplay);
-    addOption(PreferenceType.Checkbox, 'Pause on Unfocus', 'If enabled, game automatically pauses when it loses focus.', function(value:Bool):Void {
+    addOption(Checkbox, 'Pause on Unfocus', 'If enabled, game automatically pauses when it loses focus.', function(value:Bool):Void {
       Preferences.autoPause = value;
     }, Preferences.autoPause);
-    addOption(PreferenceType.Checkbox, 'Launch in Fullscreen', 'Automatically launch the game in fullscreen on startup', function(value:Bool):Void {
+    addOption(Checkbox, 'Launch in Fullscreen', 'Automatically launch the game in fullscreen on startup', function(value:Bool):Void {
       Preferences.autoFullscreen = value;
     }, Preferences.autoFullscreen);
 
     #if web
-    addOption(PreferenceType.Checkbox, 'Unlocked Framerate', 'If enabled, the framerate will be unlocked.', function(value:Bool):Void {
+    addOption(Checkbox, 'Unlocked Framerate', 'If enabled, the framerate will be unlocked.', function(value:Bool):Void {
       Preferences.unlockedFramerate = value;
     }, Preferences.unlockedFramerate);
     #else
-    addOption(PreferenceType.Number, 'FPS', 'The maximum framerate that the game targets.', function(value:Int):Void {
+    addOption(Number, 'FPS', 'The maximum framerate that the game targets.', function(value:Int):Void {
       Preferences.framerate = value;
     }, Preferences.framerate, { min: 30, max: 300, step: 5, precision: 0 });
     #end
 
     addCategory('Screenshots');
-    addOption(PreferenceType.Checkbox, 'Hide Mouse', 'If enabled, the mouse will be hidden when taking a screenshot.', function(value:Bool):Void {
+    addOption(Checkbox, 'Hide Mouse', 'If enabled, the mouse will be hidden when taking a screenshot.', function(value:Bool):Void {
       Preferences.shouldHideMouse = value;
     }, Preferences.shouldHideMouse);
 
-    addOption(PreferenceType.Checkbox, 'Fancy Preview', 'If enabled, a preview will be shown after taking a screenshot.', function(value:Bool):Void {
+    addOption(Checkbox, 'Fancy Preview', 'If enabled, a preview will be shown after taking a screenshot.', function(value:Bool):Void {
       Preferences.fancyPreview = value;
     }, Preferences.fancyPreview);
-    addOption(PreferenceType.Checkbox, 'Preview on save', 'If enabled, the preview will be shown only after a screenshot is saved.', function(value:Bool):Void {
+    addOption(Checkbox, 'Preview on save', 'If enabled, the preview will be shown only after a screenshot is saved.', function(value:Bool):Void {
       Preferences.previewOnSave = value;
     }, Preferences.previewOnSave);
-    addOption(PreferenceType.Enum, 'Save Format', 'Save screenshots to this format.', function(value:String):Void {
+    addOption(Enum, 'Save Format', 'Save screenshots to this format.', function(value:String):Void {
       Preferences.saveFormat = value;
     }, Preferences.saveFormat, { values: ['PNG' => 'PNG', 'JPEG' => 'JPEG'] });
-    addOption(PreferenceType.Number, 'JPEG Quality', 'The quality of JPEG screenshots.', function(value:Float) {
+    addOption(Number, 'JPEG Quality', 'The quality of JPEG screenshots.', function(value:Float) {
       Preferences.jpegQuality = Std.int(value);
     }, Preferences.jpegQuality, { min: 0, max: 100, step: 5, precision: 0 });
   }

--- a/source/funkin/ui/options/PreferencesMenu.hx
+++ b/source/funkin/ui/options/PreferencesMenu.hx
@@ -22,12 +22,10 @@ import funkin.ui.MenuList.MenuTypedList;
 class PreferencesMenu extends Page<OptionsState.OptionsMenuPageName>
 {
   var options:MenuTypedList<PreferenceItem>;
-  // var items:TextMenuList;
-  // var preferenceItems:FlxTypedSpriteGroup<FlxSprite>;
-  // var preferenceDesc:Array<String> = [];
-  // var itemDesc:FlxText;
-  // var itemDescBox:FunkinSprite;
+  var categories:FlxTypedSpriteGroup<AtlasText>;
 
+  var itemDesc:FlxText;
+  var itemDescBox:FunkinSprite;
   var menuCamera:FlxCamera;
   var hudCamera:FlxCamera;
   var camFollow:FlxObject;
@@ -46,20 +44,17 @@ class PreferencesMenu extends Page<OptionsState.OptionsMenuPageName>
 
     camera = menuCamera;
 
-    // add(items = new TextMenuList());
-    // add(preferenceItems = new FlxTypedSpriteGroup<FlxSprite>());
+    add(itemDescBox = new FunkinSprite());
+    itemDescBox.cameras = [hudCamera];
 
-    // add(itemDescBox = new FunkinSprite());
-    // itemDescBox.cameras = [hudCamera];
+    add(itemDesc = new FlxText(0, 0, 1180, null, 32));
+    itemDesc.cameras = [hudCamera];
 
-    // add(itemDesc = new FlxText(0, 0, 1180, null, 32));
-    // itemDesc.cameras = [hudCamera];
-
-    options = new MenuTypedList<PreferenceItem>();
-    add(options);
+    add(options = new MenuTypedList<PreferenceItem>());
+    add(categories = new FlxTypedSpriteGroup<AtlasText>());
 
     createPrefItems();
-    // createPrefDescription();
+    createPrefDescription();
 
     camFollow = new FlxObject(FlxG.width / 2, 0, 140, 70);
     if (options != null) camFollow.y = options.selectedItem.y;
@@ -70,37 +65,36 @@ class PreferencesMenu extends Page<OptionsState.OptionsMenuPageName>
     menuCamera.minScrollY = 0;
 
     options.onChange.add(function(selected) {
-      camFollow.y = selected.y;
-      // itemDesc.text = preferenceDesc[items.selectedIndex];
+      camFollow.y = selected.text.y;
+      itemDesc.text = selected.description;
     });
   }
 
   /**
    * Create the description for preferences.
    */
-  // function createPrefDescription():Void
-  // {
-  //   itemDescBox.makeSolidColor(1, 1, FlxColor.BLACK);
-  //   itemDescBox.alpha = 0.6;
-  //   itemDesc.setFormat(Paths.font('vcr.ttf'), 32, FlxColor.WHITE, FlxTextAlign.CENTER, FlxTextBorderStyle.OUTLINE, FlxColor.BLACK);
-  //   itemDesc.borderSize = 3;
-
-  //   // Update the text.
-  //   itemDesc.text = preferenceDesc[items.selectedIndex];
-  //   itemDesc.screenCenter();
-  //   itemDesc.y += 270;
-
-  //   // Create the box around the text.
-  //   itemDescBox.setPosition(itemDesc.x - 10, itemDesc.y - 10);
-  //   itemDescBox.setGraphicSize(Std.int(itemDesc.width + 20), Std.int(itemDesc.height + 25));
-  //   itemDescBox.updateHitbox();
-  // }
+  function createPrefDescription():Void
+  {
+    itemDescBox.makeSolidColor(1, 1, FlxColor.BLACK);
+    itemDescBox.alpha = 0.6;
+    itemDesc.setFormat(Paths.font('vcr.ttf'), 32, FlxColor.WHITE, FlxTextAlign.CENTER, FlxTextBorderStyle.OUTLINE, FlxColor.BLACK);
+    itemDesc.borderSize = 3;
+    // Update the text.
+    itemDesc.text = options.selectedItem.description;
+    itemDesc.screenCenter();
+    itemDesc.y += 270;
+    // Create the box around the text.
+    itemDescBox.setPosition(itemDesc.x - 10, itemDesc.y - 10);
+    itemDescBox.setGraphicSize(Std.int(itemDesc.width + 20), Std.int(itemDesc.height + 25));
+    itemDescBox.updateHitbox();
+  }
 
   /**
    * Create the menu items for each of the preferences.
    */
   function createPrefItems():Void
   {
+    addCategory('Gameplay');
     addOption(PreferenceType.Checkbox, 'Naughtyness', 'If enabled, raunchy content (such as swearing, etc.) will be displayed.', function(value:Bool):Void {
       Preferences.naughtyness = value;
     }, Preferences.naughtyness);
@@ -113,6 +107,8 @@ class PreferencesMenu extends Page<OptionsState.OptionsMenuPageName>
     addOption(PreferenceType.Checkbox, 'Flashing Lights', 'If disabled, it will dampen flashing effects. Useful for people with photosensitive epilepsy.', function(value:Bool):Void {
       Preferences.flashingLights = value;
     }, Preferences.flashingLights);
+
+    addCategory('Additional');
     addOption(PreferenceType.Checkbox, 'Camera Zooms', 'If disabled, camera stops bouncing to the song.', function(value:Bool):Void {
       Preferences.zoomCamera = value;
     }, Preferences.zoomCamera);
@@ -136,6 +132,7 @@ class PreferencesMenu extends Page<OptionsState.OptionsMenuPageName>
     }, Preferences.framerate, { min: 30, max: 300, step: 5, precision: 0 });
     #end
 
+    addCategory('Screenshots');
     addOption(PreferenceType.Checkbox, 'Hide Mouse', 'If enabled, the mouse will be hidden when taking a screenshot.', function(value:Bool):Void {
       Preferences.shouldHideMouse = value;
     }, Preferences.shouldHideMouse);
@@ -146,9 +143,10 @@ class PreferencesMenu extends Page<OptionsState.OptionsMenuPageName>
     addOption(PreferenceType.Checkbox, 'Fancy Preview', 'If enabled, a preview will be shown after taking a screenshot.', function(value:Bool):Void {
       Preferences.fancyPreview = value;
     }, Preferences.fancyPreview);
-    addOption(PreferenceType.Checkbox, 'Preview on save', 'If enabled, the preview will be shown only after a screenshot is saved.', function(value:Bool):Void {
-      Preferences.previewOnSave = value;
-    }, Preferences.previewOnSave);
+    addOption(PreferenceType.Checkbox, 'Preview on save', 'If enabled, the preview will be shown only after a screenshot is saved.',
+      function(value:Bool):Void {
+        Preferences.previewOnSave = value;
+      }, Preferences.previewOnSave);
     // addOption(PreferenceType.Enum, 'Save Format', 'Save screenshots to this format.', function(value:String):Void {
     //   Preferences.saveFormat = value;
     // }, Preferences.saveFormat, {values: ['PNG' => 'PNG', 'JPEG' => 'JPEG']});
@@ -157,10 +155,17 @@ class PreferencesMenu extends Page<OptionsState.OptionsMenuPageName>
     }, Preferences.jpegQuality, { min: 0, max: 100, step: 5, precision: 0 });
   }
 
-  function addOption(type:PreferenceType, name:String, description:String, onChange:Null<Dynamic->Void>, defaultValue:Dynamic,?extraData:PreferenceItemData):Void
+  function addOption(type:PreferenceType, name:String, description:String, onChange:Null<Dynamic->Void>, defaultValue:Dynamic,
+      ?extraData:PreferenceItemData):Void
   {
-    var item = new PreferenceItem(0, (60 * options.length) + 30, type, name, description, onChange, defaultValue, extraData);
+    var item = new PreferenceItem(0, 60 * (options.length + categories.length) + 15, type, name, description, onChange, defaultValue, extraData);
     options.addItem(name, item);
+  }
+
+  function addCategory(name:String):Void
+  {
+    var labelY:Float = 120 * (options.length + categories.length) + 30;
+    categories.add(new AtlasText(0, labelY, name, AtlasFont.BOLD)).screenCenter(X);
   }
 
   override function update(elapsed:Float):Void
@@ -172,31 +177,29 @@ class PreferencesMenu extends Page<OptionsState.OptionsMenuPageName>
       var thyOffset:Int = 0;
       // Initializing thy text width (if thou text present)
       var thyTextWidth:Int = 0;
-      if (Std.isOfType(daItem, EnumPreferenceItem)) thyTextWidth = cast(daItem, EnumPreferenceItem).lefthandText.getWidth();
-      else if (Std.isOfType(daItem, NumberPreferenceItem)) thyTextWidth = cast(daItem, NumberPreferenceItem).lefthandText.getWidth();
 
-      if (thyTextWidth != 0)
+      switch (daItem.type)
       {
-        // Magic number because of the weird offset thats being added by default
-        thyOffset += thyTextWidth - 75;
+        // oh my days I'm going feral
+        case PreferenceType.Enum, PreferenceType.Number, PreferenceType.Percentage:
+          trace(Type.typeof(daItem.preferenceGraphic));
+          trace(Type.typeof(daItem));
+          if (Std.is(daItem.preferenceGraphic, AtlasText)) {
+            thyTextWidth = cast(daItem.preferenceGraphic, AtlasText).getWidth();
+          }
+        case PreferenceType.Checkbox:
+          thyTextWidth = Std.int(daItem.preferenceGraphic.width);
       }
 
-      if (options.selectedItem == daItem)
-      {
-        thyOffset += 30;
-      }
-      else
-      {
-        thyOffset += 0;
-      }
+      // setting the thy offset
+      thyOffset = thyTextWidth + PreferenceItem.SPACING_X;
 
-      daItem.x = thyOffset;
+      daItem.text.x = thyOffset;
     });
   }
 
   // - Preference item creation methods -
   // Should be moved into a separate PreferenceItems class but you can't access PreferencesMenu.items and PreferencesMenu.preferenceItems from outside.
-
   /**
    * Creates a pref item that works with booleans
    * @param onChange Gets called every time the player changes the value; use this to apply the value
@@ -205,17 +208,14 @@ class PreferencesMenu extends Page<OptionsState.OptionsMenuPageName>
   // function createPrefItemCheckbox(prefName:String, prefDesc:String, onChange:Bool->Void, defaultValue:Bool):Void
   // {
   //   var checkbox:CheckboxPreferenceItem = new CheckboxPreferenceItem(0, 120 * (items.length - 1 + 1), defaultValue);
-
   //   items.createItem(0, (120 * items.length) + 30, prefName, AtlasFont.BOLD, function() {
   //     var value = !checkbox.currentValue;
   //     onChange(value);
   //     checkbox.currentValue = value;
   //   });
-
   //   preferenceItems.add(checkbox);
   //   preferenceDesc.push(prefDesc);
   // }
-
   /**
    * Creates a pref item that works with general numbers
    * @param onChange Gets called every time the player changes the value; use this to apply the value
@@ -234,7 +234,6 @@ class PreferencesMenu extends Page<OptionsState.OptionsMenuPageName>
   //   preferenceItems.add(item.lefthandText);
   //   preferenceDesc.push(prefDesc);
   // }
-
   /**
    * Creates a pref item that works with number percentages
    * @param onChange Gets called every time the player changes the value; use this to apply the value
@@ -255,7 +254,6 @@ class PreferencesMenu extends Page<OptionsState.OptionsMenuPageName>
   //   preferenceItems.add(item.lefthandText);
   //   preferenceDesc.push(prefDesc);
   // }
-
   /**
    * Creates a pref item that works with enums
    * @param values Maps enum values to display strings _(ex: `NoteHitSoundType.PingPong => "Ping pong"`)_

--- a/source/funkin/ui/options/PreferencesMenu.hx
+++ b/source/funkin/ui/options/PreferencesMenu.hx
@@ -136,9 +136,6 @@ class PreferencesMenu extends Page<OptionsState.OptionsMenuPageName>
     addOption(PreferenceType.Checkbox, 'Hide Mouse', 'If enabled, the mouse will be hidden when taking a screenshot.', function(value:Bool):Void {
       Preferences.shouldHideMouse = value;
     }, Preferences.shouldHideMouse);
-    addOption(PreferenceType.Checkbox, 'Hide Mouse', 'If enabled, the mouse will be hidden when taking a screenshot.', function(value:Bool):Void {
-      Preferences.shouldHideMouse = value;
-    }, Preferences.shouldHideMouse);
 
     addOption(PreferenceType.Checkbox, 'Fancy Preview', 'If enabled, a preview will be shown after taking a screenshot.', function(value:Bool):Void {
       Preferences.fancyPreview = value;
@@ -194,74 +191,4 @@ class PreferencesMenu extends Page<OptionsState.OptionsMenuPageName>
       daItem.text.x = thyOffset;
     });
   }
-
-  // - Preference item creation methods -
-  // Should be moved into a separate PreferenceItems class but you can't access PreferencesMenu.items and PreferencesMenu.preferenceItems from outside.
-  /**
-   * Creates a pref item that works with booleans
-   * @param onChange Gets called every time the player changes the value; use this to apply the value
-   * @param defaultValue The value that is loaded in when the pref item is created (usually your Preferences.settingVariable)
-   */
-  // function createPrefItemCheckbox(prefName:String, prefDesc:String, onChange:Bool->Void, defaultValue:Bool):Void
-  // {
-  //   var checkbox:CheckboxPreferenceItem = new CheckboxPreferenceItem(0, 120 * (items.length - 1 + 1), defaultValue);
-  //   items.createItem(0, (120 * items.length) + 30, prefName, AtlasFont.BOLD, function() {
-  //     var value = !checkbox.currentValue;
-  //     onChange(value);
-  //     checkbox.currentValue = value;
-  //   });
-  //   preferenceItems.add(checkbox);
-  //   preferenceDesc.push(prefDesc);
-  // }
-  /**
-   * Creates a pref item that works with general numbers
-   * @param onChange Gets called every time the player changes the value; use this to apply the value
-   * @param valueFormatter Will get called every time the game needs to display the float value; use this to change how the displayed value looks
-   * @param defaultValue The value that is loaded in when the pref item is created (usually your Preferences.settingVariable)
-   * @param min Minimum value (example: 0)
-   * @param max Maximum value (example: 10)
-   * @param step The value to increment/decrement by (default = 0.1)
-   * @param precision Rounds decimals up to a `precision` amount of digits (ex: 4 -> 0.1234, 2 -> 0.12)
-   */
-  // function createPrefItemNumber(prefName:String, prefDesc:String, onChange:Float->Void, ?valueFormatter:Float->String, defaultValue:Int, min:Int, max:Int,
-  //     step:Float = 0.1, precision:Int):Void
-  // {
-  //   var item = new NumberPreferenceItem(0, (120 * items.length) + 30, prefName, defaultValue, min, max, step, precision, onChange, valueFormatter);
-  //   items.addItem(prefName, item);
-  //   preferenceItems.add(item.lefthandText);
-  //   preferenceDesc.push(prefDesc);
-  // }
-  /**
-   * Creates a pref item that works with number percentages
-   * @param onChange Gets called every time the player changes the value; use this to apply the value
-   * @param defaultValue The value that is loaded in when the pref item is created (usually your Preferences.settingVariable)
-   * @param min Minimum value (default = 0)
-   * @param max Maximum value (default = 100)
-   */
-  // function createPrefItemPercentage(prefName:String, prefDesc:String, onChange:Int->Void, defaultValue:Int, min:Int = 0, max:Int = 100):Void
-  // {
-  //   var newCallback = function(value:Float) {
-  //     onChange(Std.int(value));
-  //   };
-  //   var formatter = function(value:Float) {
-  //     return '${value}%';
-  //   };
-  //   var item = new NumberPreferenceItem(0, (120 * items.length) + 30, prefName, defaultValue, min, max, 10, 0, newCallback, formatter);
-  //   items.addItem(prefName, item);
-  //   preferenceItems.add(item.lefthandText);
-  //   preferenceDesc.push(prefDesc);
-  // }
-  /**
-   * Creates a pref item that works with enums
-   * @param values Maps enum values to display strings _(ex: `NoteHitSoundType.PingPong => "Ping pong"`)_
-   * @param onChange Gets called every time the player changes the value; use this to apply the value
-   * @param defaultValue The value that is loaded in when the pref item is created (usually your Preferences.settingVariable)
-   */
-  // function createPrefItemEnum(prefName:String, prefDesc:String, values:Map<String, String>, onChange:String->Void, defaultValue:String):Void
-  // {
-  //   var item = new EnumPreferenceItem(0, (120 * items.length) + 30, prefName, values, defaultValue, onChange);
-  //   items.addItem(prefName, item);
-  //   preferenceItems.add(item.lefthandText);
-  //   preferenceDesc.push(prefDesc);
-  // }
 }

--- a/source/funkin/ui/options/PreferencesMenu.hx
+++ b/source/funkin/ui/options/PreferencesMenu.hx
@@ -101,7 +101,7 @@ class PreferencesMenu extends Page<OptionsState.OptionsMenuPageName>
     addOption(PreferenceType.Checkbox, 'Downscroll', 'If enabled, this will make the notes move downwards.', function(value:Bool):Void {
       Preferences.downscroll = value;
     }, Preferences.downscroll);
-    addOption(PreferenceType.Percentage, 'Strumline Background', 'Give the strumline a semi-transparent background', function(value:Int):Void {
+    addOption(PreferenceType.Percentage, 'Strumline Background', 'The strumline background\'s transparency percentage.', function(value:Int):Void {
       Preferences.strumlineBackgroundOpacity = value;
     }, Preferences.strumlineBackgroundOpacity);
     addOption(PreferenceType.Checkbox, 'Flashing Lights', 'If disabled, it will dampen flashing effects. Useful for people with photosensitive epilepsy.', function(value:Bool):Void {
@@ -141,13 +141,11 @@ class PreferencesMenu extends Page<OptionsState.OptionsMenuPageName>
       Preferences.fancyPreview = value;
     }, Preferences.fancyPreview);
     addOption(PreferenceType.Checkbox, 'Preview on save', 'If enabled, the preview will be shown only after a screenshot is saved.', function(value:Bool):Void {
-        Preferences.previewOnSave = value;
+      Preferences.previewOnSave = value;
     }, Preferences.previewOnSave);
     addOption(PreferenceType.Enum, 'Save Format', 'Save screenshots to this format.', function(value:String):Void {
       Preferences.saveFormat = value;
-    }, Preferences.saveFormat, {
-      values: ['PNG' => 'PNG', 'JPEG' => 'JPEG']
-    });
+    }, Preferences.saveFormat, { values: ['PNG' => 'PNG', 'JPEG' => 'JPEG'] });
     addOption(PreferenceType.Number, 'JPEG Quality', 'The quality of JPEG screenshots.', function(value:Float) {
       Preferences.jpegQuality = Std.int(value);
     }, Preferences.jpegQuality, { min: 0, max: 100, step: 5, precision: 0 });

--- a/source/funkin/ui/options/items/CheckboxPreferenceItem.hx
+++ b/source/funkin/ui/options/items/CheckboxPreferenceItem.hx
@@ -28,9 +28,9 @@ class CheckboxPreferenceItem extends FlxSprite
     switch (animation.curAnim.name)
     {
       case 'static':
-        offset.set();
+        offset.set(10, 25);
       case 'checked':
-        // offset.set(17, 60);
+        offset.set(27, 93);
     }
   }
 

--- a/source/funkin/ui/options/items/CheckboxPreferenceItem.hx
+++ b/source/funkin/ui/options/items/CheckboxPreferenceItem.hx
@@ -5,8 +5,9 @@ import flixel.FlxSprite.FlxSprite;
 class CheckboxPreferenceItem extends FlxSprite
 {
   public var currentValue(default, set):Bool;
+  public var onChange:Null<Bool->Void>;
 
-  public function new(x:Float, y:Float, defaultValue:Bool = false)
+  public function new(x:Float, y:Float, defaultValue:Bool = false, ?onChange:Bool->Void)
   {
     super(x, y);
 
@@ -29,7 +30,7 @@ class CheckboxPreferenceItem extends FlxSprite
       case 'static':
         offset.set();
       case 'checked':
-        offset.set(17, 70);
+        // offset.set(17, 60);
     }
   }
 
@@ -42,6 +43,11 @@ class CheckboxPreferenceItem extends FlxSprite
     else
     {
       animation.play('static');
+    }
+
+    if (onChange != null)
+    {
+      onChange(value);
     }
 
     return currentValue = value;

--- a/source/funkin/ui/options/items/EnumPreferenceItem.hx
+++ b/source/funkin/ui/options/items/EnumPreferenceItem.hx
@@ -25,7 +25,7 @@ class EnumPreferenceItem extends TextMenuItem
 
   public function new(x:Float, y:Float, name:String, map:Map<String, String>, defaultValue:String, ?callback:String->Void)
   {
-    super(x, y, name, function() {
+    super(x, y, formatted(defaultValue), AtlasFont.DEFAULT, function() {
       callback(this.currentValue);
     });
 
@@ -43,7 +43,7 @@ class EnumPreferenceItem extends TextMenuItem
       i += 1;
     }
 
-    lefthandText = new AtlasText(15, y, formatted(defaultValue), AtlasFont.DEFAULT);
+    // lefthandText = new AtlasText(15, y, formatted(defaultValue), AtlasFont.DEFAULT);
 
     this.fireInstantly = true;
   }
@@ -53,25 +53,24 @@ class EnumPreferenceItem extends TextMenuItem
     super.update(elapsed);
 
     // var fancyTextFancyColor:Color;
-    if (selected)
+    if(!selected) return;
+
+    var shouldDecrease:Bool = controls().UI_LEFT_P;
+    var shouldIncrease:Bool = controls().UI_RIGHT_P;
+
+    if (shouldDecrease) index -= 1;
+    if (shouldIncrease) index += 1;
+
+    if (index > keys.length - 1) index = 0;
+    if (index < 0) index = keys.length - 1;
+
+    currentValue = keys[index];
+    if (onChangeCallback != null && (shouldIncrease || shouldDecrease))
     {
-      var shouldDecrease:Bool = controls().UI_LEFT_P;
-      var shouldIncrease:Bool = controls().UI_RIGHT_P;
-
-      if (shouldDecrease) index -= 1;
-      if (shouldIncrease) index += 1;
-
-      if (index > keys.length - 1) index = 0;
-      if (index < 0) index = keys.length - 1;
-
-      currentValue = keys[index];
-      if (onChangeCallback != null && (shouldIncrease || shouldDecrease))
-      {
-        onChangeCallback(currentValue);
-      }
+      onChangeCallback(currentValue);
     }
 
-    lefthandText.text = formatted(currentValue);
+    label.text = formatted(currentValue);
   }
 
   function formatted(value:String):String

--- a/source/funkin/ui/options/items/EnumPreferenceItem.hx
+++ b/source/funkin/ui/options/items/EnumPreferenceItem.hx
@@ -1,7 +1,7 @@
 package funkin.ui.options.items;
 
 import funkin.ui.TextMenuList.TextMenuItem;
-import funkin.ui.AtlasText;
+import funkin.ui.AtlasText.AtlasFont;
 import funkin.input.Controls;
 
 /**
@@ -13,8 +13,6 @@ class EnumPreferenceItem extends TextMenuItem
   {
     return PlayerSettings.player1.controls;
   }
-
-  public var lefthandText:AtlasText;
 
   public var currentValue:String;
   public var onChangeCallback:Null<String->Void>;
@@ -42,8 +40,6 @@ class EnumPreferenceItem extends TextMenuItem
       if (this.currentValue == key) index = i;
       i += 1;
     }
-
-    // lefthandText = new AtlasText(15, y, formatted(defaultValue), AtlasFont.DEFAULT);
 
     this.fireInstantly = true;
   }

--- a/source/funkin/ui/options/items/EnumPreferenceItem.hx
+++ b/source/funkin/ui/options/items/EnumPreferenceItem.hx
@@ -36,8 +36,6 @@ class EnumPreferenceItem extends TextMenuItem
     this.currentValue = defaultValue;
     this.onChangeCallback = callback;
 
-    trace(this.map);
-
     var i:Int = 0;
     for (key in map.keys())
     {
@@ -54,7 +52,7 @@ class EnumPreferenceItem extends TextMenuItem
     super.update(elapsed);
 
     // var fancyTextFancyColor:Color;
-    if(!selected) return;
+    if (!selected) return;
 
     var shouldDecrease:Bool = controls().UI_LEFT_P;
     var shouldIncrease:Bool = controls().UI_RIGHT_P;

--- a/source/funkin/ui/options/items/EnumPreferenceItem.hx
+++ b/source/funkin/ui/options/items/EnumPreferenceItem.hx
@@ -23,15 +23,20 @@ class EnumPreferenceItem extends TextMenuItem
 
   public function new(x:Float, y:Float, name:String, map:Map<String, String>, defaultValue:String, ?callback:String->Void)
   {
+    this.map = map;
+
     super(x, y, formatted(defaultValue), AtlasFont.DEFAULT, function() {
-      callback(this.currentValue);
+      if (callback != null) {
+        callback(this.currentValue);
+      }
     });
 
     updateHitbox();
 
-    this.map = map;
     this.currentValue = defaultValue;
     this.onChangeCallback = callback;
+
+    trace(this.map);
 
     var i:Int = 0;
     for (key in map.keys())

--- a/source/funkin/ui/options/items/NumberPreferenceItem.hx
+++ b/source/funkin/ui/options/items/NumberPreferenceItem.hx
@@ -63,7 +63,7 @@ class NumberPreferenceItem extends TextMenuItem
     super.update(elapsed);
     label.text = formatted(currentValue);
 
-    // if (!selected) return;
+    if (!selected) return;
 
     holdDelayTimer -= elapsed;
     if (holdDelayTimer <= 0.0)

--- a/source/funkin/ui/options/items/NumberPreferenceItem.hx
+++ b/source/funkin/ui/options/items/NumberPreferenceItem.hx
@@ -44,10 +44,10 @@ class NumberPreferenceItem extends TextMenuItem
   public function new(x:Float, y:Float, name:String, defaultValue:Float, min:Float, max:Float, step:Float, precision:Int, ?callback:Float->Void,
       ?valueFormatter:Float->String):Void
   {
-    super(x, y, name, function() {
+    super(x, y, formatted(defaultValue), AtlasFont.DEFAULT, function() {
       callback(this.currentValue);
     });
-    lefthandText = new AtlasText(15, y, formatted(defaultValue), AtlasFont.DEFAULT);
+    // lefthandText = new AtlasText(15, y, formatted(defaultValue), AtlasFont.DEFAULT);
 
     updateHitbox();
 
@@ -65,9 +65,9 @@ class NumberPreferenceItem extends TextMenuItem
   override function update(elapsed:Float):Void
   {
     super.update(elapsed);
-    lefthandText.text = formatted(currentValue);
+    label.text = formatted(currentValue);
 
-    if (!selected) return;
+    // if (!selected) return;
 
     holdDelayTimer -= elapsed;
     if (holdDelayTimer <= 0.0)

--- a/source/funkin/ui/options/items/NumberPreferenceItem.hx
+++ b/source/funkin/ui/options/items/NumberPreferenceItem.hx
@@ -1,7 +1,7 @@
 package funkin.ui.options.items;
 
 import funkin.ui.TextMenuList.TextMenuItem;
-import funkin.ui.AtlasText;
+import funkin.ui.AtlasText.AtlasFont;
 import funkin.input.Controls;
 
 /**
@@ -13,9 +13,6 @@ class NumberPreferenceItem extends TextMenuItem
   {
     return PlayerSettings.player1.controls;
   }
-
-  // Widgets
-  public var lefthandText:AtlasText;
 
   // Constants
   static final HOLD_DELAY:Float = 0.3; // seconds
@@ -47,7 +44,6 @@ class NumberPreferenceItem extends TextMenuItem
     super(x, y, formatted(defaultValue), AtlasFont.DEFAULT, function() {
       callback(this.currentValue);
     });
-    // lefthandText = new AtlasText(15, y, formatted(defaultValue), AtlasFont.DEFAULT);
 
     updateHitbox();
 


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->
## Briefly describe the issue(s) fixed.
* This PR aims to make adding preference items/options a little bit easier:

1. Move all of the preference items into their own class (`PreferenceItem.hx`)
2. Add Categories to the Preference menu
3. Cleanup some of the code in the `PreferenceMenu.hx`
### **‼️ THIS WILL BREAK MODS THAT HAVE OPTIONS ‼️**

## Include any relevant screenshots or videos.
* Now, we have option categories, cleaner code while maintaining the same functionality:

https://github.com/user-attachments/assets/488317eb-ff70-4f78-b6ba-f2d4aac12532

## How to add thew new options into your mods?
* Here is a code provided below that will show how to add your custom options into the mod:

```
override function onStateChangeEnd(event)
    {
        super.onStateChangeEnd(event);
        if (Std.isOfType(event.targetState, OptionsState))
        {
            var preferences = event.targetState.optionsCodex.pages.get("preferences");
            preferences.addCategory("Custom Options");
            // different types: 'checkbox', 'number', 'percentage', 'enum'
            preferences.addOption('checkbox', "Centered Strumline", "If enabled, the player's strumline will be moved to the center of the screen.", function(value){
                save.data.centeredNotes = value;
            }, save.data.centeredNotes);
            save.flush();
        }
    }
```

* And voila! Here is the custom option ready to be used *(video demonstration)*:

https://github.com/user-attachments/assets/a54c5a0d-5272-4937-a090-44934190d1bd

