### PR TITLE
[ENHANCEMENT] Always display charSelectHint after unlocking character

### DIFF
--- a/source/funkin/ui/freeplay/FreeplayState.hx
+++ b/source/funkin/ui/freeplay/FreeplayState.hx
@@ -550,7 +550,7 @@ class FreeplayState extends MusicBeatSubState
     add(fnfFreeplay);
     add(ostName);
 
-    if (PlayerRegistry.instance.hasNewCharacter())
+    if (PlayerRegistry.instance.countUnlockedCharacters() > 1)
     {
       add(charSelectHint);
     }


### PR DESCRIPTION
(Redo of #4449)

## Linked Issue
Closes #4429

## Changes
Now displays the "Press [ KEY ] to change characters" message if more than one character is unlocked (instead of only when a new character is available)