### PR TITLE
[ENHANCEMENT] Chart Editor Leave Prompt

### DIFF
--- a/source/funkin/ui/debug/charting/ChartEditorState.hx
+++ b/source/funkin/ui/debug/charting/ChartEditorState.hx
@@ -90,6 +90,9 @@ import haxe.ui.backend.flixel.UIState;
 import haxe.ui.components.Button;
 import haxe.ui.components.Label;
 import haxe.ui.components.Slider;
+import haxe.ui.containers.dialogs.Dialogs;
+import haxe.ui.containers.dialogs.Dialog.DialogButton;
+import haxe.ui.containers.dialogs.MessageBox.MessageBoxType;
 import haxe.ui.containers.dialogs.CollapsibleDialog;
 import haxe.ui.containers.menus.Menu;
 import haxe.ui.containers.menus.MenuBar;
@@ -5431,7 +5434,18 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
   @:nullSafety(Off)
   function quitChartEditor():Void
   {
-    autoSave();
+    if (saveDataDirty) {
+      Dialogs.messageBox("You are about to leave the editor without saving.\n\nAre you sure?", "Leave Editor", MessageBoxType.TYPE_YESNO, true, function(button:DialogButton) {
+        if (button == DialogButton.YES)
+        {
+          autoSave();
+          quitChartEditor();
+        }
+      });
+
+      return;
+    }
+
     stopWelcomeMusic();
     // TODO: PR Flixel to make onComplete nullable.
     if (audioInstTrack != null) audioInstTrack.onComplete = null;


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Briefly describe the issue(s) fixed. -->
## Description
* Whenever leaving the chart editor, there always was a problem, that there wasn't a prompt that asks people whether or not they actually want to leave, instead, it would just exit instantly.
* From what can be seen, people actually want this:

![image](https://github.com/user-attachments/assets/065a4e6c-da5f-4e86-84f5-14b09ae95f44)

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos
![screenshot-2025-05-14-22-40-53](https://github.com/user-attachments/assets/b81a421a-89f3-4aa8-a0c3-f482101001aa)
