### PR TITLE
[BUGFIX] Fix Latency State Exiting to Main Menu Instead of Options Menu

### DIFF
--- a/source/funkin/ui/debug/latency/LatencyState.hx
+++ b/source/funkin/ui/debug/latency/LatencyState.hx
@@ -314,7 +314,7 @@ class LatencyState extends MusicBeatSubState
     {
       // close();
       cleanup();
-      FlxG.switchState(() -> new MainMenuState());
+      FlxG.switchState(() -> new funkin.ui.options.OptionsState());
     }
 
     super.update(elapsed);


### PR DESCRIPTION
<!-- Does this PR close any issues? If so, link them below. -->
Fixes #5069 

<!-- Briefly describe the issue(s) fixed. -->
## Description
Exiting latency state (input offsets menu) would bring you back to the main menu instead of the options menu. This PR fixes that.
<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos
https://github.com/user-attachments/assets/5ff0fe30-beee-4fb7-9fe9-394c5676473a



