### PR TITLE
[BUGFIX?] Fix overly repeated trace for Chart Editor Event Sprite

### DIFF
--- a/source/funkin/ui/debug/charting/components/ChartEditorEventSprite.hx
+++ b/source/funkin/ui/debug/charting/components/ChartEditorEventSprite.hx
@@ -123,7 +123,6 @@ class ChartEditorEventSprite extends FlxSprite
   public function correctAnimationName(name:String):String
   {
     if (this.animation.exists(name)) return name;
-    trace('Warning: Invalid animation name "${name}" for song event. Using "${DEFAULT_EVENT}"');
     return DEFAULT_EVENT;
   }
 


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
https://github.com/FunkinCrew/Funkin/issues/2649 && https://github.com/FunkinCrew/Funkin/issues/4205
<!-- Briefly describe the issue(s) fixed. -->
## Description
* Don't you absolutely LOVE to try to debug a certain problem you may be experience during your development just to be interrupted with `Invalid animation name "ZoomCamera" for song event. Using "Default"`? And so do I and countless people! Thus, this PR aims to remove that eye-numbing trace that only gets in the way.
