### PR TITLE
[BUGFIX] Prevent the game from Crashing when Hot-Reloading during Dialogue

### DIFF
--- a/source/funkin/play/PlayState.hx
+++ b/source/funkin/play/PlayState.hx
@@ -1421,9 +1421,10 @@ class PlayState extends MusicBeatSubState
      */
   override function reloadAssets():Void
   {
+    performCleanup();
+
     funkin.modding.PolymodHandler.forceReloadAssets();
     lastParams.targetSong = SongRegistry.instance.fetchEntry(currentSong.id);
-    this.remove(currentStage);
     LoadingState.loadPlayState(lastParams);
   }
 


### PR DESCRIPTION
## Does this PR close any issues? If so, link them below.
Fixes #4764 

## Briefly describe the issue(s) fixed.
Made it so that the game runs a `performCleanup` call before reloading the state. This also kills off any running dialogue. 

## Include any relevant screenshots or videos.

https://github.com/user-attachments/assets/af8b1719-7347-4140-adcb-4f7b3c1b340e

Note that the HaxeFlixel icons appearing is a separate issue.