### PR TITLE
Change the way strums work with Note Hits. Reorganize classes in `funkin.play.notes` and Helper Functions.

### DIFF
--- a/source/funkin/modding/events/ScriptEvent.hx
+++ b/source/funkin/modding/events/ScriptEvent.hx
@@ -10,6 +10,7 @@ import funkin.play.cutscene.dialogue.Conversation;
 import funkin.play.Countdown.CountdownStep;
 import funkin.play.notes.NoteDirection;
 import openfl.events.KeyboardEvent;
+import funkin.play.character.BaseCharacter;
 
 /**
  * This is a base class for all events that are issued to scripted classes.
@@ -97,6 +98,11 @@ class NoteScriptEvent extends ScriptEvent
   public var note(default, null):NoteSprite;
 
   /**
+   * The character, parent strumline attached to.
+   */
+  public var targerCharacter(default, default):BaseCharacter;
+
+  /**
    * The combo count as it is with this event.
    * Will be (combo) on miss events and (combo + 1) on hit events (the stored combo count won't update if the event is cancelled).
    */
@@ -113,18 +119,29 @@ class NoteScriptEvent extends ScriptEvent
    */
   public var healthChange:Float;
 
-  public function new(type:ScriptEventType, note:NoteSprite, healthChange:Float, comboCount:Int = 0, cancelable:Bool = false):Void
+  public function new(type:ScriptEventType, note:NoteSprite, character:BaseCharacter, healthChange:Float, comboCount:Int = 0, cancelable:Bool = false):Void
   {
     super(type, cancelable);
     this.note = note;
+    targerCharacter = character;
     this.comboCount = comboCount;
-    this.playSound = true;
+    playSound = true;
     this.healthChange = healthChange;
   }
 
   public override function toString():String
   {
-    return 'NoteScriptEvent(type=' + type + ', cancelable=' + cancelable + ', note=' + note + ', comboCount=' + comboCount + ')';
+    return 'NoteScriptEvent(type='
+      + type
+      + ', char='
+      + targerCharacter
+      + ', cancelable='
+      + cancelable
+      + ', note='
+      + note
+      + ', comboCount='
+      + comboCount
+      + ')';
   }
 }
 
@@ -156,10 +173,10 @@ class HitNoteScriptEvent extends NoteScriptEvent
    */
   public var doesNotesplash:Bool = false;
 
-  public function new(note:NoteSprite, healthChange:Float, score:Int, judgement:String, isComboBreak:Bool, comboCount:Int = 0, hitDiff:Float = 0,
-      doesNotesplash:Bool = false):Void
+  public function new(note:NoteSprite, char:BaseCharacter, healthChange:Float, score:Int, judgement:String, isComboBreak:Bool, comboCount:Int = 0,
+      hitDiff:Float = 0, doesNotesplash:Bool = false):Void
   {
-    super(NOTE_HIT, note, healthChange, comboCount, true);
+    super(NOTE_HIT, note, char, healthChange, comboCount, true);
     this.score = score;
     this.judgement = judgement;
     this.isComboBreak = isComboBreak;
@@ -169,8 +186,24 @@ class HitNoteScriptEvent extends NoteScriptEvent
 
   public override function toString():String
   {
-    return 'HitNoteScriptEvent(note=' + note + ', comboCount=' + comboCount + ', judgement=' + judgement + ', score=' + score + ', isComboBreak='
-      + isComboBreak + ', hitDiff=' + hitDiff + ', doesNotesplash=' + doesNotesplash + ')';
+    return 'HitNoteScriptEvent(note='
+      + note
+      + ', char='
+      + targerCharacter
+      + ', comboCount='
+      + comboCount
+      + ', judgement='
+      + judgement
+      + ', score='
+      + score
+      + ', isComboBreak='
+      + isComboBreak
+      + ', hitDiff='
+      + hitDiff
+      + ',
+    doesNotesplash='
+      + doesNotesplash
+      + ')';
   }
 }
 
@@ -255,9 +288,10 @@ class HoldNoteScriptEvent extends NoteScriptEvent
    */
   public var doesNotesplash:Bool = false;
 
-  public function new(type:ScriptEventType, holdNote:SustainTrail, healthChange:Float, score:Int, isComboBreak:Bool, cancelable:Bool = false):Void
+  public function new(type:ScriptEventType, char:BaseCharacter, holdNote:SustainTrail, healthChange:Float, score:Int, isComboBreak:Bool,
+      cancelable:Bool = false):Void
   {
-    super(type, null, healthChange, comboCount, true);
+    super(type, null, char, healthChange, comboCount, true);
     this.holdNote = holdNote;
     this.score = score;
     this.isComboBreak = isComboBreak;
@@ -265,7 +299,8 @@ class HoldNoteScriptEvent extends NoteScriptEvent
 
   public override function toString():String
   {
-    return 'HoldNoteScriptEvent(type=$type, holdNote=$holdNote, healthChange=$healthChange, score=$score, isComboBreak=$isComboBreak, cancelable=$cancelable)';
+    return
+      'HoldNoteScriptEvent(type=$type, char=$targerCharacter, holdNote=$holdNote, healthChange=$healthChange, score=$score, isComboBreak=$isComboBreak, cancelable=$cancelable)';
   }
 }
 

