### PR TITLE
[BUGFIX] Fix two issues with the Random Capsule in Freeplay

### DIFF
--- a/source/funkin/ui/freeplay/FreeplayState.hx
+++ b/source/funkin/ui/freeplay/FreeplayState.hx
@@ -1717,14 +1717,14 @@ class FreeplayState extends MusicBeatSubState
   {
     touchTimer = 0;
     var previousVariation:String = currentVariation;
+    var daSong:Null<FreeplaySongData> = grpCapsules.members[curSelected].freeplayData;
 
     // Available variations for current character. We get this since bf is usually `default` variation, and `pico` is `pico`
     // but sometimes pico can be the default variation (weekend 1 songs), and bf can be `bf` variation (darnell)
-    var characterVariations:Array<String> = grpCapsules.members[curSelected].freeplayData?.data.getVariationsByCharacter(currentCharacter) ?? Constants.DEFAULT_VARIATION_LIST;
+    var characterVariations:Array<String> = daSong?.data.getVariationsByCharacter(currentCharacter) ?? Constants.DEFAULT_VARIATION_LIST;
     var difficultiesAvailable:Array<String> = allDifficulties;
     // Gets all available difficulties for our character, via our available variations
-    var songDifficulties:Array<String> = grpCapsules.members[curSelected].freeplayData?.data.listDifficulties(null,
-      characterVariations) ?? Constants.DEFAULT_DIFFICULTY_LIST;
+    var songDifficulties:Array<String> = daSong?.data.listDifficulties(null, characterVariations) ?? Constants.DEFAULT_DIFFICULTY_LIST;
 
     var currentDifficultyIndex:Int = difficultiesAvailable.indexOf(currentDifficulty);
 
@@ -1737,15 +1737,16 @@ class FreeplayState extends MusicBeatSubState
     // Update the current difficulty
     currentDifficulty = difficultiesAvailable[currentDifficultyIndex];
     // For when we change the difficulty, but the song doesn't have that difficulty!
-    if (!songDifficulties.contains(difficultiesAvailable[currentDifficultyIndex]))
+    if (daSong != null && !songDifficulties.contains(difficultiesAvailable[currentDifficultyIndex]))
     {
       curSelected = findClosestDiff(characterVariations, difficultiesAvailable[currentDifficultyIndex]);
-      rememberedSongId = grpCapsules.members[curSelected].freeplayData?.data.id;
+      daSong = grpCapsules.members[curSelected].freeplayData;
+      rememberedSongId = daSong?.data.id;
     }
 
     for (variation in characterVariations)
     {
-      if (grpCapsules.members[curSelected].freeplayData?.data.hasDifficulty(currentDifficulty, variation) ?? false)
+      if (daSong?.data.hasDifficulty(currentDifficulty, variation) ?? false)
       {
         currentVariation = variation;
         rememberedVariation = variation;
@@ -1753,7 +1754,6 @@ class FreeplayState extends MusicBeatSubState
       }
     }
 
-    var daSong:Null<FreeplaySongData> = grpCapsules.members[curSelected].freeplayData;
     if (daSong != null)
     {
       var targetSong:Null<Song> = SongRegistry.instance.fetchEntry(daSong.data.id);
@@ -2073,6 +2073,8 @@ class FreeplayState extends MusicBeatSubState
       intendedCompletion = 0.0;
       rememberedSongId = null;
       albumRoll.albumId = null;
+      changeDiff();
+      daSongCapsule.refreshDisplay();
     }
 
     for (index => capsule in grpCapsules.members)


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->
## Does this PR close any issues? If so, link them below.
Fixes #4856 and #4858.

I put the fixes for these together because the fix for the second issue doesn't work without the fix for the first. (Well it technically does, but it introduces another bug)
## Briefly describe the issue(s) fixed.

When switching to Erect difficulty while the Random capsule is selected, the selected song would change to Bopeebo Erect. This happens because the new functionality added for switching variations when a song doesn't have it doesn't check if the song is null (aka random). This causes it to execute the code to switch the selected song to the closest one that does have that variation, Bopeebo. I fixed this issue by making the game check if the song is null too before attempting to select a different song.

The second issue is when you leave Freeplay with the Random capsule selected, the difficulty displayed in the top left would always show Normal while the songs and ranks would be from the difficulty you left the menu on previously. This bug happens because there isn't a call to `changeDiff` in `changeSelection` when the selected song is null (aka random). The difficulty text displayed in the top left is updated inside the `changeDiff` function, so this needs to be called when the selected song is random for it to update properly.

## Include any relevant screenshots or videos.
Video showing both bugs fixed:

https://github.com/user-attachments/assets/97ff6d11-cb3c-46f4-832d-0ed0c2419ca8