### PR TITLE
[BUGFIX] Properly display difficulty ratings 16-20

### DIFF
--- a/source/funkin/ui/freeplay/DifficultyStars.hx
+++ b/source/funkin/ui/freeplay/DifficultyStars.hx
@@ -7,13 +7,13 @@ import funkin.graphics.shaders.HSVShader;
 class DifficultyStars extends FlxSpriteGroup
 {
   /**
-   * Internal handler var for difficulty... ranges from 0... to 15
-   * 0 is 1 star... 15 is 0 stars!
+   * Internal handler var for difficulty... ranges from 0... to 20
+   * 0 is 1 star... 20 is 0 stars!
    */
   var curDifficulty(default, set):Int = 0;
 
   /**
-   * Range between 0 and 15
+   * Range between 0 and 20
    */
   public var difficulty(default, set):Int = 1;
 
@@ -26,6 +26,8 @@ class DifficultyStars extends FlxSpriteGroup
   public function new(x:Float, y:Float)
   {
     super(x, y);
+
+    this.screenCenter();
 
     hsvShader = new HSVShader();
 
@@ -54,7 +56,7 @@ class DifficultyStars extends FlxSpriteGroup
     // ......
     // 1300-1499: 15 stars
     // 1500 : 0 stars
-    if (curDifficulty < 15 && stars.anim.curFrame >= (curDifficulty + 1) * 100)
+    if (curDifficulty < 20 && stars.anim.curFrame >= (curDifficulty + 1) * 100)
     {
       stars.anim.play("diff stars", true, false, curDifficulty * 100);
     }
@@ -67,16 +69,16 @@ class DifficultyStars extends FlxSpriteGroup
     if (difficulty <= 0)
     {
       difficulty = 0;
-      curDifficulty = 15;
+      curDifficulty = 20;
     }
-    else if (difficulty <= 15)
+    else if (difficulty <= 20)
     {
       difficulty = value;
       curDifficulty = difficulty - 1;
     }
     else
     {
-      difficulty = 15;
+      difficulty = 20;
       curDifficulty = difficulty - 1;
     }
 
@@ -95,9 +97,9 @@ class DifficultyStars extends FlxSpriteGroup
   function set_curDifficulty(value:Int):Int
   {
     curDifficulty = value;
-    if (curDifficulty == 15)
+    if (curDifficulty == 20)
     {
-      stars.anim.play("diff stars", true, false, 1500);
+      stars.anim.play("diff stars", true, false, 2000);
       stars.anim.pause();
     }
     else

--- a/source/funkin/ui/freeplay/FreeplayFlames.hx
+++ b/source/funkin/ui/freeplay/FreeplayFlames.hx
@@ -19,7 +19,7 @@ class FreeplayFlames extends FlxSpriteGroup
   {
     super(x, y);
 
-    for (i in 0...5)
+    for (i in 0...10)
     {
       var flame:FlxSprite = new FlxSprite(flameX + (flameSpreadX * i), flameY + (flameSpreadY * i));
       flame.frames = Paths.getSparrowAtlas("freeplay/freeplayFlame");
@@ -65,7 +65,7 @@ class FreeplayFlames extends FlxSpriteGroup
 
     this.flameCount = value;
     var visibleCount:Int = 0;
-    for (i in 0...5)
+    for (i in 0...10)
     {
       if (members[i] == null) continue;
       var flame:FlxSprite = members[i];
@@ -98,7 +98,7 @@ class FreeplayFlames extends FlxSpriteGroup
 
   function setFlamePositions()
   {
-    for (i in 0...5)
+    for (i in 0...10)
     {
       var flame:FlxSprite = members[i];
       flame.x = flameX + (flameSpreadX * i);


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->
## Does this PR close any issues? If so, link them below.
Fixes #2782 

## Briefly describe the issue(s) fixed.
This pull request updates the `freeplayStars` texture atlas to complete the remaining animations for ratings 16-20 (really all you do is change the star color to cyan and move it up a bit).

FLA can be viewed here:
[16-20_Freeplay redesign assets VER3.fla.zip](https://github.com/user-attachments/files/19986119/16-20_Freeplay.redesign.assets.VER3.fla.zip)


## Include any relevant screenshots or videos.

https://github.com/user-attachments/assets/c590754f-7833-45a2-b90d-fff14340ffeb

