### PR TITLE
[BUGFIX] Chart editor - Use first difficulty only as fallback

### DIFF
--- a/source/funkin/ui/debug/charting/handlers/ChartEditorImportExportHandler.hx
+++ b/source/funkin/ui/debug/charting/handlers/ChartEditorImportExportHandler.hx
@@ -117,12 +117,13 @@ class ChartEditorImportExportHandler
   {
     state.songMetadata = newSongMetadata;
     state.songChartData = newSongChartData;
-    state.selectedDifficulty = state.availableDifficulties[0];
 
-    if (!newSongMetadata.exists(state.selectedVariation))
+    if (!state.songMetadata.exists(state.selectedVariation))
     {
       state.selectedVariation = Constants.DEFAULT_VARIATION;
     }
+    // Use the first available difficulty as a fallback if the currently selected one cannot be found.
+    if (state.availableDifficulties.indexOf(state.selectedDifficulty) < 0) state.selectedDifficulty = state.availableDifficulties[0];
 
     Conductor.instance.forceBPM(null); // Disable the forced BPM.
     Conductor.instance.instrumentalOffset = state.currentInstrumentalOffset; // Loads from the metadata.


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->
## Does this PR close any issues? If so, link them below.
Fix #4947
## Briefly describe the issue(s) fixed.
A fix for my other PR. Use the first available difficulty as a fallback if the currently selected one cannot be found.
## Include any relevant screenshots or videos.

https://github.com/user-attachments/assets/d3ba1303-3439-4e36-90cd-2b9b29291e81