--- a/source/funkin/modding/events/ScriptEvent.hx
+++ b/source/funkin/modding/events/ScriptEvent.hx
@@ -100,7 +100,7 @@ class NoteScriptEvent extends ScriptEvent
   /**
    * The character, parent strumline attached to.
    */
-  public var targerCharacter(default, default):BaseCharacter;
+  public var targetCharacter(default, default):BaseCharacter;
 
   /**
    * The combo count as it is with this event.
@@ -123,7 +123,7 @@ class NoteScriptEvent extends ScriptEvent
   {
     super(type, cancelable);
     this.note = note;
-    targerCharacter = character;
+    targetCharacter = character;
     this.comboCount = comboCount;
     playSound = true;
     this.healthChange = healthChange;
@@ -134,7 +134,7 @@ class NoteScriptEvent extends ScriptEvent
     return 'NoteScriptEvent(type='
       + type
       + ', char='
-      + targerCharacter
+      + targetCharacter
       + ', cancelable='
       + cancelable
       + ', note='
@@ -186,24 +186,8 @@ class HitNoteScriptEvent extends NoteScriptEvent
 
   public override function toString():String
   {
-    return 'HitNoteScriptEvent(note='
-      + note
-      + ', char='
-      + targerCharacter
-      + ', comboCount='
-      + comboCount
-      + ', judgement='
-      + judgement
-      + ', score='
-      + score
-      + ', isComboBreak='
-      + isComboBreak
-      + ', hitDiff='
-      + hitDiff
-      + ',
-    doesNotesplash='
-      + doesNotesplash
-      + ')';
+    return 'HitNoteScriptEvent(note=' + note + ', char=' + targetCharacter + ', comboCount=' + comboCount + ', judgement=' + judgement + ', score=' + score
+      + ', isComboBreak=' + isComboBreak + ', hitDiff=' + hitDiff + ', doesNotesplash=' + doesNotesplash + ')';
   }
 }
 
@@ -300,7 +284,7 @@ class HoldNoteScriptEvent extends NoteScriptEvent
   public override function toString():String
   {
     return
-      'HoldNoteScriptEvent(type=$type, char=$targerCharacter, holdNote=$holdNote, healthChange=$healthChange, score=$score, isComboBreak=$isComboBreak, cancelable=$cancelable)';
+      'HoldNoteScriptEvent(type=$type, char=$targetCharacter, holdNote=$holdNote, healthChange=$healthChange, score=$score, isComboBreak=$isComboBreak, cancelable=$cancelable)';
   }
 }
 

--- a/source/funkin/play/PlayState.hx
+++ b/source/funkin/play/PlayState.hx
@@ -2199,11 +2199,11 @@ class PlayState extends MusicBeatSubState
 
       if (Conductor.instance.songPosition > hitWindowEnd)
       {
-        if (note.hasMissed || note.hasBeenHit) continue;
+        if (note.hasBeenMissed || note.hasBeenHit) continue;
 
         note.tooEarly = false;
         note.mayHit = false;
-        note.hasMissed = true;
+        note.hasBeenMissed = true;
 
         if (note.holdNoteSprite != null)
         {
@@ -2234,18 +2234,18 @@ class PlayState extends MusicBeatSubState
       }
       else if (Conductor.instance.songPosition > hitWindowStart)
       {
-        if (note.hasBeenHit || note.hasMissed) continue;
+        if (note.hasBeenHit || note.hasBeenMissed) continue;
 
         note.tooEarly = false;
         note.mayHit = true;
-        note.hasMissed = false;
+        note.hasBeenMissed = false;
         if (note.holdNoteSprite != null) note.holdNoteSprite.missedNote = false;
       }
       else
       {
         note.tooEarly = true;
         note.mayHit = false;
-        note.hasMissed = false;
+        note.hasBeenMissed = false;
         if (note.holdNoteSprite != null) note.holdNoteSprite.missedNote = false;
       }
     }
@@ -2285,7 +2285,7 @@ class PlayState extends MusicBeatSubState
       {
         note.tooEarly = false;
         note.mayHit = false;
-        note.hasMissed = false;
+        note.hasBeenMissed = false;
         continue;
       }
 
@@ -2295,10 +2295,10 @@ class PlayState extends MusicBeatSubState
 
       if (Conductor.instance.songPosition > hitWindowEnd)
       {
-        if (note.hasMissed || note.hasBeenHit) continue;
+        if (note.hasBeenMissed || note.hasBeenHit) continue;
         note.tooEarly = false;
         note.mayHit = false;
-        note.hasMissed = true;
+        note.hasBeenMissed = true;
         if (note.holdNoteSprite != null)
         {
           note.holdNoteSprite.missedNote = true;
@@ -2323,29 +2323,26 @@ class PlayState extends MusicBeatSubState
         // NOTE: This is what handles the strumline and cleaning up the note itself!
         playerStrumline.hitNote(note);
 
-        if (note.holdNoteSprite != null)
-        {
-          playerStrumline.playNoteHoldCover(note.holdNoteSprite);
-        }
+        if (note.holdNoteSprite != null) playerStrumline.playNoteHoldCover(note.holdNoteSprite);
       }
       else if (Conductor.instance.songPosition > hitWindowStart)
       {
         note.tooEarly = false;
         note.mayHit = true;
-        note.hasMissed = false;
+        note.hasBeenMissed = false;
         if (note.holdNoteSprite != null) note.holdNoteSprite.missedNote = false;
       }
       else
       {
         note.tooEarly = true;
         note.mayHit = false;
-        note.hasMissed = false;
+        note.hasBeenMissed = false;
         if (note.holdNoteSprite != null) note.holdNoteSprite.missedNote = false;
       }
 
       // This becomes true when the note leaves the hit window.
       // It might still be on screen.
-      if (note.hasMissed && !note.handledMiss)
+      if (note.hasBeenMissed && !note.handledMiss)
       {
         // Call an event to allow canceling the note miss.
         // NOTE: This is what handles the character animations!
@@ -2385,10 +2382,8 @@ class PlayState extends MusicBeatSubState
         }
 
         // Make sure the player keeps singing while the note is held by the bot.
-        if (isBotPlayMode && currentStage != null && currentStage.getBoyfriend() != null && currentStage.getBoyfriend().isSinging())
-        {
-          currentStage.getBoyfriend().holdTimer = 0;
-        }
+        if (isBotPlayMode && currentStage != null && currentStage.getBoyfriend() != null && currentStage.getBoyfriend()
+          .isSinging()) currentStage.getBoyfriend().holdTimer = 0;
       }
 
       if (holdNote.missedNote && !holdNote.handledMiss)

--- a/source/funkin/play/PlayState.hx
+++ b/source/funkin/play/PlayState.hx
@@ -1781,8 +1781,10 @@ class PlayState extends MusicBeatSubState
     if (noteStyle == null) noteStyle = NoteStyleRegistry.instance.fetchDefault();
 
     playerStrumline = new Strumline(noteStyle, !isBotPlayMode);
+    playerStrumline.targetCharacter = currentStage?.getBoyfriend();
     playerStrumline.onNoteIncoming.add(onStrumlineNoteIncoming);
     opponentStrumline = new Strumline(noteStyle, false);
+    opponentStrumline.targetCharacter = currentStage?.getDad();
     opponentStrumline.onNoteIncoming.add(onStrumlineNoteIncoming);
     add(playerStrumline);
     add(opponentStrumline);
@@ -1971,7 +1973,7 @@ class PlayState extends MusicBeatSubState
 
   function onStrumlineNoteIncoming(noteSprite:NoteSprite):Void
   {
-    var event:NoteScriptEvent = new NoteScriptEvent(NOTE_INCOMING, noteSprite, 0, false);
+    var event:NoteScriptEvent = new NoteScriptEvent(NOTE_INCOMING, noteSprite, noteSprite.targetChar, 0, false);
 
     dispatchEvent(event);
   }
@@ -2215,7 +2217,7 @@ class PlayState extends MusicBeatSubState
         // Call an event to allow canceling the note hit.
         // NOTE: This is what handles the character animations!
 
-        var event:NoteScriptEvent = new HitNoteScriptEvent(note, 0.0, 0, 'perfect', false, 0);
+        var event:NoteScriptEvent = new HitNoteScriptEvent(note, note.targetChar, 0.0, 0, 'perfect', false, 0);
         dispatchEvent(event);
 
         // Calling event.cancelEvent() skips all the other logic! Neat!
@@ -2311,7 +2313,7 @@ class PlayState extends MusicBeatSubState
 
         // Call an event to allow canceling the note hit.
         // NOTE: This is what handles the character animations!
-        var event:NoteScriptEvent = new HitNoteScriptEvent(note, 0.0, 0, 'perfect', false, 0);
+        var event:NoteScriptEvent = new HitNoteScriptEvent(note, note.targetChar, 0.0, 0, 'perfect', false, 0);
         dispatchEvent(event);
 
         // Calling event.cancelEvent() skips all the other logic! Neat!
@@ -2347,7 +2349,7 @@ class PlayState extends MusicBeatSubState
       {
         // Call an event to allow canceling the note miss.
         // NOTE: This is what handles the character animations!
-        var event:NoteScriptEvent = new NoteScriptEvent(NOTE_MISS, note, Constants.HEALTH_MISS_PENALTY, 0, true);
+        var event:NoteScriptEvent = new NoteScriptEvent(NOTE_MISS, note, note.targetChar, Constants.HEALTH_MISS_PENALTY, 0, true);
         dispatchEvent(event);
 
         // Calling event.cancelEvent() skips all the other logic! Neat!
@@ -2414,7 +2416,8 @@ class PlayState extends MusicBeatSubState
             var healthChange = healthChangeUncapped.clamp(healthChangeMax, 0);
             var scoreChange = Std.int(Constants.SCORE_HOLD_DROP_PENALTY_PER_SECOND * remainingLengthSec);
 
-            var event:HoldNoteScriptEvent = new HoldNoteScriptEvent(NOTE_HOLD_DROP, holdNote, healthChange, scoreChange, true);
+            var event:HoldNoteScriptEvent = new HoldNoteScriptEvent(NOTE_HOLD_DROP, holdNote._parentStrum.targetCharacter, holdNote, healthChange,
+              scoreChange, true);
             dispatchEvent(event);
 
             trace('Penalizing score by ${event.score} and health by ${event.healthChange} for dropping hold note (is combo break: ${event.isComboBreak})!');
@@ -2575,8 +2578,8 @@ class PlayState extends MusicBeatSubState
     }
 
     // Send the note hit event.
-    var event:HitNoteScriptEvent = new HitNoteScriptEvent(note, healthChange, score, daRating, isComboBreak, Highscore.tallies.combo + 1, noteDiff,
-      daRating == 'sick');
+    var event:HitNoteScriptEvent = new HitNoteScriptEvent(note, note.targetChar, healthChange, score, daRating, isComboBreak, Highscore.tallies.combo + 1,
+      noteDiff, daRating == 'sick');
     dispatchEvent(event);
 
     // Calling event.cancelEvent() skips all the other logic! Neat!

--- a/source/funkin/play/character/AnimateAtlasCharacter.hx
+++ b/source/funkin/play/character/AnimateAtlasCharacter.hx
@@ -197,6 +197,13 @@ class AnimateAtlasCharacter extends BaseCharacter
     if (clipRect != null) clipRectTransform(sprite, clipRect);
   }
 
+  // Also can be overriden for more comples characters, like Nene.
+  override public function setShader(newShader:flixel.system.FlxAssets.FlxShader):Void
+  {
+    super.setShader(newShader);
+    if (mainSprite != null) mainSprite.shader = newShader;
+  }
+
   function loadAnimations():Void
   {
     trace('[ATLASCHAR] Attempting to load ${_data.animations.length} animations for ${characterId}');

--- a/source/funkin/play/character/BaseCharacter.hx
+++ b/source/funkin/play/character/BaseCharacter.hx
@@ -514,9 +514,7 @@ class BaseCharacter extends Bopper
     if (event.targerCharacter == this)
     {
       playSingAnimation(event.note.noteData.getDirection(), false);
-      if (characterType != BF) holdTimer = -(event.note.length / 1000); // ms to s
-      else
-        holdTimer = 0;
+      hitHoldTimer(event.note.length);
     }
 
     if (/*characterType == GF &&*/ event.note.noteData.getMustHitNote())
