### PR TITLE
[BUGFIX] Fix Countdown Stacking upon Restarting

### DIFF
--- a/source/funkin/play/PlayState.hx
+++ b/source/funkin/play/PlayState.hx
@@ -3170,6 +3170,9 @@ class PlayState extends MusicBeatSubState
       // TODO: Uncache the song.
     }
 
+    // Prevent vwoosh timer from running outside PlayState (e.g Chart Editor)
+    vwooshTimer.cancel();
+
     if (overrideMusic)
     {
       // Stop the music. Do NOT destroy it, something still references it!

--- a/source/funkin/play/PlayState.hx
+++ b/source/funkin/play/PlayState.hx
@@ -186,6 +186,11 @@ class PlayState extends MusicBeatSubState
   public var needsReset:Bool = false;
 
   /**
+   * A timer that gets active once resetting happens. Used to vwoosh in notes.
+   */
+  public var vwooshTimer:FlxTimer = new FlxTimer();
+
+  /**
    * The current 'Blueball Counter' to display in the pause menu.
    * Resets when you beat a song or go back to the main menu.
    */
@@ -803,7 +808,7 @@ class PlayState extends MusicBeatSubState
 
   public override function update(elapsed:Float):Void
   {
-    if (criticalFailure) return;
+    if (criticalFailure || vwooshTimer.active) return;
 
     super.update(elapsed);
 
@@ -887,7 +892,6 @@ class PlayState extends MusicBeatSubState
       songScore = 0;
       Highscore.tallies.combo = 0;
       // timer for vwoosh
-      var vwooshTimer = new FlxTimer();
       vwooshTimer.start(0.5, function(t:FlxTimer) {
         Conductor.instance.update(startTimestamp - Conductor.instance.combinedOffset, false);
         if (playerStrumline.notes.length == 0) playerStrumline.updateNotes();
@@ -900,6 +904,9 @@ class PlayState extends MusicBeatSubState
       // Reset the health icons.
       currentStage?.getBoyfriend()?.initHealthIcon(false);
       currentStage?.getDad()?.initHealthIcon(true);
+
+      // Stops any existing countdown.
+      Countdown.stopCountdown();
 
       needsReset = false;
     }


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->
## Does this PR close any issues? If so, link them below.
Fixes #4822, fixes https://github.com/FunkinCrew/Funkin/issues/4892, fixes #5047 
##
This is basically @KoloInDaCrib's PR #4825 redone with his permission. His commit was cherry-picked so he'll still get credit for some of the changes.

## Original Description
This is caused by the vwooshTimer recently implemented, because the game simultaneously runs updating for both the timer and the countdown, causing the countdowns to be stackable.

~~Right now I've made it so that nothing can update while the timer is active, let me know if that should be changed.~~
New Author's note: This is not the case anymore.

## Include any relevant screenshots or videos.
https://private-user-images.githubusercontent.com/67389779/437747749-be4ad467-dc8e-4976-89e1-9fb598de6086.mp4?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3NDU4ODM1NzQsIm5iZiI6MTc0NTg4MzI3NCwicGF0aCI6Ii82NzM4OTc3OS80Mzc3NDc3NDktYmU0YWQ0NjctZGM4ZS00OTc2LTg5ZTEtOWZiNTk4ZGU2MDg2Lm1wND9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNTA0MjglMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjUwNDI4VDIzMzQzNFomWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPTRlYzEwYTE0ZDdlMzZhNGNlNWRjNDdjM2JlZDliYmU5YTE3ODhkNWFlNmNjYzZhMjA1YWU4ZmQ4ZjEzMThkMzAmWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0In0.qe2IQltI90_Td-cTaIOhhVL47PjtWKyz6-A3pz-Y8OI