### PR TITLE
[BUGFIX] Fix Freeplay Name Cycling

### DIFF
--- a/source/funkin/ui/freeplay/FreeplayState.hx
+++ b/source/funkin/ui/freeplay/FreeplayState.hx
@@ -1347,6 +1347,7 @@ class FreeplayState extends MusicBeatSubState
             grpCapsules.members[realShit].favIcon.visible = false;
             grpCapsules.members[realShit].favIconBlurred.visible = false;
             grpCapsules.members[realShit].checkClip();
+            grpCapsules.members[realShit].selected = grpCapsules.members[realShit].selected; // set selected again, so it can run it's getter function to initialize movement
           });
 
           busy = true;
@@ -1773,6 +1774,8 @@ class FreeplayState extends MusicBeatSubState
 
     // Set difficulty star count.
     albumRoll.setDifficultyStars(daSong?.data.getDifficulty(currentDifficulty, currentVariation)?.difficultyRating ?? 0);
+
+    grpCapsules.members[curSelected].selected = grpCapsules.members[curSelected].selected; // set selected again, so it can run it's getter function to initialize movement
   }
 
   function capsuleOnConfirmRandom(randomCapsule:SongMenuItem):Void


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->
## Does this PR close any issues? If so, link them below.
Fixes #4675
## Briefly describe the issue(s) fixed.
Songs that have long names that don't fit in the capsule will have their name cycle so you can see it all. When changing difficulties or unfavoriting a song, the name of the song would stop cycling. This PR fixes this issue by setting the select capsule again after changing difficulties or unfavoriting a song to initialize movement.

(For some reason this was done correctly for favoriting a song, but not unfavoriting it)
## Include any relevant screenshots or videos.

Before:

https://github.com/user-attachments/assets/34bff216-979b-4755-8af5-b434b73302bf

After:

https://github.com/user-attachments/assets/66861077-c530-47eb-8d86-f8dc11744c4d