### PR TITLE
[VULNERABILITY] FileUtil restriction in Polymod

### DIFF
--- a/source/funkin/modding/PolymodHandler.hx
+++ b/source/funkin/modding/PolymodHandler.hx
@@ -284,6 +284,11 @@ class PolymodHandler
     // System.load() can load malicious DLLs
     Polymod.blacklistImport('lime.system.System');
 
+    // `funkin.util.FileUtil`
+    // FileUtil can access the file system most likely OUTSIDE of mods, which is a big nono!
+    // Thanks to @Burgerballs for finding this one.
+    Polymod.blacklistImport('funkin.util.FileUtil');
+
     // `lime.utils.Assets`
     // Literally just has a private `resolveClass` function for some reason?
     Polymod.blacklistImport('lime.utils.Assets');


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->
## Does this PR close any issues? If so, link them below.
Fixes https://github.com/FunkinCrew/Funkin/issues/4737, thanks a lot @Burgerballs 
## Briefly describe the issue(s) fixed.
* As described in the issue, giving the access to `FileUtil` can give bad actors the possibility to run malicious code on users devices via mods. This is why this tiny change just outright removes mods the ability to use `FileUtil`.
* Whenever a mod tries to use the `FileUtil` class, it will just give them an error that the class can't be found, thus not being imported.