### PR TITLE
[ENHANCEMENT] Add to Blue Ball counter when restarting from Pause Menu

### DIFF
--- a/source/funkin/play/PauseSubState.hx
+++ b/source/funkin/play/PauseSubState.hx
@@ -664,6 +664,7 @@ class PauseSubState extends MusicBeatSubState
    */
   static function restartPlayState(state:PauseSubState):Void
   {
+    PlayState.instance.deathCounter += 1;
     PlayState.instance.needsReset = true;
     state.close();
   }


### PR DESCRIPTION
## Linked Issue
Closes #4664

## Changes
Discussed this with Eric and decided we might want to count the "Restart Song" option in the Pause Menu as a Blue Ball.
Otherwise you'd be able to cheese the counter by restarting until you finish the song.

## Include any relevant screenshots or videos.

https://github.com/user-attachments/assets/4e801663-d290-4a73-8064-39318dfe6c35

