### PR TITLE
[BUGFIX] Fix the song preview restarting when changing difficulties within the same variation

### DIFF
--- a/source/funkin/ui/freeplay/FreeplayState.hx
+++ b/source/funkin/ui/freeplay/FreeplayState.hx
@@ -787,7 +787,7 @@ class FreeplayState extends MusicBeatSubState
     FlxG.console.registerFunction('changeSelection', changeSelection);
 
     rememberSelection();
-    changeSelection();
+    changeSelection(0, false);
     refreshCapsuleDisplays();
   }
 
@@ -1741,6 +1741,7 @@ class FreeplayState extends MusicBeatSubState
     {
       curSelected = findClosestDiff(characterVariations, difficultiesAvailable[currentDifficultyIndex]);
       rememberedSongId = grpCapsules.members[curSelected].freeplayData?.data.id;
+      characterVariations = grpCapsules.members[curSelected].freeplayData?.data.getVariationsByCharacter(currentCharacter) ?? Constants.DEFAULT_VARIATION_LIST;
     }
 
     for (variation in characterVariations)
@@ -2045,7 +2046,7 @@ class FreeplayState extends MusicBeatSubState
     }
   }
 
-  function changeSelection(change:Int = 0):Void
+  function changeSelection(change:Int = 0, playPreview:Bool = true):Void
   {
     var prevSelected:Int = curSelected;
 
@@ -2088,7 +2089,7 @@ class FreeplayState extends MusicBeatSubState
 
     if (grpCapsules.countLiving() > 0 && !prepForNewRank)
     {
-      playCurSongPreview(daSongCapsule);
+      if (playPreview) playCurSongPreview(daSongCapsule);
       grpCapsules.members[curSelected].selected = true;
 
       // switchBackingImage(daSongCapsule.freeplayData);


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->
## Does this PR close any issues? If so, link them below.
Fixes #4821
## Briefly describe the issue(s) fixed.
The recent update changed the calls to `generateSongList` after difficulty changes to set `onlyIfChanged` to `false`. This would make them do their switching animation, but it would also call `changeSelection` which resets the song preview.

This PR fixes this issue by adding a parameter to `changeSelection` with a default value of `true`. If this value is `false`, `playCurSongPreview` won't get called. I set the call to `changeSelection` in `generateSongList` to pass in a value of `false` over the default `true`. Because `changeSelection` is called in several different places, this change doesn't cause the song preview to not restart when it should.

I also had to fix `changeDiff` to ensure its call to `playCurSongPreview` worked. When switching to erect difficulty on a song that doesn't have it, it will change the selected song to the closest song which does have it. I added in an update to `characterVariations` for the new selected song so `currentVariation` would be updated correctly.
## Include any relevant screenshots or videos.

https://github.com/user-attachments/assets/02b3b9be-ed5b-4006-a781-dbf0cbd79fc3