### PR TITLE
[BIGFIX] Fix Options not loading from Save Data

### DIFF
--- a/source/Main.hx
+++ b/source/Main.hx
@@ -62,14 +62,6 @@ class Main extends Sprite
 
   function init(?event:Event):Void
   {
-    #if web
-    // set this variable (which is a function) from the lime version at lime/_internal/backend/html5/HTML5Application.hx
-    // The framerate cap will more thoroughly initialize via Preferences in InitState.hx
-    funkin.Preferences.lockedFramerateFunction = untyped js.Syntax.code("window.requestAnimationFrame");
-    #end
-
-    WindowUtil.setVSyncMode(funkin.Preferences.vsyncMode);
-
     if (hasEventListener(Event.ADDED_TO_STAGE))
     {
       removeEventListener(Event.ADDED_TO_STAGE, init);
@@ -107,6 +99,17 @@ class Main extends Sprite
 
     // George recommends binding the save before FlxGame is created.
     Save.load();
+    
+    // Don't call anything from the preferences until the save is loaded!
+    #if web
+    // set this variable (which is a function) from the lime version at lime/_internal/backend/html5/HTML5Application.hx
+    // The framerate cap will more thoroughly initialize via Preferences in InitState.hx
+    funkin.Preferences.lockedFramerateFunction = untyped js.Syntax.code("window.requestAnimationFrame");
+    #end
+
+    WindowUtil.setVSyncMode(funkin.Preferences.vsyncMode);
+
+
     var game:FlxGame = new FlxGame(gameWidth, gameHeight, initialState, Preferences.framerate, Preferences.framerate, skipSplash, startFullscreen);
 
     // FlxG.game._customSoundTray wants just the class, it calls new from

--- a/source/funkin/Preferences.hx
+++ b/source/funkin/Preferences.hx
@@ -185,15 +185,41 @@ class Preferences
 
   static function get_vsyncMode():lime.ui.WindowVSyncMode
   {
-    return Save?.instance?.options?.vsyncMode ?? lime.ui.WindowVSyncMode.OFF;
+    var value = Save?.instance?.options?.vsyncMode ?? "Off";
+
+    return switch (value)
+    {
+      case "Off":
+        lime.ui.WindowVSyncMode.OFF;
+      case "On":
+        lime.ui.WindowVSyncMode.ON;
+      case "Adaptive":
+        lime.ui.WindowVSyncMode.ADAPTIVE;
+      default:
+        lime.ui.WindowVSyncMode.OFF;
+    };
   }
 
   static function set_vsyncMode(value:lime.ui.WindowVSyncMode):lime.ui.WindowVSyncMode
   {
+    var string;
+
+    switch (value)
+    {
+      case lime.ui.WindowVSyncMode.OFF:
+        string = "Off";
+      case lime.ui.WindowVSyncMode.ON:
+        string = "On";
+      case lime.ui.WindowVSyncMode.ADAPTIVE:
+        string = "Adaptive";
+      default:
+        string = "Off";
+    };
+
     WindowUtil.setVSyncMode(value);
 
     var save:Save = Save.instance;
-    save.options.vsyncMode = value;
+    save.options.vsyncMode = string;
     save.flush();
     return value;
   }

--- a/source/funkin/save/Save.hx
+++ b/source/funkin/save/Save.hx
@@ -115,7 +115,7 @@ class Save
           zoomCamera: true,
           debugDisplay: false,
           autoPause: true,
-          vsyncMode: lime.ui.WindowVSyncMode.OFF,
+          vsyncMode: 'Off',
           strumlineBackgroundOpacity: 0,
           autoFullscreen: false,
           inputOffset: 0,
@@ -1401,9 +1401,9 @@ typedef SaveDataOptions =
 
   /**
    * If enabled, the game will utilize VSync (or adaptive VSync) on startup.
-   * @default `OFF`
+   * @default `Off`
    */
-  var vsyncMode:lime.ui.WindowVSyncMode;
+  var vsyncMode:String;
 
   /**
    * If >0, the game will display a semi-opaque background under the notes.


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->
## Does this PR close any issues? If so, link them below.
Fixes #4803
## Briefly describe the issue(s) fixed.
The vsync mode enum was directly saved into the save data and caused it to break like the last time this was done (not that I was around when that happened) so I've instead changed it to save as a string.

Also fixes the save data loading twice by only calling preferences _after_ the save is loaded.
## Include any relevant screenshots or videos.
[Nah.](https://wiki.teamfortress.com/w/images/b/b2/Engineer_no02.wav)