### PR TITLE
[BUGFIX] Fix LatencyState cleanup not being performed in hot-reload

### DIFF
--- a/source/funkin/ui/debug/latency/LatencyState.hx
+++ b/source/funkin/ui/debug/latency/LatencyState.hx
@@ -179,10 +179,10 @@ class LatencyState extends MusicBeatSubState
     strumLine.releaseKey(event.noteDirection);
   }
 
-  override public function close():Void
+  override public function destroy():Void
   {
     cleanup();
-    super.close();
+    super.destroy();
   }
 
   function cleanup():Void


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
Fixes the NOR in #4252 (please make two different things two separate issues ok thx)
<!-- Briefly describe the issue(s) fixed. -->
## Description
The `close` function was never being called by anything so in some cases `cleanup` would never run and cause an error.
But `destroy` on the other hand can be relied on, so this fixes this by simply replacing `close` with it.

(Not sure why someone would run hot-reload in the input offsets state though... oh wait, this also happens if you press F4 since there's also a state switch, so valid issue I guess)
<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos
N/A ~guhh i can't be bothered to make a video for this fix~