### PR TITLE
[BUGFIX] Prevent Pixel Notes from being destroyed early

### DIFF
--- a/source/funkin/ui/transition/LoadingState.hx
+++ b/source/funkin/ui/transition/LoadingState.hx
@@ -316,10 +316,15 @@ class LoadingState extends MusicBeatSubState
     FunkinSprite.cacheTexture(Paths.image('ui/popup/pixel/num7'));
     FunkinSprite.cacheTexture(Paths.image('ui/popup/pixel/num8'));
     FunkinSprite.cacheTexture(Paths.image('ui/popup/pixel/num9'));
-    FunkinSprite.cacheTexture(Paths.image('notes', 'shared'));
-    FunkinSprite.cacheTexture(Paths.image('noteSplashes', 'shared'));
-    FunkinSprite.cacheTexture(Paths.image('noteStrumline', 'shared'));
-    FunkinSprite.cacheTexture(Paths.image('NOTE_hold_assets'));
+
+    FunkinSprite.cacheTexture(Paths.image('notestyles/funkin/notes', 'shared'));
+    FunkinSprite.cacheTexture(Paths.image('notestyles/funkin/noteSplashes', 'shared'));
+    FunkinSprite.cacheTexture(Paths.image('notestyles/funkin/noteStrumline', 'shared'));
+    FunkinSprite.cacheTexture(Paths.image('notestyles/funkin/NOTE_hold_assets', 'shared'));
+    FunkinSprite.cacheTexture(Paths.image('notestyles/pixel/arrows-pixels', 'shared'));
+    FunkinSprite.cacheTexture(Paths.image('notestyles/pixel/arrowEndsNew', 'shared'));
+    FunkinSprite.cacheTexture(Paths.image('notestyles/pixel/pixelNoteSplash', 'shared'));
+    FunkinSprite.cacheTexture(Paths.image('notestyles/pixel/pixelNoteHoldCover', 'shared'));
 
     FunkinSprite.cacheTexture(Paths.image('ui/countdown/funkin/ready', 'shared'));
     FunkinSprite.cacheTexture(Paths.image('ui/countdown/funkin/set', 'shared'));


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->
## Does this PR close any issues? If so, link them below.
Fixes #4400 and #4478
## Briefly describe the issue(s) fixed.

The pixel note assets were not in the shared images folder. Instead, they are located in the week 6 folder which is only loaded when you are on week 6 songs. This can cause the pixel note graphics to be destroyed while they are still in use, so I moved them out of the week 6 folder into the shared images folder. I also moved the regular notestyle assets to make the folders look cleaner.

The PR here changes the paths the note assets are loaded from. This will also require PR FunkinCrew/funkin.assets#161 in the assets submodule that moves the note assets to be merged. 

## Include any relevant screenshots or videos.

F5 hot reloading (You can see the placeholder images don't appear):

https://github.com/user-attachments/assets/3dacab73-5950-4bcc-a6ed-881f223f01db

Returning to chart editor several times. The game doesn't crash:

https://github.com/user-attachments/assets/b363e2a6-ff49-4f2b-9033-740e742d02f1