### PR TITLE
Chore: Add null safety to 21 classes in `graphics` 

### DIFF
--- a/source/funkin/graphics/FlxFilteredSprite.hx
+++ b/source/funkin/graphics/FlxFilteredSprite.hx
@@ -32,6 +32,7 @@ import openfl.display._internal.CairoGraphics as GfxRenderer;
  * A modified `FlxSprite` that supports filters.
  * The name's pretty much self-explanatory.
  */
+@:nullSafety
 @:access(openfl.geom.Rectangle)
 @:access(openfl.filters.BitmapFilter)
 @:access(flixel.graphics.frames.FlxFrame)
@@ -39,12 +40,12 @@ class FlxFilteredSprite extends FlxSprite
 {
   @:noCompletion var _renderer:FlxAnimateFilterRenderer = new FlxAnimateFilterRenderer();
 
-  @:noCompletion var _filterMatrix:FlxMatrix;
+  @:noCompletion var _filterMatrix:FlxMatrix = new FlxMatrix();
 
   /**
    * An `Array` of shader filters (aka `BitmapFilter`).
    */
-  public var filters(default, set):Array<BitmapFilter>;
+  public var filters(default, set):Null<Array<BitmapFilter>>;
 
   /**
    * a flag to update the image with the filters.
@@ -52,11 +53,15 @@ class FlxFilteredSprite extends FlxSprite
    */
   public var filterDirty:Bool = false;
 
-  @:noCompletion var filtered:Bool;
+  @:noCompletion var filtered:Bool = false;
 
+  // These appear to be a little troublesome to null safe.
+  @:nullSafety(Off)
   @:noCompletion var _blankFrame:FlxFrame;
 
+  @:nullSafety(Off)
   var _filterBmp1:BitmapData;
+  @:nullSafety(Off)
   var _filterBmp2:BitmapData;
 
   override public function update(elapsed:Float)
@@ -162,6 +167,7 @@ class FlxFilteredSprite extends FlxSprite
       }
       _flashRect.width += frameWidth;
       _flashRect.height += frameHeight;
+      @:nullSafety(Off)
       if (_blankFrame == null) _blankFrame = new FlxFrame(null);
 
       if (_blankFrame.parent == null || _flashRect.width > _blankFrame.parent.width || _flashRect.height > _blankFrame.parent.height)
@@ -178,6 +184,7 @@ class FlxFilteredSprite extends FlxSprite
         _filterBmp2 = new BitmapData(_blankFrame.parent.width, _blankFrame.parent.height, 0);
       }
       _blankFrame.offset.copyFrom(_frame.offset);
+      @:nullSafety(Off)
       _blankFrame.parent.bitmap = _renderer.applyFilter(_blankFrame.parent.bitmap, _filterBmp1, _filterBmp2, frame.parent.bitmap, filters, _flashRect,
         frame.frame.copyToFlash());
       _blankFrame.frame = FlxRect.get(0, 0, _blankFrame.parent.bitmap.width, _blankFrame.parent.bitmap.height);
@@ -193,7 +200,7 @@ class FlxFilteredSprite extends FlxSprite
   }
 
   @:noCompletion
