### PR TITLE
[BUGFIX] Fix Debug Results not showing correct rank

### DIFF
--- a/source/funkin/ui/debug/results/DebugTallies.hx
+++ b/source/funkin/ui/debug/results/DebugTallies.hx
@@ -12,8 +12,8 @@ class DebugTallies
    */
   public static var LOSS:SaveScoreTallyData =
     {
-      sick: 130,
-      good: 60,
+      sick: 190,
+      good: 69,
       bad: 69,
       shit: 69,
       missed: 69,
@@ -28,8 +28,8 @@ class DebugTallies
    */
   public static var NICE:SaveScoreTallyData =
     {
-      sick: 130,
-      good: 60,
+      sick: 190,
+      good: 69,
       bad: 69,
       shit: 69,
       missed: 69,
@@ -44,8 +44,8 @@ class DebugTallies
    */
   public static var GOOD:SaveScoreTallyData =
     {
-      sick: 130,
-      good: 60,
+      sick: 190,
+      good: 69,
       bad: 69,
       shit: 69,
       missed: 69,
@@ -60,8 +60,8 @@ class DebugTallies
    */
   public static var GREAT:SaveScoreTallyData =
     {
-      sick: 130,
-      good: 60,
+      sick: 190,
+      good: 69,
       bad: 69,
       shit: 69,
       missed: 69,
@@ -76,8 +76,8 @@ class DebugTallies
    */
   public static var EXCELLENT:SaveScoreTallyData =
     {
-      sick: 130,
-      good: 60,
+      sick: 190,
+      good: 69,
       bad: 69,
       shit: 69,
       missed: 69,
@@ -92,8 +92,8 @@ class DebugTallies
    */
   public static var PERFECT:SaveScoreTallyData =
     {
-      sick: 130,
-      good: 60,
+      sick: 190,
+      good: 69,
       bad: 69,
       shit: 69,
       missed: 69,


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->
## Does this PR close any issues? If so, link them below.
Fixes #4951.
## Briefly describe the issue(s) fixed.
Turns out that the new scoring changes broke the ranks on the test result screen...
This fixes it by adding 60 notes to the sick count and 9 notes to the good count on each debug ranking. Can be fixed by zero-ing the missed notes too but then no funny number.
## Include any relevant screenshots or videos.

https://github.com/user-attachments/assets/b46f7dbb-99f2-4daa-af72-da264cd8e2b4

