### PR TITLE
[BUGFIX] Hit window offset when downscroll

### DIFF
--- a/source/funkin/play/notes/notestyle/NoteStyle.hx
+++ b/source/funkin/play/notes/notestyle/NoteStyle.hx
@@ -315,7 +315,7 @@ class NoteStyle implements IRegistryEntry<NoteStyleData>
   {
     var offsets = getStrumlineOffsets();
     target.x += offsets[0];
-    target.y += offsets[1];
+    target.y += Preferences.downscroll ? -offsets[1] : offsets[1];
   }
 
   public function getStrumlineScale():Float


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
Fixes FunkinCrew/Funkin#2969, fixes FunkinCrew/Funkin#2400, closes FunkinCrew/Funkin#2877
<!-- Briefly describe the issue(s) fixed. -->
## Description
>[!IMPORTANT]
> Requires Assets PR: https://github.com/FunkinCrew/funkin.assets/pull/142

Subtracts the notestyle strumnote y offset when downscroll.

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos
With offset, before fix
![Screenshot 2025-05-10 213741](https://github.com/user-attachments/assets/640c4b8a-7326-4ad4-871c-56ece6a06fb1)
With offset, after fix
![Screenshot 2025-05-10 213432](https://github.com/user-attachments/assets/d9946507-5839-4ef8-8af0-a6b2242b2a5b)
