### PR TITLE
[ENHANCEMENT] Sandboxed API Classes

### DIFF
--- a/source/funkin/api/discord/DiscordClient.hx
+++ b/source/funkin/api/discord/DiscordClient.hx
@@ -204,4 +204,17 @@ typedef DiscordClientPresenceParams =
    */
   var ?smallImageKey:String;
 }
+
+class DiscordClientSandboxed
+{
+  public static function setPresence(params:DiscordClientPresenceParams)
+  {
+    return DiscordClient.instance.setPresence(params);
+  }
+
+  public static function shutdown()
+  {
+    DiscordClient.instance.shutdown();
+  }
+}
 #end

--- a/source/funkin/api/newgrounds/Leaderboards.hx
+++ b/source/funkin/api/newgrounds/Leaderboards.hx
@@ -2,7 +2,10 @@ package funkin.api.newgrounds;
 
 #if FEATURE_NEWGROUNDS
 import io.newgrounds.Call.CallError;
+import io.newgrounds.components.ScoreBoardComponent;
+import io.newgrounds.objects.Score;
 import io.newgrounds.objects.ScoreBoard as LeaderboardData;
+import io.newgrounds.objects.User;
 import io.newgrounds.objects.events.Outcome;
 import io.newgrounds.utils.ScoreBoardList;
 
@@ -67,6 +70,41 @@ class Leaderboards
   }
 
   /**
+   * Request to receive scores from Newgrounds.
+   * @param leaderboard The leaderboard to fetch scores from.
+   * @param params Additional parameters for fetching the score.
+   */
+  public static function requestScores(leaderboard:Leaderboard, params:RequestScoresParams)
+  {
+    // Silently reject retrieving scores from unknown leaderboards.
+    if (leaderboard == Leaderboard.Unknown) return;
+
+    var leaderboardList = NewgroundsClient.instance.leaderboards;
+    if (leaderboardList == null) return;
+
+    var leaderboardData:Null<LeaderboardData> = leaderboardList.get(leaderboard.getId());
+    if (leaderboardData == null) return;
+
+    var user:Null<User> = null;
+    if ((params?.useCurrentUser ?? false) && NewgroundsClient.instance.isLoggedIn()) user = NewgroundsClient.instance.user;
+
+    leaderboardData.requestScores(params?.limit ?? 10, params?.skip ?? 0, params?.period ?? ALL, params?.social ?? false, params?.tag, user,
+      function(outcome:Outcome<CallError>):Void {
+        switch (outcome)
+        {
+          case SUCCESS:
+            trace('[NEWGROUNDS] Fetched scores!');
+            if (params?.onComplete != null) params.onComplete(leaderboardData.scores);
+
+          case FAIL(error):
+            trace('[NEWGROUNDS] Failed to fetch scores!');
+            trace(error);
+            if (params?.onFail != null) params.onFail();
+        }
+      });
+  }
+
+  /**
    * Submit a score for a Story Level to Newgrounds.
    */
   public static function submitLevelScore(levelId:String, difficultyId:String, score:Int):Void
@@ -83,6 +121,74 @@ class Leaderboards
     var tag = '${difficultyId}';
     Leaderboards.submitScore(Leaderboard.getLeaderboardBySong(songId, difficultyId), score, tag);
   }
+}
+
+/**
+ * Wrapper for `Leaderboards` that prevents submitting scores.
+ */
+@:nullSafety
+class LeaderboardsSandboxed
+{
+  public static function getLeaderboardBySong(songId:String, difficultyId:String)
+  {
+    return Leaderboard.getLeaderboardBySong(songId, difficultyId);
+  }
+
+  public static function getLeaderboardByLevel(levelId:String)
+  {
+    return Leaderboard.getLeaderboardByLevel(levelId);
+  }
+
+  public function requestScores(leaderboard:Leaderboard, params:RequestScoresParams)
+  {
+    Leaderboards.requestScores(leaderboard, params);
+  }
+}
+
+/**
+ * Additional parameters for `Leaderboards.requestScores()`
+ */
+typedef RequestScoresParams =
+{
+  /**
+   * How many scores to include in a list.
+   * @default `10`
+   */
+  var ?limit:Int;
+
+  /**
+   * How many scores to skip before starting the list.
+   * @default `0`
+   */
+  var ?skip:Int;
+
+  /**
+   * The time-frame to pull the scores from.
+   * @default `Period.ALL`
+   */
+  var ?period:Period;
+
+  /**
+   * If true, only scores by the user and their friends will be loaded. Ignored if no user is set.
+   * @default `false`
+   */
+  var ?social:Bool;
+
+  /**
+   * An optional tag to filter the results by.
+   * @default `null`
+   */
+  var ?tag:String;
+
+  /**
+   * If true, only the scores from the currently logged in user will be loaded.
+   * Additionally, if `social` is set to true, the scores of the user's friend will be loaded.
+   * @default `false`
+   */
+  var ?useCurrentUser:Bool;
+
+  var ?onComplete:Array<Score>->Void;
+  var ?onFail:Void->Void;
 }
 #end
 

