### PR TITLE
Chart editor - Crash event fix

### DIFF
--- a/source/funkin/ui/debug/charting/toolboxes/ChartEditorEventDataToolbox.hx
+++ b/source/funkin/ui/debug/charting/toolboxes/ChartEditorEventDataToolbox.hx
@@ -54,7 +54,7 @@ class ChartEditorEventDataToolbox extends ChartEditorBaseToolbox
         trace('ChartEditorEventDataToolbox: Event data is null');
       }
 
-      var eventType:String = event.data.id;
+      var eventType:String = event.data?.id;
 
       trace('ChartEditorEventDataToolbox - Event type changed: $eventType');
 


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->
## Does this PR close any issues? If so, link them below.
Fixes #4690
## Briefly describe the issue(s) fixed.

The event toolbox can cause a null reference crash because it doesn't return when `event.data` is `null` in `initialize`.

## Include any relevant screenshots or videos.

[Nah.](https://wiki.teamfortress.com/w/images/b/b2/Engineer_no02.wav)