### PR TITLE
RECOVERY: Add `fromOrigin` to character positioning (#2991)

### DIFF
--- a/source/funkin/data/stage/StageData.hx
+++ b/source/funkin/data/stage/StageData.hx
@@ -249,6 +249,16 @@ typedef StageDataCharacter =
   var position:Array<Float>;
 
   /**
+   * If set to true, when positioning the character, the position origin will be at vertical bottom and horizontal center of the sprite.
+   * If set to false, when positioning the character, the position origin will be at the top-left of the sprite.
+   * This prevents characters from not being properly positioned.
+   * @default true
+   */
+  @:optional
+  @:default(true)
+  var fromOrigin:Bool;
+
+  /**
    * The scale to render the character at.
    */
   @:optional

--- a/source/funkin/play/character/BaseCharacter.hx
+++ b/source/funkin/play/character/BaseCharacter.hx
@@ -249,8 +249,9 @@ class BaseCharacter extends Bopper
   /**
    * Set the character's sprite scale to the appropriate value.
    * @param scale The desired scale.
+   * @param fromOrigin If true, it will reposition the character from its origin.
    */
-  public function setScale(scale:Null<Float>):Void
+  public function setScale(scale:Null<Float>, fromOrigin:Bool = true):Void
   {
     if (scale == null) scale = 1.0;
 
@@ -258,9 +259,12 @@ class BaseCharacter extends Bopper
     this.scale.x = scale;
     this.scale.y = scale;
     this.updateHitbox();
-    // Reposition with newly scaled sprite.
-    this.x = feetPos.x - characterOrigin.x + globalOffsets[0];
-    this.y = feetPos.y - characterOrigin.y + globalOffsets[1];
+    if (fromOrigin)
+    {
+      // Reposition with newly scaled sprite.
+      this.x = feetPos.x - characterOrigin.x + globalOffsets[0];
+      this.y = feetPos.y - characterOrigin.y + globalOffsets[1];
+    }
   }
 
   /**

--- a/source/funkin/play/stage/Stage.hx
+++ b/source/funkin/play/stage/Stage.hx
@@ -102,7 +102,7 @@ class Stage extends FlxSpriteGroup implements IPlayStateScriptedClass implements
       // Reapply the camera offsets.
       var stageCharData:StageDataCharacter = _data.characters.bf;
       var finalScale:Float = getBoyfriend().getBaseScale() * stageCharData.scale;
-      getBoyfriend().setScale(finalScale);
+      getBoyfriend().setScale(finalScale, stageCharData.fromOrigin);
       getBoyfriend().cameraFocusPoint.x += stageCharData.cameraOffsets[0];
       getBoyfriend().cameraFocusPoint.y += stageCharData.cameraOffsets[1];
     }
@@ -116,7 +116,7 @@ class Stage extends FlxSpriteGroup implements IPlayStateScriptedClass implements
       // Reapply the camera offsets.
       var stageCharData:StageDataCharacter = _data.characters.gf;
       var finalScale:Float = getGirlfriend().getBaseScale() * stageCharData.scale;
-      getGirlfriend().setScale(finalScale);
+      getGirlfriend().setScale(finalScale, stageCharData.fromOrigin);
       getGirlfriend().cameraFocusPoint.x += stageCharData.cameraOffsets[0];
       getGirlfriend().cameraFocusPoint.y += stageCharData.cameraOffsets[1];
     }
@@ -126,7 +126,7 @@ class Stage extends FlxSpriteGroup implements IPlayStateScriptedClass implements
       // Reapply the camera offsets.
       var stageCharData:StageDataCharacter = _data.characters.dad;
       var finalScale:Float = getDad().getBaseScale() * stageCharData.scale;
-      getDad().setScale(finalScale);
+      getDad().setScale(finalScale, stageCharData.fromOrigin);
       getDad().cameraFocusPoint.x += stageCharData.cameraOffsets[0];
       getDad().cameraFocusPoint.y += stageCharData.cameraOffsets[1];
     }
@@ -439,13 +439,22 @@ class Stage extends FlxSpriteGroup implements IPlayStateScriptedClass implements
       // Subtracting the origin ensures characters are positioned relative to their feet.
       // Subtracting the global offset allows positioning on a per-character basis.
       // We previously applied the global offset here but that is now done elsewhere.
-      character.x = stageCharData.position[0] - character.characterOrigin.x;
-      character.y = stageCharData.position[1] - character.characterOrigin.y;
+      character.x = stageCharData.position[0];
+      character.y = stageCharData.position[1];
+
+      if (stageCharData.fromOrigin)
+      {
+        character.x -= character.characterOrigin.x;
+        character.y -= character.characterOrigin.y;
+      }
+
+      character.x += character.globalOffsets[0];
+      character.y += character.globalOffsets[1];
 
       character.originalPosition.set(character.x, character.y);
 
       var finalScale = character.getBaseScale() * stageCharData.scale;
-      character.setScale(finalScale); // Don't use scale.set for characters!
+      character.setScale(finalScale, stageCharData.fromOrigin); // Don't use scale.set for characters!
       character.cameraFocusPoint.x += stageCharData.cameraOffsets[0];
       character.cameraFocusPoint.y += stageCharData.cameraOffsets[1];
 


### PR DESCRIPTION
# About this pull request
This pull request was made to recover https://github.com/FunkinCrew/Funkin/pull/2991 which was closed due to inactivity, as the author no longer appears to be active on the repository. 
If this pull request is merged, the original author will receive credit instead of me.

NOTE: If the original author returns to update the original pull request, this pull request will be closed.

# Original pull request description
Adds a `fromOrigin` property to stage character data (defaults to true)

```
"bf": {
	"zIndex": 300,
	"position": [4200, 2850],
	"fromOrigin": false,
	"cameraOffsets": [-300, -300]
},
```

It set to true, everything just acts like normal, but if you turn it off, it positions the character in absolute coordinates (also using character position offsets), ignoring the feet position and horizontal center. Pretty useful when moving stuff from old engines.