--- a/source/funkin/api/newgrounds/Medals.hx
+++ b/source/funkin/api/newgrounds/Medals.hx
@@ -131,32 +131,78 @@ class Medals
     }
   }
 
-  public static function awardStoryLevel(id:String):Void
+  public static function fetchMedalData(medal:Medal):Null<FetchedMedalData>
   {
-    switch (id)
+    var medalList = NewgroundsClient.instance.medals;
+    @:privateAccess
+    if (medalList == null || medalList._map == null) return null;
+
+    var medalData:Null<MedalData> = medalList.get(medal.getId());
+    @:privateAccess
+    if (medalData == null || medalData._data == null)
     {
-      case 'tutorial':
-        Medals.award(Medal.StoryTutorial);
-      case 'week1':
-        Medals.award(Medal.StoryWeek1);
-      case 'week2':
-        Medals.award(Medal.StoryWeek2);
-      case 'week3':
-        Medals.award(Medal.StoryWeek3);
-      case 'week4':
-        Medals.award(Medal.StoryWeek4);
-      case 'week5':
-        Medals.award(Medal.StoryWeek5);
-      case 'week6':
-        Medals.award(Medal.StoryWeek6);
-      case 'week7':
-        Medals.award(Medal.StoryWeek7);
-      case 'weekend1':
-        Medals.award(Medal.StoryWeekend1);
-      default:
-        trace('[NEWGROUNDS] Story level does not have a medal! (${id}).');
+      trace('[NEWGROUNDS] Could not retrieve data for medal: ${medal}');
+      return null;
+    }
+
+    return {
+      id: medalData.id,
+      name: medalData.name,
+      description: medalData.description,
+      icon: medalData.icon,
+      value: medalData.value,
+      difficulty: medalData.difficulty,
+      secret: medalData.secret,
+      unlocked: medalData.unlocked
     }
   }
+
+  public static function awardStoryLevel(id:String):Void
+  {
+    var medal:Medal = Medal.getMedalByStoryLevel(id);
+    if (medal == Medal.Unknown)
+    {
+      trace('[NEWGROUNDS] Story level does not have a medal! (${id}).');
+      return;
+    }
+    Medals.award(medal);
+  }
+}
+
+/**
+ * Wrapper for `Medals` that prevents awarding medals.
+ */
+class MedalsSandboxed
+{
+  public static function fetchMedalData(medal:Medal):Null<FetchedMedalData>
+  {
+    return Medals.fetchMedalData(medal);
+  }
+
+  public static function getMedalByStoryLevel(id:String):Medal
+  {
+    return Medal.getMedalByStoryLevel(id);
+  }
+
+  public static function getAllMedals():Array<Medal>
+  {
+    return Medal.getAllMedals();
+  }
+}
+
+/**
+ * Contains data for a Medal, but excludes functions like `sendUnlock()`.
+ */
+typedef FetchedMedalData =
+{
+  var id:Int;
+  var name:String;
+  var description:String;
+  var icon:String;
+  var value:Int;
+  var difficulty:Int;
+  var secret:Bool;
+  var unlocked:Bool;
 }
 #end
 
@@ -324,6 +370,8 @@ enum abstract Medal(Int) from Int to Int
   {
     switch (levelId)
     {
+      case "tutorial":
+        return StoryTutorial;
       case "week1":
         return StoryWeek1;
       case "week2":
@@ -343,5 +391,34 @@ enum abstract Medal(Int) from Int to Int
       default:
         return Unknown;
     }
+  }
+
+  /**
+   * Lists all medals aside from the `Unknown` one.
+   */
+  public static function getAllMedals()
+  {
+    return [
+      StartGame,
+      StoryTutorial,
+      StoryWeek1,
+      StoryWeek2,
+      StoryWeek3,
+      StoryWeek4,
+      StoryWeek5,
+      StoryWeek6,
+      StoryWeek7,
+      StoryWeekend1,
+      CharSelect,
+      FreeplayPicoMix,
+      FreeplayStressPico,
+      LossRating,
+      PerfectRatingHard,
+      GoldPerfectRatingHard,
+      ErectDifficulty,
+      GoldPerfectRatingNightmare,
+      FridayNight,
+      Nice
+    ];
   }
 }

