### PR TITLE
chore: Add null safety for 9 classes in `funkin.audio.*`

### DIFF
--- a/source/funkin/audio/FlxStreamSound.hx
+++ b/source/funkin/audio/FlxStreamSound.hx
@@ -11,6 +11,7 @@ import openfl.utils.AssetType;
 /**
  * a FlxSound that just overrides loadEmbedded to allow for "streamed" sounds to load with better performance!
  */
+@:nullSafety
 class FlxStreamSound extends FlxSound
 {
   public function new()
@@ -18,7 +19,7 @@ class FlxStreamSound extends FlxSound
     super();
   }
 
-  override public function loadEmbedded(EmbeddedSound:FlxSoundAsset, Looped:Bool = false, AutoDestroy:Bool = false, ?OnComplete:Void->Void):FlxSound
+  override public function loadEmbedded(EmbeddedSound:Null<FlxSoundAsset>, Looped:Bool = false, AutoDestroy:Bool = false, ?OnComplete:Void->Void):FlxSound
   {
     if (EmbeddedSound == null) return this;
 

--- a/source/funkin/audio/SoundGroup.hx
+++ b/source/funkin/audio/SoundGroup.hx
@@ -7,6 +7,7 @@ import flixel.tweens.FlxTween;
  * A group of FunkinSounds that are all synced together.
  * Unlike FlxSoundGroup, you can also control their time and pitch.
  */
+@:nullSafety
 class SoundGroup extends FlxTypedGroup<FunkinSound>
 {
   public var time(get, set):Float;
@@ -36,6 +37,7 @@ class SoundGroup extends FlxTypedGroup<FunkinSound>
       return result;
     }
 
+    @:nullSafety(Off)
     for (sndFile in files)
     {
       var snd:FunkinSound = FunkinSound.load(Paths.voices(song, '$sndFile'));
@@ -70,7 +72,7 @@ class SoundGroup extends FlxTypedGroup<FunkinSound>
   /**
    * Add a sound to the group.
    */
-  public override function add(sound:FunkinSound):FunkinSound
+  public override function add(sound:FunkinSound):Null<FunkinSound>
   {
     var result:FunkinSound = super.add(sound);
 
@@ -134,6 +136,7 @@ class SoundGroup extends FlxTypedGroup<FunkinSound>
   /**
    * Fade in all the sounds in the group.
    */
+  @:nullSafety(Off)
   public function fadeIn(duration:Float, ?from:Float = 0.0, ?to:Float = 1.0, ?onComplete:FlxTween->Void):Void
   {
     forEachAlive(function(sound:FunkinSound) {
@@ -144,6 +147,7 @@ class SoundGroup extends FlxTypedGroup<FunkinSound>
   /**
    * Fade out all the sounds in the group.
    */
+  @:nullSafety(Off)
   public function fadeOut(duration:Float, ?to:Float = 0.0, ?onComplete:FlxTween->Void):Void
   {
     forEachAlive(function(sound:FunkinSound) {
@@ -238,7 +242,7 @@ class SoundGroup extends FlxTypedGroup<FunkinSound>
 
   function get_muted():Bool
   {
-    if (getFirstAlive() != null) return getFirstAlive().muted;
+    if (getFirstAlive() != null) return getFirstAlive()?.muted ?? false;
     else
       return false;
   }

--- a/source/funkin/audio/VoicesGroup.hx
+++ b/source/funkin/audio/VoicesGroup.hx
@@ -3,10 +3,11 @@ package funkin.audio;
 import flixel.group.FlxGroup.FlxTypedGroup;
 import funkin.audio.waveform.WaveformData;
 
+@:nullSafety
 class VoicesGroup extends SoundGroup
 {
-  var playerVoices:FlxTypedGroup<FunkinSound>;
-  var opponentVoices:FlxTypedGroup<FunkinSound>;
+  var playerVoices:Null<FlxTypedGroup<FunkinSound>>;
+  var opponentVoices:Null<FlxTypedGroup<FunkinSound>>;
 
   /**
    * Control the volume of only the sounds in the player group.
@@ -41,12 +42,12 @@ class VoicesGroup extends SoundGroup
   public function addPlayerVoice(sound:FunkinSound):Void
   {
     super.add(sound);
-    playerVoices.add(sound);
+    playerVoices?.add(sound);
   }
 
   function set_playerVolume(volume:Float):Float
   {
-    playerVoices.forEachAlive(function(voice:FunkinSound) {
+    playerVoices?.forEachAlive(function(voice:FunkinSound) {
       voice.volume = volume;
     });
     return playerVolume = volume;
@@ -59,10 +60,10 @@ class VoicesGroup extends SoundGroup
       snd.time = time;
     });
 
-    playerVoices.forEachAlive(function(voice:FunkinSound) {
+    playerVoices?.forEachAlive(function(voice:FunkinSound) {
       voice.time -= playerVoicesOffset;
     });
-    opponentVoices.forEachAlive(function(voice:FunkinSound) {
+    opponentVoices?.forEachAlive(function(voice:FunkinSound) {
       voice.time -= opponentVoicesOffset;
     });
 
@@ -71,7 +72,7 @@ class VoicesGroup extends SoundGroup
 
   function set_playerVoicesOffset(offset:Float):Float
   {
-    playerVoices.forEachAlive(function(voice:FunkinSound) {
+    playerVoices?.forEachAlive(function(voice:FunkinSound) {
       voice.time += playerVoicesOffset;
       voice.time -= offset;
     });
@@ -80,7 +81,7 @@ class VoicesGroup extends SoundGroup
 
   function set_opponentVoicesOffset(offset:Float):Float
   {
-    opponentVoices.forEachAlive(function(voice:FunkinSound) {
+    opponentVoices?.forEachAlive(function(voice:FunkinSound) {
       voice.time += opponentVoicesOffset;
       voice.time -= offset;
     });
@@ -93,12 +94,12 @@ class VoicesGroup extends SoundGroup
   public function addOpponentVoice(sound:FunkinSound):Void
   {
     super.add(sound);
-    opponentVoices.add(sound);
+    opponentVoices?.add(sound);
   }
 
   function set_opponentVolume(volume:Float):Float
   {
-    opponentVoices.forEachAlive(function(voice:FunkinSound) {
+    opponentVoices?.forEachAlive(function(voice:FunkinSound) {
       voice.volume = volume;
     });
     return opponentVolume = volume;
@@ -106,26 +107,26 @@ class VoicesGroup extends SoundGroup
 
   public function getPlayerVoice(index:Int = 0):Null<FunkinSound>
   {
-    return playerVoices.members[index];
+    return playerVoices?.members[index];
   }
 
   public function getOpponentVoice(index:Int = 0):Null<FunkinSound>
   {
-    return opponentVoices.members[index];
+    return opponentVoices?.members[index];
   }
 
   public function getPlayerVoiceWaveform():Null<WaveformData>
   {
-    if (playerVoices.members.length == 0) return null;
+    if (playerVoices?.members.length == 0) return null;
 
-    return playerVoices.members[0].waveformData;
+    return playerVoices?.members[0].waveformData;
   }
 
   public function getOpponentVoiceWaveform():Null<WaveformData>
   {
-    if (opponentVoices.members.length == 0) return null;
+    if (opponentVoices?.members.length == 0) return null;
 
-    return opponentVoices.members[0].waveformData;
+    return opponentVoices?.members[0].waveformData;
   }
 
   /**
@@ -133,9 +134,9 @@ class VoicesGroup extends SoundGroup
    */
   public function getPlayerVoiceLength():Float
   {
-    if (playerVoices.members.length == 0) return 0.0;
+    if (playerVoices?.members.length == 0) return 0.0;
 
-    return playerVoices.members[0].length;
+    return playerVoices?.members[0]?.length ?? 0.0;
   }
 
   /**
@@ -143,15 +144,15 @@ class VoicesGroup extends SoundGroup
    */
   public function getOpponentVoiceLength():Float
   {
-    if (opponentVoices.members.length == 0) return 0.0;
+    if (opponentVoices?.members.length == 0) return 0.0;
 
-    return opponentVoices.members[0].length;
+    return opponentVoices?.members[0]?.length ?? 0.0;
   }
 
   public override function clear():Void
   {
-    playerVoices.clear();
-    opponentVoices.clear();
+    playerVoices?.clear();
+    opponentVoices?.clear();
     super.clear();
   }
 
@@ -159,13 +160,13 @@ class VoicesGroup extends SoundGroup
   {
     if (playerVoices != null)
     {
-      playerVoices.destroy();
+      playerVoices?.destroy();
       playerVoices = null;
     }
 
     if (opponentVoices != null)
     {
-      opponentVoices.destroy();
+      opponentVoices?.destroy();
       opponentVoices = null;
     }
 

--- a/source/funkin/audio/visualize/ABot.hx
+++ b/source/funkin/audio/visualize/ABot.hx
@@ -3,6 +3,7 @@ package funkin.audio.visualize;
 import flixel.FlxSprite;
 import flixel.group.FlxSpriteGroup.FlxTypedSpriteGroup;
 
+@:nullSafety
 class ABot extends FlxTypedSpriteGroup<FlxSprite>
 {
   public function new()

--- a/source/funkin/audio/visualize/PolygonVisGroup.hx
+++ b/source/funkin/audio/visualize/PolygonVisGroup.hx
@@ -3,11 +3,12 @@ package funkin.audio.visualize;
 import flixel.group.FlxGroup.FlxTypedGroup;
 import flixel.sound.FlxSound;
 
+@:nullSafety
 class PolygonVisGroup extends FlxTypedGroup<PolygonSpectogram>
 {
-  public var playerVis:PolygonSpectogram;
-  public var opponentVis:PolygonSpectogram;
-  public var instVis:PolygonSpectogram;
+  public var playerVis:Null<PolygonSpectogram>;
+  public var opponentVis:Null<PolygonSpectogram>;
+  public var instVis:Null<PolygonSpectogram>;
 
   public function new()
   {
@@ -99,8 +100,14 @@ class PolygonVisGroup extends FlxTypedGroup<PolygonSpectogram>
 
   public override function destroy():Void
   {
-    playerVis.destroy();
-    opponentVis.destroy();
+    if (playerVis != null)
+    {
+      playerVis.destroy();
+    }
+    if (opponentVis != null)
+    {
+      opponentVis.destroy();
+    }
     super.destroy();
   }
 }

--- a/source/funkin/audio/visualize/dsp/Complex.hx
+++ b/source/funkin/audio/visualize/dsp/Complex.hx
@@ -4,6 +4,7 @@ package funkin.audio.visualize.dsp;
   Complex number representation.
 **/
 @:forward(real, imag) @:notNull @:pure
+@:nullSafety
 abstract Complex({
   final real:Float;
   final imag:Float;

--- a/source/funkin/audio/visualize/dsp/FFT.hx
+++ b/source/funkin/audio/visualize/dsp/FFT.hx
@@ -8,6 +8,7 @@ using funkin.audio.visualize.dsp.Signal;
 /**
   Fast/Finite Fourier Transforms.
 **/
+@:nullSafety
 class FFT
 {
   /**

--- a/source/funkin/audio/visualize/dsp/OffsetArray.hx
+++ b/source/funkin/audio/visualize/dsp/OffsetArray.hx
@@ -6,6 +6,7 @@ package funkin.audio.visualize.dsp;
   Usages include 1-indexed sequences or zero-centered buffers with negative indexing.
 **/
 @:forward(array, offset)
+@:nullSafety
 abstract OffsetArray<T>({
   final array:Array<T>;
   final offset:Int;

--- a/source/funkin/audio/visualize/dsp/Signal.hx
+++ b/source/funkin/audio/visualize/dsp/Signal.hx
@@ -5,12 +5,13 @@ using Lambda;
 /**
   Signal processing miscellaneous utilities.
 **/
+@:nullSafety
 class Signal
 {
   /**
     Returns a smoothed version of the input array using a moving average.
   **/
-  public static function smooth(y:Array<Float>, n:Int):Array<Float>
+  public static function smooth(y:Array<Float>, n:Int):Null<Array<Float>>
   {
     if (n <= 0)
     {

--- a/source/funkin/audio/waveform/WaveformDataParser.hx
+++ b/source/funkin/audio/waveform/WaveformDataParser.hx
@@ -2,6 +2,7 @@ package funkin.audio.waveform;
 
 import funkin.util.TimerUtil;
 
+@:nullSafety
 class WaveformDataParser
 {
   static final INT16_MAX:Int = 32767;
@@ -10,7 +11,7 @@ class WaveformDataParser
   static final INT8_MAX:Int = 127;
   static final INT8_MIN:Int = -128;
 
-  public static function interpretFlxSound(sound:flixel.sound.FlxSound):Null<WaveformData>
+  public static function interpretFlxSound(sound:Null<flixel.sound.FlxSound>):Null<WaveformData>
   {
     if (sound == null) return null;
 


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->
## Does this PR close any issues? If so, link them below.
Contribution to #4303

This PR enables null safety for 9 classes in `funkin.audio.*`, the list includes:
- `funkin.audio.FlxStreamSound`
- `funkin.audio.SoundGroup`
- `funkin.audio.VoicesGroup`
- `funkin.audio.visualize.ABot`
- `funkin.audio.visualize.PolygonVisGroup`
- `funkin.audio.visualize.dsp.Complex`
- `funkin.audio.visualize.dsp.FFT`
- `funkin.audio.visualize.dsp.OffsetArray`
- `funkin.audio.visualize.dsp.Signal`
- `funkin.audio.waveform.WaveformDataParser`
