### PR TITLE
[BUGFIX] Disable Movement in OptionsState when the Clear Save Data prompt is active

### DIFF
--- a/source/funkin/ui/options/OptionsState.hx
+++ b/source/funkin/ui/options/OptionsState.hx
@@ -145,6 +145,12 @@ class OptionsMenu extends Page<OptionsMenuPageName>
     return item;
   }
 
+  override function update(elapsed:Float)
+  {
+    enabled = (prompt == null);
+    super.update(elapsed);
+  }
+
   override function set_enabled(value:Bool)
   {
     items.enabled = value;


### PR DESCRIPTION
## Does this PR close any issues? If so, link them below.
Closes #4702 

## Briefly describe the issue(s) fixed.
`enabled = (prompt == null);` is the fix. I <3 easy fixes

## Include any relevant screenshots or videos.

https://github.com/user-attachments/assets/668a8063-68c6-4c39-a15b-8c146ba36a9e
