### PR TITLE
[ENHANCEMENT] Story Menu Score Commas

### DIFF
--- a/source/funkin/ui/story/StoryMenuState.hx
+++ b/source/funkin/ui/story/StoryMenuState.hx
@@ -8,6 +8,7 @@ import flixel.tweens.FlxEase;
 import flixel.tweens.FlxTween;
 import flixel.util.FlxColor;
 import flixel.util.FlxTimer;
+import flixel.util.FlxStringUtil;
 import funkin.audio.FunkinSound;
 import funkin.data.story.level.LevelRegistry;
 import funkin.data.song.SongRegistry;
@@ -314,7 +315,8 @@ class StoryMenuState extends MusicBeatState
 
     highScoreLerp = Std.int(MathUtil.smoothLerp(highScoreLerp, highScore, elapsed, 0.25));
 
-    scoreText.text = 'LEVEL SCORE: ${Math.round(highScoreLerp)}';
+    var commaSeparated:Bool = true;
+    scoreText.text = 'LEVEL SCORE: ${FlxStringUtil.formatMoney(highScoreLerp, false, commaSeparated)}';
 
     levelTitleText.text = currentLevel.getTitle();
     levelTitleText.x = FlxG.width - (levelTitleText.width + 10); // Right align.


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->
## Does this PR close any issues? If so, link them below.
No, this Pull Request does not close any open issues.

## Briefly describe the issue(s) fixed.
This Pull Request adds commas to the Story Menu score, the reason is to make the score easier to read.

## Include any relevant screenshots or videos.
![image](https://github.com/user-attachments/assets/b24ddb2d-e82d-4e10-a15e-6a2407b94de3)
![image](https://github.com/user-attachments/assets/d5ea5f40-fae8-43ab-8773-1baab22a3a4e)


