### PR TITLE
[BUGFIX] Chart editor - Holding the sustain trail of a hold note causes a space leak

### DIFF
--- a/source/funkin/ui/debug/charting/ChartEditorState.hx
+++ b/source/funkin/ui/debug/charting/ChartEditorState.hx
@@ -4564,11 +4564,15 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
               dragLengthCurrent = dragLengthSteps;
             }
 
-            gridGhostHoldNote.visible = true;
-            gridGhostHoldNote.noteData = currentPlaceNoteData;
-            gridGhostHoldNote.noteDirection = currentPlaceNoteData.getDirection();
+            if (!gridGhostHoldNote.visible)
+            {
+              gridGhostHoldNote.visible = true;
+              gridGhostHoldNote.noteData = currentPlaceNoteData;
+              gridGhostHoldNote.noteDirection = currentPlaceNoteData.getDirection();
+              gridGhostHoldNote.noteStyle = NoteKindManager.getNoteStyleId(currentPlaceNoteData.kind, currentSongNoteStyle) ?? currentSongNoteStyle;
+            }
+
             gridGhostHoldNote.setHeightDirectly(dragLengthPixels, true);
-            gridGhostHoldNote.noteStyle = NoteKindManager.getNoteStyleId(currentPlaceNoteData.kind, currentSongNoteStyle) ?? currentSongNoteStyle;
             gridGhostHoldNote.updateHoldNotePosition(renderedHoldNotes);
           }
           else


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->
## Does this PR close any issues? If so, link them below.
Fixes #5012
## Briefly describe the issue(s) fixed.

Every single frame a sustain trail is held, the following lines of code are run:
https://github.com/FunkinCrew/Funkin/blob/0927966c09591c43795147137dc505ea4c605cc8/source/funkin/ui/debug/charting/ChartEditorState.hx#L4567-L4571

But it only really needs to be run once, as all it does is set the grid ghost hold note to the one currently being dragged.

Line 4570 is fine though (`setHeightDirectly`), it's needed to make the stretch look smooth.

## Include any relevant screenshots or videos.
Before:

https://github.com/user-attachments/assets/52601e5f-a4cf-4e36-a1f9-3dd53581121d

After:

https://github.com/user-attachments/assets/d1c24c1f-4313-46f1-8818-4e49a224de2b