-  function set_filters(value:Array<BitmapFilter>)
+  function set_filters(value:Null<Array<BitmapFilter>>)
   {
     if (filters != value) filterDirty = true;
 

--- a/source/funkin/graphics/FunkinSprite.hx
+++ b/source/funkin/graphics/FunkinSprite.hx
@@ -17,6 +17,7 @@ import flixel.FlxCamera;
  * - A more efficient method for creating solid color sprites.
  * - TODO: Better cache handling for textures.
  */
+@:nullSafety
 class FunkinSprite extends FlxSprite
 {
   /**
@@ -158,9 +159,14 @@ class FunkinSprite extends FlxSprite
    * @param input The OpenFL `TextureBase` to apply
    * @return This sprite, for chaining
    */
-  public function loadTextureBase(input:TextureBase):FunkinSprite
+  public function loadTextureBase(input:TextureBase):Null<FunkinSprite>
   {
-    var inputBitmap:FixedBitmapData = FixedBitmapData.fromTexture(input);
+    var inputBitmap:Null<FixedBitmapData> = FixedBitmapData.fromTexture(input);
+    if (inputBitmap == null)
+    {
+      FlxG.log.warn('loadTextureBase - input resulted in null bitmap! $input');
+      return null;
+    }
 
     return loadBitmapData(inputBitmap);
   }
@@ -219,7 +225,7 @@ class FunkinSprite extends FlxSprite
       // Move the graphic from the previous cache to the current cache.
       var graphic = previousCachedTextures.get(key);
       previousCachedTextures.remove(key);
-      currentCachedTextures.set(key, graphic);
+      if (graphic != null) currentCachedTextures.set(key, graphic);
       return;
     }
 
@@ -271,8 +277,9 @@ class FunkinSprite extends FlxSprite
 
   static function isGraphicCached(graphic:FlxGraphic):Bool
   {
+    var result = null;
     if (graphic == null) return false;
-    var result = FlxG.bitmap.get(graphic.key);
+    result = FlxG.bitmap.get(graphic.key);
     if (result == null) return false;
     if (result != graphic)
     {
@@ -288,8 +295,9 @@ class FunkinSprite extends FlxSprite
    */
   public function isAnimationDynamic(id:String):Bool
   {
+    var animData = null;
     if (this.animation == null) return false;
-    var animData = this.animation.getByName(id);
+    animData = this.animation.getByName(id);
     if (animData == null) return false;
     return animData.numFrames > 1;
   }
@@ -428,6 +436,7 @@ class FunkinSprite extends FlxSprite
 
   public override function destroy():Void
   {
+    @:nullSafety(Off) // TODO: Remove when flixel.FlxSprite is null safed.
     frames = null;
     // Cancel all tweens so they don't continue to run on a destroyed sprite.
     // This prevents crashes.

--- a/source/funkin/graphics/adobeanimate/FlxAtlasSprite.hx
+++ b/source/funkin/graphics/adobeanimate/FlxAtlasSprite.hx
@@ -11,6 +11,7 @@ import flxanimate.animate.FlxKeyFrame;
 /**
  * A sprite which provides convenience functions for rendering a texture atlas with animations.
  */
+@:nullSafety
 class FlxAtlasSprite extends FlxAnimate
 {
   static final SETTINGS:Settings =
@@ -40,10 +41,11 @@ class FlxAtlasSprite extends FlxAnimate
    */
   public var onAnimationLoop:FlxTypedSignal<String->Void> = new FlxTypedSignal();
 
-  var currentAnimation:String;
+  var currentAnimation:String = '';
 
   var canPlayOtherAnims:Bool = true;
 
+  @:nullSafety(Off) // null safety HATES new classes atm, it'll be fixed in haxe 4.0.0?
   public function new(x:Float, y:Float, ?path:String, ?settings:Settings)
   {
     if (settings == null) settings = SETTINGS;
@@ -108,7 +110,7 @@ class FlxAtlasSprite extends FlxAnimate
 
   var _completeAnim:Bool = false;
 
-  var fr:FlxKeyFrame = null;
+  var fr:Null<FlxKeyFrame> = null;
 
   var looping:Bool = false;
 
@@ -193,8 +195,9 @@ class FlxAtlasSprite extends FlxAnimate
 
       fr = null;
     }
+    var frameLabelNames = getFrameLabelNames();
     // Only call goToFrameLabel if there is a frame label with that name. This prevents annoying warnings!
-    if (getFrameLabelNames().indexOf(id) != -1)
+    if (frameLabelNames != null && frameLabelNames.indexOf(id) != -1)
     {
       goToFrameLabel(id);
       fr = anim.getFrameLabel(id);
@@ -264,7 +267,7 @@ class FlxAtlasSprite extends FlxAnimate
     this.anim.goToFrameLabel(label);
   }
 
-  function getFrameLabelNames(?layer:haxe.extern.EitherType<Int, String>):Array<String>
+  function getFrameLabelNames(?layer:haxe.extern.EitherType<Int, String>):Null<Array<String>>
   {
     var labels = this.anim.getFrameLabels(layer);
     var array = [];
@@ -373,6 +376,7 @@ class FlxAtlasSprite extends FlxAnimate
     var prevFrame:FlxFrame = prevFrames.get(index) ?? frames.getByIndex(index).copyTo();
     prevFrames.set(index, prevFrame);
 
+    @:nullSafety(Off) // TODO: Remove this once flixel.system.frontEnds.BitmapFrontEnd has been null safed
     var frame = FlxG.bitmap.add(graphic).imageFrame.frame;
     frame.copyTo(frames.getByIndex(index));
 

--- a/source/funkin/graphics/framebuffer/BitmapDataUtil.hx
+++ b/source/funkin/graphics/framebuffer/BitmapDataUtil.hx
@@ -12,6 +12,7 @@ import openfl.filters.BitmapFilter;
 /**
  * Provides cool stuff for `BitmapData`s that have a hardware texture internally.
  */
+@:nullSafety
 @:access(openfl.display.BitmapData)
 @:access(openfl.display3D.textures.TextureBase)
 @:access(openfl.display3D.Context3D)
@@ -19,7 +20,7 @@ class BitmapDataUtil
 {
   static function getCache():{sprite:Sprite, bitmap:Bitmap}
   {
-    static var cache:{sprite:Sprite, bitmap:Bitmap} = null;
+    static var cache:Null<{sprite:Sprite, bitmap:Bitmap}> = null;
     if (cache == null)
     {
       final sprite = new Sprite();
@@ -56,7 +57,7 @@ class BitmapDataUtil
    * @param format the format if the internal texture
    * @return the bitmap
    */
-  public static function create(width:Int, height:Int, format:Context3DTextureFormat = BGRA):FixedBitmapData
+  public static function create(width:Int, height:Int, format:Context3DTextureFormat = BGRA):Null<FixedBitmapData>
   {
     final texture = Lib.current.stage.context3D.createTexture(width, height, format, true);
     return FixedBitmapData.fromTexture(texture);
@@ -83,6 +84,7 @@ class BitmapDataUtil
    * @param width the width
    * @param height the height
    */
+  @:nullSafety(Off) // the final context there is causing an error, idk how to fix it
   public static function resizeTexture(texture:TextureBase, width:Int, height:Int):Void
   {
     if (texture.__width == width && texture.__height == height) return;
@@ -101,6 +103,7 @@ class BitmapDataUtil
    * @param dst the destination bitmap
    * @param src the source bitmap
    */
+  @:nullSafety(Off) // TODO: Remove this once openfl.display.Sprite has been null safed.
   public static function copy(dst:BitmapData, src:BitmapData):Void
   {
     hardwareCheck(dst);

--- a/source/funkin/graphics/framebuffer/FixedBitmapData.hx
+++ b/source/funkin/graphics/framebuffer/FixedBitmapData.hx
@@ -10,6 +10,7 @@ import openfl.display3D.textures.TextureBase;
 /**
  * `BitmapData` is kinda broken so I fixed it.
  */
+@:nullSafety
 @:access(openfl.display3D.textures.TextureBase)
 @:access(openfl.display.OpenGLRenderer)
 class FixedBitmapData extends BitmapData
@@ -29,7 +30,7 @@ class FixedBitmapData extends BitmapData
    * @param texture the texture
    * @return the bitmap data
    */
-  public static function fromTexture(texture:TextureBase):FixedBitmapData
+  public static function fromTexture(texture:Null<TextureBase>):Null<FixedBitmapData>
   {
     if (texture == null) return null;
     final bitmapData:FixedBitmapData = new FixedBitmapData(texture.__width, texture.__height, true, 0);

--- a/source/funkin/graphics/rendering/MeshRender.hx
+++ b/source/funkin/graphics/rendering/MeshRender.hx
@@ -7,6 +7,7 @@ import flixel.util.FlxColor;
  * Yoinked from AustinEast, thanks hopefully u dont mind me using some of ur good code
  * instead of my dumbass ugly code bro
  */
+@:nullSafety
 class MeshRender extends FlxStrip
 {
   public var vertex_count(default, null):Int = 0;

--- a/source/funkin/graphics/shaders/AdjustColorShader.hx
+++ b/source/funkin/graphics/shaders/AdjustColorShader.hx
@@ -2,12 +2,13 @@ package funkin.graphics.shaders;
 
 import flixel.addons.display.FlxRuntimeShader;
 
+@:nullSafety
 class AdjustColorShader extends FlxRuntimeShader
 {
-  public var hue(default, set):Float;
-  public var saturation(default, set):Float;
-  public var brightness(default, set):Float;
-  public var contrast(default, set):Float;
+  public var hue(default, set):Float = 0;
+  public var saturation(default, set):Float = 0;
+  public var brightness(default, set):Float = 0;
+  public var contrast(default, set):Float = 0;
 
   public function new()
   {

--- a/source/funkin/graphics/shaders/BlendModeEffect.hx
+++ b/source/funkin/graphics/shaders/BlendModeEffect.hx
@@ -8,12 +8,13 @@ typedef BlendModeShader =
   var uBlendColor:ShaderParameter<Float>;
 }
 
+@:nullSafety
 class BlendModeEffect
 {
   public var shader(default, null):BlendModeShader;
 
   @:isVar
-  public var color(default, set):FlxColor;
+  public var color(default, set):FlxColor = new FlxColor();
 
   public function new(shader:BlendModeShader, color:FlxColor):Void
   {

--- a/source/funkin/graphics/shaders/BlendModesShader.hx
+++ b/source/funkin/graphics/shaders/BlendModesShader.hx
@@ -4,10 +4,11 @@ import flixel.addons.display.FlxRuntimeShader;
 import openfl.display.BitmapData;
 import openfl.display.ShaderInput;
 
+@:nullSafety
 class BlendModesShader extends FlxRuntimeShader
 {
-  public var camera:ShaderInput<BitmapData>;
-  public var cameraData:BitmapData;
+  public var camera:Null<ShaderInput<BitmapData>>;
+  public var cameraData:Null<BitmapData>;
 
   public function new()
   {

--- a/source/funkin/graphics/shaders/BlueFade.hx
+++ b/source/funkin/graphics/shaders/BlueFade.hx
@@ -5,7 +5,7 @@ import flixel.tweens.FlxTween;
 
 class BlueFade extends FlxShader
 {
-  public var fadeVal(default, set):Float;
+  public var fadeVal(default, set):Float = 1;
 
   function set_fadeVal(val:Float):Float
   {

--- a/source/funkin/graphics/shaders/GaussianBlurShader.hx
+++ b/source/funkin/graphics/shaders/GaussianBlurShader.hx
@@ -5,9 +5,10 @@ import flixel.addons.display.FlxRuntimeShader;
 /**
  * Note... not actually gaussian!
  */
+@:nullSafety
 class GaussianBlurShader extends FlxRuntimeShader
 {
-  public var amount:Float;
+  public var amount:Float = 1;
 
   public function new(amount:Float = 1.0)
   {

--- a/source/funkin/graphics/shaders/Grayscale.hx
+++ b/source/funkin/graphics/shaders/Grayscale.hx
@@ -2,6 +2,7 @@ package funkin.graphics.shaders;
 
 import flixel.addons.display.FlxRuntimeShader;
 
+@:nullSafety
 class Grayscale extends FlxRuntimeShader
 {
   public var amount:Float = 1;

--- a/source/funkin/graphics/shaders/HSVShader.hx
+++ b/source/funkin/graphics/shaders/HSVShader.hx
@@ -2,11 +2,12 @@ package funkin.graphics.shaders;
 
 import flixel.addons.display.FlxRuntimeShader;
 
+@:nullSafety
 class HSVShader extends FlxRuntimeShader
 {
-  public var hue(default, set):Float;
-  public var saturation(default, set):Float;
-  public var value(default, set):Float;
+  public var hue(default, set):Float = 1;
+  public var saturation(default, set):Float = 1;
+  public var value(default, set):Float = 1;
 
   public function new(h:Float = 1, s:Float = 1, v:Float = 1)
   {

--- a/source/funkin/graphics/shaders/InverseDotsShader.hx
+++ b/source/funkin/graphics/shaders/InverseDotsShader.hx
@@ -5,9 +5,10 @@ import flixel.addons.display.FlxRuntimeShader;
 /**
  * Create a little dotting effect.
  */
+@:nullSafety
 class InverseDotsShader extends FlxRuntimeShader
 {
-  public var amount:Float;
+  public var amount:Float = 0;
 
   public function new(amount:Float = 1.0)
   {

--- a/source/funkin/graphics/shaders/MosaicEffect.hx
+++ b/source/funkin/graphics/shaders/MosaicEffect.hx
@@ -3,6 +3,7 @@ package funkin.graphics.shaders;
 import flixel.addons.display.FlxRuntimeShader;
 import flixel.math.FlxPoint;
 
+@:nullSafety
 class MosaicEffect extends FlxRuntimeShader
 {
   public var blockSize:FlxPoint = FlxPoint.get(1.0, 1.0);

--- a/source/funkin/graphics/shaders/PuddleShader.hx
+++ b/source/funkin/graphics/shaders/PuddleShader.hx
@@ -3,6 +3,7 @@ package funkin.graphics.shaders;
 import flixel.addons.display.FlxRuntimeShader;
 import openfl.Assets;
 
+@:nullSafety
 class PuddleShader extends FlxRuntimeShader
 {
   public function new()

--- a/source/funkin/graphics/shaders/WaveShader.hx
+++ b/source/funkin/graphics/shaders/WaveShader.hx
@@ -2,6 +2,7 @@ package funkin.graphics.shaders;
 
 import flixel.system.FlxAssets.FlxShader;
 
+@:nullSafety
 class WaveShader extends FlxShader
 {
   @:glFragmentSource('

--- a/source/funkin/graphics/shaders/WiggleEffectRuntime.hx
+++ b/source/funkin/graphics/shaders/WiggleEffectRuntime.hx
@@ -18,16 +18,17 @@ enum WiggleEffectType
  * 2. Call `sprite.shader = wiggleEffect` on the target sprite.
  * 3. Call the update() method on the instance every frame.
  */
+@:nullSafety
 class WiggleEffectRuntime extends FlxRuntimeShader
 {
-  public static function getEffectTypeId(v:WiggleEffectType):Int
+  public static function getEffectTypeId(v:Null<WiggleEffectType>):Int
   {
     return WiggleEffectType.getConstructors().indexOf(Std.string(v));
   }
 
-  public var effectType(default, set):WiggleEffectType = DREAMY;
+  public var effectType(default, set):Null<WiggleEffectType> = DREAMY;
 
-  function set_effectType(v:WiggleEffectType):WiggleEffectType
+  function set_effectType(v:Null<WiggleEffectType>):Null<WiggleEffectType>
   {
     this.setInt('effectType', getEffectTypeId(v));
     return effectType = v;

--- a/source/funkin/graphics/video/FlxVideo.hx
+++ b/source/funkin/graphics/video/FlxVideo.hx
@@ -13,6 +13,7 @@ import openfl.net.NetStream;
  * This does NOT replace hxvlc, nor does hxvlc replace this.
  * hxvlc only works on desktop and does not work on HTML5!
  */
+@:nullSafety
 class FlxVideo extends FunkinSprite
 {
   var video:Video;
@@ -22,14 +23,16 @@ class FlxVideo extends FunkinSprite
   /**
    * A callback to execute when the video finishes.
    */
-  public var finishCallback:Void->Void;
+  public var finishCallback:Null<Void->Void> = null;
 
+  @:nullSafety(Off)
   public function new(videoPath:String)
   {
     super();
 
     this.videoPath = videoPath;
 
+    @:nullSafety(Off) // Why do I to do this here as well for this to build?
     makeGraphic(2, 2, FlxColor.TRANSPARENT);
 
     video = new Video();
@@ -72,7 +75,7 @@ class FlxVideo extends FunkinSprite
   }
 
   var videoAvailable:Bool = false;
-  var frameTimer:Float;
+  var frameTimer:Float = 0;
 
   static final FRAME_RATE:Float = 60;
 

--- a/source/funkin/graphics/video/FunkinVideoSprite.hx
+++ b/source/funkin/graphics/video/FunkinVideoSprite.hx
@@ -7,6 +7,7 @@ import hxvlc.flixel.FlxVideoSprite;
  * Not to be confused with FlxVideo, this is a hxvlc based video class
  * We override it simply to correct/control our volume easier.
  */
+@:nullSafety
 class FunkinVideoSprite extends FlxVideoSprite
 {
   public function new(x:Float = 0, y:Float = 0)


### PR DESCRIPTION
A contribution towards #4303

I was hoping to add it to all the classes in graphics but most of them are shaders and I don't know how to get the null safety to work with the shader code.
