### PR TITLE
[BUGFIX] Prevent Chart Editor playhead from scrolling before song start

### DIFF
--- a/source/funkin/ui/debug/charting/ChartEditorState.hx
+++ b/source/funkin/ui/debug/charting/ChartEditorState.hx
@@ -355,6 +355,10 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
       value = 0;
     }
 
+    // Make sure playhead doesn't scroll outside the song.
+    if (value + playheadPositionInPixels < 0) playheadPositionInPixels = -value;
+    if (value + playheadPositionInPixels > songLengthInPixels) playheadPositionInPixels = songLengthInPixels - value;
+
     if (value > songLengthInPixels) value = songLengthInPixels;
 
     if (value == scrollPositionInPixels) return value;


### PR DESCRIPTION
(Redo of #4711)

## Linked Issues
Fixes #4713 

## Changes
Prevents the playhead from disappearing above or below the grid when the playhead isn't in its default position

## Video
https://github.com/user-attachments/assets/3b105a33-7101-482f-ae38-4f918cc1bb9b

## Help Wanted
Please let me know if there's a better way (or place) to do this!
I also need some more playtesting on this to ensure everything works. Any help is appreciated :)