### PR TITLE
[CHORE] "Auto Pause" -> "Pause on Unfocus" in Module.hx comments

### DIFF
--- a/source/funkin/modding/module/Module.hx
+++ b/source/funkin/modding/module/Module.hx
@@ -176,13 +176,13 @@ class Module implements IPlayStateScriptedClass implements IStateChangingScripte
 
   /**
    * Called when the game regains focus.
-   * This does not get called if "Auto Pause" is disabled.
+   * This does not get called if "Pause on Unfocus" is disabled.
    */
   public function onFocusGained(event:FocusScriptEvent) {}
 
   /**
    * Called when the game loses focus.
-   * This does not get called if "Auto Pause" is disabled.
+   * This does not get called if "Pause on Unfocus" is disabled.
    */
   public function onFocusLost(event:FocusScriptEvent) {}
 


### PR DESCRIPTION
<!-- Briefly describe the issue(s) fixed. -->
## Description
Comments in Module.hx incorrectly refer to `Pause on Unfocus` as `Auto Pause` even after the option was renamed, so this PR fixes that. 