### PR TITLE
[BUGFIX?] Comment-accurate offsets

### DIFF
--- a/source/funkin/Conductor.hx
+++ b/source/funkin/Conductor.hx
@@ -279,7 +279,7 @@ class Conductor
 
   function get_combinedOffset():Float
   {
-    return instrumentalOffset + audioVisualOffset + inputOffset;
+    return instrumentalOffset + audioVisualOffset + formatOffset;
   }
 
   /**


### PR DESCRIPTION
As of right now, `combinedOffset` in Conductor is calculated using `instrumentalOffset + audioVisualOffset + formatOffset`. (view [here](https://github.com/FunkinCrew/Funkin/blob/0b976b0d711af80f6a8ed39e6f97fadd554805e9/source/funkin/Conductor.hx#L282))
However, later in the code, there exists a comment stating that it should be `instrumentalOffset + formatOffset + audioVisualOffset`. (view [here](https://github.com/FunkinCrew/Funkin/blob/0b976b0d711af80f6a8ed39e6f97fadd554805e9/source/funkin/Conductor.hx#L403))

This PR accomodates the combined offsets to the said comment.
I'm not sure if this completely fixes the input offsets or not, but I always found it weird that conductor updates based on the input offsets.