### PR TITLE
[BUGFIX] Fix crash when spamming enter when opening game (properly this time)

### DIFF
--- a/source/funkin/api/newgrounds/Medals.hx
+++ b/source/funkin/api/newgrounds/Medals.hx
@@ -44,7 +44,8 @@ class Medals
     if (NewgroundsClient.instance.isLoggedIn())
     {
       var medalList = NewgroundsClient.instance.medals;
-      if (medalList == null) return;
+      @:privateAccess
+      if (medalList == null || medalList._map == null) return;
 
       var medalData:Null<MedalData> = medalList.get(medal.getId());
       @:privateAccess


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->
## Does this PR close any issues? If so, link them below.
Fixes #4498.
## Briefly describe the issue(s) fixed.
Even though the medal list isn't null, its internal map can be if it can't retrieve the medals on time. This fixes it by adding a null-check to that darn map as well.
This is a bit of a band-aid fix imo but it'll serve for now.
