### PR TITLE
[Enhancement(?)/BUGFIX] Proper Time Signature support.

### DIFF
--- a/source/funkin/Conductor.hx
+++ b/source/funkin/Conductor.hx
@@ -228,6 +228,16 @@ class Conductor
   public var currentStepTime(default, null):Float = 0;
 
   /**
+   * The measure time at before the latest time signature change.
+   */
+  public var storedPrevTimeChangeMeasureEnd(default, null):Float = 0;
+
+  /**
+   * The measure time at the start the latest time signature change.
+   */
+  public var storedCurTimeChangeMeasureStart(default, null):Float = 0;
+
+  /**
    * An offset tied to the current chart file to compensate for a delay in the instrumental.
    */
   public var instrumentalOffset:Float = 0;
@@ -427,6 +437,9 @@ class Conductor
     var oldMeasure:Float = this.currentMeasure;
     var oldBeat:Float = this.currentBeat;
     var oldStep:Float = this.currentStep;
+    var oldNumerator:Int = this.timeSignatureNumerator;
+    var oldDenominator:Int = this.timeSignatureDenominator;
+    var oldMeasureTime:Float = this.currentMeasureTime;
 
     // If the song is playing, limit the song position to the length of the song or beginning of the song.
     if (FlxG.sound.music != null && FlxG.sound.music.playing)
@@ -451,6 +464,14 @@ class Conductor
       }
     }
 
+    if (oldNumerator != timeSignatureNumerator || oldDenominator != timeSignatureDenominator)
+    {
+      // storedPrevTimeChangeMeasureEnd = oldMeasureTime;
+      storedPrevTimeChangeMeasureEnd = getTimeInSteps(currentTimeChange.timeStamp, true) / (oldNumerator * Constants.STEPS_PER_BEAT);
+      trace('[CONDUCTOR] Time signature changed from ${oldNumerator}/${oldDenominator} to ${timeSignatureNumerator}/${timeSignatureDenominator}.');
+      trace('[CONDUCTOR] Stored previous measure time end: ${storedPrevTimeChangeMeasureEnd}');
+    }
+
     if (currentTimeChange == null && bpmOverride == null && FlxG.sound.music != null)
     {
       trace('WARNING: Conductor is broken, timeChanges is empty.');
@@ -461,7 +482,12 @@ class Conductor
       this.currentStepTime = FlxMath.roundDecimal((currentTimeChange.beatTime * Constants.STEPS_PER_BEAT)
         + (this.songPosition - currentTimeChange.timeStamp) / stepLengthMs, 6);
       this.currentBeatTime = currentStepTime / Constants.STEPS_PER_BEAT;
-      this.currentMeasureTime = currentStepTime / stepsPerMeasure;
+      if (oldNumerator != timeSignatureNumerator || oldDenominator != timeSignatureDenominator)
+      {
+        storedCurTimeChangeMeasureStart = getTimeInSteps(currentTimeChange.timeStamp) / stepsPerMeasure;
+        trace('[CONDUCTOR] Stored new measure time start: ${storedCurTimeChangeMeasureStart}');
+      }
+      this.currentMeasureTime = storedPrevTimeChangeMeasureEnd + (currentStepTime / stepsPerMeasure - storedCurTimeChangeMeasureStart);
       this.currentStep = Math.floor(currentStepTime);
       this.currentBeat = Math.floor(currentBeatTime);
       this.currentMeasure = Math.floor(currentMeasureTime);
@@ -576,7 +602,7 @@ class Conductor
    * @param ms The time in milliseconds.
    * @return The time in steps.
    */
-  public function getTimeInSteps(ms:Float):Float
+  public function getTimeInSteps(ms:Float, usePreviousOne:Bool = false):Float
   {
     if (timeChanges.length == 0)
     {
@@ -588,12 +614,14 @@ class Conductor
       var resultStep:Float = 0;
 
       var lastTimeChange:SongTimeChange = timeChanges[0];
+      var i:Int = -1;
       for (timeChange in timeChanges)
       {
         if (ms >= timeChange.timeStamp)
         {
           lastTimeChange = timeChange;
           resultStep = lastTimeChange.beatTime * Constants.STEPS_PER_BEAT;
+          i++;
         }
         else
         {
@@ -602,7 +630,14 @@ class Conductor
         }
       }
 
-      var lastStepLengthMs:Float = (((Constants.SECS_PER_MIN / lastTimeChange.bpm) * Constants.MS_PER_SEC) * (4 / timeSignatureDenominator)) / Constants.STEPS_PER_BEAT;
+      // Go back a single time change if we're not using the last one.
+      if (usePreviousOne)
+      {
+        lastTimeChange = timeChanges[i - 1 < 0 ? 0 : i - 1];
+        resultStep = lastTimeChange.beatTime * Constants.STEPS_PER_BEAT;
+      }
+
+      var lastStepLengthMs:Float = (((Constants.SECS_PER_MIN / lastTimeChange.bpm) * Constants.MS_PER_SEC) * (4 / lastTimeChange.timeSignatureDen)) / Constants.STEPS_PER_BEAT;
       var resultFractionalStep:Float = (ms - lastTimeChange.timeStamp) / lastStepLengthMs;
       resultStep += resultFractionalStep;
 
@@ -641,7 +676,7 @@ class Conductor
         }
       }
 
-      var lastStepLengthMs:Float = (((Constants.SECS_PER_MIN / lastTimeChange.bpm) * Constants.MS_PER_SEC) * (4 / timeSignatureDenominator)) / Constants.STEPS_PER_BEAT;
+      var lastStepLengthMs:Float = (((Constants.SECS_PER_MIN / lastTimeChange.bpm) * Constants.MS_PER_SEC) * (4 / lastTimeChange.timeSignatureDen)) / Constants.STEPS_PER_BEAT;
       resultMs += (stepTime - lastTimeChange.beatTime * Constants.STEPS_PER_BEAT) * lastStepLengthMs;
 
       return resultMs;
@@ -679,7 +714,7 @@ class Conductor
         }
       }
 
