### PR TITLE
[ENHANCEMENT] Freeplay navigation enhancements (e.g. collapsing songs by week, variation scrolling)

### DIFF
--- a/source/funkin/data/song/SongRegistry.hx
+++ b/source/funkin/data/song/SongRegistry.hx
@@ -516,4 +516,59 @@ class SongRegistry extends BaseRegistry<Song, SongMetadata> implements ISingleto
 
     return allDifficulties;
   }
+
+  /**
+   * List all difficulties grouped by their shared variations.
+   */
+  public function listAllDiffsByVariation(characterId:String):Array<Array<String>>
+  {
+    var groups:Array<Array<String>> = [];
+    var variationToDiffs:Map<String, Array<String>> = [];
+    var character = PlayerRegistry.instance.fetchEntry(characterId);
+
+    if (character == null)
+    {
+      trace('  [WARN] Could not locate character $characterId');
+      return [Constants.DEFAULT_VARIATION_LIST.copy()];
+    }
+
+    for (songId in listEntryIds())
+    {
+      var song = fetchEntry(songId);
+      if (song == null) continue;
+
+      for (variation in song.getVariationsByCharacter(character))
+      {
+        if (!variationToDiffs.exists(variation)) variationToDiffs[variation] = [];
+        var curDiffs:Array<String> = variationToDiffs[variation] ?? [];
+
+        for (diff in song.listDifficulties(variation))
+          if (!curDiffs.contains(diff)) curDiffs.push(diff);
+      }
+    }
+
+    for (variation => diffs in variationToDiffs)
+    {
+      var foundGroup = false;
+      for (group in groups)
+      {
+        for (diff in diffs)
+        {
+          if (group.contains(diff))
+          {
+            foundGroup = true;
+          }
+          else if (foundGroup)
+          {
+            group.push(diff);
+          }
+        }
+        if (foundGroup) break;
+      }
+
+      if (!foundGroup && diffs.length > 0) groups.push(diffs);
+    }
+
+    return groups;
+  }
 }

--- a/source/funkin/data/story/level/LevelData.hx
+++ b/source/funkin/data/story/level/LevelData.hx
@@ -17,7 +17,7 @@ typedef LevelData =
   var version:String;
 
   /**
-   * The title of the level, as seen in the top corner.
+   * The title of the level, as seen in the top corner of the story menu.
    */
   var name:String;
 
@@ -47,6 +47,22 @@ typedef LevelData =
    */
   @:default(['bopeebo'])
   var songs:Array<String>;
