### PR TITLE
[BUGFIX] Character Unlock Notification plays once per save

### DIFF
--- a/source/funkin/data/freeplay/player/PlayerRegistry.hx
+++ b/source/funkin/data/freeplay/player/PlayerRegistry.hx
@@ -67,6 +67,50 @@ class PlayerRegistry extends BaseRegistry<PlayableCharacter, PlayerData, PlayerE
     return count;
   }
 
+  public function hasNewCharacterUnlock():Bool
+  {
+    #if (!UNLOCK_EVERYTHING)
+    var charactersUnlocked = Save.instance.charactersUnlocked.clone();
+
+    for (charId in listEntryIds())
+    {
+      var player = fetchEntry(charId);
+      if (player == null) continue;
+
+      if (!player.isUnlocked()) continue;
+      if (charactersUnlocked.contains(charId)) continue;
+
+      // This character is unlocked but we haven't seen their unlock notification yet.
+      return true;
+    }
+    #end
+
+    // Fallthrough case.
+    return false;
+  }
+
+  public function listNewCharacterUnlocks():Array<String>
+  {
+    var result = [];
+
+    #if (!UNLOCK_EVERYTHING)
+    var charactersUnlocked = Save.instance.charactersUnlocked.clone();
+    for (charId in listEntryIds())
+    {
+      var player = fetchEntry(charId);
+      if (player == null) continue;
+
+      if (!player.isUnlocked()) continue;
+      if (charactersUnlocked.contains(charId)) continue;
+
+      // This character is unlocked but we haven't seen their unlock notification yet.
+      result.push(charId);
+    }
+    #end
+
+    return result;
+  }
+
   public function hasNewCharacter():Bool
   {
     #if (!UNLOCK_EVERYTHING)

--- a/source/funkin/play/ResultState.hx
+++ b/source/funkin/play/ResultState.hx
@@ -848,12 +848,12 @@ class ResultState extends MusicBeatSubState
 
       if (params.storyMode)
       {
-        if (PlayerRegistry.instance.hasNewCharacter())
+        if (PlayerRegistry.instance.hasNewCharacterUnlock())
         {
           // New character, display the notif.
           targetState = new StoryMenuState(null);
 
-          var newCharacters = PlayerRegistry.instance.listNewCharacters();
+          var newCharacters = PlayerRegistry.instance.listNewCharacterUnlocks();
 
           for (charId in newCharacters)
           {

--- a/source/funkin/save/Save.hx
+++ b/source/funkin/save/Save.hx
@@ -176,6 +176,7 @@ class Save implements ConsoleClass
         {
           // Default to having seen the default character.
           charactersSeen: ["bf"],
+          charactersUnlocked: ["bf"],
           oldChar: false
         },
 
@@ -554,6 +555,13 @@ class Save implements ConsoleClass
     return data.unlocks.charactersSeen;
   }
 
+  public var charactersUnlocked(get, never):Array<String>;
+
+  function get_charactersUnlocked():Array<String>
+  {
+    return data.unlocks.charactersUnlocked;
+  }
+
   /**
    * Marks whether the player has seen the spotlight animation, which should only display once per save file ever.
    */
@@ -711,7 +719,7 @@ class Save implements ConsoleClass
   }
 
   /**
-   * When we've seen a character unlock, add it to the list of characters seen.
+   * When we've seen a character unlock animation, add it to the list of characters seen.
    * @param character
    */
   public function addCharacterSeen(character:String):Void
@@ -721,6 +729,21 @@ class Save implements ConsoleClass
       trace('Character seen: ' + character);
       data.unlocks.charactersSeen.push(character);
       trace('New characters seen list: ' + data.unlocks.charactersSeen);
+      flush();
+    }
+  }
+
+  /**
+   * When we've seen a character unlock notification, add it to the list of characters unlocked.
+   * @param character
+   */
+  public function addCharacterUnlocked(character:String):Void
+  {
+    if (!data.unlocks.charactersUnlocked.contains(character))
+    {
+      trace('Character unlocked: ' + character);
+      data.unlocks.charactersUnlocked.push(character);
+      trace('New characters unlocked list: ' + data.unlocks.charactersUnlocked);
       flush();
     }
   }
@@ -1491,6 +1514,12 @@ typedef SaveDataUnlocks =
    * add it to this list so that we don't show it again.
    */
   var charactersSeen:Array<String>;
+
+  /**
+   * Every time we see the unlock prompt for a character,
+   * add it to this list so that we don't show it again.
+   */
+  var charactersUnlocked:Array<String>;
 
   /**
    * This is a conditional when the player enters the character state

--- a/source/funkin/ui/charSelect/CharacterUnlockState.hx
+++ b/source/funkin/ui/charSelect/CharacterUnlockState.hx
@@ -10,6 +10,7 @@ import funkin.graphics.FunkinSprite;
 import flixel.util.FlxColor;
 import funkin.data.character.CharacterData.CharacterDataParser;
 import funkin.play.components.HealthIcon;
+import funkin.save.Save;
 import funkin.ui.freeplay.charselect.PlayableCharacter;
 import funkin.data.freeplay.player.PlayerRegistry;
 import funkin.ui.mainmenu.MainMenuState;
@@ -101,6 +102,7 @@ class CharacterUnlockState extends MusicBeatState
         healthIcon.size.set(0.5 * curScale, 0.5 * curScale);
       });
 
+    Save.instance.addCharacterUnlocked(targetCharacterId);
     // performUnlock();
   }
 


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->
## Does this PR close any issues? If so, link them below.
Fixes #3263
## Briefly describe the issue(s) fixed.
The notification "You can now play as Pico" would play after beating any story week until you view the unlock animation in Freeplay. This PR fixes this issue by adding a list of characters unlocked to the save data. Once you view the unlock notification for the character, they are added to the list of characters unlocked. The game won't show the unlock notification for them again on the current save.
## Include any relevant screenshots or videos.

In this video, you can see that I exited the results screen for a story week without seeing the "You can now play as Pico" message. I scroll down to show that I have a score on Weekend 1, so I would have Pico unlocked. I then enter Freeplay to show that I have a new character unlock, meaning I haven't viewed Pico's unlock animation yet.

https://github.com/user-attachments/assets/d36d32f2-f375-43ac-bbfd-4029ae2a5a2d