-      var lastStepLengthMs:Float = (((Constants.SECS_PER_MIN / lastTimeChange.bpm) * Constants.MS_PER_SEC) * (4 / timeSignatureDenominator)) / Constants.STEPS_PER_BEAT;
+      var lastStepLengthMs:Float = (((Constants.SECS_PER_MIN / lastTimeChange.bpm) * Constants.MS_PER_SEC) * (4 / lastTimeChange.timeSignatureDen)) / Constants.STEPS_PER_BEAT;
       resultMs += (beatTime - lastTimeChange.beatTime) * lastStepLengthMs * Constants.STEPS_PER_BEAT;
 
       return resultMs;

--- a/source/funkin/Conductor.hx
+++ b/source/funkin/Conductor.hx
@@ -228,16 +228,6 @@ class Conductor
   public var currentStepTime(default, null):Float = 0;
 
   /**
-   * The measure time at before the latest time signature change.
-   */
-  public var storedPrevTimeChangeMeasureEnd(default, null):Float = 0;
-
-  /**
-   * The measure time at the start the latest time signature change.
-   */
-  public var storedCurTimeChangeMeasureStart(default, null):Float = 0;
-
-  /**
    * An offset tied to the current chart file to compensate for a delay in the instrumental.
    */
   public var instrumentalOffset:Float = 0;

