### PR TITLE
[ENHANCEMENT] Options Menu scrolling

### DIFF
--- a/source/funkin/ui/options/OptionsState.hx
+++ b/source/funkin/ui/options/OptionsState.hx
@@ -3,7 +3,9 @@ package funkin.ui.options;
 import funkin.ui.Page.PageName;
 import funkin.ui.transition.LoadingState;
 import funkin.ui.debug.latency.LatencyState;
+import flixel.math.FlxPoint;
 import flixel.FlxSprite;
+import flixel.FlxObject;
 import flixel.FlxSubState;
 import flixel.group.FlxGroup;
 import flixel.util.FlxSignal;
@@ -85,11 +87,19 @@ class OptionsMenu extends Page<OptionsMenuPageName>
 {
   var items:TextMenuList;
 
+  /**
+   * Camera focus point
+   */
+  var camFocusPoint:FlxObject;
+
+  final CAMERA_MARGIN:Int = 150;
+
   public function new()
   {
     super();
 
     add(items = new TextMenuList());
+
     createItem("PREFERENCES", function() codex.switchPage(Preferences));
     createItem("CONTROLS", function() codex.switchPage(Controls));
     createItem("INPUT OFFSETS", function() {
@@ -135,6 +145,25 @@ class OptionsMenu extends Page<OptionsMenuPageName>
     });
 
     createItem("EXIT", exit);
+
+    // Create an object for the camera to track.
+    camFocusPoint = new FlxObject(0, 0, 140, 70);
+    add(camFocusPoint);
+
+    // Follow the camera focus as we scroll.
+    FlxG.camera.follow(camFocusPoint, null, 0.085);
+    FlxG.camera.deadzone.set(0, CAMERA_MARGIN / 2, FlxG.camera.width, FlxG.camera.height - CAMERA_MARGIN + 40);
+    FlxG.camera.minScrollY = -CAMERA_MARGIN / 2;
+
+    // Move the camera when the menu is scrolled.
+    items.onChange.add(onMenuChange);
+
+    onMenuChange(items.members[0]);
+  }
+
+  function onMenuChange(selected:TextMenuList.TextMenuItem)
+  {
+    camFocusPoint.y = selected.y;
   }
 
   function createItem(name:String, callback:Void->Void, fireInstantly = false)


### PR DESCRIPTION
This PR adds scrolling to the options menu, very useful for mods that add a lot of menu items since they can now be scrolled to instead of having everything crammed onscreen.
Code was mostly copypasted from `PreferencesMenu` lol

https://github.com/user-attachments/assets/7ba94468-d593-4701-9be3-5ef4df716644

Disclaimer: The 8 "FUCK" items are not included in this PR, sorry.