### PR TITLE
[BUGFIX] Fix the Gitaroo Man Easter Egg screen not saving all PlayState Parameters

### DIFF
--- a/source/funkin/play/PlayState.hx
+++ b/source/funkin/play/PlayState.hx
@@ -965,12 +965,7 @@ class PlayState extends MusicBeatSubState
         if (!isSubState && event.gitaroo)
         {
           this.remove(currentStage);
-          FlxG.switchState(() -> new GitarooPause(
-            {
-              targetSong: currentSong,
-              targetDifficulty: currentDifficulty,
-              targetVariation: currentVariation,
-            }));
+          FlxG.switchState(() -> new GitarooPause(lastParams));
         }
         else
         {


### PR DESCRIPTION
## Does this PR close any issues? If so, link them below.
Fixes #4955

## Briefly describe the issue(s) fixed.
`GitarooPause` state only saved current song's id, current variation and current difficulty, nothing else. This PR fixes that by using `lastParams` as the construction parameter.

## Include any relevant screenshots or videos.

https://github.com/user-attachments/assets/0864e0b4-c6de-4a6c-9550-ecb34eca6c80