--- a/source/funkin/Conductor.hx
+++ b/source/funkin/Conductor.hx
@@ -16,20 +16,32 @@ import flixel.sound.FlxSound;
 @:nullSafety
 class Conductor
 {
-  // onBeatHit is called every quarter note
-  // onStepHit is called every sixteenth note
+  // onBeatHit is called on every note determined by the denominator (4 = quarter, 8 = eighth, etc.)
+  // onStepHit is called on every note which is a quarter of a beat (4 = sixteenth, 8 = thirty-second, etc.)
   // 4/4 = 4 beats per measure = 16 steps per measure
   //   120 BPM = 120 quarter notes per minute = 2 onBeatHit per second
   //   120 BPM = 480 sixteenth notes per minute = 8 onStepHit per second
   //   60 BPM = 60 quarter notes per minute = 1 onBeatHit per second
   //   60 BPM = 240 sixteenth notes per minute = 4 onStepHit per second
   // 3/4 = 3 beats per measure = 12 steps per measure
-  //   (IDENTICAL TO 4/4 but shorter measure length)
+  //   (Identical to 4/4 but has a shorter measure length)
   //   120 BPM = 120 quarter notes per minute = 2 onBeatHit per second
   //   120 BPM = 480 sixteenth notes per minute = 8 onStepHit per second
   //   60 BPM = 60 quarter notes per minute = 1 onBeatHit per second
   //   60 BPM = 240 sixteenth notes per minute = 4 onStepHit per second
-  // 7/8 = 3.5 beats per measure = 14 steps per measure
+  // 7/8 = 7 beats per measure = 28 steps per measure
+  //   Beats are EIGHTH NOTES!!
+  //   (Identical to 7/4 but beats happen twice as fast)
+  //   120 BPM = 240 eighth notes per minute = 4 onBeatHit per second
+  //   120 BPM = 960 twenty-second notes per minute = 16 onStepHit per second
+  // 15/16 = 15 beats per measure = 60 steps per measure
+  //   Beats are SIXTEENTH NOTES!!
+  //   120 BPM = 480 sixteenth notes per minute = 8 onBeatHit per second
+  //   120 BPM = 1920 sixty-fourth notes per minute = 32 onStepHit per second
+  // 3/2 = 3 beats per measure = 12 steps per measure
+  //   Beats are HALF NOTES!!
+  //   120 BPM = 60 half notes per minute = 1 onBeatHit per second
+  //   120 BPM = 240 eighth notes per minute = 4 onStepHit per second
 
   /**
    * The current instance of the Conductor.
@@ -141,24 +153,24 @@ class Conductor
   }
 
   /**
-   * Duration of a beat (quarter note) in milliseconds. Calculated based on bpm.
+   * Duration of a beat in milliseconds. Calculated based on bpm.
    */
   public var beatLengthMs(get, never):Float;
 
   function get_beatLengthMs():Float
   {
     // Tied directly to BPM.
-    return ((Constants.SECS_PER_MIN / bpm) * Constants.MS_PER_SEC);
+    return ((Constants.SECS_PER_MIN / bpm) * Constants.MS_PER_SEC) * (4 / timeSignatureDenominator);
   }
 
   /**
-   * Duration of a step (sixtennth note) in milliseconds. Calculated based on bpm.
+   * Duration of a step in milliseconds. Calculated based on bpm.
    */
   public var stepLengthMs(get, never):Float;
 
   function get_stepLengthMs():Float
   {
-    return beatLengthMs / timeSignatureNumerator;
+    return beatLengthMs / Constants.STEPS_PER_BEAT;
   }
 
   /**
@@ -227,7 +239,7 @@ class Conductor
 
   function get_instrumentalOffsetSteps():Float
   {
-    var startingStepLengthMs:Float = ((Constants.SECS_PER_MIN / startingBPM) * Constants.MS_PER_SEC) / timeSignatureNumerator;
+    var startingStepLengthMs:Float = (((Constants.SECS_PER_MIN / startingBPM) * Constants.MS_PER_SEC) * (4 / timeSignatureDenominator)) / Constants.STEPS_PER_BEAT;
 
     return instrumentalOffset / startingStepLengthMs;
   }
@@ -283,26 +295,23 @@ class Conductor
   }
 
   /**
-   * The number of beats in a measure. May be fractional depending on the time signature.
+   * The number of beats in a measure.
    */
   public var beatsPerMeasure(get, never):Float;
 
   function get_beatsPerMeasure():Float
   {
-    // NOTE: Not always an integer, for example 7/8 is 3.5 beats per measure
-    return stepsPerMeasure / Constants.STEPS_PER_BEAT;
+    return timeSignatureNumerator;
   }
 
   /**
    * The number of steps in a measure.
-   * TODO: I don't think this can be fractional?
    */
   public var stepsPerMeasure(get, never):Int;
 
   function get_stepsPerMeasure():Int
   {
-    // TODO: Is this always an integer?
-    return Std.int(timeSignatureNumerator / timeSignatureDenominator * Constants.STEPS_PER_BEAT * Constants.STEPS_PER_BEAT);
+    return Std.int(timeSignatureNumerator * Constants.STEPS_PER_BEAT);
   }
 
   /**
@@ -593,7 +602,7 @@ class Conductor
         }
       }
 
-      var lastStepLengthMs:Float = ((Constants.SECS_PER_MIN / lastTimeChange.bpm) * Constants.MS_PER_SEC) / timeSignatureNumerator;
+      var lastStepLengthMs:Float = (((Constants.SECS_PER_MIN / lastTimeChange.bpm) * Constants.MS_PER_SEC) * (4 / timeSignatureDenominator)) / Constants.STEPS_PER_BEAT;
       var resultFractionalStep:Float = (ms - lastTimeChange.timeStamp) / lastStepLengthMs;
       resultStep += resultFractionalStep;
 
@@ -632,7 +641,7 @@ class Conductor
         }
       }
 
-      var lastStepLengthMs:Float = ((Constants.SECS_PER_MIN / lastTimeChange.bpm) * Constants.MS_PER_SEC) / timeSignatureNumerator;
+      var lastStepLengthMs:Float = (((Constants.SECS_PER_MIN / lastTimeChange.bpm) * Constants.MS_PER_SEC) * (4 / timeSignatureDenominator)) / Constants.STEPS_PER_BEAT;
       resultMs += (stepTime - lastTimeChange.beatTime * Constants.STEPS_PER_BEAT) * lastStepLengthMs;
 
       return resultMs;
@@ -670,7 +679,7 @@ class Conductor
         }
       }
 
-      var lastStepLengthMs:Float = ((Constants.SECS_PER_MIN / lastTimeChange.bpm) * Constants.MS_PER_SEC) / timeSignatureNumerator;
+      var lastStepLengthMs:Float = (((Constants.SECS_PER_MIN / lastTimeChange.bpm) * Constants.MS_PER_SEC) * (4 / timeSignatureDenominator)) / Constants.STEPS_PER_BEAT;
       resultMs += (beatTime - lastTimeChange.beatTime) * lastStepLengthMs * Constants.STEPS_PER_BEAT;
 
       return resultMs;

--- a/source/funkin/Conductor.hx
+++ b/source/funkin/Conductor.hx
@@ -437,9 +437,6 @@ class Conductor
     var oldMeasure:Float = this.currentMeasure;
     var oldBeat:Float = this.currentBeat;
     var oldStep:Float = this.currentStep;
-    var oldNumerator:Int = this.timeSignatureNumerator;
-    var oldDenominator:Int = this.timeSignatureDenominator;
-    var oldMeasureTime:Float = this.currentMeasureTime;
 
     // If the song is playing, limit the song position to the length of the song or beginning of the song.
     if (FlxG.sound.music != null && FlxG.sound.music.playing)
@@ -464,14 +461,6 @@ class Conductor
       }
     }
 
-    if (oldNumerator != timeSignatureNumerator || oldDenominator != timeSignatureDenominator)
-    {
-      // storedPrevTimeChangeMeasureEnd = oldMeasureTime;
-      storedPrevTimeChangeMeasureEnd = getTimeInSteps(currentTimeChange.timeStamp, true) / (oldNumerator * Constants.STEPS_PER_BEAT);
-      trace('[CONDUCTOR] Time signature changed from ${oldNumerator}/${oldDenominator} to ${timeSignatureNumerator}/${timeSignatureDenominator}.');
-      trace('[CONDUCTOR] Stored previous measure time end: ${storedPrevTimeChangeMeasureEnd}');
-    }
-
     if (currentTimeChange == null && bpmOverride == null && FlxG.sound.music != null)
     {
       trace('WARNING: Conductor is broken, timeChanges is empty.');
@@ -482,12 +471,7 @@ class Conductor
       this.currentStepTime = FlxMath.roundDecimal((currentTimeChange.beatTime * Constants.STEPS_PER_BEAT)
         + (this.songPosition - currentTimeChange.timeStamp) / stepLengthMs, 6);
       this.currentBeatTime = currentStepTime / Constants.STEPS_PER_BEAT;
-      if (oldNumerator != timeSignatureNumerator || oldDenominator != timeSignatureDenominator)
-      {
-        storedCurTimeChangeMeasureStart = getTimeInSteps(currentTimeChange.timeStamp) / stepsPerMeasure;
-        trace('[CONDUCTOR] Stored new measure time start: ${storedCurTimeChangeMeasureStart}');
-      }
-      this.currentMeasureTime = storedPrevTimeChangeMeasureEnd + (currentStepTime / stepsPerMeasure - storedCurTimeChangeMeasureStart);
+      this.currentMeasureTime = getMeasureTime(songPos);
       this.currentStep = Math.floor(currentStepTime);
       this.currentBeat = Math.floor(currentBeatTime);
       this.currentMeasure = Math.floor(currentMeasureTime);
@@ -580,7 +564,8 @@ class Conductor
         {
           var prevTimeChange:SongTimeChange = timeChanges[timeChanges.length - 1];
           songTimeChange.beatTime = FlxMath.roundDecimal(prevTimeChange.beatTime
-            + ((songTimeChange.timeStamp - prevTimeChange.timeStamp) * prevTimeChange.bpm / Constants.SECS_PER_MIN / Constants.MS_PER_SEC),
+            +
+            ((songTimeChange.timeStamp - prevTimeChange.timeStamp) * prevTimeChange.bpm / Constants.SECS_PER_MIN / Constants.MS_PER_SEC * (prevTimeChange.timeSignatureDen / 4)),
             4);
         }
       }
@@ -598,11 +583,57 @@ class Conductor
   }
 
   /**
+   * Calculates the measure time for a given time in milliseconds.
+   * @param ms The time in milliseconds.
+   * @return The time in measures.
+   */
+  public function getMeasureTime(ms:Float):Float
+  {
+    if (timeChanges.length == 0)
+    {
+      // Assume a constant BPM equal to the forced value.
+      return ms / stepLengthMs / stepsPerMeasure;
+    }
+    else
+    {
+      var resultMeasureTime:Float = 0;
+
+      var lastTimeChange:SongTimeChange = timeChanges[0];
+      var i:Int = -1;
+      for (timeChange in timeChanges)
+      {
+        if (ms >= timeChange.timeStamp)
+        {
+          // We do NOT want to add the current time change's MEASURE LENGTH to the result, same for if we're inside the song's last time change.
+          if (ms < timeChange.timeStamp || i == timeChanges.length - 1)
+          {
+            // However, we still want this for the ending calculation.
+            lastTimeChange = timeChange;
+            break;
+          }
+          var currentStepLengthMs:Float = (((Constants.SECS_PER_MIN / lastTimeChange.bpm) * Constants.MS_PER_SEC) * (4 / lastTimeChange.timeSignatureDen)) / Constants.STEPS_PER_BEAT;
+          var currentStepsPerMeasure:Int = lastTimeChange.timeSignatureNum * Constants.STEPS_PER_BEAT;
+          resultMeasureTime += (timeChange.timeStamp - lastTimeChange.timeStamp) / currentStepLengthMs / currentStepsPerMeasure;
+          lastTimeChange = timeChange;
+        }
+        i++;
+      }
+
+      var remainingStepLengthMs:Float = (((Constants.SECS_PER_MIN / lastTimeChange.bpm) * Constants.MS_PER_SEC) * (4 / lastTimeChange.timeSignatureDen)) / Constants.STEPS_PER_BEAT;
+      var remainingStepsPerMeasure:Int = lastTimeChange.timeSignatureNum * Constants.STEPS_PER_BEAT;
+      var remainingFractionalMeasure:Float = (ms - lastTimeChange.timeStamp) / remainingStepLengthMs / remainingStepsPerMeasure;
+      resultMeasureTime += remainingFractionalMeasure;
+
+      return resultMeasureTime;
+    }
+  }
+
+  /**
    * Given a time in milliseconds, return a time in steps.
    * @param ms The time in milliseconds.
    * @return The time in steps.
    */
-  public function getTimeInSteps(ms:Float, usePreviousOne:Bool = false):Float
+  public function getTimeInSteps(ms:Float):Float
   {
     if (timeChanges.length == 0)
     {
@@ -619,29 +650,24 @@ class Conductor
       {
         if (ms >= timeChange.timeStamp)
         {
+          // We do NOT want to add the current time change's STEP LENGTH to the result, same for if we're inside the song's last time change.
+          if (ms < timeChange.timeStamp || i == timeChanges.length - 1)
+          {
+            // However, we still want this for the ending calculation.
+            lastTimeChange = timeChange;
+            break;
+          }
+          resultStep += (timeChange.beatTime - lastTimeChange.beatTime) * Constants.STEPS_PER_BEAT;
           lastTimeChange = timeChange;
-          resultStep = lastTimeChange.beatTime * Constants.STEPS_PER_BEAT;
-          i++;
         }
-        else
-        {
-          // This time change is after the requested time.
-          break;
-        }
-      }
-
-      // Go back a single time change if we're not using the last one.
-      if (usePreviousOne)
-      {
-        lastTimeChange = timeChanges[i - 1 < 0 ? 0 : i - 1];
-        resultStep = lastTimeChange.beatTime * Constants.STEPS_PER_BEAT;
+        i++;
       }
 
       var lastStepLengthMs:Float = (((Constants.SECS_PER_MIN / lastTimeChange.bpm) * Constants.MS_PER_SEC) * (4 / lastTimeChange.timeSignatureDen)) / Constants.STEPS_PER_BEAT;
       var resultFractionalStep:Float = (ms - lastTimeChange.timeStamp) / lastStepLengthMs;
       resultStep += resultFractionalStep;
 
-      return resultStep;
+      return resultStep; // FIX THIS SHIT
     }
   }
 
@@ -662,24 +688,28 @@ class Conductor
       var resultMs:Float = 0;
 
       var lastTimeChange:SongTimeChange = timeChanges[0];
+      var i:Int = -1;
       for (timeChange in timeChanges)
       {
         if (stepTime >= timeChange.beatTime * Constants.STEPS_PER_BEAT)
         {
+          // We do NOT want to add the current time change's TIME LENGTH to the result, same for if we're inside the song's last time change.
+          if (stepTime < (timeChange.beatTime * Constants.STEPS_PER_BEAT) || i == timeChanges.length - 1)
+          {
+            // However, we still want this for the ending calculation.
+            lastTimeChange = timeChange;
+            break;
+          }
+          resultMs += timeChange.timeStamp - lastTimeChange.timeStamp;
           lastTimeChange = timeChange;
-          resultMs = lastTimeChange.timeStamp;
         }
-        else
-        {
-          // This time change is after the requested time.
-          break;
-        }
+        i++;
       }
 
       var lastStepLengthMs:Float = (((Constants.SECS_PER_MIN / lastTimeChange.bpm) * Constants.MS_PER_SEC) * (4 / lastTimeChange.timeSignatureDen)) / Constants.STEPS_PER_BEAT;
       resultMs += (stepTime - lastTimeChange.beatTime * Constants.STEPS_PER_BEAT) * lastStepLengthMs;
 
-      return resultMs;
+      return resultMs; // FIX THIS SHIT
     }
   }
 

