### PR TITLE
[BUGFIX] Fix removal of stacked events

### DIFF
--- a/source/funkin/util/tools/SongEventDataArrayTools.hx
+++ b/source/funkin/util/tools/SongEventDataArrayTools.hx
@@ -46,10 +46,15 @@ class SongEventDataArrayTools
         // Search the lower half of the range.
         highIndex = midIndex - 1;
       }
+      // Found it? Make a more thorough check.
+      else if (midNote == note)
+      {
+        return midIndex;
+      }
       else
       {
-        // Found it!
-        return midIndex;
+        // We may be close, so constrain the range (but only a little) and try again.
+        highIndex -= 1;
       }
     }
     return -1;


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->
## Does this PR close any issues? If so, link them below.
Fixes #4722 
## Briefly describe the issue(s) fixed.
`SongEventDataArrayTools` only checked for the time when searching for the index of an event, which caused a deleted event's sprite to not get killed since the editor would think another event with the same time was the event that got deleted.

This adds an extra check to ensure it's actually the same event. For some reason this was previously only done for notes.
## Include any relevant screenshots or videos.

[!rest is a secret I start to believe it](https://github.com/user-attachments/assets/540294f3-7a6e-4ba7-bdfb-a2660ced46c2)