+
+  /**
+   * The title of the level, as seen in the freeplay menu.
+   * Used when scrolling by week. `null` if unspecified.
+   */
+  @:default(null)
+  @:optional
+  var freeplayTitle:Null<String>;
+
+  /**
+   * The pixel icon of the level, as seen in the top corner.
+   * Used when scrolling by week. `null` if unspecified.
+   */
+  @:default(null)
+  @:optional
+  var freeplayIcon:Null<String>;
 
   /**
    * The background for the level behind the props.

--- a/source/funkin/input/Controls.hx
+++ b/source/funkin/input/Controls.hx
@@ -63,6 +63,9 @@ class Controls extends FlxActionSet
   var _freeplay_char_select = new FunkinAction(Action.FREEPLAY_CHAR_SELECT);
   var _freeplay_jump_to_top = new FunkinAction(Action.FREEPLAY_JUMP_TO_TOP);
   var _freeplay_jump_to_bottom = new FunkinAction(Action.FREEPLAY_JUMP_TO_BOTTOM);
+  var _freeplay_switch_remix = new FunkinAction(Action.FREEPLAY_SWITCH_REMIX);
+  var _freeplay_scroll_faster = new FunkinAction(Action.FREEPLAY_SCROLL_FASTER);
+  var _freeplay_scroll_levels = new FunkinAction(Action.FREEPLAY_SCROLL_LEVELS);
   var _cutscene_advance = new FunkinAction(Action.CUTSCENE_ADVANCE);
   var _debug_menu = new FunkinAction(Action.DEBUG_MENU);
   #if FEATURE_CHART_EDITOR
@@ -282,6 +285,46 @@ class Controls extends FlxActionSet
   inline function get_FREEPLAY_JUMP_TO_BOTTOM()
     return _freeplay_jump_to_bottom.check();
 
+  public var FREEPLAY_SCROLL_FASTER(get, never):Bool;
+
+  public var FREEPLAY_SWITCH_REMIX(get, never):Bool;
+
+  inline function get_FREEPLAY_SWITCH_REMIX()
+    return _freeplay_switch_remix.checkPressed();
+
+  public var FREEPLAY_SWITCH_REMIX_P(get, never):Bool;
+
+  inline function get_FREEPLAY_SWITCH_REMIX_P()
+    return _freeplay_switch_remix.checkJustPressed();
+
+  inline function get_FREEPLAY_SCROLL_FASTER()
+    return _freeplay_scroll_faster.checkPressed();
+
+  public var FREEPLAY_SCROLL_FASTER_P(get, never):Bool;
+
+  inline function get_FREEPLAY_SCROLL_FASTER_P()
+    return _freeplay_scroll_faster.checkJustPressed();
+
+  public var FREEPLAY_SCROLL_FASTER_R(get, never):Bool;
+
+  inline function get_FREEPLAY_SCROLL_FASTER_R()
+    return _freeplay_scroll_faster.checkJustPressed();
+
+  public var FREEPLAY_SCROLL_LEVELS(get, never):Bool;
+
+  inline function get_FREEPLAY_SCROLL_LEVELS()
+    return _freeplay_scroll_levels.checkPressed();
+
+  public var FREEPLAY_SCROLL_LEVELS_P(get, never):Bool;
+
+  inline function get_FREEPLAY_SCROLL_LEVELS_P()
+    return _freeplay_scroll_levels.checkJustPressed();
+
+  public var FREEPLAY_SCROLL_LEVELS_R(get, never):Bool;
+
+  inline function get_FREEPLAY_SCROLL_LEVELS_R()
+    return _freeplay_scroll_levels.checkJustReleased();
+
   public var CUTSCENE_ADVANCE(get, never):Bool;
 
   inline function get_CUTSCENE_ADVANCE()
@@ -473,6 +516,9 @@ class Controls extends FlxActionSet
       case FREEPLAY_CHAR_SELECT: _freeplay_char_select;
       case FREEPLAY_JUMP_TO_TOP: _freeplay_jump_to_top;
       case FREEPLAY_JUMP_TO_BOTTOM: _freeplay_jump_to_bottom;
+      case FREEPLAY_SWITCH_REMIX: _freeplay_switch_remix;
+      case FREEPLAY_SCROLL_FASTER: _freeplay_scroll_faster;
+      case FREEPLAY_SCROLL_LEVELS: _freeplay_scroll_levels;
       case CUTSCENE_ADVANCE: _cutscene_advance;
       case DEBUG_MENU: _debug_menu;
       #if FEATURE_CHART_EDITOR case DEBUG_CHART: _debug_chart; #end
@@ -557,6 +603,17 @@ class Controls extends FlxActionSet
         func(_freeplay_jump_to_top, JUST_PRESSED);
       case FREEPLAY_JUMP_TO_BOTTOM:
         func(_freeplay_jump_to_bottom, JUST_PRESSED);
+      case FREEPLAY_SWITCH_REMIX:
+        func(_freeplay_switch_remix, PRESSED);
+        func(_freeplay_switch_remix, JUST_PRESSED);
+      case FREEPLAY_SCROLL_FASTER:
+        func(_freeplay_scroll_faster, PRESSED);
+        func(_freeplay_scroll_faster, JUST_PRESSED);
+        func(_freeplay_scroll_faster, JUST_RELEASED);
+      case FREEPLAY_SCROLL_LEVELS:
+        func(_freeplay_scroll_levels, PRESSED);
+        func(_freeplay_scroll_levels, JUST_PRESSED);
+        func(_freeplay_scroll_levels, JUST_RELEASED);
       case CUTSCENE_ADVANCE:
         func(_cutscene_advance, JUST_PRESSED);
       case DEBUG_MENU:
@@ -787,6 +844,9 @@ class Controls extends FlxActionSet
     bindKeys(Control.FREEPLAY_CHAR_SELECT, getDefaultKeybinds(scheme, Control.FREEPLAY_CHAR_SELECT));
     bindKeys(Control.FREEPLAY_JUMP_TO_TOP, getDefaultKeybinds(scheme, Control.FREEPLAY_JUMP_TO_TOP));
     bindKeys(Control.FREEPLAY_JUMP_TO_BOTTOM, getDefaultKeybinds(scheme, Control.FREEPLAY_JUMP_TO_BOTTOM));
+    bindKeys(Control.FREEPLAY_SWITCH_REMIX, getDefaultKeybinds(scheme, Control.FREEPLAY_SWITCH_REMIX));
+    bindKeys(Control.FREEPLAY_SCROLL_FASTER, getDefaultKeybinds(scheme, Control.FREEPLAY_SCROLL_FASTER));
+    bindKeys(Control.FREEPLAY_SCROLL_LEVELS, getDefaultKeybinds(scheme, Control.FREEPLAY_SCROLL_LEVELS));
     bindKeys(Control.CUTSCENE_ADVANCE, getDefaultKeybinds(scheme, Control.CUTSCENE_ADVANCE));
     bindKeys(Control.DEBUG_MENU, getDefaultKeybinds(scheme, Control.DEBUG_MENU));
     #if FEATURE_CHART_EDITOR
@@ -829,6 +889,9 @@ class Controls extends FlxActionSet
           case Control.FREEPLAY_CHAR_SELECT: return [TAB];
           case Control.FREEPLAY_JUMP_TO_TOP: return [HOME];
           case Control.FREEPLAY_JUMP_TO_BOTTOM: return [END];
+          case Control.FREEPLAY_SWITCH_REMIX: return [ALT];
+          case Control.FREEPLAY_SCROLL_FASTER: return [SHIFT];
+          case Control.FREEPLAY_SCROLL_LEVELS: return [CONTROL];
           case Control.CUTSCENE_ADVANCE: return [Z, ENTER];
           case Control.DEBUG_MENU: return [GRAVEACCENT];
           #if FEATURE_CHART_EDITOR case Control.DEBUG_CHART: return []; #end
@@ -860,6 +923,9 @@ class Controls extends FlxActionSet
           case Control.FREEPLAY_CHAR_SELECT: return [TAB];
           case Control.FREEPLAY_JUMP_TO_TOP: return [HOME];
           case Control.FREEPLAY_JUMP_TO_BOTTOM: return [END];
+          case Control.FREEPLAY_SWITCH_REMIX: return [ALT];
+          case Control.FREEPLAY_SCROLL_FASTER: return [SHIFT];
+          case Control.FREEPLAY_SCROLL_LEVELS: return [CONTROL];
           case Control.CUTSCENE_ADVANCE: return [G, Z];
           case Control.DEBUG_MENU: return [GRAVEACCENT];
           #if FEATURE_CHART_EDITOR case Control.DEBUG_CHART: return []; #end
@@ -891,6 +957,9 @@ class Controls extends FlxActionSet
           case Control.FREEPLAY_CHAR_SELECT: return [];
           case Control.FREEPLAY_JUMP_TO_TOP: return [];
           case Control.FREEPLAY_JUMP_TO_BOTTOM: return [];
+          case Control.FREEPLAY_SWITCH_REMIX: return [ALT];
+          case Control.FREEPLAY_SCROLL_FASTER: return [SHIFT];
+          case Control.FREEPLAY_SCROLL_LEVELS: return [CONTROL];
           case Control.CUTSCENE_ADVANCE: return [ENTER];
           case Control.DEBUG_MENU: return [];
           #if FEATURE_CHART_EDITOR case Control.DEBUG_CHART: return []; #end
@@ -1009,6 +1078,9 @@ class Controls extends FlxActionSet
       Control.FREEPLAY_CHAR_SELECT => getDefaultGamepadBinds(Control.FREEPLAY_CHAR_SELECT),
       Control.FREEPLAY_JUMP_TO_TOP => getDefaultGamepadBinds(Control.FREEPLAY_JUMP_TO_TOP),
       Control.FREEPLAY_JUMP_TO_BOTTOM => getDefaultGamepadBinds(Control.FREEPLAY_JUMP_TO_BOTTOM),
+      Control.FREEPLAY_SWITCH_REMIX => getDefaultGamepadBinds(Control.FREEPLAY_SWITCH_REMIX),
+      Control.FREEPLAY_SCROLL_FASTER => getDefaultGamepadBinds(Control.FREEPLAY_SCROLL_FASTER),
+      Control.FREEPLAY_SCROLL_LEVELS => getDefaultGamepadBinds(Control.FREEPLAY_SCROLL_LEVELS),
       Control.VOLUME_UP => getDefaultGamepadBinds(Control.VOLUME_UP),
       Control.VOLUME_DOWN => getDefaultGamepadBinds(Control.VOLUME_DOWN),
       Control.VOLUME_MUTE => getDefaultGamepadBinds(Control.VOLUME_MUTE),
@@ -1069,6 +1141,12 @@ class Controls extends FlxActionSet
       case Control.FREEPLAY_JUMP_TO_TOP:
         return [];
       case Control.FREEPLAY_JUMP_TO_BOTTOM:
+        return [];
+      case Control.FREEPLAY_SWITCH_REMIX:
+        return [];
+      case Control.FREEPLAY_SCROLL_FASTER:
+        return [];
+      case Control.FREEPLAY_SCROLL_LEVELS:
         return [];
       case Control.VOLUME_UP:
         [];
@@ -1656,6 +1734,9 @@ enum Control
   FREEPLAY_CHAR_SELECT;
   FREEPLAY_JUMP_TO_TOP;
   FREEPLAY_JUMP_TO_BOTTOM;
+  FREEPLAY_SWITCH_REMIX;
+  FREEPLAY_SCROLL_FASTER;
+  FREEPLAY_SCROLL_LEVELS;
   // WINDOW
   #if FEATURE_SCREENSHOTS WINDOW_SCREENSHOT; #end
   WINDOW_FULLSCREEN;
@@ -1715,6 +1796,9 @@ enum abstract Action(String) to String from String
   var FREEPLAY_CHAR_SELECT = "freeplay_char_select";
   var FREEPLAY_JUMP_TO_TOP = "freeplay_jump_to_top";
   var FREEPLAY_JUMP_TO_BOTTOM = "freeplay_jump_to_bottom";
+  var FREEPLAY_SWITCH_REMIX = "freeplay_switch_remix";
+  var FREEPLAY_SCROLL_FASTER = "freeplay_scroll_faster";
+  var FREEPLAY_SCROLL_LEVELS = "freeplay_scroll_levels";
   // VOLUME
   var VOLUME_UP = "volume_up";
   var VOLUME_DOWN = "volume_down";

--- a/source/funkin/play/song/Song.hx
+++ b/source/funkin/play/song/Song.hx
@@ -689,7 +689,7 @@ class Song implements IPlayStateScriptedClass implements IRegistryEntry<SongMeta
    */
   static function validateVariationId(variation:String):Bool
   {
-    if (Constants.DEFAULT_VARIATION_LIST.contains(variation)) return true;
+    if (Constants.DEFAULT_VARIATION_LIST_FULL.contains(variation)) return true;
 
     return VARIATION_REGEX.match(variation);
   }

