### PR TITLE
no ghost tapping penalty

### DIFF
--- a/source/funkin/play/PlayState.hx
+++ b/source/funkin/play/PlayState.hx
@@ -2489,7 +2489,6 @@ class PlayState extends MusicBeatSubState
 
       var notesInDirection:Array<NoteSprite> = notesByDirection[input.noteDirection];
 
-
       #if FEATURE_GHOST_TAPPING
       if ((!playerStrumline.mayGhostTap()) && notesInDirection.length == 0)
       #else

--- a/source/funkin/play/PlayState.hx
+++ b/source/funkin/play/PlayState.hx
@@ -2489,28 +2489,28 @@ class PlayState extends MusicBeatSubState
 
       var notesInDirection:Array<NoteSprite> = notesByDirection[input.noteDirection];
 
+
       #if FEATURE_GHOST_TAPPING
       if ((!playerStrumline.mayGhostTap()) && notesInDirection.length == 0)
       #else
       if (notesInDirection.length == 0)
       #end
       {
-        // Pressed a wrong key with no notes nearby.
-        // Perform a ghost miss (anti-spam).
-        ghostNoteMiss(input.noteDirection, notesInRange.length > 0);
-
-        // Play the strumline animation.
-        playerStrumline.playPress(input.noteDirection);
-        trace('PENALTY Score: ${songScore}');
+         // Pressed a wrong key with no notes nearby.
+         #if FEATURE_GHOST_TAPPING
+            // Perform a ghost miss (anti-spam).
+            // nope
+            // Play the strumline animation.
+            playerStrumline.playPress(input.noteDirection);
+            trace('Score: ${songScore}');
+         #else
+            // Perform a ghost miss (anti-spam).
+            ghostNoteMiss(input.noteDirection, notesInRange.length > 0);
+            // Play the strumline animation.
+            playerStrumline.playPress(input.noteDirection);
+            trace('PENALTY Score: ${songScore}');
+         #end
       }
-    else if (notesInDirection.length == 0)
-    {
-      // Press a key with no penalty.
-
-      // Play the strumline animation.
-      playerStrumline.playPress(input.noteDirection);
-      trace('NO PENALTY Score: ${songScore}');
-    }
     else
     {
       // Choose the first note, deprioritizing low priority notes.


### PR DESCRIPTION
ghost tapping giving penalty when some fnf engines with the same thing don't do that like psych engine and it's many forks/versions or most newer versions of kade engine and whatever else has this feature they don't give a penalty for mashing most of the time if enabled if the engine version or whatever has this feature

If you want the same for the base fnf engine it would make the game somewhat easier for players especially if they add spammy or difficult songs to the game but only if they enable this feature through building the game like before or add it in the options menu somewhere or whatever you decide to do with this