### PR TITLE
[BUGFIX] Fix Retry Sound after Death Quote finishes

### DIFF
--- a/source/funkin/play/GameOverSubState.hx
+++ b/source/funkin/play/GameOverSubState.hx
@@ -391,7 +391,6 @@ class GameOverSubState extends MusicBeatSubState
     if (!isEnding)
     {
       isEnding = true;
-      startDeathMusic(1.0, true); // isEnding changes this function's behavior.
 
       // Stop death quotes immediately.
       hasPlayedDeathQuote = true;
@@ -400,6 +399,8 @@ class GameOverSubState extends MusicBeatSubState
         deathQuoteSound.stop();
         deathQuoteSound = null;
       }
+
+      startDeathMusic(1.0, true); // isEnding changes this function's behavior.
 
       if (PlayState.instance.isMinimalMode || boyfriend == null) {}
       else


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->
## Does this PR close any issues? If so, link them below.
Fixes #4637
## Briefly describe the issue(s) fixed.

When a death quote finishes playing, the `startDeathMusic` function call in `confirmDeath` somehow also affects `deathQuoteSound`, giving it the same values as `gameOverMusic`. Because `deathQuoteSound` is now not null, the game stops it, but this stops `gameOverMusic` too as they had the same values.

This PR fixes this issue by calling `startDeathMusic` after the death quote is checked for and stopped.
## Include any relevant screenshots or videos.

Before:

https://github.com/user-attachments/assets/dece1cf8-4c85-46d8-b6b5-21a1946d3e20

After:

https://github.com/user-attachments/assets/ad795090-60ba-4afe-8a15-14200a730465