### PR TITLE
Remove an unnecessary line from `FreeplayState.hx`

### DIFF
--- a/source/funkin/ui/freeplay/FreeplayState.hx
+++ b/source/funkin/ui/freeplay/FreeplayState.hx
@@ -726,10 +726,6 @@ class FreeplayState extends MusicBeatSubState
     currentFilteredSongs = tempSongs;
     curSelected = 0;
 
-    // If curSelected is 0, the result will be null and fall back to the rememberedSongId.
-    // We set this so if we change the filter, we'd remain on the same song if it's still in the list.
-    rememberedSongId = grpCapsules.members[curSelected]?.freeplayData?.data.id ?? rememberedSongId;
-
     grpCapsules.killMembers();
 
     // Initialize the random capsule, with empty/blank info (which we display once bf/pico does his hand)


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

In `FreeplayState.hx` , there is a line with some comments above it on lines 729-731:

```haxe
// If curSelected is 0, the result will be null and fall back to the rememberedSongId.
// We set this so if we change the filter, we'd remain on the same song if it's still in the list.
rememberedSongId = grpCapsules.members[curSelected]?.freeplayData?.data.id ?? rememberedSongId;
```

However, here is the line directly above this:
```haxe
curSelected = 0;
```

This renders the line below it pointless because `curSelected` will always be 0 meaning the value of `rememberedSongId` never changes. This line doesn't need to stay as it doesn't do anything. It also isn't necessary for changing filters because that function doesn't use `rememberedSongId`.