--- a/source/funkin/ui/freeplay/FreeplayState.hx
+++ b/source/funkin/ui/freeplay/FreeplayState.hx
@@ -167,6 +167,8 @@ class FreeplayState extends MusicBeatSubState
   public static var rememberedVariation:String = Constants.DEFAULT_VARIATION;
 
   var allDifficulties:Array<String> = Constants.DEFAULT_DIFFICULTY_LIST_FULL;
+  var allDifficultiesGrouped:Array<Array<String>> = [Constants.DEFAULT_DIFFICULTY_LIST, Constants.DEFAULT_DIFFICULTY_LIST_ERECT];
+  var difficultyGroupIndices:Map<String, Int> = [];
 
   var funnyCam:FunkinCamera;
   var rankCamera:FunkinCamera;
@@ -636,6 +638,12 @@ class FreeplayState extends MusicBeatSubState
     }
 
     allDifficulties = SongRegistry.instance.listAllDifficulties(currentCharacterId);
+    allDifficultiesGrouped = SongRegistry.instance.listAllDiffsByVariation(currentCharacterId);
+    difficultyGroupIndices = [
+      for (i in 0...allDifficultiesGrouped.length)
+        for (diff in allDifficultiesGrouped[i])
+          diff => i
+    ];
 
     // Generates song list with the starter params (who our current character is, last remembered difficulty, etc.)
     generateSongList(null, false);