--- a/source/funkin/ui/debug/charting/ChartEditorState.hx
+++ b/source/funkin/ui/debug/charting/ChartEditorState.hx
@@ -567,7 +567,7 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
 
   function get_noteSnapRatio():Float
   {
-    return BASE_QUANT / noteSnapQuant;
+    return BASE_QUANT / (noteSnapQuant * 4 / Conductor.instance.timeSignatureDenominator);
   }
 
   /**
@@ -3574,8 +3574,9 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
 
       // Let's try testing only notes within a certain range of the view area.
       // TODO: I don't think this messes up really long sustains, does it?
-      var viewAreaTopMs:Float = scrollPositionInMs - (Conductor.instance.measureLengthMs * 2); // Is 2 measures enough?
-      var viewAreaBottomMs:Float = scrollPositionInMs + (Conductor.instance.measureLengthMs * 2); // Is 2 measures enough?
+      // Only at Numerator of 1 do we need to extend the view area. Though, who makes songs with 1 beat in a measure?
+      var viewAreaTopMs:Float = scrollPositionInMs - (Conductor.instance.measureLengthMs * (Conductor.instance.timeSignatureNumerator == 1 ? 4 : 2));
+      var viewAreaBottomMs:Float = scrollPositionInMs + (Conductor.instance.measureLengthMs * (Conductor.instance.timeSignatureNumerator == 1 ? 4 : 2));
 
       // Add notes that are now visible.
       for (noteData in currentSongChartNoteData)
@@ -5129,7 +5130,7 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
 
     playbarNoteSnap.text = '1/${noteSnapQuant}';
     playbarDifficulty.text = '${selectedDifficulty.toTitleCase()}';
-    playbarBPM.text = 'BPM: ${(Conductor.instance.bpm ?? 0.0)}';
+    playbarBPM.text = 'BPM: ${(Conductor.instance.bpm ?? 0.0)} in ${Conductor.instance.timeSignatureNumerator}/${Conductor.instance.timeSignatureDenominator}';
   }
 
   function handlePlayhead():Void

--- a/source/funkin/ui/debug/charting/ChartEditorState.hx
+++ b/source/funkin/ui/debug/charting/ChartEditorState.hx
@@ -3405,7 +3405,7 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
 
         var oldStepTime:Float = Conductor.instance.currentStepTime;
         var oldSongPosition:Float = Conductor.instance.songPosition + Conductor.instance.instrumentalOffset;
-        Conductor.instance.update(audioInstTrack.time);
+        updateSongTime();
         handleHitsounds(oldSongPosition, Conductor.instance.songPosition + Conductor.instance.instrumentalOffset);
         // Resync vocals.
         if (Math.abs(audioInstTrack.time - audioVocalTrackGroup.time) > 100)
@@ -3423,7 +3423,7 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
       {
         // Else, move the entire view.
         var oldSongPosition:Float = Conductor.instance.songPosition + Conductor.instance.instrumentalOffset;
-        Conductor.instance.update(audioInstTrack.time);
+        updateSongTime();
         handleHitsounds(oldSongPosition, Conductor.instance.songPosition + Conductor.instance.instrumentalOffset);
         // Resync vocals.
         if (Math.abs(audioInstTrack.time - audioVocalTrackGroup.time) > 100)
@@ -5634,6 +5634,10 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
 
   function handleQuickWatch():Void
   {
+    FlxG.watch.addQuick('songLengthInMs', audioInstTrack?.length ?? 0.0);
+    FlxG.watch.addQuick('songLengthInSteps', Conductor.instance.getTimeInSteps(audioInstTrack?.length ?? 0.0));
+    FlxG.watch.addQuick('gridHeight', gridTiledSprite?.height ?? 0.0);
+
     FlxG.watch.addQuick('musicTime', audioInstTrack?.time ?? 0.0);
 
     FlxG.watch.addQuick('noteKindToPlace', noteKindToPlace);
@@ -6092,7 +6096,7 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
     {
       audioInstTrack.time = scrollPositionInMs + playheadPositionInMs - Conductor.instance.instrumentalOffset;
       // Update the songPosition in the Conductor.
-      Conductor.instance.update(audioInstTrack.time);
+      updateSongTime();
       audioVocalTrackGroup.time = audioInstTrack.time;
     }
 
@@ -6162,7 +6166,6 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
 
   function updateTimeSignature():Void
   {
-    // Redo the grid bitmap to be 4/4.
     this.updateTheme();
     gridTiledSprite.loadGraphic(gridBitmap);
     measureTicks.reloadTickBitmap();
@@ -6277,6 +6280,18 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
         case 1: // Opponent
           if (hitsoundVolumeOpponent > 0) this.playSound(Paths.sound('chartingSounds/hitNoteOpponent'), hitsoundVolumeOpponent);
       }
+    }
+  }
+
+  function updateSongTime():Void
+  {
+    var oldTimeSignatureNum:Int = Conductor.instance.timeSignatureNumerator;
+    var oldTimeSignatureDen:Int = Conductor.instance.timeSignatureDenominator;
+    Conductor.instance.update(audioInstTrack.time);
+    if (Conductor.instance.timeSignatureNumerator != oldTimeSignatureNum
+      || Conductor.instance.timeSignatureDenominator != oldTimeSignatureDen)
+    {
+      updateTimeSignature();
     }
   }
 

--- a/source/funkin/ui/debug/charting/ChartEditorState.hx
+++ b/source/funkin/ui/debug/charting/ChartEditorState.hx
@@ -5636,6 +5636,7 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
   {
     FlxG.watch.addQuick('songLengthInMs', audioInstTrack?.length ?? 0.0);
     FlxG.watch.addQuick('songLengthInSteps', Conductor.instance.getTimeInSteps(audioInstTrack?.length ?? 0.0));
+    FlxG.watch.addQuick('songLengthInPixels', songLengthInPixels);
     FlxG.watch.addQuick('gridHeight', gridTiledSprite?.height ?? 0.0);
 
     FlxG.watch.addQuick('musicTime', audioInstTrack?.time ?? 0.0);

--- a/source/funkin/ui/debug/charting/components/ChartEditorMeasureTicks.hx
+++ b/source/funkin/ui/debug/charting/components/ChartEditorMeasureTicks.hx
@@ -12,7 +12,7 @@ class ChartEditorMeasureTicks extends FlxTypedSpriteGroup<FlxSprite>
   var chartEditorState:ChartEditorState;
 
   var tickTiledSprite:FlxTiledSprite;
-  var measureNumber:FlxText;
+  var measureNumbers:Array<FlxText> = [];
 
   override function set_y(value:Float):Float
   {
@@ -32,11 +32,15 @@ class ChartEditorMeasureTicks extends FlxTypedSpriteGroup<FlxSprite>
     tickTiledSprite = new FlxTiledSprite(chartEditorState.measureTickBitmap, chartEditorState.measureTickBitmap.width, 1000, false, true);
     add(tickTiledSprite);
 
-    measureNumber = new FlxText(0, 0, ChartEditorState.GRID_SIZE, "1");
-    measureNumber.setFormat(Paths.font('vcr.ttf'), 20, FlxColor.WHITE);
-    measureNumber.borderStyle = FlxTextBorderStyle.OUTLINE;
-    measureNumber.borderColor = FlxColor.BLACK;
-    add(measureNumber);
+    for (i in 0...5)
+    {
+      var measureNumber = new FlxText(0, 0, ChartEditorState.GRID_SIZE, "1");
+      measureNumber.setFormat(Paths.font('vcr.ttf'), 20, FlxColor.WHITE);
+      measureNumber.borderStyle = FlxTextBorderStyle.OUTLINE;
+      measureNumber.borderColor = FlxColor.BLACK;
+      add(measureNumber);
+      measureNumbers.push(measureNumber);
+    }
   }
 
   public function reloadTickBitmap():Void
@@ -49,23 +53,27 @@ class ChartEditorMeasureTicks extends FlxTypedSpriteGroup<FlxSprite>
    */
   function updateMeasureNumber()
   {
-    if (measureNumber == null) return;
-
     var viewTopPosition = 0 - this.y;
     var viewHeight = FlxG.height - ChartEditorState.MENU_BAR_HEIGHT - ChartEditorState.PLAYBAR_HEIGHT;
     var viewBottomPosition = viewTopPosition + viewHeight;
 
-    var measureNumberInViewport = Math.floor(viewTopPosition / ChartEditorState.GRID_SIZE / Conductor.instance.stepsPerMeasure) + 1;
-    var measureNumberPosition = measureNumberInViewport * ChartEditorState.GRID_SIZE * Conductor.instance.stepsPerMeasure;
+    for (i in 0...measureNumbers.length)
+    {
+      var measureNumber:FlxText = measureNumbers[i];
+      if (measureNumber == null) continue;
 
-    measureNumber.y = measureNumberPosition + this.y;
+      var measureNumberInViewport = Math.floor(viewTopPosition / ChartEditorState.GRID_SIZE / Conductor.instance.stepsPerMeasure) + 1 + i;
+      var measureNumberPosition = measureNumberInViewport * ChartEditorState.GRID_SIZE * Conductor.instance.stepsPerMeasure;
 
-    // Show the measure number only if it isn't beneath the end of the note grid.
-    // Using measureNumber + 1 because the cut-off bar at the bottom is technically a bar, but it looks bad if a measure number shows up there.
-    if ((measureNumberInViewport + 1) < chartEditorState.songLengthInSteps / Conductor.instance.stepsPerMeasure)
-      measureNumber.text = '${measureNumberInViewport + 1}';
-    else
-      measureNumber.text = '';
+      measureNumber.y = measureNumberPosition + this.y;
+
+      // Show the measure number only if it isn't beneath the end of the note grid.
+      // Using measureNumber + 1 because the cut-off bar at the bottom is technically a bar, but it looks bad if a measure number shows up there.
+      if ((measureNumberInViewport + 1) < chartEditorState.songLengthInSteps / Conductor.instance.stepsPerMeasure)
+        measureNumber.text = '${measureNumberInViewport + 1}';
+      else
+        measureNumber.text = '';
+    }
 
     // trace(measureNumber.text + ' at ' + measureNumber.y);
   }