--- a/source/funkin/api/newgrounds/NewgroundsClient.hx
+++ b/source/funkin/api/newgrounds/NewgroundsClient.hx
@@ -331,4 +331,22 @@ class NewgroundsClient
     return Save.instance.ngSessionId;
   }
 }
+
+/**
+ * Wrapper for `NewgroundsClient` that prevents submitting cheated data.
+ */
+class NewgroundsClientSandboxed
+{
+  public static var user(get, never):Null<User>;
+
+  static function get_user()
+  {
+    return NewgroundsClient.instance.user;
+  }
+
+  public static function isLoggedIn()
+  {
+    return NewgroundsClient.instance.isLoggedIn();
+  }
+}
 #end

--- a/source/funkin/modding/PolymodHandler.hx
+++ b/source/funkin/modding/PolymodHandler.hx
@@ -258,6 +258,21 @@ class PolymodHandler
     // `funkin.util.FileUtil` has unrestricted access to the file system.
     Polymod.addImportAlias('funkin.util.FileUtil', funkin.util.FileUtilSandboxed);
 
+    #if FEATURE_NEWGROUNDS
+    // `funkin.api.newgrounds.Leaderboards` allows for submitting cheated scores.
+    Polymod.addImportAlias('funkin.api.newgrounds.Leaderboards', funkin.api.newgrounds.Leaderboards.LeaderboardsSandboxed);
+
+    // `funkin.api.newgrounds.Medals` allows for unfair granting of medals.
+    Polymod.addImportAlias('funkin.api.newgrounds.Medals', funkin.api.newgrounds.Medals.MedalsSandboxed);
+
+    // `funkin.api.newgrounds.NewgroundsClientSandboxed` allows for submitting cheated data.
+    Polymod.addImportAlias('funkin.api.newgrounds.NewgroundsClient', funkin.api.newgrounds.NewgroundsClient.NewgroundsClientSandboxed);
+    #end
+
+    #if FEATURE_DISCORD_RPC
+    Polymod.addImportAlias('funkin.api.discord.DiscordClient', funkin.api.discord.DiscordClient.DiscordClientSandboxed);
+    #end
+
     // Add blacklisting for prohibited classes and packages.
 
     // `Sys`
@@ -310,21 +325,13 @@ class PolymodHandler
     {
       if (cls == null) continue;
       var className:String = Type.getClassName(cls);
+      if (polymod.hscript._internal.PolymodScriptClass.importOverrides.exists(className)) continue;
       Polymod.blacklistImport(className);
     }
 
     // `polymod.*`
     // Contains functions which may allow for un-blacklisting other modules.
     for (cls in ClassMacro.listClassesInPackage('polymod'))
-    {
-      if (cls == null) continue;
-      var className:String = Type.getClassName(cls);
-      Polymod.blacklistImport(className);
-    }
-
-    // `funkin.api.newgrounds.*`
-    // Contains functions which allow for cheating medals and leaderboards.
-    for (cls in ClassMacro.listClassesInPackage('funkin.api.newgrounds'))
     {
       if (cls == null) continue;
       var className:String = Type.getClassName(cls);


### PR DESCRIPTION
## Linked Issues
Closes #4996 
Closes #4997
Closes #4998

## Description
Adds sandboxes for following API Classes: 
* `NewgroundsClient`
* `Medals`
* `Leaderboards`
* `DiscordClient`

The newgrounds class sandboxes only provide getter support, and DiscordClientSandbox provides support for setting the status and shutting it down. Let me know if you think the masses crave for something more.

## Screenshots/Videos
### Allowed methods for Medals
![image](https://github.com/user-attachments/assets/eaacb60f-47b4-4d6e-9b3d-2d072b25aa7a)

### Allowed methods for Leaderboards
![image](https://github.com/user-attachments/assets/6d4bec53-0a21-47db-83ac-7ef2f88f57c2)

### Allowed methods for NewgroundsClient
![image](https://github.com/user-attachments/assets/1edb610e-cdd0-4629-b661-94a2349ecbc4)

### Allowed methods for DiscordClient
![image](https://github.com/user-attachments/assets/ec05c8e4-5187-4157-9ebc-272e355b6239)