@@ -687,40 +695,53 @@ class FreeplayState extends MusicBeatSubState
   {
     var tempSongs:Array<Null<FreeplaySongData>> = songs;
 
-    if (filterStuff != null) tempSongs = sortSongs(tempSongs, filterStuff);
-
-    tempSongs = tempSongs.filter(song -> {
-      if (song == null) return true; // Random
-
-      // Available variations for current character. We get this since bf is usually `default` variation, and `pico` is `pico`
-      // but sometimes pico can be the default variation (weekend 1 songs), and bf can be `bf` variation (darnell)
-      var characterVariations:Array<String> = song.data.getVariationsByCharacter(currentCharacter);
-
-      // Gets all available difficulties for our character, via our available variations
-      var difficultiesAvailable:Array<String> = song.data.listDifficulties(null, characterVariations);
-      return difficultiesAvailable.contains(currentDifficulty);
-    });
-
-    if (onlyIfChanged)
+    if (filterStuff?.filterType == LEVEL_SCROLL)
     {
-      if (tempSongs.isEqualUnordered(currentFilteredSongs))
-      {
-        // If the song list is the same, we don't need to generate a new list.
-
-        // Instead, we just apply the jump-in animation to the existing capsules.
-        for (capsule in grpCapsules.members)
-        {
-          capsule.initPosition(FlxG.width, 0);
-          capsule.initJumpIn(0, force);
-        }
-
-        // Stop processing.
-        return;
-      }
+      // Handle level scrolling. Assumes the song list was already generated before,
+      // and skips the regular flow of execution. Also, don't remember this filter.
+      tempSongs = sortSongs(currentFilteredSongs, {filterType: LEVEL_SCROLL});
     }
+    else
+    {
+      if (filterStuff != null) tempSongs = sortSongs(tempSongs, filterStuff);
 
-    // Only now do we know that the filter is actually changing.
-    currentFilter = filterStuff;
+      tempSongs = tempSongs.filter(song -> {
+        if (song == null) return true; // Random
+
+        // Available variations for current character. We get this since bf is usually `default` variation, and `pico` is `pico`
+        // but sometimes pico can be the default variation (weekend 1 songs), and bf can be `bf` variation (darnell)
+        var characterVariations:Array<String> = song.data.getVariationsByCharacter(currentCharacter);
+
+        // Gets all available difficulties for our character, via our available variations
+        var difficultiesAvailable:Array<String> = song.data.listDifficulties(null, characterVariations);
+        return difficultiesAvailable.contains(currentDifficulty);
+      });
+
+      if (onlyIfChanged)
+      {
+        if (tempSongs.isEqualUnordered(currentFilteredSongs))
+        {
+          // If the song list is the same, we don't need to generate a new list.
+
+          // Instead, we just apply the jump-in animation to the existing capsules.
+          for (capsule in grpCapsules.members)
+          {
+            capsule.initPosition(FlxG.width, 0);
+            capsule.initJumpIn(0, force);
+          }
+
+          // Stop processing.
+          return;
+        }
+      }
+
+      // Only now do we know that the filter is actually changing.
+      currentFilter = filterStuff;
+
+      // Sometimes you're still scrolling by level when the song list regenerates,
+      // like when changing difficulties. In that case, just do it again!
+      if (scrollByLevel) tempSongs = sortSongs(tempSongs, {filterType: LEVEL_SCROLL});
+    }
 
     currentFilteredSongs = tempSongs;
     curSelected = 0;
@@ -738,10 +759,6 @@ class FreeplayState extends MusicBeatSubState
     randomCapsule.y = randomCapsule.intendedY(0) + 10;
     randomCapsule.targetPos.x = randomCapsule.x;
     randomCapsule.alpha = 0;
-    randomCapsule.songText.visible = false;
-    randomCapsule.favIcon.visible = false;
-    randomCapsule.favIconBlurred.visible = false;
-    randomCapsule.ranking.visible = false;
     randomCapsule.onConfirm = function() {
       capsuleOnConfirmRandom(randomCapsule);
     };
@@ -773,6 +790,7 @@ class FreeplayState extends MusicBeatSubState
       funnyMenu.targetPos.x = funnyMenu.x;
       funnyMenu.ID = i;
       funnyMenu.capsule.alpha = 0.5;
+      funnyMenu.isLevelDisplay = scrollByLevel;
       funnyMenu.hsvShader = hsvShader;
       funnyMenu.newText.animation.curAnim.curFrame = 45 - ((i * 4) % 45);
 
@@ -826,8 +844,10 @@ class FreeplayState extends MusicBeatSubState
           if (filteredSong == null) return true; // Random
           return filteredSong.data.songName.toLowerCase().startsWith(songFilter.filterData ?? '');
         });
