### PR TITLE
[BUGFIX] Ensure Song starts at Correct time when Restarting Songs with BPM Changes

### DIFF
--- a/source/funkin/Conductor.hx
+++ b/source/funkin/Conductor.hx
@@ -5,6 +5,7 @@ import flixel.util.FlxSignal;
 import flixel.math.FlxMath;
 import funkin.data.song.SongData.SongTimeChange;
 import funkin.data.song.SongDataUtils;
+import funkin.play.PlayState;
 import funkin.save.Save;
 import funkin.util.TimerUtil.SongSequence;
 import haxe.Timer;
@@ -112,6 +113,17 @@ class Conductor
     if (bpmOverride != null) return bpmOverride;
 
     if (currentTimeChange == null) return Constants.DEFAULT_BPM;
+
+    @:privateAccess
+    if (PlayState.instance != null && PlayState.instance.startingSong)
+    {
+      for (i in 0...timeChanges.length)
+      {
+        if (PlayState.instance.startTimestamp >= timeChanges[i].timeStamp) currentTimeChange = timeChanges[i];
+
+        if (PlayState.instance.startTimestamp < timeChanges[i].timeStamp) break;
+      }
+    }
 
     return currentTimeChange.bpm;
   }

--- a/source/funkin/modding/PolymodHandler.hx
+++ b/source/funkin/modding/PolymodHandler.hx
@@ -557,11 +557,9 @@ class PolymodHandler
     Polymod.clearScripts();
 
     // Forcibly reload Polymod so it finds any new files.
+    // This will also register all scripts.
     // TODO: Replace this with loadEnabledMods().
     funkin.modding.PolymodHandler.loadAllMods();
-
-    // Reload scripted classes so stages and modules will update.
-    Polymod.registerAllScriptClasses();
 
     // Reload everything that is cached.
     // Currently this freezes the game for a second but I guess that's tolerable?

--- a/source/funkin/ui/debug/stageeditor/components/WelcomeDialog.hx
+++ b/source/funkin/ui/debug/stageeditor/components/WelcomeDialog.hx
@@ -57,7 +57,7 @@ class WelcomeDialog extends Dialog
 
     boxDrag.onClick = function(_) FileUtil.browseForSaveFile([FileUtil.FILE_FILTER_FNFS], loadFromFilePath, null, null, "Open Stage Data");
 
-    var defaultStages:Array<String> = StageRegistry.instance.listBaseGameEntryIds();
+    var defaultStages:Array<String> = StageRegistry.instance.listEntryIds();
     defaultStages.sort(funkin.util.SortUtil.alphabetically);
 
     for (stage in defaultStages)


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->
## Does this PR close any issues? If so, link them below.
Fixes #4434
## Briefly describe the issue(s) fixed.
Restarting a song that has BPM changes when the song has a different BPM than its starting BPM causes the song to start at the incorrect time. 
When the BPM is lower than the starting BPM, the song will start later than it should. This is noticeable in Eggnog Erect where restarting after the BPM change at the end causes the song to start two seconds after the countdown ends.

When the BPM is higher than the starting BPM, the song will start before the countdown ends. This is somewhat noticeable in Monster where restarting during its highest BPM causes the instrumental to start slightly before the countdown ends and the camera event focusing on Boyfriend happens before the countdown ends.

This happens because the time the song starts at in the countdown is based on `beatLengthMs`, but the BPM hasn't changed yet because the song position hasn't updated yet. This causes the song position to be set based on the current BPM rather than the starting BPM.

I fixed this issue by checking if `startingSong` is `true`, and if it is, the `bpm` variable is set to the BPM of the song at the `startTimestamp`.
## Include any relevant screenshots or videos.

### Songs with BPM changes starting at the incorrect time
Eggnog Erect:

https://github.com/user-attachments/assets/3e56c6cb-ade7-40e5-a64c-e8619069492d

Monster:

https://github.com/user-attachments/assets/bbd47c10-7d54-47e8-943f-18dff746bf05

### Starting at the correct time after changes

Eggnog Erect:

https://github.com/user-attachments/assets/03b5b9ad-8ad1-45a3-b3e4-28274aae76b1

Monster:

https://github.com/user-attachments/assets/4e17f59a-7b84-4903-a829-9c1a8b14ce39