### PR TITLE
[BUGFIX] Avoid crash when restarting song without characters.

### DIFF
--- a/source/funkin/play/PlayState.hx
+++ b/source/funkin/play/PlayState.hx
@@ -878,7 +878,6 @@ class PlayState extends MusicBeatSubState
       // so the song doesn't start too early :D
       Conductor.instance.update(-5000, false);
 
-
       // Reset camera zooming
       cameraBopIntensity = Constants.DEFAULT_BOP_INTENSITY;
       hudCameraZoomIntensity = (cameraBopIntensity - 1.0) * 2.0;
@@ -898,16 +897,9 @@ class PlayState extends MusicBeatSubState
         Countdown.performCountdown();
       });
 
-
       // Reset the health icons.
-      if (currentStage.getBoyfriend() != null)
-      {
-      currentStage.getBoyfriend().initHealthIcon(false);
-      }
-      if (currentStage.getDad() != null)
-      {
-      currentStage.getDad().initHealthIcon(true);
-      }
+      if (currentStage != null && currentStage.getBoyfriend() != null) currentStage.getBoyfriend().initHealthIcon(false);
+      if (currentStage != null && currentStage.getBoyfriend() != null) currentStage.getDad().initHealthIcon(true);
 
       needsReset = false;
     }

--- a/source/funkin/play/PlayState.hx
+++ b/source/funkin/play/PlayState.hx
@@ -899,7 +899,7 @@ class PlayState extends MusicBeatSubState
 
       // Reset the health icons.
       if (currentStage != null && currentStage.getBoyfriend() != null) currentStage.getBoyfriend().initHealthIcon(false);
-      if (currentStage != null && currentStage.getBoyfriend() != null) currentStage.getDad().initHealthIcon(true);
+      if (currentStage != null && currentStage.getDad() != null) currentStage.getDad().initHealthIcon(true);
 
       needsReset = false;
     }

--- a/source/funkin/play/PlayState.hx
+++ b/source/funkin/play/PlayState.hx
@@ -898,8 +898,8 @@ class PlayState extends MusicBeatSubState
       });
 
       // Reset the health icons.
-      if (currentStage != null && currentStage.getBoyfriend() != null) currentStage.getBoyfriend().initHealthIcon(false);
-      if (currentStage != null && currentStage.getDad() != null) currentStage.getDad().initHealthIcon(true);
+      currentStage?.getBoyfriend()?.initHealthIcon(false);
+      currentStage?.getDad()?.initHealthIcon(true);
 
       needsReset = false;
     }


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->
## Does this PR close any issues? If so, link them below.
unsure, attempted to find any but couldn't.

## Briefly describe the issue(s) fixed.
If you loaded a song that had no characters and attempted to restart the song, it would crash due to the game attempting to initialize a health icon of a non-existent character. This resolves that issue by adding a null check before attempting to re-initialize the health icon.