@@ -531,6 +529,8 @@ class BaseCharacter extends Bopper
     }
   }
 
+  // HELPERS
+
   /**
    * Writing `this` in Polymod scritped class returns `PolymodScriptedClass`, not modified(extended) class!?
    * @return BaseCharacter
@@ -539,6 +539,10 @@ class BaseCharacter extends Bopper
   {
     return this; // Stuff for polymod?
   }
+
+  // Sets holdTimer and checks, if character BF type or not.
+  public inline function hitHoldTimer(noteLength:Float):Float
+    return holdTimer = ((characterType == BF) ? 0 : -(noteLength / 1000));
 
   // Also can be overriden for more comples characters, like Nene. (ABot)
   public function setShader(shader:flixel.system.FlxAssets.FlxShader):Void

--- a/source/funkin/play/character/BaseCharacter.hx
+++ b/source/funkin/play/character/BaseCharacter.hx
@@ -544,6 +544,10 @@ class BaseCharacter extends Bopper
   public inline function hitHoldTimer(noteLength:Float):Float
     return holdTimer = ((characterType == BF) ? 0 : -(noteLength / 1000));
 
+  /**
+   * Created for AnimateAtlasCharacter, but also can be used for complex (like Nene) characters.
+   * @param shader
+   */
   // Also can be overriden for more comples characters, like Nene. (ABot)
   public function setShader(shader:flixel.system.FlxAssets.FlxShader):Void
   {

--- a/source/funkin/play/character/BaseCharacter.hx
+++ b/source/funkin/play/character/BaseCharacter.hx
@@ -511,7 +511,7 @@ class BaseCharacter extends Bopper
     // If another script cancelled the event, don't do anything.
     if (event.eventCanceled) return;
 
-    if (event.targerCharacter == this)
+    if (event.targetCharacter == this)
     {
       playSingAnimation(event.note.noteData.getDirection(), false);
       hitHoldTimer(event.note.length);
@@ -565,7 +565,7 @@ class BaseCharacter extends Bopper
     // If another script cancelled the event, don't do anything.
     if (event.eventCanceled) return;
 
-    if (event.targerCharacter == this) playSingAnimation(event.note.noteData.getDirection(), true);
+    if (event.targetCharacter == this) playSingAnimation(event.note.noteData.getDirection(), true);
     if (event.note.noteData.getMustHitNote() /*&& characterType == GF*/) playComboDropAnimation(event.comboCount);
   }
 
@@ -576,7 +576,7 @@ class BaseCharacter extends Bopper
     // If another script cancelled the event, don't do anything.
     if (event.eventCanceled) return;
 
-    if (event.targerCharacter == this) playSingAnimation(event.holdNote.noteData.getDirection(), true);
+    if (event.targetCharacter == this) playSingAnimation(event.holdNote.noteData.getDirection(), true);
 
     if (event.holdNote.noteData.getMustHitNote()
       && event.isComboBreak /*&& characterType == GF*/) playComboDropAnimation(event.comboCount);

--- a/source/funkin/play/character/BaseCharacter.hx
+++ b/source/funkin/play/character/BaseCharacter.hx
@@ -517,7 +517,7 @@ class BaseCharacter extends Bopper
       hitHoldTimer(event.note.length);
     }
 
