### PR TITLE
[BUGFIX] Sing animations not ignored when animation is forced

### DIFF
--- a/source/funkin/play/character/BaseCharacter.hx
+++ b/source/funkin/play/character/BaseCharacter.hx
@@ -152,8 +152,6 @@ class BaseCharacter extends Bopper
 
     this.characterId = id;
 
-    ignoreExclusionPref = ["sing"];
-
     _data = CharacterDataParser.fetchCharacterData(this.characterId);
     if (_data == null)
     {


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
Fixes #3491
<!-- Briefly describe the issue(s) fixed. -->
## Description
Animations starting with `sing` are not ignored when an animation is forced for a character.
<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos

https://github.com/user-attachments/assets/1ea15d4c-28c0-4110-962b-d7369830ab56