--- a/source/funkin/ui/debug/charting/toolboxes/ChartEditorMetadataToolbox.hx
+++ b/source/funkin/ui/debug/charting/toolboxes/ChartEditorMetadataToolbox.hx
@@ -130,7 +130,8 @@ class ChartEditorMetadataToolbox extends ChartEditorBaseToolbox
     };
 
     inputTSNum.onChange = function(event:UIEvent) {
-      var numerator:Int = Std.parseInt(event.data.text);
+      var numerator:Null<Int> = Std.parseInt(event?.data?.text);
+      if (numerator == null) return;
       var prevNumerator:Int = chartEditorState.currentSongMetadata.timeChanges[0].timeSignatureNum;
       if (numerator == prevNumerator) return;
 
@@ -139,7 +140,8 @@ class ChartEditorMetadataToolbox extends ChartEditorBaseToolbox
     }
 
     inputTSDen.onChange = function(event:UIEvent) {
-      var denominator:Int = Std.parseInt(event.data.text);
+      var denominator:Null<Int> = Std.parseInt(event?.data?.text);
+      if (denominator == null) return;
       var prevDenominator:Int = chartEditorState.currentSongMetadata.timeChanges[0].timeSignatureDen;
       if (denominator == prevDenominator) return;
 

--- a/source/funkin/ui/debug/charting/toolboxes/ChartEditorMetadataToolbox.hx
+++ b/source/funkin/ui/debug/charting/toolboxes/ChartEditorMetadataToolbox.hx
@@ -129,25 +129,23 @@ class ChartEditorMetadataToolbox extends ChartEditorBaseToolbox
       }
     };
 
