### PR TITLE
Check if TERM starts with `xterm`

### DIFF
--- a/source/funkin/util/logging/AnsiTrace.hx
+++ b/source/funkin/util/logging/AnsiTrace.hx
@@ -28,7 +28,8 @@ class AnsiTrace
     #end
   }
 
-  public static var colorSupported:Bool = #if sys (Sys.getEnv("TERM") == "xterm" || Sys.getEnv("ANSICON") != null) #else false #end;
+  public static var colorSupported:Bool = #if sys (Sys.getEnv("TERM").startsWith('xterm')
+    || Sys.getEnv("ANSICON") != null) #else false #end;
 
   // ansi stuff
   public static inline var RED = "\x1b[31m";

--- a/source/funkin/util/logging/AnsiTrace.hx
+++ b/source/funkin/util/logging/AnsiTrace.hx
@@ -28,7 +28,7 @@ class AnsiTrace
     #end
   }
 
-  public static var colorSupported:Bool = #if sys (Sys.getEnv("TERM").startsWith('xterm')
+  public static var colorSupported:Bool = #if sys (Sys.getEnv("TERM")?.startsWith('xterm')
     || Sys.getEnv("ANSICON") != null) #else false #end;
 
   // ansi stuff


### PR DESCRIPTION
easiest fucking line change of my life lol

for context:
```
[USER]@[REDACTED]s-MacBook-Air lol % $TERM
zsh: command not found: xterm-256color
```
ansitrace was directly checking if it was simply `xterm` instead of if it started with `xterm`