### PR TITLE
[BUGFIX] Fix the game crashing when hot-reloading with F5

### DIFF
--- a/source/funkin/play/PlayState.hx
+++ b/source/funkin/play/PlayState.hx
@@ -1424,7 +1424,7 @@ class PlayState extends MusicBeatSubState
     performCleanup();
 
     // `performCleanup()` clears the static reference to this state
-    // scripts might sitll need it, so we set it back to `this`
+    // scripts might still need it, so we set it back to `this`
     instance = this;
 
     funkin.modding.PolymodHandler.forceReloadAssets();

--- a/source/funkin/play/PlayState.hx
+++ b/source/funkin/play/PlayState.hx
@@ -1423,6 +1423,10 @@ class PlayState extends MusicBeatSubState
   {
     performCleanup();
 
+    // `performCleanup()` clears the static reference to this state
+    // scripts might sitll need it, so we set it back to `this`
+    instance = this;
+
     funkin.modding.PolymodHandler.forceReloadAssets();
     lastParams.targetSong = SongRegistry.instance.fetchEntry(currentSong.id);
     LoadingState.loadPlayState(lastParams);


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
Fixes https://github.com/FunkinCrew/Funkin/issues/4990

<!-- Briefly describe the issue(s) fixed. -->
## Description
`instance` gets set to `null` in `performCleanup()` when the game hot-reloads, this was caused by https://github.com/FunkinCrew/Funkin/pull/4769.
This led to multiple errors from scripts that tried to access `instance`, and eventually a crash from line 1882 from `DiscordClient`.

This PR sets `instance` back to `this`, fixing the errors and the aforementioned crash.