### PR TITLE
Chore: Funkin null safe

### DIFF
--- a/source/funkin/Highscore.hx
+++ b/source/funkin/Highscore.hx
@@ -3,6 +3,7 @@ package funkin;
 /**
  * A core class which handles tracking score and combo for the current song.
  */
+@:nullSafety
 class Highscore
 {
   /**

--- a/source/funkin/InitState.hx
+++ b/source/funkin/InitState.hx
@@ -50,6 +50,7 @@ import funkin.api.newgrounds.NewgroundsClient;
  *
  * It should not contain any sprites or rendering.
  */
+@:nullSafety
 class InitState extends FlxState
 {
   /**
@@ -306,7 +307,7 @@ class InitState extends FlxState
    */
   function startSong(songId:String, difficultyId:String = 'normal'):Void
   {
-    var songData:funkin.play.song.Song = funkin.data.song.SongRegistry.instance.fetchEntry(songId);
+    var songData:Null<funkin.play.song.Song> = funkin.data.song.SongRegistry.instance.fetchEntry(songId);
 
     if (songData == null)
     {
@@ -343,6 +344,7 @@ class InitState extends FlxState
         PlayStatePlaylist.campaignId = 'weekend1';
     }
 
+    @:nullSafety(Off) // Cannot unify?
     LoadingState.loadPlayState(
       {
         targetSong: songData,
@@ -357,7 +359,7 @@ class InitState extends FlxState
    */
   function startLevel(levelId:String, difficultyId:String = 'normal'):Void
   {
-    var currentLevel:funkin.ui.story.Level = funkin.data.story.level.LevelRegistry.instance.fetchEntry(levelId);
+    var currentLevel:Null<funkin.ui.story.Level> = funkin.data.story.level.LevelRegistry.instance.fetchEntry(levelId);
 
     if (currentLevel == null)
     {
@@ -373,10 +375,19 @@ class InitState extends FlxState
     PlayStatePlaylist.isStoryMode = true;
     PlayStatePlaylist.campaignScore = 0;
 
-    var targetSongId:String = PlayStatePlaylist.playlistSongIds.shift();
+    var targetSongId:Null<String> = PlayStatePlaylist.playlistSongIds.shift();
 
-    var targetSong:funkin.play.song.Song = SongRegistry.instance.fetchEntry(targetSongId);
+    var targetSong:Null<funkin.play.song.Song> = null;
 
+    if (targetSongId != null) targetSong = SongRegistry.instance.fetchEntry(targetSongId);
+
+    if (targetSongId == null)
+    {
+      startGameNormally();
+      return;
+    }
+
+    @:nullSafety(Off)
     LoadingState.loadPlayState(
       {
         targetSong: targetSong,
@@ -384,6 +395,7 @@ class InitState extends FlxState
       });
   }
 
+  @:nullSafety(Off) // Meh, remove when flixel.system.debug.log.LogStyle is null safe
   function setupFlixelDebug():Void
   {
     //
@@ -463,17 +475,17 @@ class InitState extends FlxState
     #end
   }
 
-  function defineSong():String
+  function defineSong():Null<String>
   {
     return MacroUtil.getDefine('SONG');
   }
 
-  function defineLevel():String
+  function defineLevel():Null<String>
   {
     return MacroUtil.getDefine('LEVEL');
   }
 
-  function defineDifficulty():String
+  function defineDifficulty():Null<String>
   {
     return MacroUtil.getDefine('DIFFICULTY');
   }

--- a/source/funkin/Paths.hx
+++ b/source/funkin/Paths.hx
@@ -6,6 +6,7 @@ import openfl.utils.AssetType;
 /**
  * A core class which handles determining asset paths.
  */
+@:nullSafety
 class Paths
 {
   static var currentLevel:Null<String> = null;
@@ -136,7 +137,7 @@ class Paths
    * @param withExtension if it should return with the audio file extension `.mp3` or `.ogg`.
    * @return String
    */
-  public static function inst(song:String, ?suffix:String = '', ?withExtension:Bool = true):String
+  public static function inst(song:String, ?suffix:String = '', withExtension:Bool = true):String
   {
     var ext:String = withExtension ? '.${Constants.EXT_SOUND}' : '';
     return 'songs:assets/songs/${song.toLowerCase()}/Inst$suffix$ext';

--- a/source/funkin/PlayerSettings.hx
+++ b/source/funkin/PlayerSettings.hx
@@ -9,12 +9,17 @@ import flixel.util.FlxSignal.FlxTypedSignal;
 /**
  * A core class which represents the current player(s) and their controls and other configuration.
  */
+@:nullSafety
 class PlayerSettings
 {
   // TODO: Finish implementation of second player.
   public static var numPlayers(default, null) = 0;
   public static var numAvatars(default, null) = 0;
+  // TODO: Making both of these null makes a lot of errors with the controls.
+  // That'd explain why unplugging input devices can cause the game to crash?
+  @:nullSafety(Off)
   public static var player1(default, null):PlayerSettings;
+  @:nullSafety(Off)
   public static var player2(default, null):PlayerSettings;
 
   public static var onAvatarAdd(default, null) = new FlxTypedSignal<PlayerSettings->Void>();
@@ -70,6 +75,7 @@ class PlayerSettings
   /**
    * Forcibly destroy the PlayerSettings singletons for each player.
    */
+  @:nullSafety(Off)
   public static function reset():Void
   {
     player1 = null;

--- a/source/funkin/Preferences.hx
+++ b/source/funkin/Preferences.hx
@@ -5,6 +5,7 @@ import funkin.save.Save;
 /**
  * A core class which provides a store of user-configurable, globally relevant values.
  */
+@:nullSafety
 class Preferences
 {
   /**
@@ -44,7 +45,7 @@ class Preferences
 
   static function get_naughtyness():Bool
   {
-    return Save?.instance?.options?.naughtyness;
+    return Save?.instance?.options?.naughtyness ?? true;
   }
 
   static function set_naughtyness(value:Bool):Bool
@@ -63,7 +64,7 @@ class Preferences
 
   static function get_downscroll():Bool
   {
-    return Save?.instance?.options?.downscroll;
+    return Save?.instance?.options?.downscroll ?? false;
   }
 
   static function set_downscroll(value:Bool):Bool
@@ -101,7 +102,7 @@ class Preferences
 
   static function get_zoomCamera():Bool
   {
-    return Save?.instance?.options?.zoomCamera;
+    return Save?.instance?.options?.zoomCamera ?? true;
   }
 
   static function set_zoomCamera(value:Bool):Bool
@@ -120,7 +121,7 @@ class Preferences
 
   static function get_debugDisplay():Bool
   {
-    return Save?.instance?.options?.debugDisplay;
+    return Save?.instance?.options?.debugDisplay ?? false;
   }
 
   static function set_debugDisplay(value:Bool):Bool
@@ -180,7 +181,7 @@ class Preferences
 
   static function get_unlockedFramerate():Bool
   {
-    return Save?.instance?.options?.unlockedFramerate;
+    return Save?.instance?.options?.unlockedFramerate ?? false;
   }
 
   static function set_unlockedFramerate(value:Bool):Bool


### PR DESCRIPTION
A small contribution towards #4303

Null safety added to 

`Highscore`
`InitState` (Partial)
`Paths`
`PlayerSettings` (Partial)
`Preferences`