-    if (/*characterType == GF &&*/ event.note.noteData.getMustHitNote())
+    if (characterType != BF && event.note.noteData.getMustHitNote())
     {
       switch (event.judgement)
       {
@@ -566,7 +566,7 @@ class BaseCharacter extends Bopper
     if (event.eventCanceled) return;
 
     if (event.targetCharacter == this) playSingAnimation(event.note.noteData.getDirection(), true);
-    if (event.note.noteData.getMustHitNote() /*&& characterType == GF*/) playComboDropAnimation(event.comboCount);
+    if (event.note.noteData.getMustHitNote() && characterType != BF) playComboDropAnimation(event.comboCount);
   }
 
   public override function onNoteHoldDrop(event:HoldNoteScriptEvent):Void
@@ -578,8 +578,7 @@ class BaseCharacter extends Bopper
 
     if (event.targetCharacter == this) playSingAnimation(event.holdNote.noteData.getDirection(), true);
 
-    if (event.holdNote.noteData.getMustHitNote()
-      && event.isComboBreak /*&& characterType == GF*/) playComboDropAnimation(event.comboCount);
+    if (event.holdNote.noteData.getMustHitNote() && event.isComboBreak && characterType != BF) playComboDropAnimation(event.comboCount);
   }
 
   function playComboAnimation(comboCount:Int):Void