+
       case ALL:
         // no filter!
+
       case FAVORITE:
         songsToFilter = songsToFilter.filter(filteredSong -> {
           if (filteredSong == null) return true; // Random
@@ -835,6 +855,40 @@ class FreeplayState extends MusicBeatSubState
         });
 
         songsToFilter.sort(filterAlphabetically);
+
+      case FIRST:
+        // All the first songs of every level!
+        // Goes unused, actually.
+        songsToFilter = songsToFilter.filter(filteredSong -> {
+          if (filteredSong == null) return true; // Random
+          return filteredSong.levelIndex == 0;
+        });
+
+        songsToFilter.sort(filterAlphabetically);
+
+      case LEVEL_SCROLL:
+        // Altered version of `FIRST` for level scrolling, essentially getting the first* song in a week.
+        var currentSelection:Null<FreeplaySongData> = grpCapsules.members[curSelected].freeplayData;
+        var firstSongsInLevels:Map<String, FreeplaySongData> = [];
+
+        // Grab the smallest song index loaded.
+        for (song in songsToFilter)
+        {
+          if (song != null && song.levelId != null)
+          {
+            var levelId:String = song.levelId ?? ''; // Need this due to Haxe's null safety erroneously triggering. Thank you, Haxe
+            var firstSongIndex:Int = firstSongsInLevels[levelId]?.levelIndex ?? (song.levelIndex + 1);
+            if (firstSongIndex > song.levelIndex) firstSongsInLevels[levelId] = song;
+          }
+        }
+
+        if (currentSelection != null) firstSongsInLevels[currentSelection.levelId ?? ''] = currentSelection; // Prioritize already-picked level
+
+        // Filtering only without sorting to preserve item order.
+        songsToFilter = songsToFilter.filter(filteredSong -> {
+          if (filteredSong == null || filteredSong.levelId == null) return true; // Random
+          return filteredSong == firstSongsInLevels[filteredSong.levelId ?? ''];
+        });
 
       default:
         // return all on default
@@ -1431,6 +1485,8 @@ class FreeplayState extends MusicBeatSubState
     if (dj != null) FlxG.watch.addQuick('dj-anim', dj.getCurrentAnimation());
   }
 
+  public var scrollByLevel:Bool = false;
+
   function handleInputs(elapsed:Float):Void
   {
     if (busy) return;
@@ -1513,6 +1569,7 @@ class FreeplayState extends MusicBeatSubState
 
     if ((controls.UI_UP || controls.UI_DOWN))
     {
+      var changeFactor = controls.FREEPLAY_SCROLL_FASTER ? 3 : 1;
       if (spamming)
       {
         if (spamTimer >= 0.07)
@@ -1521,11 +1578,11 @@ class FreeplayState extends MusicBeatSubState
 
           if (controls.UI_UP)
           {
-            changeSelection(-1);
+            changeSelection(-changeFactor);
           }
           else
           {
-            changeSelection(1);
+            changeSelection(changeFactor);
           }
         }
       }
@@ -1537,11 +1594,11 @@ class FreeplayState extends MusicBeatSubState
       {
         if (controls.UI_UP)
         {
-          changeSelection(-1);
+          changeSelection(-changeFactor);
         }
         else
         {
-          changeSelection(1);
+          changeSelection(changeFactor);
         }
       }
 
@@ -1576,13 +1633,19 @@ class FreeplayState extends MusicBeatSubState
     if (controls.UI_LEFT_P)
     {
       if (dj != null) dj.resetAFKTimer();
-      changeDiff(-1);
+      changeDiff(-1, controls.FREEPLAY_SCROLL_FASTER || controls.FREEPLAY_SWITCH_REMIX);
       generateSongList(currentFilter, true, false);
     }
     if (controls.UI_RIGHT_P)
     {
       if (dj != null) dj.resetAFKTimer();
-      changeDiff(1);
+      changeDiff(1, controls.FREEPLAY_SCROLL_FASTER || controls.FREEPLAY_SWITCH_REMIX);
+      generateSongList(currentFilter, true, false);
+    }
+    if (controls.FREEPLAY_SWITCH_REMIX_P)
+    {
+      if (dj != null) dj.resetAFKTimer();
+      changeDiff(-allDifficultiesGrouped.length + 1, true); // Ensures that we land on the hardest difficulty of the group.
       generateSongList(currentFilter, true, false);
     }
 
@@ -1656,9 +1719,28 @@ class FreeplayState extends MusicBeatSubState
       });
     }
 