-    inputTimeSignature.onChange = function(event:UIEvent) {
-      var timeSignatureStr:String = event.data.text;
-      var timeSignature = timeSignatureStr.split('/');
-      if (timeSignature.length != 2) return;
+    inputTSNum.onChange = function(event:UIEvent) {
+      var numerator:Int = Std.parseInt(event.data.text);
+      var prevNumerator:Int = chartEditorState.currentSongMetadata.timeChanges[0].timeSignatureNum;
+      if (numerator == prevNumerator) return;
 
-      var timeSignatureNum:Int = Std.parseInt(timeSignature[0]);
-      var timeSignatureDen:Int = Std.parseInt(timeSignature[1]);
-
-      var previousTimeSignatureNum:Int = chartEditorState.currentSongMetadata.timeChanges[0].timeSignatureNum;
-      var previousTimeSignatureDen:Int = chartEditorState.currentSongMetadata.timeChanges[0].timeSignatureDen;
-      if (timeSignatureNum == previousTimeSignatureNum && timeSignatureDen == previousTimeSignatureDen) return;
-
-      chartEditorState.currentSongMetadata.timeChanges[0].timeSignatureNum = timeSignatureNum;
-      chartEditorState.currentSongMetadata.timeChanges[0].timeSignatureDen = timeSignatureDen;
-
-      trace('Time signature changed to ${timeSignatureNum}/${timeSignatureDen}');
-
+      chartEditorState.currentSongMetadata.timeChanges[0].timeSignatureNum = numerator;
       chartEditorState.updateTimeSignature();
-    };
+    }
+
+    inputTSDen.onChange = function(event:UIEvent) {
+      var denominator:Int = Std.parseInt(event.data.text);
+      var prevDenominator:Int = chartEditorState.currentSongMetadata.timeChanges[0].timeSignatureDen;
+      if (denominator == prevDenominator) return;
+
+      chartEditorState.currentSongMetadata.timeChanges[0].timeSignatureDen = denominator;
+      chartEditorState.updateTimeSignature();
+    }
 
     inputScrollSpeed.onChange = function(event:UIEvent) {
       var valid:Bool = event.target.value != null && event.target.value > 0;
@@ -199,9 +197,9 @@ class ChartEditorMetadataToolbox extends ChartEditorBaseToolbox
     frameVariation.text = 'Variation: ${chartEditorState.selectedVariation.toTitleCase()}';
     frameDifficulty.text = 'Difficulty: ${chartEditorState.selectedDifficulty.toTitleCase()}';
 
-    var currentTimeSignature = '${chartEditorState.currentSongMetadata.timeChanges[0].timeSignatureNum}/${chartEditorState.currentSongMetadata.timeChanges[0].timeSignatureDen}';
-    trace('Setting time signature to ${currentTimeSignature}');
-    inputTimeSignature.value = {id: currentTimeSignature, text: currentTimeSignature};
+    inputTSNum.value = '${chartEditorState.currentSongMetadata.timeChanges[0].timeSignatureNum}';
+    inputTSDen.value = '${chartEditorState.currentSongMetadata.timeChanges[0].timeSignatureDen}';
+    trace('Setting time signature to ${chartEditorState.currentSongMetadata.timeChanges[0].timeSignatureNum}/${chartEditorState.currentSongMetadata.timeChanges[0].timeSignatureDen}');
 
     var stageId:String = chartEditorState.currentSongMetadata.playData.stage;
     var stage:Null<Stage> = StageRegistry.instance.fetchEntry(stageId);

--- a/source/funkin/util/Constants.hx
+++ b/source/funkin/util/Constants.hx
@@ -388,7 +388,7 @@ class Constants
 
   /**
    * Number of steps in a beat.
-   * One step is one 16th note and one beat is one quarter note.
+   * The note length of a step varies based on the time signature denominator.
    */
   public static final STEPS_PER_BEAT:Int = 4;
 


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->
## Does this PR close any issues? If so, link them below.
#3066 

## Things still left to fix.
- [ ] Note preview lines being in wrong places. Possibly because they do not take time signatures into count.
- [ ] Measure numbers' values shifting when passing time signature changes.
- [ ] Measure numbers' positioning.
- [ ] Measure ticks only showing the current time signature's ticks. (Might be the hardest to change.)

## Briefly describe the issue(s) fixed.
For a more indepth explanation check the issue linked above. **TL:DR** is that time signature support was added, then given up on making most of the `Conductor` classes' calculations not function properly when time signatures other then 4/4 **OR** time signature changes were thrown into the mix.

List of changes & fixes so far:

- Fixed `stepLengthMs` and `beatLengthMs` not being calculated properly with time signatures.
- Fixed `stepsPerMeasure` and `beatsPerMeasure` being calculated wrong.
- Fixed a given time changes' `beatTime` not calculating properly with time signatures.
- Fixed `Conductor.currentMeasureTime` shifting on time signature changes. This is done with a new function `getMeasureTime(ms)`
- Fixed the charting grid ending before it's meant to with time signatures existing.
- Add more measure numbers to the measure ticks because we can see more of them now with low numerators.
- Changed the BPM display in the bottom-right of the chart editor to include the current time signature.

I have fixed multiple other things that were caused by my older attempts at fixing things, so excuse me if the list above isn't the whole story.

## Include any relevant screenshots or videos.
![screenshot-2025-04-21-15-42-47](https://github.com/user-attachments/assets/54bec31d-7e1f-4904-9c0a-5fbf8f899640)
> The modified metadata window, allowing for more freedom in choosing the starting time signature.

https://github.com/user-attachments/assets/79959132-fc2d-477c-ab27-c4e279caa215
> Testing the song "7 of 8" from FNF Weekly, with 4/4 -> 2/4 -> 7/8 -> 4/4 time signature changes.

