### PR TITLE
Remove Changelog from game files

### DIFF
--- a/project.hxp
+++ b/project.hxp
@@ -773,13 +773,12 @@ class Project extends HXProject {
 		addAssetLibrary("weekend1", shouldEmbed, shouldPreload);
 		addAssetPath("assets/weekend1", "assets/weekend1", "weekend1", ["*"], exclude, shouldEmbed);
 
-		// Art asset library (where README and CHANGELOG pull from)
+		// Art asset library (where README pulls from)
 		var shouldEmbedArt = false;
 		var shouldPreloadArt = false;
 		addAssetLibrary("art", shouldEmbedArt, shouldPreloadArt);
 		addAsset("art/readme.txt", "do NOT readme.txt", "art", shouldEmbedArt);
 		addAsset("LICENSE.md", "LICENSE.md", "art", shouldEmbedArt);
-		addAsset("CHANGELOG.md", "CHANGELOG.md", "art", shouldEmbedArt);
 	}
 
   /**


### PR DESCRIPTION
## Change
Removes `CHANGELOG.md` from project.hxp

Eric mentioned potentially excluding the Changelog from the game files since it keeps getting revised after updates are released.
Perhaps we could find a better way to direct players to the latest Changelog.