--- a/source/funkin/play/notes/NoteHoldCover.hx
+++ b/source/funkin/play/notes/NoteHoldCover.hx
@@ -16,7 +16,7 @@ class NoteHoldCover extends FlxTypedSpriteGroup<FlxSprite>
   /**
    * NOT USED HERE, but exists in `.fla` file for hold covers.
    */
-  var sparks:FlxSprite;
+  // var sparks:FlxSprite;
 
   public function new(noteStyle:NoteStyle)
   {
@@ -30,7 +30,9 @@ class NoteHoldCover extends FlxTypedSpriteGroup<FlxSprite>
    */
   function setupHoldNoteCover(noteStyle:NoteStyle):Void
   {
-    add(glow = new FlxSprite());
+    glow = new FlxSprite();
+    add(glow);
+
     noteStyle.buildHoldCoverSprite(this);
     glow.animation.onFinish.add(this.onAnimationFinished);
     if (glow.animation.getAnimationList().length < 3 * 4) trace('WARNING: NoteHoldCover failed to initialize all animations.');
@@ -66,7 +68,7 @@ class NoteHoldCover extends FlxTypedSpriteGroup<FlxSprite>
     this.visible = false;
 
     if (glow != null) glow.visible = false;
-    if (sparks != null) sparks.visible = false;
+    // if (sparks != null) sparks.visible = false;
   }
 
   public override function revive():Void
@@ -77,7 +79,7 @@ class NoteHoldCover extends FlxTypedSpriteGroup<FlxSprite>
     this.alpha = 1.0;
 
     if (glow != null) glow.visible = true;
-    if (sparks != null) sparks.visible = true;
+    // if (sparks != null) sparks.visible = true;
   }
 
   public function onAnimationFinished(animationName:String):Void

--- a/source/funkin/play/notes/NoteHoldCover.hx
+++ b/source/funkin/play/notes/NoteHoldCover.hx
@@ -11,9 +11,11 @@ class NoteHoldCover extends FlxTypedSpriteGroup<FlxSprite>
   static final FRAMERATE_DEFAULT:Int = 24;
 
   public var holdNote:SustainTrail;
