### PR TITLE
[BUGFIX] Prevent the game from crashing when clicking a recent chart before tooltip shows up

### DIFF
--- a/source/funkin/ui/debug/charting/dialogs/ChartEditorWelcomeDialog.hx
+++ b/source/funkin/ui/debug/charting/dialogs/ChartEditorWelcomeDialog.hx
@@ -91,6 +91,8 @@ class ChartEditorWelcomeDialog extends ChartEditorBaseDialog
     #end
 
     linkRecentChart.onClick = function(_event) {
+      linkRecentChart.hide();
+
       this.hideDialog(DialogButton.CANCEL);
 
       // Load chart from file


### PR DESCRIPTION
## Does this PR close any issues? If so, link them below.
#4802 

## Briefly describe the issue(s) fixed.
This pr prevents a game crash when you quickly open a recent .fnfc chart before the tooltip for the recent link appears.

This is solved by simply just hiding the link before the entire welcome dialog is hidden so the tooltip doesn't try showing up at all after you click on the link.

## Include any relevant screenshots or videos.
### Before:
https://github.com/user-attachments/assets/cef72b1a-f34b-40d6-91dc-e6124950a361

### After:
https://github.com/user-attachments/assets/0dcf304b-9b01-4624-9b04-09da47dc45e7

### (Loading times are more longer on the after since i ran it with a debug build)