+    if (controls.FREEPLAY_SCROLL_LEVELS_P)
+    {
+      scrollByLevel = true;
+      generateSongList({filterType: LEVEL_SCROLL});
+    }
+    else if (controls.FREEPLAY_SCROLL_LEVELS_R && !controls.FREEPLAY_SCROLL_LEVELS)
+    {
+      scrollByLevel = false;
+      generateSongList(currentFilter, true, false);
+    }
+
     if (accepted && !busy)
     {
-      grpCapsules.members[curSelected].onConfirm();
+      if (!controls.FREEPLAY_SCROLL_LEVELS)
+      {
+        grpCapsules.members[curSelected].onConfirm();
+      }
+      else
+      {
+        if (grpCapsules.members[curSelected].freeplayData == null) changeSelection(FlxG.random.int(1, grpCapsules.length - 2));
+        FunkinSound.playOnce(Paths.sound('cancelMenu'));
+      }
     }
   }
 
@@ -1711,31 +1793,56 @@ class FreeplayState extends MusicBeatSubState
    * It will check the difficulty of the current variation, all available variations, and all available difficulties per variation.
    * It's generally recommended that after calling this you re-sort the song list, however usually it's already on the way to being sorted.
    * @param change
+   * @param changeVariation
    * @param force
    */
