### PR TITLE
[BUGFIX] Fix Freeplay Softlock when getting out of a song

### DIFF
--- a/source/funkin/ui/freeplay/FreeplayDJ.hx
+++ b/source/funkin/ui/freeplay/FreeplayDJ.hx
@@ -87,7 +87,7 @@ class FreeplayDJ extends FlxAtlasSprite
       case Intro:
         // Play the intro animation then leave this state immediately.
         var animPrefix = playableCharData.getAnimationPrefix('intro');
-        if (getCurrentAnimation() != animPrefix) playFlashAnimation(animPrefix, true);
+        if (getCurrentAnimation() != animPrefix || !this.anim.isPlaying) playFlashAnimation(animPrefix, true);
         timeIdling = 0;
       case Idle:
         // We are in this state the majority of the time.


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->
## Does this PR close any issues? If so, link them below.
#4409

## Briefly describe the issue(s) fixed.
Sometimes, Freeplay will softlock and stay on the Intro. This PR fixes that issue by also checking if the animation is currently playing.
