### PR TITLE
[OPTIMISATION] Remove unnecessary lines in `FreeplayState`

### DIFF
--- a/source/funkin/ui/freeplay/FreeplayState.hx
+++ b/source/funkin/ui/freeplay/FreeplayState.hx
@@ -2284,6 +2284,9 @@ class FreeplayState extends MusicBeatSubState
       if (targetSong == null)
       {
         FlxG.log.warn('WARN: could not find song with id (${daSong.data.id})');
+        intendedScore = 0;
+        intendedCompletion = 0.0;
+        rememberedDifficulty = currentDifficulty;
         return;
       }
 


### PR DESCRIPTION
Removes lines 2070-2073 and 2079-2080:

https://github.com/FunkinCrew/Funkin/blob/56259b91434c79347458a263badcf9dc2e154991/source/funkin/ui/freeplay/FreeplayState.hx#L2070-L2073

https://github.com/FunkinCrew/Funkin/blob/56259b91434c79347458a263badcf9dc2e154991/source/funkin/ui/freeplay/FreeplayState.hx#L2079-L2080

These lines were being overridden by the exact same lines in `changeDiff`, which is why #4898 and #4923 now exist.... Basically, they were only causing confusion.

Also prevents a possible case of the capsule data not being null but the song itself being null not also resetting the scores to zero before returning with these changes, not that I think anyone will experience such a problem (or care).

https://github.com/user-attachments/assets/83d994f6-9d12-448c-b671-3561ccfe47e4

I might have gotten a little too mesmerised by my freeplay fixes in my quick test of this.. 