-  function changeDiff(change:Int = 0, force:Bool = false):Void
+  function changeDiff(change:Int = 0, changeVariation:Bool = false, force:Bool = false):Void
   {
     touchTimer = 0;
     var previousVariation:String = currentVariation;
     var daSong:Null<FreeplaySongData> = grpCapsules.members[curSelected].freeplayData;
 
     // Available variations for current character. We get this since bf is usually `default` variation, and `pico` is `pico`
-    // but sometimes pico can be the default variation (weekend 1 songs), and bf can be `bf` variation (darnell)
-    var characterVariations:Array<String> = daSong?.data.getVariationsByCharacter(currentCharacter) ?? Constants.DEFAULT_VARIATION_LIST;
+    // but sometimes pico can be the default variation (weekend 1 songs), and bf can be `bf` variation (weekends)
+    var characterVariations:Array<String> = daSong?.data.getVariationsByCharacter(currentCharacter) ?? Constants.DEFAULT_VARIATION_LIST_FULL;
     var difficultiesAvailable:Array<String> = allDifficulties;
+
+    var difficultiesGrouped:Array<Array<String>> = allDifficultiesGrouped;
+    var diffGroupIndices:Map<String, Int> = difficultyGroupIndices;
+
     // Gets all available difficulties for our character, via our available variations
     var songDifficulties:Array<String> = daSong?.data.listDifficulties(null, characterVariations) ?? Constants.DEFAULT_DIFFICULTY_LIST;
 
     var currentDifficultyIndex:Int = difficultiesAvailable.indexOf(currentDifficulty);
-
     if (currentDifficultyIndex == -1) currentDifficultyIndex = difficultiesAvailable.indexOf(Constants.DEFAULT_DIFFICULTY);
 
-    currentDifficultyIndex += change;
+    if (!changeVariation)
+    {
+      currentDifficultyIndex += change;
 
-    if (currentDifficultyIndex < 0) currentDifficultyIndex = Std.int(difficultiesAvailable.length - 1);
-    if (currentDifficultyIndex >= difficultiesAvailable.length) currentDifficultyIndex = 0;
+      if (currentDifficultyIndex < 0) currentDifficultyIndex = Std.int(difficultiesAvailable.length - 1);
+      if (currentDifficultyIndex >= difficultiesAvailable.length) currentDifficultyIndex = 0;
+    }
+    else if (change != 0)
+    {
+      var currentGroupIndex:Int = diffGroupIndices[currentDifficulty] ?? 0;
+      currentGroupIndex += change;
+
+      if (currentGroupIndex < 0) currentGroupIndex = Std.int(difficultiesGrouped.length - 1);
+      if (currentGroupIndex >= difficultiesGrouped.length) currentGroupIndex = 0;
+
+      var newGroup = difficultiesGrouped[currentGroupIndex];
+      if (change > 0) currentDifficultyIndex = difficultiesAvailable.indexOf(newGroup[0]);
+      else
+        currentDifficultyIndex = difficultiesAvailable.indexOf(newGroup[newGroup.length - 1]);
+
+      if (currentDifficultyIndex == -1) currentDifficultyIndex = difficultiesAvailable.indexOf(Constants.DEFAULT_DIFFICULTY);
+      currentDifficulty = difficultiesAvailable[currentDifficultyIndex];
+    }
+
     // Update the current difficulty
     currentDifficulty = difficultiesAvailable[currentDifficultyIndex];
+
     // For when we change the difficulty, but the song doesn't have that difficulty!
     if (daSong != null && !songDifficulties.contains(difficultiesAvailable[currentDifficultyIndex]))
     {
@@ -2261,9 +2368,19 @@ enum abstract FilterType(String)
   public var FAVORITE;
 
   /**
+   * Filter to songs which are first in their level
+   */
+  public var FIRST;
+
+  /**
    * Filter to all songs
    */
   public var ALL;
+
+  /**
+   * Internal filter for songs used in level scrolling.
+   */
+  public var LEVEL_SCROLL;
 }
 
 /**
@@ -2319,6 +2436,42 @@ class FreeplaySongData
   public var fullSongName(get, never):String;
 
   /**
+   * The index of a song in its level.
+   */
+  public var levelIndex(get, never):Int;
+
+  function get_levelIndex():Int
+  {
+    return _levelIndex;
+  }
+
+  var _levelIndex:Int;
+
+  /**
+   * The freeplay icon of the song's level.
+   */
+  public var levelCharacter(get, never):Null<String>;
+
+  function get_levelCharacter():Null<String>
+  {
+    return _levelCharacter;
+  }
+
+  var _levelCharacter:Null<String>;
+
+  /**
+   * The freeplay title of the song's level.
+   */
+  public var levelName(get, never):String;
+
+  function get_levelName():String
+  {
+    return _levelName ?? '';
+  }
+
+  var _levelName:Null<String>;
+
+  /**
    * The starting BPM of the song, dynamically generated depending on your current (or rather, rememberd) variation and difficulty.
    */
   public var songStartingBpm(get, never):Float;
@@ -2330,6 +2483,9 @@ class FreeplaySongData
   public function new(data:Song, levelData:Level)
   {
     this.data = data;
+    _levelIndex = levelData.getSongs().indexOf(data.id);
+    _levelCharacter = levelData.getFreeplayIcon();
+    _levelName = levelData.getFreeplayTitle();
     _levelId = levelData.id;
     this.isFav = Save.instance.isSongFavorited(data.songName);
   }

--- a/source/funkin/ui/freeplay/SongMenuItem.hx
+++ b/source/funkin/ui/freeplay/SongMenuItem.hx
@@ -32,6 +32,7 @@ class SongMenuItem extends FlxSpriteGroup
   public var freeplayData(default, null):Null<FreeplaySongData> = null;
 
   public var selected(default, set):Bool;
+  public var isLevelDisplay:Bool = false;
 
   public var songText:CapsuleText;
   public var favIconBlurred:FlxSprite;
@@ -390,28 +391,54 @@ class SongMenuItem extends FlxSpriteGroup
     return evilTrail.color;
   }
 
