### PR TITLE
[ENCHANCEMENT] Additional Functionality for Playbars

### DIFF
--- a/source/funkin/ui/debug/charting/ChartEditorState.hx
+++ b/source/funkin/ui/debug/charting/ChartEditorState.hx
@@ -2842,6 +2842,10 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
       {
         noteSnapQuantIndex = BASE_QUANT_INDEX;
       }
+      if (FlxG.keys.pressed.CONTROL)
+      {
+        this.switchToolboxState(CHART_EDITOR_TOOLBOX_NOTE_DATA_LAYOUT);
+      }
       else
       {
         noteSnapQuantIndex++;
@@ -2852,7 +2856,7 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
     playbarBPM.onClick = _ -> {
       if (pressingControl())
       {
-        this.setToolboxState(CHART_EDITOR_TOOLBOX_METADATA_LAYOUT, true);
+        this.switchToolboxState(CHART_EDITOR_TOOLBOX_METADATA_LAYOUT);
       }
       else
       {
@@ -2869,7 +2873,7 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
     playbarDifficulty.onClick = _ -> {
       if (pressingControl())
       {
-        this.setToolboxState(CHART_EDITOR_TOOLBOX_DIFFICULTY_LAYOUT, true);
+        this.switchToolboxState(CHART_EDITOR_TOOLBOX_DIFFICULTY_LAYOUT);
       }
       else
       {
@@ -2881,6 +2885,10 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
     playbarDifficulty.onRightClick = _ -> {
       incrementDifficulty(1);
       this.refreshToolbox(CHART_EDITOR_TOOLBOX_DIFFICULTY_LAYOUT);
+    }
+
+    playbarSongRemaining.onClick = _ -> {
+      this.switchToolboxState(CHART_EDITOR_TOOLBOX_OFFSETS_LAYOUT);
     }
 
     // Add functionality to the menu items.

--- a/source/funkin/ui/debug/charting/handlers/ChartEditorCheckboxesHandler.hx
+++ b/source/funkin/ui/debug/charting/handlers/ChartEditorCheckboxesHandler.hx
@@ -1,0 +1,40 @@
+package funkin.ui.debug.charting.handlers;
+
+import haxe.ui.containers.menus.MenuCheckBox;
+
+/**
+ * Static functions which handle value of checkboxes for a provided ChartEditorState. Used for playbars Windows panel changes.
+ */
+@:nullSafety
+@:access(funkin.ui.debug.charting.ChartEditorState)
+class ChartEditorCheckboxesHandler
+{
+  public static function setCheckboxState(state:ChartEditorState, id:String, shown:Bool):Void
+  {
+    var checkbox:Null<MenuCheckBox> = getCheckbox(state, id);
+    if (checkbox != null)
+    {
+      checkbox.selected = shown;
+      // TODO: why it isnt changing when shown = false nothing is changing
+    }
+  }
+
+  public static function getCheckbox(state:ChartEditorState, id:String):Null<MenuCheckBox>
+  {
+    return switch (id)
+    {
+      case ChartEditorState.CHART_EDITOR_TOOLBOX_DIFFICULTY_LAYOUT:
+        state.menubarItemToggleToolboxDifficulty;
+      case ChartEditorState.CHART_EDITOR_TOOLBOX_METADATA_LAYOUT:
+        state.menubarItemToggleToolboxMetadata;
+      case ChartEditorState.CHART_EDITOR_TOOLBOX_NOTE_DATA_LAYOUT:
+        state.menubarItemToggleToolboxNoteData;
+      case ChartEditorState.CHART_EDITOR_TOOLBOX_OFFSETS_LAYOUT:
+        state.menubarItemToggleToolboxOffsets;
+      default:
+        // This happens if you try to get an unknown checkbox.
+        trace("ChartEditorCheckboxesHandler.getCheckbox() - Unknown toolbox ID for checkbox: $id");
+        null;
+    }
+  }
+}

--- a/source/funkin/ui/debug/charting/handlers/ChartEditorToolboxHandler.hx
+++ b/source/funkin/ui/debug/charting/handlers/ChartEditorToolboxHandler.hx
@@ -14,6 +14,13 @@ import funkin.ui.debug.charting.toolboxes.ChartEditorFreeplayToolbox;
 import funkin.ui.debug.charting.toolboxes.ChartEditorEventDataToolbox;
 import funkin.ui.debug.charting.toolboxes.ChartEditorNoteDataToolbox;
 import funkin.ui.debug.charting.toolboxes.ChartEditorDifficultyToolbox;
+import funkin.ui.debug.charting.handlers.ChartEditorCheckboxesHandler;
+import haxe.ui.containers.Frame;
+import haxe.ui.containers.Grid;
+import haxe.ui.containers.TreeView;
+import haxe.ui.containers.TreeViewNode;
+import haxe.ui.core.Component;
+import haxe.ui.events.UIEvent;
 
 /**
  * Static functions which handle building themed UI elements for a provided ChartEditorState.
@@ -24,7 +31,7 @@ class ChartEditorToolboxHandler
 {
   public static function setToolboxState(state:ChartEditorState, id:String, shown:Bool):Void
   {
-    FlxG.log.add("setToolbox called, value: " + shown);
+    ChartEditorCheckboxesHandler.setCheckboxState(state, id, shown);
     if (shown)
     {
       showToolbox(state, id);
@@ -37,34 +44,13 @@ class ChartEditorToolboxHandler
 
   public static function switchToolboxState(state:ChartEditorState, id:String):Void
   {
-    var toolbox:Null<CollapsibleDialog> = state.activeToolboxes.get(id);
-
-    if (toolbox == null) toolbox = initToolbox(state, id);
-
-    if (toolbox != null) {
-      var show:Bool = !toolbox.visible;
-      switch (id){
-        case ChartEditorState.CHART_EDITOR_TOOLBOX_DIFFICULTY_LAYOUT:
-          state.menubarItemToggleToolboxDifficulty.selected = show;
-        case ChartEditorState.CHART_EDITOR_TOOLBOX_METADATA_LAYOUT:
-          state.menubarItemToggleToolboxMetadata.selected = show;
-          case ChartEditorState.CHART_EDITOR_TOOLBOX_NOTE_DATA_LAYOUT:
-            state.menubarItemToggleToolboxNoteData.selected = show;
-          case ChartEditorState.CHART_EDITOR_TOOLBOX_OFFSETS_LAYOUT:
-            state.menubarItemToggleToolboxOffsets.selected = show;
-        default:
-          trace("ChartEditorToolboxHandler.switchToolboxState() - Unknown toolbox ID: $id");
-          return;
-      }
-      setToolboxState(state, id, show);
-    }
+    var toolbox:Null<CollapsibleDialog> = getToolbox(state, id);
+    if (toolbox != null) setToolboxState(state, id, !toolbox.visible);
   }
 
   public static function showToolbox(state:ChartEditorState, id:String):Void
   {
-    var toolbox:Null<CollapsibleDialog> = state.activeToolboxes.get(id);
-
-    if (toolbox == null) toolbox = initToolbox(state, id);
+    var toolbox:Null<CollapsibleDialog> = getToolbox(state, id);
 
     if (toolbox != null && !toolbox.visible)
     {
@@ -107,9 +93,7 @@ class ChartEditorToolboxHandler
 
   public static function hideToolbox(state:ChartEditorState, id:String):Void
   {
-    var toolbox:Null<CollapsibleDialog> = state.activeToolboxes.get(id);
-
-    if (toolbox == null) toolbox = initToolbox(state, id);
+    var toolbox:Null<CollapsibleDialog> = getToolbox(state, id);
 
     if (toolbox != null && toolbox.visible)
     {
@@ -126,6 +110,14 @@ class ChartEditorToolboxHandler
           onHideToolboxPlayerPreview(state, toolbox);
         case ChartEditorState.CHART_EDITOR_TOOLBOX_OPPONENT_PREVIEW_LAYOUT:
           onHideToolboxOpponentPreview(state, toolbox);
+        case ChartEditorState.CHART_EDITOR_TOOLBOX_DIFFICULTY_LAYOUT:
+          // have no particular value
+        case ChartEditorState.CHART_EDITOR_TOOLBOX_METADATA_LAYOUT:
+          //
+        case ChartEditorState.CHART_EDITOR_TOOLBOX_NOTE_DATA_LAYOUT:
+          //
+        case ChartEditorState.CHART_EDITOR_TOOLBOX_OFFSETS_LAYOUT:
+          //
         default:
           // This happens if you try to load an unknown layout.
           trace('ChartEditorToolboxHandler.hideToolbox() - Unknown toolbox ID: $id');

--- a/source/funkin/ui/debug/charting/handlers/ChartEditorToolboxHandler.hx
+++ b/source/funkin/ui/debug/charting/handlers/ChartEditorToolboxHandler.hx
@@ -24,6 +24,7 @@ class ChartEditorToolboxHandler
 {
   public static function setToolboxState(state:ChartEditorState, id:String, shown:Bool):Void
   {
+    FlxG.log.add("setToolbox called, value: " + shown);
     if (shown)
     {
       showToolbox(state, id);
@@ -34,14 +35,40 @@ class ChartEditorToolboxHandler
     }
   }
 
+  public static function switchToolboxState(state:ChartEditorState, id:String):Void
+  {
+    var toolbox:Null<CollapsibleDialog> = state.activeToolboxes.get(id);
+
+    if (toolbox == null) toolbox = initToolbox(state, id);
+
+    if (toolbox != null) {
+      var show:Bool = !toolbox.visible;
+      switch (id){
+        case ChartEditorState.CHART_EDITOR_TOOLBOX_DIFFICULTY_LAYOUT:
+          state.menubarItemToggleToolboxDifficulty.selected = show;
+        case ChartEditorState.CHART_EDITOR_TOOLBOX_METADATA_LAYOUT:
+          state.menubarItemToggleToolboxMetadata.selected = show;
+          case ChartEditorState.CHART_EDITOR_TOOLBOX_NOTE_DATA_LAYOUT:
+            state.menubarItemToggleToolboxNoteData.selected = show;
+          case ChartEditorState.CHART_EDITOR_TOOLBOX_OFFSETS_LAYOUT:
+            state.menubarItemToggleToolboxOffsets.selected = show;
+        default:
+          trace("ChartEditorToolboxHandler.switchToolboxState() - Unknown toolbox ID: $id");
+          return;
+      }
+      setToolboxState(state, id, show);
+    }
+  }
+
   public static function showToolbox(state:ChartEditorState, id:String):Void
   {
     var toolbox:Null<CollapsibleDialog> = state.activeToolboxes.get(id);
 
     if (toolbox == null) toolbox = initToolbox(state, id);
 
-    if (toolbox != null)
+    if (toolbox != null && !toolbox.visible)
     {
+      toolbox.visible = true;
       toolbox.showDialog(false);
 
       state.playSound(Paths.sound('chartingSounds/openWindow'));
@@ -84,8 +111,9 @@ class ChartEditorToolboxHandler
 
     if (toolbox == null) toolbox = initToolbox(state, id);
 
-    if (toolbox != null)
+    if (toolbox != null && toolbox.visible)
     {
+      toolbox.visible = false;
       toolbox.hideDialog(DialogButton.CANCEL);
 
       state.playSound(Paths.sound('chartingSounds/exitWindow'));

--- a/source/funkin/ui/debug/charting/import.hx
+++ b/source/funkin/ui/debug/charting/import.hx
@@ -4,6 +4,7 @@ package funkin.ui.debug.charting;
 // Apply handlers so they can be called as though they were functions in ChartEditorState
 using funkin.ui.debug.charting.handlers.ChartEditorAudioHandler;
 using funkin.ui.debug.charting.handlers.ChartEditorContextMenuHandler;
+using funkin.ui.debug.charting.handlers.ChartEditorCheckboxesHandler;
 using funkin.ui.debug.charting.handlers.ChartEditorDialogHandler;
 using funkin.ui.debug.charting.handlers.ChartEditorGamepadHandler;
 using funkin.ui.debug.charting.handlers.ChartEditorImportExportHandler;


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

## Does this PR close any issues?  
Fixes #4141

## Brief description of changes  
This PR improves Chart Editor playbars by adding on/off (open/close) logic to each element:

- **Difficulty** (`playbarDifficulty`)  
  - **Ctrl + Click** → Open/Close Difficulty Window
- **BPM** (`playbarBPM`)  
  - **Ctrl + Click** → Open/Close Metadata Window
- **Note Snap** (`playbarNoteSnap`)  
  - **Ctrl + Click** → Open/Close Note Window
- **Song Remaining Time** (`playbarSongRemaining`) (_new toolbox function, hover color added_)  
  - **Click** → Open/Close Offsets Window

### Additional Notes
> [!IMPORTANT]
> Requires related PR in the assets repository:  
  https://github.com/FunkinCrew/funkin.assets/pull/132  
  (Needed for correct tooltip UI display.)

- Based on the solution from #4143.

## Screenshots / Videos

[Video demonstration](https://github.com/user-attachments/assets/57ca91f8-b110-4934-861b-2934068d3c4b)

![Screenshot](https://github.com/user-attachments/assets/99d2430a-f54f-4d5f-a5d6-7b45f549a66e)

## Current goals / known bugs
- [ ] Before opening 'Windows' updates of checkbox values is inconsistent
- [ ] 'Windows' can open toolbox *without hesitations?* (if checkbox.selected is true it can open already closed toolbox)
- if all goals will be completed, will change to full pr.