### PR TITLE
[CHORE] Add null-safety to the Legacy Importer

### DIFF
--- a/source/funkin/data/song/importer/FNFLegacyImporter.hx
+++ b/source/funkin/data/song/importer/FNFLegacyImporter.hx
@@ -9,9 +9,10 @@ import funkin.data.song.SongData.SongTimeChange;
 import funkin.data.song.importer.FNFLegacyData;
 import funkin.data.song.importer.FNFLegacyData.LegacyNoteSection;
 
+@:nullSafety
 class FNFLegacyImporter
 {
-  public static function parseLegacyDataRaw(input:String, fileName:String = 'raw'):FNFLegacyData
+  public static function parseLegacyDataRaw(input:String, fileName:String = 'raw'):Null<FNFLegacyData>
   {
     var parser = new json2object.JsonParser<FNFLegacyData>();
     parser.ignoreUnknownVariables = true; // Set to true to ignore extra variables that might be included in the JSON.
@@ -38,16 +39,14 @@ class FNFLegacyImporter
 
     var songMetadata:SongMetadata = new SongMetadata('Import', Constants.DEFAULT_ARTIST, 'default');
 
-    var hadError:Bool = false;
-
     // Set generatedBy string for debugging.
     songMetadata.generatedBy = 'Chart Editor Import (FNF Legacy)';
 
-    songMetadata.playData.stage = songData?.song?.stageDefault ?? 'mainStage';
-    songMetadata.songName = songData?.song?.song ?? 'Import';
+    songMetadata.playData.stage = songData.song?.stageDefault ?? 'mainStage';
+    songMetadata.songName = songData.song?.song ?? 'Import';
     songMetadata.playData.difficulties = [];
 
-    if (songData?.song?.notes != null)
+    if (songData.song?.notes != null)
     {
       switch (songData.song.notes)
       {
@@ -65,7 +64,7 @@ class FNFLegacyImporter
 
     songMetadata.timeChanges = rebuildTimeChanges(songData);
 
-    songMetadata.playData.characters = new SongCharacterData(songData?.song?.player1 ?? 'bf', 'gf', songData?.song?.player2 ?? 'dad');
+    songMetadata.playData.characters = new SongCharacterData(songData.song?.player1 ?? 'bf', 'gf', songData.song?.player2 ?? 'dad');
 
     return songMetadata;
   }
@@ -76,7 +75,7 @@ class FNFLegacyImporter
 
     var songChartData:SongChartData = new SongChartData([difficulty => 1.0], [], [difficulty => []]);
 
-    if (songData?.song?.notes != null)
+    if (songData.song?.notes != null)
     {
       switch (songData.song.notes)
       {
@@ -84,7 +83,6 @@ class FNFLegacyImporter
           // One difficulty of notes.
           songChartData.notes.set(difficulty, migrateNoteSections(notes));
         case Right(difficulties):
-          var baseDifficulty = null;
           if (difficulties.easy != null) songChartData.notes.set('easy', migrateNoteSections(difficulties.easy));
           if (difficulties.normal != null) songChartData.notes.set('normal', migrateNoteSections(difficulties.normal));
           if (difficulties.hard != null) songChartData.notes.set('hard', migrateNoteSections(difficulties.hard));
@@ -124,8 +122,8 @@ class FNFLegacyImporter
         noteSections = notes;
       case Right(difficulties):
         if (difficulties.normal != null) noteSections = difficulties.normal;
-        if (difficulties.hard != null) noteSections = difficulties.normal;
-        if (difficulties.easy != null) noteSections = difficulties.normal;
+        if (difficulties.hard != null) noteSections = difficulties.hard;
+        if (difficulties.easy != null) noteSections = difficulties.easy;
     }
 
     if (noteSections == null || noteSections.length == 0) return result;
@@ -158,7 +156,7 @@ class FNFLegacyImporter
   {
     var result:Array<SongTimeChange> = [];
 
-    result.push(new SongTimeChange(0, songData?.song?.bpm ?? Constants.DEFAULT_BPM));
+    result.push(new SongTimeChange(0, songData.song?.bpm ?? Constants.DEFAULT_BPM));
 
     var noteSections = [];
     switch (songData.song.notes)
@@ -168,8 +166,8 @@ class FNFLegacyImporter
         noteSections = notes;
       case Right(difficulties):
         if (difficulties.normal != null) noteSections = difficulties.normal;
-        if (difficulties.hard != null) noteSections = difficulties.normal;
-        if (difficulties.easy != null) noteSections = difficulties.normal;
+        if (difficulties.hard != null) noteSections = difficulties.hard;
+        if (difficulties.easy != null) noteSections = difficulties.easy;
     }
 
     if (noteSections == null || noteSections.length == 0) return result;
@@ -179,7 +177,7 @@ class FNFLegacyImporter
       if (noteSection.changeBPM ?? false)
       {
         var firstNote:LegacyNote = noteSection.sectionNotes[0];
-        if (firstNote != null) result.push(new SongTimeChange(firstNote.time, noteSection.bpm));
+        if (firstNote != null) result.push(new SongTimeChange(firstNote.time, noteSection.bpm ?? Constants.DEFAULT_BPM));
       }
     }
 

--- a/source/funkin/ui/debug/charting/handlers/ChartEditorDialogHandler.hx
+++ b/source/funkin/ui/debug/charting/handlers/ChartEditorDialogHandler.hx
@@ -1100,7 +1100,14 @@ class ChartEditorDialogHandler
     onDropFile = function(pathStr:String) {
       var path:Path = new Path(pathStr);
       var selectedFileText:String = FileUtil.readStringFromPath(path.toString());
-      var selectedFileData:FNFLegacyData = FNFLegacyImporter.parseLegacyDataRaw(selectedFileText, path.toString());
+      var selectedFileData:Null<FNFLegacyData> = FNFLegacyImporter.parseLegacyDataRaw(selectedFileText, path.toString());
+
+      if (selectedFileData == null)
+      {
+        state.error('Failure', 'Failed to parse FNF chart file (${path.file}.${path.ext})');
+        return;
+      }
+
       var songMetadata:SongMetadata = FNFLegacyImporter.migrateMetadata(selectedFileData);
       var songChartData:SongChartData = FNFLegacyImporter.migrateChartData(selectedFileData);
 


### PR DESCRIPTION
A contribution towards #4303. Also fixes #4790. Well, the crash from it. If the game didn't crash from the NOR, it would've said that it failed to parse the chart file. You wouldn't be able to see exactly what error happened while parsing unless you had a console open because the `printError` function prints them as trace calls.