### PR TITLE
RECOVERY: Working input offset (#3234)

### DIFF
--- a/source/funkin/play/PlayState.hx
+++ b/source/funkin/play/PlayState.hx
@@ -2287,9 +2287,9 @@ class PlayState extends MusicBeatSubState
         continue;
       }
 
-      var hitWindowStart = note.strumTime - Constants.HIT_WINDOW_MS;
-      var hitWindowCenter = note.strumTime;
-      var hitWindowEnd = note.strumTime + Constants.HIT_WINDOW_MS;
+      var hitWindowStart = note.strumTime + Conductor.instance.inputOffset - Constants.HIT_WINDOW_MS;
+      var hitWindowCenter = note.strumTime + Conductor.instance.inputOffset;
+      var hitWindowEnd = note.strumTime + Conductor.instance.inputOffset + Constants.HIT_WINDOW_MS;
 
       if (Conductor.instance.songPosition > hitWindowEnd)
       {


### PR DESCRIPTION
# About this pull request
This pull request was made to recover https://github.com/FunkinCrew/Funkin/pull/3234 which was closed due to inactivity, as the author no longer appears to be active on the repository. 
If this pull request is merged, the original author will receive credit instead of me.

NOTE: If the original author returns to update the original pull request, this pull request will be closed.

# Original pull request description
## Does this PR close any issues? If so, link them below.

#2382
## Briefly describe the issue(s) fixed. 

The input offset value currently doesn't adjust the hit windows for the player.
## Include any relevant screenshots or videos.
 
Here are two videos. The first is on the current build of the game, and the second is on a build with this fix implemented. The offset in both is 800ms. You can see that in the first video, the hit window occurs well before the notes reach the strumline, whereas in the second video the hit window lines up with when the notes hit the strumline.

https://private-user-images.githubusercontent.com/169327791/367469908-fee4b7a9-1a07-4546-a3ee-203904579184.mp4

https://private-user-images.githubusercontent.com/169327791/367469924-19f12ddf-bbbc-465d-a60a-b27fac46fb45.mp4

The event animations (like the BF "hey") still don't adjust for offset, but I'm not sure how to go about fixing that (Also my IDE added a bunch of whitespace to some of the comments for some reason, please disregard)