### PR TITLE
[BUGFIX] Fix the Behavior of Selected Song when Changing Filters in Freeplay

### DIFF
--- a/source/funkin/ui/freeplay/FreeplayState.hx
+++ b/source/funkin/ui/freeplay/FreeplayState.hx
@@ -510,10 +510,10 @@ class FreeplayState extends MusicBeatSubState
           generateSongList({filterType: REGEXP, filterData: str}, true);
       }
 
-      // If the current song is still in the list (aka not null?), we'll land on it
+      // If the current song is still in the list, or if it was random, we'll land on it
       // Otherwise we want to land on the first song of the group, rather than random song when changing letter sorts
       // that is, only if there's more than one song in the group!
-      if (curSong != null && currentFilteredSongs.length > 1)
+      if (curSong == null || currentFilteredSongs.contains(curSong))
       {
         changeSelection();
       }


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->
## Does this PR close any issues? If so, link them below.
No, but I did mention this issue here: https://github.com/FunkinCrew/Funkin/issues/4856#issuecomment-2837162544
## Briefly describe the issue(s) fixed.
Based on the comment in the code, when changing filters, the game should land on the song you had currently selected if it is still in the list. Otherwise, it should land on the first song in the group (or the random capsule if there are no songs in the group). This isn't what actually happens though. If the song you had selected previously isn't in the list, it will switch to the random capsule. If you had the random capsule selected, it will switch to the first song in the list (if there are songs in the list).

This happens because the code uses a variable `curSong` defined in the callback for changing filters and checks if it is null to determine if it is still in the list. `curSong` is never updated after the call to `generateSongList`, however, so the only time it will be null is if the random capsule was previously selected. This is why changing filters with the random capsule selected switches to the first song, and doing it with a song not still in the list switches to random.

I fixed this issue by changing the conditional above the code for switching to the previously selected capsule if it is still in the group. If `curSong` is null (random), or if `currentFilteredSongs` contains `curSong`, it will select it.
## Include any relevant screenshots or videos.

Before:

https://github.com/user-attachments/assets/372b840b-7992-4b44-9217-083099b6245c

After:

https://github.com/user-attachments/assets/b9405ef8-ae4f-4efc-9278-75c9ed88cebf