### PR TITLE
[ENHANCEMENT] Sanitize `.json` text before parsing

### DIFF
--- a/source/funkin/util/SerializerUtil.hx
+++ b/source/funkin/util/SerializerUtil.hx
@@ -34,11 +34,7 @@ class SerializerUtil
    */
   public static function fromJSON(input:String):Dynamic
   {
-    while (!input.startsWith("{"))
-      input = input.substring(1);
-
-    while (!input.endsWith("}"))
-      input = input.substring(0, input.length - 1);
+    input = input.substring(input.indexOf("{"), input.lastIndexOf("}") + 1);
 
     try
     {

--- a/source/funkin/util/SerializerUtil.hx
+++ b/source/funkin/util/SerializerUtil.hx
@@ -34,6 +34,12 @@ class SerializerUtil
    */
   public static function fromJSON(input:String):Dynamic
   {
+    while (!input.startsWith("{"))
+      input = input.substring(1);
+
+    while (!input.endsWith("}"))
+      input = input.substring(0, input.length - 1);
+
     try
     {
       return Json.parse(input);

--- a/source/funkin/util/macro/RegistryMacro.hx
+++ b/source/funkin/util/macro/RegistryMacro.hx
@@ -182,7 +182,7 @@ class RegistryMacro
           switch (this.loadEntryFile(id))
           {
             case {fileName: fileName, contents: contents}:
-              parser.fromJson(contents, fileName);
+              parser.fromJson(contents.substring(contents.indexOf("{"), contents.lastIndexOf("}") + 1), fileName);
             default:
               return null;
           }


### PR DESCRIPTION
## Description
Sometimes when converting `Bytes` directly into a `String`, a bit of gibberish would be left at the start or end, causing the json parsing process to throw an error. This PR adds automatic removal of said gibberish before parsing a json text with `SerializerUtil` and before any registry json is parsed, which would spare modders having to do this themselves or struggling to find the issue.