### PR TITLE
[ENHANCEMENT] Change Stage Event

### DIFF
--- a/source/funkin/play/event/SetStageSongEvent.hx
+++ b/source/funkin/play/event/SetStageSongEvent.hx
@@ -1,3 +1,72 @@
 package funkin.play.event;
 
-// TODO: Add a song event which switches stages.
+import funkin.data.event.SongEventSchema;
+import funkin.data.song.SongData.SongEventData;
+import funkin.data.song.SongData;
+import funkin.data.stage.StageData;
+import funkin.data.stage.StageRegistry;
+import funkin.play.PlayState;
+import funkin.play.character.CharacterData.HealthIconData;
+
+/**
+ * This class represents a handler for set stage events.
+ *
+ * Example: Set the stage to "Main Stage [Erect]":
+ * ```
+ * {
+ *   'e': 'SetStage',
+ * 	 "v": {
+ * 	 	 "stageId": "mainStageErect"
+ *   }
+ * }
+ * ```
+ */
+class SetStageSongEvent extends SongEvent
+{
+  public function new()
+  {
+    super('SetStage');
+  }
+
+  public override function handleEvent(data:SongEventData):Void
+  {
+    // Does nothing if there is no stage.
+    if (PlayState.instance?.currentStage == null) return;
+
+    PlayState.instance.swapStage(data.value.stageId);
+  }
+
+  public override function getTitle():String
+  {
+    return 'Set Stage';
+  }
+
+  public override function getEventSchema():SongEventSchema
+  {
+    return new SongEventSchema([
+      {
+        name: 'stageId',
+        title: 'Stage',
+        defaultValue: "mainStage",
+        type: SongEventFieldType.ENUM,
+        keys: generateStageList(),
+      }
+    ]);
+  }
+
+  /**
+   * Returns the entry IDs of all stages.
+   */
+  static function generateStageList():Map<String, String>
+  {
+    var stageIDs:Array<String> = StageRegistry.instance.listEntryIds();
+    var stageMap:Map<String, String> = new Map<String, String>();
+
+    for (stage in stageIDs)
+    {
+      var stageData:StageData = StageRegistry.instance.parseEntryDataWithMigration(stage, StageRegistry.instance.fetchEntryVersion(stage));
+      stageMap.set(stageData.name, stage);
+    }
+    return stageMap;
+  }
+}

--- a/source/funkin/play/stage/Stage.hx
+++ b/source/funkin/play/stage/Stage.hx
@@ -152,8 +152,9 @@ class Stage extends FlxSpriteGroup implements IPlayStateScriptedClass implements
   /**
    * The default stage construction routine. Called when the stage is going to be played in.
    * Instantiates each prop and adds it to the stage, while setting its parameters.
+   * @param fromSwap If true, this was called from the "Set Stage" song event.
    */
-  function buildStage():Void
+  public function buildStage(fromSwap:Bool = false):Void
   {
     trace('Building stage for display: ${this.id}');
 


### PR DESCRIPTION
This PR adds a functional change stage event, featuring more or less features the same implementation from my mod [Stage Changer+](https://gamebanana.com/mods/587120), with modifications to fit the source code. This comes with the added benefit of prop preloading to hopefully minimize lag when switching stages!

Additional changes include:
- Changed `currentStageId` to now return the ID from `currentStage`. The old implementation has been moved to `chartStageId`.
- `buildStage` is now a public function and has a `fromSwap` boolean, so song scripts can accommodate for this song event when overriding it.
- `loadStage` now has a `swap` boolean to handle changing stages.
![screenshot-2025-04-08-16-08-52](https://github.com/user-attachments/assets/bcb5479a-9f12-4548-9735-4753e60e4a3e)

I highly encourage you to playtest this for any issues!!