### PR TITLE
Bump Repo Versions to 0.6.4

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -45,7 +45,7 @@ body:
     attributes:
       label: Version
       description: Which version are you playing on? The game version is in the bottom left corner of the main menu.
-      placeholder: ex. 0.6.3
+      placeholder: ex. 0.6.4
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/charting.yml
+++ b/.github/ISSUE_TEMPLATE/charting.yml
@@ -46,7 +46,7 @@ body:
     attributes:
       label: Version
       description: Which version are you playing on? The game version is in the bottom left corner of the main menu. 
-      placeholder: ex. 0.6.3
+      placeholder: ex. 0.6.4
     validations:
       required: true
   

--- a/.github/ISSUE_TEMPLATE/compiling.yml
+++ b/.github/ISSUE_TEMPLATE/compiling.yml
@@ -34,7 +34,7 @@ body:
     attributes:
       label: Version
       description: Which version are you compiling? The game version is in the bottom left corner of the main menu or in the project.hxp file. 
-      placeholder: ex. 0.6.3
+      placeholder: ex. 0.6.4
     validations:
       required: true
   

--- a/.github/ISSUE_TEMPLATE/crash.yml
+++ b/.github/ISSUE_TEMPLATE/crash.yml
@@ -46,7 +46,7 @@ body:
     attributes:
       label: Version
       description: Which version are you playing on? The game version is in the bottom left corner of the main menu. 
-      placeholder: ex. 0.6.3
+      placeholder: ex. 0.6.4
     validations:
       required: true
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -60,7 +60,7 @@ This section provides guidelines to follow when [opening an issue](https://githu
 
 ## Requirements
 Make sure you're playing:
-- the latest version of the game (currently v0.6.3)
+- the latest version of the game (currently v0.6.4)
 - without any mods
 - on [Newgrounds](https://www.newgrounds.com/portal/view/770371) or downloaded from [itch.io](https://ninja-muffin24.itch.io/funkin)
 


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->
## Changes
Bumps templates and docs to 0.6.4 in preparation for the update. 