### PR TITLE
chore: Add null-safety to `Leaderboards` and `Medals`

### DIFF
--- a/source/funkin/api/newgrounds/Leaderboards.hx
+++ b/source/funkin/api/newgrounds/Leaderboards.hx
@@ -9,6 +9,7 @@ import io.newgrounds.objects.User;
 import io.newgrounds.objects.events.Outcome;
 import io.newgrounds.utils.ScoreBoardList;
 
+@:nullSafety
 class Leaderboards
 {
   public static function listLeaderboardData():Map<Leaderboard, LeaderboardData>
@@ -19,21 +20,8 @@ class Leaderboards
       trace('[NEWGROUNDS] Not logged in, cannot fetch medal data!');
       return [];
     }
-    else
-    {
-      var result:Map<Leaderboard, LeaderboardData> = [];
 
-      for (leaderboardId in leaderboardList.keys())
-      {
-        var leaderboardData = leaderboardList.get(leaderboardId);
-        if (leaderboardData == null) continue;
-
-        // A little hacky, but it works.
-        result.set(cast leaderboardId, leaderboardData);
-      }
-
-      return result;
-    }
+    return @:privateAccess leaderboardList._map?.copy() ?? [];
   }
 
   /**
@@ -74,7 +62,7 @@ class Leaderboards
    * @param leaderboard The leaderboard to fetch scores from.
    * @param params Additional parameters for fetching the score.
    */
-  public static function requestScores(leaderboard:Leaderboard, params:RequestScoresParams)
+  public static function requestScores(leaderboard:Leaderboard, ?params:RequestScoresParams)
   {
     // Silently reject retrieving scores from unknown leaderboards.
     if (leaderboard == Leaderboard.Unknown) return;
@@ -94,12 +82,12 @@ class Leaderboards
         {
           case SUCCESS:
             trace('[NEWGROUNDS] Fetched scores!');
-            if (params?.onComplete != null) params.onComplete(leaderboardData.scores);
+            if (params != null && params.onComplete != null) params.onComplete(leaderboardData.scores);
 
           case FAIL(error):
             trace('[NEWGROUNDS] Failed to fetch scores!');
             trace(error);
-            if (params?.onFail != null) params.onFail();
+            if (params != null && params.onFail != null) params.onFail();
         }
       });
   }
@@ -192,7 +180,7 @@ typedef RequestScoresParams =
 }
 #end
 
-enum abstract Leaderboard(Int)
+enum abstract Leaderboard(Int) from Int to Int
 {
   /**
    * Represents an undefined or invalid leaderboard.

--- a/source/funkin/api/newgrounds/Medals.hx
+++ b/source/funkin/api/newgrounds/Medals.hx
@@ -8,6 +8,7 @@ import openfl.display.BitmapData;
 import io.newgrounds.utils.MedalList;
 import haxe.Json;
 
+@:nullSafety
 class Medals
 {
   public static var medalJSON:Array<MedalJSON> = [];
@@ -21,22 +22,8 @@ class Medals
       trace('[NEWGROUNDS] Not logged in, cannot fetch medal data!');
       return [];
     }
-    else
-    {
-      // TODO: Why do I have to do this, @:nullSafety is fucked up
-      var result:Map<Medal, MedalData> = [];
 
-      for (medalId in medalList.keys())
-      {
-        var medalData = medalList.get(medalId);
-        if (medalData == null) continue;
-
-        // A little hacky, but it works.
-        result.set(cast medalId, medalData);
-      }
-
-      return result;
-    }
+    return @:privateAccess medalList._map?.copy() ?? [];
   }
 
   public static function award(medal:Medal):Void


### PR DESCRIPTION
A tiny contribution towards #4303.

Seems like it wasn't implemented in these classes because of a compile error when retrieving values from the internal maps.
Turns out there's no need to iterate through the lists, you can just `@:privateAccess` them, and since both `Medal` and `Leaderboard` are just abstracts over integers the internal map type is compatible with them, which allows you to just return them directly.

> [!NOTE]
> ~`_map` itself and the rest of the Newgrounds API isn't null-safe so this might still cause a Null Object Reference error if either the medals or leader boards aren't fully loaded.~ I've made it fallback to an empty map just in case so this might not be a problem anymore.