### PR TITLE
[BUGFIX] Fix Medals being granted sometimes crashing the game

### DIFF
--- a/source/funkin/api/newgrounds/Medals.hx
+++ b/source/funkin/api/newgrounds/Medals.hx
@@ -67,7 +67,7 @@ class Medals
           NewgroundsMedalPlugin.play(medalData.value, medalData.name, medalGraphic);
         });
         #else
-        if (medalJSON == null) loadMedalJSON();
+        if ((medalJSON?.length ?? 0) == 0) loadMedalJSON();
         // We have to use a medal image from the game files. We use a Base64 encoded image that NG spits out.
         // TODO: Wait, don't they give us the medal icon?
 


### PR DESCRIPTION
## Does this PR close any issues? If so, link them below.
It fixes this issue (not my screenshot but posted somewhere on the VSlice network server)
![image](https://github.com/user-attachments/assets/e584b38c-ff69-454f-aba3-a7e7a39e0e04)

it hasn't been reported yet afaik

## Briefly describe the issue(s) fixed.
The `medalJSON` array is never null, so it never gets populated properly. This pr changes the check to if the length is 0.
