### PR TITLE
[BUGFIX] Fix Two Issues With Song Text on Freeplay Capsules

### DIFF
--- a/source/funkin/ui/freeplay/FreeplayState.hx
+++ b/source/funkin/ui/freeplay/FreeplayState.hx
@@ -497,6 +497,7 @@ class FreeplayState extends MusicBeatSubState
     // Reminder, this is a callback function being set, rather than these being called here in create()
     letterSort.changeSelectionCallback = (str) -> {
       var curSong:Null<FreeplaySongData> = grpCapsules.members[curSelected]?.freeplayData;
+      grpCapsules.members[curSelected].selected = false;
 
       switch (str)
       {
@@ -1718,6 +1719,7 @@ class FreeplayState extends MusicBeatSubState
     touchTimer = 0;
     var previousVariation:String = currentVariation;
     var daSong:Null<FreeplaySongData> = grpCapsules.members[curSelected].freeplayData;
+    grpCapsules.members[curSelected].selected = false;
 
     // Available variations for current character. We get this since bf is usually `default` variation, and `pico` is `pico`
     // but sometimes pico can be the default variation (weekend 1 songs), and bf can be `bf` variation (darnell)

--- a/source/funkin/ui/freeplay/SongMenuItem.hx
+++ b/source/funkin/ui/freeplay/SongMenuItem.hx
@@ -492,8 +492,6 @@ class SongMenuItem extends FlxSpriteGroup
       spr.visible = value;
     }
 
-    textAppear();
-
     updateSelected();
   }
 
@@ -660,7 +658,11 @@ class SongMenuItem extends FlxSpriteGroup
    */
   public function confirm():Void
   {
-    if (songText != null) songText.flickerText();
+    if (songText != null)
+    {
+      textAppear();
+      songText.flickerText();
+    }
     if (pixelIcon != null && pixelIcon.visible)
     {
       pixelIcon.animation.play('confirm');


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
Fixes #4876. Fixes #2659.
<!-- Briefly describe the issue(s) fixed. -->
## Description
When switching song lists (changing filters or difficulties) from a song not in the new list, its text would remain highlighted when you switched back to the list it is in. This PR fixes the issue by setting the `selected` value of the capsule to `false` before the song list might change.

I also made an adjustment in `SongMenuItem.hx` to fix the squashed text. A detailed description of the change is in a comment below.
<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos
Video of song text not being highlighted:

https://github.com/user-attachments/assets/cd647ce0-f5e1-4034-9aae-8198eb12759d

After the 0.6.4 update, there were three scenarios I found that would always result in a capsule having squished text which is shown below:

https://github.com/user-attachments/assets/9141f79a-1276-48a3-bf75-4cede81fb4e3

Here, you can see these same scenarios no longer produce squished text:

https://github.com/user-attachments/assets/ac74250e-aaf3-4197-8679-b56fe8bcd861
