### PR TITLE
[BUGFIX] Fix Countdown Stacking upon Restarting

### DIFF
--- a/source/funkin/play/PlayState.hx
+++ b/source/funkin/play/PlayState.hx
@@ -186,6 +186,11 @@ class PlayState extends MusicBeatSubState
   public var needsReset:Bool = false;
 
   /**
+   * A timer that gets active once resetting happens. Used to vwoosh in notes.
+   */
+  public var vwooshTimer:FlxTimer = new FlxTimer();
+
+  /**
    * The current 'Blueball Counter' to display in the pause menu.
    * Resets when you beat a song or go back to the main menu.
    */
@@ -803,7 +808,7 @@ class PlayState extends MusicBeatSubState
 
   public override function update(elapsed:Float):Void
   {
-    if (criticalFailure) return;
+    if (criticalFailure || vwooshTimer.active) return;
 
     super.update(elapsed);
 
@@ -878,7 +883,6 @@ class PlayState extends MusicBeatSubState
       // so the song doesn't start too early :D
       Conductor.instance.update(-5000, false);
 
-
       // Reset camera zooming
       cameraBopIntensity = Constants.DEFAULT_BOP_INTENSITY;
       hudCameraZoomIntensity = (cameraBopIntensity - 1.0) * 2.0;
@@ -888,7 +892,6 @@ class PlayState extends MusicBeatSubState
       songScore = 0;
       Highscore.tallies.combo = 0;
       // timer for vwoosh
-      var vwooshTimer = new FlxTimer();
       vwooshTimer.start(0.5, function(t:FlxTimer) {
         Conductor.instance.update(startTimestamp - Conductor.instance.combinedOffset, false);
         if (playerStrumline.notes.length == 0) playerStrumline.updateNotes();
@@ -898,15 +901,17 @@ class PlayState extends MusicBeatSubState
         Countdown.performCountdown();
       });
 
+      // Stops any existing countdown.
+      Countdown.stopCountdown();
 
       // Reset the health icons.
       if (currentStage.getBoyfriend() != null)
       {
-      currentStage.getBoyfriend().initHealthIcon(false);
+        currentStage.getBoyfriend().initHealthIcon(false);
       }
       if (currentStage.getDad() != null)
       {
-      currentStage.getDad().initHealthIcon(true);
+        currentStage.getDad().initHealthIcon(true);
       }
 
       needsReset = false;


### PR DESCRIPTION
## Does this PR close any issues? If so, link them below.
Fixes #4822 

## Briefly describe the issue(s) fixed.
This is caused by the `vwooshTimer` recently implemented, because the game simultaneously runs updating for both the timer and the countdown, causing the countdowns to be stackable.

Right now I've made it so that nothing can update while the timer is active, let me know if that should be changed.

## Include any relevant screenshots or videos.

https://github.com/user-attachments/assets/be4ad467-dc8e-4976-89e1-9fb598de6086
