### PR TITLE
WaveformDataParser: 32bit float audio support

### DIFF
--- a/source/funkin/audio/waveform/WaveformData.hx
+++ b/source/funkin/audio/waveform/WaveformData.hx
@@ -72,12 +72,12 @@ class WaveformData
     return (channelData == null) ? buildChannelData()[index] : channelData[index];
   }
 
-  public function get(index:Int):Int
+  public inline function get(index:Int):Int
   {
     return data[index] ?? 0;
   }
 
-  public function set(index:Int, value:Int)
+  public inline function set(index:Int, value:Int)
   {
     data[index] = value;
   }
@@ -88,8 +88,9 @@ class WaveformData
    */
   public function maxSampleValue():Int
   {
+    // TODO: Should this still be cached?
     if (_maxSampleValue != 0) return _maxSampleValue;
-    return _maxSampleValue = Std.int(Math.pow(2, bits));
+    return _maxSampleValue = 1 << bits;
   }
 
   /**


### PR DESCRIPTION
## Associated PR
https://github.com/FunkinCrew/lime/pull/12

## Linked Issues
N/A
<!-- Briefly describe the issue(s) fixed. -->
## Description
This is part of my work on implementing multiple audio file formats (like MP3, FLAC and some others), which required changing this class to also accommodate for 32bit audio.
Just two things to consider: 
* It expects all audio to be either signed 8 bit, signed 16 bit, or 32 bit float (could've been 32 bit int too but limitations on the current OpenAL-Soft version prevented that). I can probably adjust the Lime PR to also allow for detecting the sign though.
* The game doesn't seem to be actually able to decode 32 bit audio to actual 32 bit, the OGG decoder seems to only decode to 16 bits at most, and while WAV can there's no handling for that bit per sample on `NativeAudioSource`. To put it simple, this PR only really makes sense if merged alongside the Lime one.
<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos
(Note: Being able to load MP3 audio is not part of this PR)

https://github.com/user-attachments/assets/fdb8378b-709d-4ffb-b04c-d810439b95f5

There is also no significant difference between waveforms!

| 8 bit | 16 bit | 32 bit Float |
|--------|--------|--------|
| ![8bit](https://github.com/user-attachments/assets/c1255b4c-fa00-4d9a-a48f-537dd37e6773) | ![16bit](https://github.com/user-attachments/assets/dc17baf8-7fc3-4d83-9543-13bc23f19b8f) |  ![32bit](https://github.com/user-attachments/assets/0fb3ce3a-eb0f-4950-bae0-9abce7d085ee) | 