+  public function toggleSongInfo(show:Bool):Void
+  {
+    ranking.visible = show;
+    favIcon.visible = show;
+    favIconBlurred.visible = show;
+    toggleNumberInfo(show);
+  }
+
+  public function toggleNumberInfo(show:Bool):Void
+  {
+    bpmText.visible = show;
+    for (number in smallNumbers)
+      number.visible = show;
+    difficultyText.visible = show;
+    for (number in bigNumbers)
+      number.visible = show;
+  }
+
   public function refreshDisplay():Void
   {
     if (freeplayData == null)
     {
       songText.text = 'Random';
       pixelIcon.visible = false;
-      ranking.visible = false;
-      favIcon.visible = false;
-      favIconBlurred.visible = false;
       newText.visible = false;
+      toggleSongInfo(false);
     }
     else
     {
-      songText.text = freeplayData.fullSongName;
-      if (freeplayData.songCharacter != null) pixelIcon.setCharacter(freeplayData.songCharacter);
+      if (isLevelDisplay)
+      {
+        songText.text = freeplayData.levelName;
+        if (freeplayData.songCharacter != null) pixelIcon.setCharacter(freeplayData.levelCharacter);
+        toggleSongInfo(false);
+      }
+      else
+      {
+        songText.text = freeplayData.fullSongName;
+        if (freeplayData.songCharacter != null) pixelIcon.setCharacter(freeplayData.songCharacter);
+        updateBPM(Std.int(freeplayData.songStartingBpm) ?? 0);
+        updateDifficultyRating(freeplayData.difficultyRating ?? 0);
+        updateScoringRank(freeplayData.scoringRank);
+        newText.visible = freeplayData.isNew;
+        favIcon.visible = freeplayData.isFav;
+        favIconBlurred.visible = freeplayData.isFav;
+        toggleNumberInfo(true);
+      }
       pixelIcon.visible = true;
-      updateBPM(Std.int(freeplayData.songStartingBpm) ?? 0);
-      updateDifficultyRating(freeplayData.difficultyRating ?? 0);
-      updateScoringRank(freeplayData.scoringRank);
-      newText.visible = freeplayData.isNew;
-      favIcon.visible = freeplayData.isFav;
-      favIconBlurred.visible = freeplayData.isFav;
       checkClip();
     }
     updateSelected();

--- a/source/funkin/ui/freeplay/SongMenuItem.hx
+++ b/source/funkin/ui/freeplay/SongMenuItem.hx
@@ -420,16 +420,16 @@ class SongMenuItem extends FlxSpriteGroup
     }
     else
     {
+      if (freeplayData.songCharacter != null) pixelIcon.setCharacter(freeplayData.songCharacter);
       if (isLevelDisplay)
       {
         songText.text = freeplayData.levelName;
-        if (freeplayData.songCharacter != null) pixelIcon.setCharacter(freeplayData.levelCharacter);
+        if (freeplayData.levelCharacter != null) pixelIcon.setCharacter(freeplayData.levelCharacter);
         toggleSongInfo(false);
       }
       else
       {
         songText.text = freeplayData.fullSongName;
-        if (freeplayData.songCharacter != null) pixelIcon.setCharacter(freeplayData.songCharacter);
         updateBPM(Std.int(freeplayData.songStartingBpm) ?? 0);
         updateDifficultyRating(freeplayData.difficultyRating ?? 0);
         updateScoringRank(freeplayData.scoringRank);

--- a/source/funkin/ui/story/Level.hx
+++ b/source/funkin/ui/story/Level.hx
@@ -40,13 +40,32 @@ class Level implements IRegistryEntry<LevelData>
   }
 
   /**
-   * Retrieve the title of the level for display on the menu.
+   * Retrieve the title of the level for display on the story menu.
    * @return Title of the level as a string
    */
   public function getTitle():String
   {
     // TODO: Maybe add localization support?
     return _data.name;
+  }
+
+  /**
+   * Retrieve the freeplay title of the level for display when scrolling by level.
+   * @return Title of the level as a string
+   */
+  public function getFreeplayTitle():String
+  {
+    // TODO: Maybe add localization support?
+    return _data.freeplayTitle ?? getTitle();
+  }
+
+  /**
+   * Retrieve the freeplay icon of the level for display when scrolling by level.
+   * @return The ID of the icon's character.
+   */
+  public function getFreeplayIcon():Null<String>
+  {
+    return _data.freeplayIcon;
   }
 
   /**

--- a/source/funkin/util/Constants.hx
+++ b/source/funkin/util/Constants.hx
@@ -234,9 +234,21 @@ class Constants
   public static final DEFAULT_VARIATION:String = 'default';
 
   /**
-   * Standardized variations for charts
+   * Standardized variations for charts.
+   * Assumes no Erect mode, etc.
    */
-  public static final DEFAULT_VARIATION_LIST:Array<String> = ['default', 'erect', 'pico', 'bf'];
+  public static final DEFAULT_VARIATION_LIST:Array<String> = ['default', 'pico', 'bf'];
+
+  /**
+   * Standardized variations for Erect mode.
+   */
+  public static final DEFAULT_VARIATION_LIST_ERECT:Array<String> = ['erect'];
+
+  /**
+   * List of all standardized variations used by the base game.
+   * Includes Erect.
+   */
+  public static final DEFAULT_VARIATION_LIST_FULL:Array<String> = ['default', 'erect', 'pico', 'bf'];
 
   /**
    * Default sticker pack for transitions


### PR DESCRIPTION
This PR does a bunch of things!

First off, it restores legacy freeplay menu functionality of holding SHIFT to go faster (and it's rebindable!)

Secondly, it allows you to switch between song variations/remixes regardless of the song you're on!
It does this in two ways: one, by scrolling through difficulties while holding down SHIFT - the same as the 'scroll faster' keybind, and by simply pressing CTRL (the 'switch remixes' keybind! The difference is that this one always selects the hardest difficulty.)

The main thing, though, is that there's a new bind that collapses all the songs, allowing you to scroll by week/level instead!!
The random button in this mode even selects a random week for you (but doesn't auto-play the song!)

If you have any complaints, better implementations, or rooms for improvement, do request changes!!

## Does this PR close any issues? If so, link them below.
https://github.com/FunkinCrew/Funkin/issues/4502, maybe??? (Not really, as far as I know)

## Include any relevant screenshots or videos.
(OUTDATED: Fixed 'Random' button not working sometimes)

https://github.com/user-attachments/assets/e35855d4-e7bd-4992-be45-63d7cafac27e

_(redo of https://github.com/FunkinCrew/Funkin/pull/4625 AGAIN, due to 0.6.3 changes that made me want to redo it cleaner :3c)_