### PR TITLE
[BUGFIX] Difficulty Select goes off screen fix

### DIFF
--- a/source/funkin/ui/story/StoryMenuState.hx
+++ b/source/funkin/ui/story/StoryMenuState.hx
@@ -205,7 +205,7 @@ class StoryMenuState extends MusicBeatState
     buildDifficultySprite(Constants.DEFAULT_DIFFICULTY);
     buildDifficultySprite();
 
-    rightDifficultyArrow = new FlxSprite(1245, leftDifficultyArrow.y);
+    rightDifficultyArrow = new FlxSprite(1231, leftDifficultyArrow.y);
     rightDifficultyArrow.frames = leftDifficultyArrow.frames;
     rightDifficultyArrow.animation.addByPrefix('idle', 'rightIdle0');
     rightDifficultyArrow.animation.addByPrefix('press', 'rightConfirm0');
@@ -262,7 +262,7 @@ class StoryMenuState extends MusicBeatState
     difficultySprite = difficultySprites.get(diff);
     if (difficultySprite == null)
     {
-      difficultySprite = new FlxSprite(leftDifficultyArrow.x + leftDifficultyArrow.width + 10, leftDifficultyArrow.y);
+      difficultySprite = new FlxSprite(leftDifficultyArrow.x + leftDifficultyArrow.width + 10 - 8, leftDifficultyArrow.y);
 
       if (Assets.exists(Paths.file('images/storymenu/difficulties/${diff}.xml')))
       {


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->
## Does this PR close any issues? If so, link them below.
#4652 

## Briefly describe the issue(s) fixed.
The right difficulty arrow goes a little off screen

## Include any relevant screenshots or videos.
My fix: 
![image](https://github.com/user-attachments/assets/a382afa2-a716-4f7d-8ff1-7c9a83aa8083)
![image](https://github.com/user-attachments/assets/49bfc2b0-c5db-4cce-95c2-1825007775a7)

It may not be perfect but its 5:45 rn and im a lil tired