-
   public var glow:FlxSprite;
 
+  /**
+   * NOT USED HERE, but exists in `.fla` file for hold covers.
+   */
   var sparks:FlxSprite;
 
   public function new(noteStyle:NoteStyle)
@@ -28,18 +30,10 @@ class NoteHoldCover extends FlxTypedSpriteGroup<FlxSprite>
    */
   function setupHoldNoteCover(noteStyle:NoteStyle):Void
   {
-    glow = new FlxSprite();
-    add(glow);
-
-    // TODO: null check here like how NoteSplash does
+    add(glow = new FlxSprite());
     noteStyle.buildHoldCoverSprite(this);
-
     glow.animation.onFinish.add(this.onAnimationFinished);
-
-    if (glow.animation.getAnimationList().length < 3 * 4)
-    {
-      trace('WARNING: NoteHoldCover failed to initialize all animations.');
-    }
+    if (glow.animation.getAnimationList().length < 3 * 4) trace('WARNING: NoteHoldCover failed to initialize all animations.');
   }
 
   public override function update(elapsed):Void
@@ -88,10 +82,7 @@ class NoteHoldCover extends FlxTypedSpriteGroup<FlxSprite>
 
   public function onAnimationFinished(animationName:String):Void
   {
-    if (animationName.startsWith('holdCoverStart'))
-    {
-      playContinue();
-    }
+    if (animationName.startsWith('holdCoverStart')) playContinue();
     if (animationName.startsWith('holdCoverEnd'))
     {
       // *lightning* *zap* *crackle*

--- a/source/funkin/play/notes/NoteSplash.hx
+++ b/source/funkin/play/notes/NoteSplash.hx
@@ -7,18 +7,16 @@ import flixel.FlxSprite;
 
 class NoteSplash extends FlxSprite
 {
+  // static var frameCollection:FlxFramesCollection;
+  // GOT SET FROM NOTESTYLE
   public var splashFramerate:Int = 24;
   public var splashFramerateVariance:Int = 2;
-
-  static var frameCollection:FlxFramesCollection;
 
   public function new(noteStyle:NoteStyle)
   {
     super(0, 0);
-
     setupSplashGraphic(noteStyle);
-
-    this.animation.onFinish.add(this.onAnimationFinished);
+    animation.onFinish.add(this.onAnimationFinished);
   }
 
   /**
@@ -27,24 +25,14 @@ class NoteSplash extends FlxSprite
   function setupSplashGraphic(noteStyle:NoteStyle):Void
   {
     if (frames == null) noteStyle.buildSplashSprite(this);
-
-    if (this.animation.getAnimationList().length < 8)
-    {
-      trace('WARNING: NoteSplash failed to initialize all animations.');
-    }
-  }
-
-  public function playAnimation(name:String, force:Bool = false, reversed:Bool = false, startFrame:Int = 0):Void
-  {
-    this.animation.play(name, force, reversed, startFrame);
+    if (animation.getAnimationList().length < 8) trace('WARNING: NoteSplash failed to initialize all animations.');
   }
 
   public function play(direction:NoteDirection, variant:Int = null):Void
   {
     if (variant == null)
     {
-      var animationAmount:Int = this.animation.getAnimationList().filter(function(anim) return anim.name.startsWith('splash${direction.nameUpper}')).length
-        - 1;
+      var animationAmount:Int = animation.getAnimationList().filter(function(anim) return anim.name.startsWith('splash${direction.nameUpper}')).length - 1;
       variant = FlxG.random.int(0, animationAmount);
     }
 
@@ -59,6 +47,11 @@ class NoteSplash extends FlxSprite
 
     // Center the animation on the note splash.
     offset.set(width * 0.3, height * 0.3);
+  }
+
+  public function playAnimation(name:String, force:Bool = false, reversed:Bool = false, startFrame:Int = 0):Void
+  {
+    this.animation.play(name, force, reversed, startFrame);
   }
 
   public function onAnimationFinished(animationName:String):Void

--- a/source/funkin/play/notes/NoteSprite.hx
+++ b/source/funkin/play/notes/NoteSprite.hx
@@ -19,7 +19,7 @@ class NoteSprite extends FunkinSprite
 
   function get_strumTime():Float
   {
-    return noteData?.time ?? 0.0; // If somethin happens with time noteData, note will be on 0 milisecond of song.
+    return noteData?.time ?? 0.0;
   }
 
   function set_strumTime(value:Float):Float
@@ -101,12 +101,14 @@ class NoteSprite extends FunkinSprite
   /**
    * The direction of the note.
    * Redirects to `noteData` variable.
+   * Used in CharacterStrumLine on note creation.
    */
-  public var direction(default, set):NoteDirection; // Used in CharacterStrumLine on note creation.
+  public var direction(default, set):NoteDirection;
 
   function set_direction(value:Int):Int
   {
-    if (frames == null) return value; // If there no loaded frames, we cant continue direction set.
+    // If there are no loaded frames, we cant continue direction set.
+    if (frames == null) return value;
 
     playNoteAnimation(value);
 
@@ -190,6 +192,7 @@ class NoteSprite extends FunkinSprite
 
   /**
    * Creates frames and animations
+   * @param noteStyle The `NoteStyle` instance.
    */
   public function setupNoteGraphic(noteStyle:NoteStyle):Void
   {

--- a/source/funkin/play/notes/NoteSprite.hx
+++ b/source/funkin/play/notes/NoteSprite.hx
@@ -131,17 +131,17 @@ class NoteSprite extends FunkinSprite
   public var hasBeenHit:Bool = false;
 
   /**
-   * Register this note as hit only after any other notes
-   */
-  public var lowPriority:Bool = false;
-
-  /**
    * This is true if the note is later than 10 frames within the strumline,
    * and thus can't be hit by the player.
    * It will be destroyed after it moves offscreen.
    * Managed by PlayState.
    */
-  public var hasMissed:Bool;
+  public var hasBeenMissed:Bool;
+
+  /**
+   * Register this note as hit only after any other notes
+   */
+  public var lowPriority:Bool = false;
 
   /**
    * This is true if the note is earlier than 10 frames within the strumline.
@@ -228,7 +228,7 @@ class NoteSprite extends FunkinSprite
     this.tooEarly = false;
     this.hasBeenHit = false;
     this.mayHit = false;
-    this.hasMissed = false;
+    this.hasBeenMissed = false;
 
     this.hsvShader.hue = 1.0;
     this.hsvShader.saturation = 1.0;

--- a/source/funkin/play/notes/StrumlineNote.hx
+++ b/source/funkin/play/notes/StrumlineNote.hx
@@ -10,10 +10,14 @@ import funkin.play.notes.NoteSprite;
  */
 class StrumlineNote extends FunkinSprite
 {
+  static final CONFIRM_HOLD_TIME:Float = 0.1;
+  static final DEFAULT_OFFSET:Int = 13;
+
   /**
-   * Whether this strumline note is on the player's side or the opponent's side.
+   * Set this flag to `true` to disable performance optimizations that cause
+   * the Strumline note sprite to ignore `velocity` and `acceleration`.
    */
-  public var isPlayer(default, null):Bool;
+  public var forceActive:Bool = false;
 
   /**
    * The direction which this strumline note is facing.
@@ -32,26 +36,16 @@ class StrumlineNote extends FunkinSprite
   public var yOffset:Float = 0.0;
 
   /**
-   * Set this flag to `true` to disable performance optimizations that cause
-   * the Strumline note sprite to ignore `velocity` and `acceleration`.
-   */
-  public var forceActive:Bool = false;
-
-  /**
    * How long to continue the hold note animation after a note is pressed.
    */
-  static final CONFIRM_HOLD_TIME:Float = 0.1;
-
   /**
    * How long the hold note animation has been playing after a note is pressed.
    */
   var confirmHoldTimer:Float = -1;
 
-  public function new(noteStyle:NoteStyle, isPlayer:Bool, direction:NoteDirection)
+  public function new(noteStyle:NoteStyle, direction:NoteDirection)
   {
     super(0, 0);
-
-    this.isPlayer = isPlayer;
 
     this.direction = direction;
 
@@ -74,10 +68,7 @@ class StrumlineNote extends FunkinSprite
     // Run a timer before we stop playing the confirm animation.
     // On opponent, this prevent issues with hold notes.
     // On player, this allows holding the confirm key to fall back to press.
-    if (name == 'confirm')
-    {
-      confirmHoldTimer = 0;
-    }
+    if (name == 'confirm') confirmHoldTimer = 0;
   }
 
   override function update(elapsed:Float)
@@ -110,9 +101,7 @@ class StrumlineNote extends FunkinSprite
 
     noteStyle.applyStrumlineFrames(this);
     noteStyle.applyStrumlineAnimations(this, this.direction);
-
-    var scale = noteStyle.getStrumlineScale();
-    this.scale.set(scale, scale);
+    scale.x = scale.y = noteStyle.getStrumlineScale();
     this.updateHitbox();
     noteStyle.applyStrumlineOffsets(this);
 
@@ -154,22 +143,14 @@ class StrumlineNote extends FunkinSprite
   {
     this.active = true;
 
-    if (getCurrentAnimation() == "confirm-hold")
+    if (getCurrentAnimation() == "confirm-hold") return;
+    else if (getCurrentAnimation() == "confirm") if (isAnimationFinished())
     {
-      return;
-    }
-    else if (getCurrentAnimation() == "confirm")
-    {
-      if (isAnimationFinished())
-      {
-        this.confirmHoldTimer = -1;
-        this.playAnimation('confirm-hold', false, false);
-      }
+      this.confirmHoldTimer = -1;
+      this.playAnimation('confirm-hold', false, false);
     }
     else
-    {
-      this.playAnimation('confirm', false, false);
-    }
+      playAnimation('confirm', false, false);
   }
 
   /**
@@ -188,8 +169,6 @@ class StrumlineNote extends FunkinSprite
     return this.animation.finished;
   }
 
-  static final DEFAULT_OFFSET:Int = 13;
-
   /**
    * Adjusts the position of the sprite's graphic relative to the hitbox.
    */
@@ -206,8 +185,6 @@ class StrumlineNote extends FunkinSprite
       this.offset.y -= DEFAULT_OFFSET;
     }
     else
-    {
       this.centerOrigin();
-    }
   }
 }

--- a/source/funkin/play/notes/SustainTrail.hx
+++ b/source/funkin/play/notes/SustainTrail.hx
@@ -153,7 +153,7 @@ class SustainTrail extends FlxSprite
     }
 
     zoom = 1.0;
-    zoom *= noteStyle.fetchHoldNoteScale();
+    zoom *= noteStyle.getHoldNoteScale();
 
     // CALCULATE SIZE
     graphicWidth = graphic.width / 8 * zoom; // amount of notes * 2

--- a/source/funkin/play/notes/notestyle/NoteStyle.hx
+++ b/source/funkin/play/notes/notestyle/NoteStyle.hx
@@ -425,9 +425,9 @@ class NoteStyle implements IRegistryEntry<NoteStyleData>
     return _data?.assets?.holdNote?.isPixel ?? fallback?.isHoldNotePixel() ?? false;
   }
 
-  public function fetchHoldNoteScale():Float
+  public function getHoldNoteScale():Float
   {
-    return _data?.assets?.holdNote?.scale ?? fallback?.fetchHoldNoteScale() ?? 1.0;
+    return _data?.assets?.holdNote?.scale ?? fallback?.getHoldNoteScale() ?? 1.0;
   }
 
   public function getHoldNoteOffsets():Array<Float>

--- a/source/funkin/ui/debug/charting/ChartEditorState.hx
+++ b/source/funkin/ui/debug/charting/ChartEditorState.hx
@@ -6264,7 +6264,7 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
       var tempNote:NoteSprite = new NoteSprite(NoteStyleRegistry.instance.fetchDefault());
       tempNote.noteData = noteData;
       tempNote.scrollFactor.set(0, 0);
-      var event:NoteScriptEvent = new HitNoteScriptEvent(tempNote, 0.0, 0, 'perfect', false, 0);
+      var event:NoteScriptEvent = new HitNoteScriptEvent(tempNote, null, 0.0, 0, 'perfect', false, 0);
       dispatchEvent(event);
 
       // Calling event.cancelEvent() skips all the other logic! Neat!

--- a/source/funkin/ui/debug/charting/components/ChartEditorHoldNoteSprite.hx
+++ b/source/funkin/ui/debug/charting/components/ChartEditorHoldNoteSprite.hx
@@ -75,7 +75,7 @@ class ChartEditorHoldNoteSprite extends SustainTrail
     }
 
     zoom = 1.0;
