### PR TITLE
[MODDING ENHANCEMENT] Add Constants.MENU_MUSIC and make Main Menu BG accessible to Mods

### DIFF
--- a/source/funkin/FunkinMemory.hx
+++ b/source/funkin/FunkinMemory.hx
@@ -86,7 +86,7 @@ class FunkinMemory
     permanentCacheSound(Paths.sound("soundtray/Voldown"));
     permanentCacheSound(Paths.sound("soundtray/VolMAX"));
     permanentCacheSound(Paths.sound("soundtray/Volup"));
-    permanentCacheSound(Paths.music("freakyMenu/freakyMenu"));
+    permanentCacheSound(Paths.music('${Constants.MENU_MUSIC}/${Constants.MENU_MUSIC}'));
     permanentCacheSound(Paths.music("offsetsLoop/offsetsLoop"));
     permanentCacheSound(Paths.music("offsetsLoop/drumsLoop"));
     permanentCacheSound(Paths.sound("missnote1", "shared"));
@@ -405,7 +405,7 @@ class FunkinMemory
     Assets.cache.clear("songs");
     Assets.cache.clear("music");
     // Felt lazy.
-    var key = Paths.music("freakyMenu/freakyMenu");
+    var key = Paths.music('${Constants.MENU_MUSIC}/${Constants.MENU_MUSIC}');
     var sound:Null<Sound> = Assets.getSound(key, true);
     if (sound != null)
     {

--- a/source/funkin/InitState.hx
+++ b/source/funkin/InitState.hx
@@ -444,7 +444,7 @@ class InitState extends FlxState
     }
     else
     {
-      // FlxG.sound.cache(Paths.music('freakyMenu/freakyMenu'));
+      // FlxG.sound.cache(Paths.music('${Constants.MENU_MUSIC}/${Constants.MENU_MUSIC}'));
       #if mobile
       funkin.mobile.util.FNFCUtil.onFNFCOpen.add(function(fnfcFile:String) {
         flixel.tweens.FlxTween.globalManager.clear();

--- a/source/funkin/ui/debug/stage/StageBuilderState.hx
+++ b/source/funkin/ui/debug/stage/StageBuilderState.hx
@@ -66,7 +66,7 @@ class StageBuilderState extends MusicBeatState
 
     // snd.addEventListener(SampleDataEvent.SAMPLE_DATA, sineShit);
     // snd.__buffer.
-    // snd = Assets.getSound(Paths.music('freakyMenu/freakyMenu'));
+    // snd = Assets.getSound(Paths.music('${Constants.MENU_MUSIC}/${Constants.MENU_MUSIC}'));
     // for (thing in snd.load)
     // thing = Std.int(thing / 2);
     // snd.play();

--- a/source/funkin/ui/freeplay/FreeplayState.hx
+++ b/source/funkin/ui/freeplay/FreeplayState.hx
@@ -2257,7 +2257,7 @@ class FreeplayState extends MusicBeatSubState
       FlxTransitionableState.skipNextTransOut = true;
       if (Type.getClass(_parentState) == MainMenuState)
       {
-        FunkinSound.playMusic('freakyMenu',
+        FunkinSound.playMusic(Constants.MENU_MUSIC,
           {
             overrideExisting: true,
             restartTrack: false,

--- a/source/funkin/ui/mainmenu/MainMenuState.hx
+++ b/source/funkin/ui/mainmenu/MainMenuState.hx
@@ -322,7 +322,7 @@ class MainMenuState extends MusicBeatState
 
   function playMenuMusic():Void
   {
-    FunkinSound.playMusic('freakyMenu',
+    FunkinSound.playMusic(Constants.MENU_MUSIC,
       {
         overrideExisting: true,
         restartTrack: false,

--- a/source/funkin/ui/options/OptionsState.hx
+++ b/source/funkin/ui/options/OptionsState.hx
@@ -116,7 +116,7 @@ class OptionsState extends MusicBeatState
       drumsBG.fadeOut(0.5, 0);
     }
     FlxG.sound.music.fadeOut(0.5, 0, function(tw) {
-      FunkinSound.playMusic('freakyMenu',
+      FunkinSound.playMusic(Constants.MENU_MUSIC,
         {
           startingVolume: 0,
           overrideExisting: true,

--- a/source/funkin/ui/story/StoryMenuState.hx
+++ b/source/funkin/ui/story/StoryMenuState.hx
@@ -249,7 +249,7 @@ class StoryMenuState extends MusicBeatState
 
   function playMenuMusic():Void
   {
-    FunkinSound.playMusic('freakyMenu',
+    FunkinSound.playMusic(Constants.MENU_MUSIC,
       {
         overrideExisting: true,
         restartTrack: false,

--- a/source/funkin/ui/title/TitleState.hx
+++ b/source/funkin/ui/title/TitleState.hx
@@ -175,7 +175,7 @@ class TitleState extends MusicBeatState
   {
     var shouldFadeIn:Bool = (FlxG.sound.music == null);
     // Load music. Includes logic to handle BPM changes.
-    FunkinSound.playMusic('freakyMenu',
+    FunkinSound.playMusic(Constants.MENU_MUSIC,
       {
         startingVolume: 0.0,
         overrideExisting: true,

--- a/source/funkin/util/Constants.hx
+++ b/source/funkin/util/Constants.hx
@@ -673,4 +673,10 @@ class Constants
    * Alter this if you want to use a different save slot.
    */
   public inline static final BASE_SAVE_SLOT:Int = 1;
+
+  /**
+   * The ID of the music used for the main menus.
+   */
+  @SuppressWarnings('checkstyle:Final')
+  public static var MENU_MUSIC:String = 'freakyMenu';
 }


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->
## Does this PR close any issues? If so, link them below.
Fixes suggestion outside of GitHub by [Denoohay](https://x.com/Denoohay/status/1918756315653935151).

## Briefly describe the issue(s) fixed.
This PR adds a variable called `MENU_MUSIC` to `Constants`. This should make changing the Main Menu music easier without changing `freakyMenu`. It also moves the `bg` variable outside of `create()`, making it accessible to mods.