-    zoom *= noteStyle.fetchHoldNoteScale();
+    zoom *= noteStyle.getHoldNoteScale();
     zoom *= 0.7;
     zoom *= ChartEditorState.GRID_SIZE / Strumline.STRUMLINE_SIZE;
 

--- a/source/funkin/ui/options/ColorsMenu.hx
+++ b/source/funkin/ui/options/ColorsMenu.hx
@@ -23,7 +23,7 @@ class ColorsMenu extends Page<OptionsState.OptionsMenuPageName>
 
     for (i in 0...4)
     {
-      var note:NoteSprite = new NoteSprite(NoteStyleRegistry.instance.fetchDefault(), i);
+      var note:NoteSprite = new NoteSprite(NoteStyleRegistry.instance.fetchDefault(), null, i);
 
       note.x = (100 * i) + i;
       note.screenCenter(Y);


### PR DESCRIPTION
## Changes
- A lot of classes in`funkin.play.notes`  got reorganized.
- Strumline now have _targetCharacter_ (to determine what character uses this strum) and _downScroll_ (self explanatory) variables.
- Some classes in `funkin.play.notes` now have __parentStrum_.
- Rewrites how **BaseCharacter** handle **NoteScriptEvent**.
- NoteSprite now have _targetCharacter_ , thats override Strumline _targetCharacter_ , and it can be set manually via scripts.
It should work with NoteKinds, i guess

- BaseCharacter got new Helper Functions (Especially _setShader_, because its now used for **AnimateAtlasCharacter** and can be overriden for complex characters, like Nene)

Also a lot of scripts got cleaned up. (No more PlayState.instance.currentStage code in STAGE scripts, duh -_-).

Its hard to write EVERY change in this pr, so check code and write your opinions and what to change.

(the hell is that .github files)


