### PR TITLE
[CHORE] Null safety to 4 `ui.freeplay.backcards` classes

### DIFF
--- a/source/funkin/ui/freeplay/backcards/BackingCard.hx
+++ b/source/funkin/ui/freeplay/backcards/BackingCard.hx
@@ -15,6 +15,7 @@ import flixel.group.FlxSpriteGroup;
 /**
  * A class for the backing cards so they dont have to be part of freeplayState......
  */
+@:nullSafety
 class BackingCard extends FlxSpriteGroup
 {
   public var backingTextYeah:FlxAtlasSprite;
@@ -29,13 +30,13 @@ class BackingCard extends FlxSpriteGroup
   var _exitMovers:Null<FreeplayState.ExitMoverData>;
   var _exitMoversCharSel:Null<FreeplayState.ExitMoverData>;
 
-  public var instance:FreeplayState;
+  public var instance:Null<FreeplayState>;
 
   public function new(currentCharacter:PlayableCharacter, ?_instance:FreeplayState)
   {
     super();
 
-    if (_instance != null) instance = _instance;
+    if (_instance != null) this.instance = _instance;
 
     cardGlow = new FlxSprite(-30, -30).loadGraphic(Paths.image('freeplay/cardGlow'));
     confirmGlow = new FlxSprite(-30, 240).loadGraphic(Paths.image('freeplay/confirmGlow'));
@@ -184,10 +185,10 @@ class BackingCard extends FlxSpriteGroup
     confirmGlow2.alpha = 0;
     confirmGlow.alpha = 0;
 
-    FlxTween.color(instance.backingImage, 0.5, 0xFFA8A8A8, 0xFF646464,
+    if (instance != null) FlxTween.color(instance?.backingImage, 0.5, 0xFFA8A8A8, 0xFF646464,
       {
         onUpdate: function(_) {
-          instance.angleMaskShader.extraColor = instance.backingImage.color;
+          if (instance != null) instance.angleMaskShader.extraColor = instance.backingImage.color;
         }
       });
     FlxTween.tween(confirmGlow2, {alpha: 0.5}, 0.33,
@@ -200,11 +201,11 @@ class BackingCard extends FlxSpriteGroup
           confirmTextGlow.alpha = 1;
           FlxTween.tween(confirmTextGlow, {alpha: 0.4}, 0.5);
           FlxTween.tween(confirmGlow, {alpha: 0}, 0.5);
-          FlxTween.color(instance.backingImage, 2, 0xFFCDCDCD, 0xFF555555,
+          if (instance != null) FlxTween.color(instance.backingImage, 2, 0xFFCDCDCD, 0xFF555555,
             {
               ease: FlxEase.expoOut,
               onUpdate: function(_) {
-                instance.angleMaskShader.extraColor = instance.backingImage.color;
+                if (instance != null) instance.angleMaskShader.extraColor = instance.backingImage.color;
               }
             });
         }

--- a/source/funkin/ui/freeplay/backcards/BoyfriendCard.hx
+++ b/source/funkin/ui/freeplay/backcards/BoyfriendCard.hx
@@ -8,6 +8,7 @@ import flixel.util.FlxSpriteUtil;
 import funkin.ui.freeplay.charselect.PlayableCharacter;
 import openfl.display.BlendMode;
 
+@:nullSafety
 class BoyfriendCard extends BackingCard
 {
   public var moreWays:BGScrollingText;
@@ -85,6 +86,8 @@ class BoyfriendCard extends BackingCard
     moreWays2 = new BGScrollingText(0, 397, currentCharacter.getFreeplayDJText(2), FlxG.width, true, 43);
     txtNuts = new BGScrollingText(0, 285, currentCharacter.getFreeplayDJText(3), FlxG.width / 2, true, 43);
     funnyScroll3 = new BGScrollingText(0, orangeBackShit.y + 10, currentCharacter.getFreeplayDJText(1), FlxG.width / 2, 60);
+    glow = new FlxSprite(-300, 330).loadGraphic(Paths.image('freeplay/beatglow'));
+    glowDark = new FlxSprite(-300, 330).loadGraphic(Paths.image('freeplay/beatglow'));
   }
 
   public override function init():Void
@@ -148,11 +151,9 @@ class BoyfriendCard extends BackingCard
     funnyScroll3.speed = -3.8;
     add(funnyScroll3);
 
-    glowDark = new FlxSprite(-300, 330).loadGraphic(Paths.image('freeplay/beatglow'));
     glowDark.blend = BlendMode.MULTIPLY;
     add(glowDark);
 
-    glow = new FlxSprite(-300, 330).loadGraphic(Paths.image('freeplay/beatglow'));
     glow.blend = BlendMode.ADD;
     add(glow);
 

--- a/source/funkin/ui/freeplay/backcards/NewCharacterCard.hx
+++ b/source/funkin/ui/freeplay/backcards/NewCharacterCard.hx
@@ -7,11 +7,13 @@ import flixel.tweens.FlxEase;
 import flixel.tweens.FlxTween;
 import flixel.util.FlxColor;
 import funkin.graphics.adobeanimate.FlxAtlasSprite;
+import funkin.ui.freeplay.charselect.PlayableCharacter;
 import openfl.display.BlendMode;
 
+@:nullSafety
 class NewCharacterCard extends BackingCard
 {
-  var confirmAtlas:FlxAtlasSprite;
+  // var confirmAtlas:FlxAtlasSprite;
 
   var darkBg:FlxSprite;
   var lightLayer:FlxSprite;
@@ -22,7 +24,7 @@ class NewCharacterCard extends BackingCard
   var yellow:FlxSprite;
   var multiplyBar:FlxSprite;
 
-  var bruh:FlxSprite;
+  // var bruh:FlxSprite;
 
   public var friendFoe:BGScrollingText;
   public var newUnlock1:BGScrollingText;
@@ -108,6 +110,26 @@ class NewCharacterCard extends BackingCard
     FlxTween.tween(newUnlock3, {speed: 0}, 0.8, {ease: FlxEase.sineIn});
   }
 
+  public override function new(currentCharacter:PlayableCharacter)
+  {
+    super(currentCharacter);
+
+    friendFoe = new BGScrollingText(0, 163, "COULD IT BE A NEW FRIEND? OR FOE??", FlxG.width, true, 43);
+    newUnlock1 = new BGScrollingText(-440, 215, 'NEW UNLOCK!', FlxG.width / 2, true, 80);
+    waiting = new BGScrollingText(0, 286, "SOMEONE'S WAITING!", FlxG.width / 2, true, 43);
+    newUnlock2 = new BGScrollingText(-220, 331, 'NEW UNLOCK!', FlxG.width / 2, true, 80);
+    friendFoe2 = new BGScrollingText(0, 402, 'COULD IT BE A NEW FRIEND? OR FOE??', FlxG.width, true, 43);
+    newUnlock3 = new BGScrollingText(0, 458, 'NEW UNLOCK!', FlxG.width / 2, true, 80);
+    darkBg = new FlxSprite(0, 0).loadGraphic(Paths.image('freeplay/backingCards/newCharacter/darkback'));
+    multiplyBar = new FlxSprite(-10, 440).loadGraphic(Paths.image('freeplay/backingCards/newCharacter/multiplyBar'));
+    lightLayer = new FlxSprite(-360, 230).loadGraphic(Paths.image('freeplay/backingCards/newCharacter/orange gradient'));
+    multiply1 = new FlxSprite(-15, -125).loadGraphic(Paths.image('freeplay/backingCards/newCharacter/red'));
+    multiply2 = new FlxSprite(-15, -125).loadGraphic(Paths.image('freeplay/backingCards/newCharacter/red'));
+    lightLayer2 = new FlxSprite(-360, 230).loadGraphic(Paths.image('freeplay/backingCards/newCharacter/orange gradient'));
+    yellow = new FlxSprite(0, 0).loadGraphic(Paths.image('freeplay/backingCards/newCharacter/yellow bg piece'));
+    lightLayer3 = new FlxSprite(-360, 290).loadGraphic(Paths.image('freeplay/backingCards/newCharacter/red gradient'));
+  }
+
   public override function init():Void
   {
     FlxTween.tween(pinkBack, {x: 0}, 0.6, {ease: FlxEase.quartOut});
@@ -121,14 +143,6 @@ class NewCharacterCard extends BackingCard
     confirmGlow.visible = false;
     confirmGlow2.visible = false;
 
-    friendFoe = new BGScrollingText(0, 163, "COULD IT BE A NEW FRIEND? OR FOE??", FlxG.width, true, 43);
-    newUnlock1 = new BGScrollingText(-440, 215, 'NEW UNLOCK!', FlxG.width / 2, true, 80);
-    waiting = new BGScrollingText(0, 286, "SOMEONE'S WAITING!", FlxG.width / 2, true, 43);
-    newUnlock2 = new BGScrollingText(-220, 331, 'NEW UNLOCK!', FlxG.width / 2, true, 80);
-    friendFoe2 = new BGScrollingText(0, 402, 'COULD IT BE A NEW FRIEND? OR FOE??', FlxG.width, true, 43);
-    newUnlock3 = new BGScrollingText(0, 458, 'NEW UNLOCK!', FlxG.width / 2, true, 80);
-
-    darkBg = new FlxSprite(0, 0).loadGraphic(Paths.image('freeplay/backingCards/newCharacter/darkback'));
     add(darkBg);
 
     friendFoe.funnyColor = 0xFF139376;
@@ -155,31 +169,24 @@ class NewCharacterCard extends BackingCard
     newUnlock3.speed = 2;
     add(newUnlock3);
 
-    multiplyBar = new FlxSprite(-10, 440).loadGraphic(Paths.image('freeplay/backingCards/newCharacter/multiplyBar'));
     multiplyBar.blend = BlendMode.MULTIPLY;
     add(multiplyBar);
 
-    lightLayer = new FlxSprite(-360, 230).loadGraphic(Paths.image('freeplay/backingCards/newCharacter/orange gradient'));
     lightLayer.blend = BlendMode.ADD;
     add(lightLayer);
 
-    multiply1 = new FlxSprite(-15, -125).loadGraphic(Paths.image('freeplay/backingCards/newCharacter/red'));
     multiply1.blend = BlendMode.MULTIPLY;
     add(multiply1);
 
-    multiply2 = new FlxSprite(-15, -125).loadGraphic(Paths.image('freeplay/backingCards/newCharacter/red'));
     multiply2.blend = BlendMode.MULTIPLY;
     add(multiply2);
 
-    lightLayer2 = new FlxSprite(-360, 230).loadGraphic(Paths.image('freeplay/backingCards/newCharacter/orange gradient'));
     lightLayer2.blend = BlendMode.ADD;
     add(lightLayer2);
 
-    yellow = new FlxSprite(0, 0).loadGraphic(Paths.image('freeplay/backingCards/newCharacter/yellow bg piece'));
     yellow.blend = BlendMode.MULTIPLY;
     add(yellow);
 
-    lightLayer3 = new FlxSprite(-360, 290).loadGraphic(Paths.image('freeplay/backingCards/newCharacter/red gradient'));
     lightLayer3.blend = BlendMode.ADD;
     add(lightLayer3);
 

--- a/source/funkin/ui/freeplay/backcards/PicoCard.hx
+++ b/source/funkin/ui/freeplay/backcards/PicoCard.hx
@@ -7,9 +7,11 @@ import flixel.tweens.FlxEase;
 import flixel.tweens.FlxTween;
 import flixel.util.FlxTimer;
 import funkin.graphics.adobeanimate.FlxAtlasSprite;
+import funkin.ui.freeplay.charselect.PlayableCharacter;
 import openfl.display.BlendMode;
 import flixel.addons.display.FlxBackdrop;
 
+@:nullSafety
 class PicoCard extends BackingCard
 {
   var scrollBack:FlxBackdrop;
@@ -72,6 +74,20 @@ class PicoCard extends BackingCard
       });
   }
 
+  public override function new(currentCharacter:PlayableCharacter)
+  {
+    super(currentCharacter);
+
+    scrollBack = new FlxBackdrop(Paths.image('freeplay/backingCards/pico/lowerLoop'), X, 20);
+    scrollLower = new FlxBackdrop(Paths.image('freeplay/backingCards/pico/lowerLoop'), X, 20);
+    blueBar = new FlxSprite(0, 239).loadGraphic(Paths.image('freeplay/backingCards/pico/blueBar'));
+    scrollTop = new FlxBackdrop(null, X, 20);
+    scrollMiddle = new FlxBackdrop(Paths.image('freeplay/backingCards/pico/middleLoop'), X, 15);
+    glowDark = new FlxSprite(-300, 330).loadGraphic(Paths.image('freeplay/backingCards/pico/glow'));
+    glow = new FlxSprite(-300, 330).loadGraphic(Paths.image('freeplay/backingCards/pico/glow'));
+    confirmAtlas = new FlxAtlasSprite(5, 55, Paths.animateAtlas("freeplay/backingCards/pico/pico-confirm"));
+  }
+
   public override function init():Void
   {
     FlxTween.tween(pinkBack, {x: 0}, 0.6, {ease: FlxEase.quartOut});
@@ -85,24 +101,20 @@ class PicoCard extends BackingCard
     confirmGlow.visible = false;
     confirmGlow2.visible = false;
 
-    scrollBack = new FlxBackdrop(Paths.image('freeplay/backingCards/pico/lowerLoop'), X, 20);
     scrollBack.setPosition(0, 200);
     scrollBack.flipX = true;
     scrollBack.alpha = 0.39;
     scrollBack.velocity.x = 110;
     add(scrollBack);
 
-    scrollLower = new FlxBackdrop(Paths.image('freeplay/backingCards/pico/lowerLoop'), X, 20);
     scrollLower.setPosition(0, 406);
     scrollLower.velocity.x = -110;
     add(scrollLower);
 
-    blueBar = new FlxSprite(0, 239).loadGraphic(Paths.image('freeplay/backingCards/pico/blueBar'));
     blueBar.blend = BlendMode.MULTIPLY;
     blueBar.alpha = 0.4;
     add(blueBar);
 
-    scrollTop = new FlxBackdrop(null, X, 20);
     scrollTop.setPosition(0, 80);
     scrollTop.velocity.x = -220;
 
@@ -116,16 +128,13 @@ class PicoCard extends BackingCard
 
     add(scrollTop);
 
-    scrollMiddle = new FlxBackdrop(Paths.image('freeplay/backingCards/pico/middleLoop'), X, 15);
     scrollMiddle.setPosition(0, 346);
     add(scrollMiddle);
     scrollMiddle.velocity.x = 220;
 
-    glowDark = new FlxSprite(-300, 330).loadGraphic(Paths.image('freeplay/backingCards/pico/glow'));
     glowDark.blend = BlendMode.MULTIPLY;
     add(glowDark);
 
-    glow = new FlxSprite(-300, 330).loadGraphic(Paths.image('freeplay/backingCards/pico/glow'));
     glow.blend = BlendMode.ADD;
     add(glow);
 
@@ -137,7 +146,6 @@ class PicoCard extends BackingCard
     glow.visible = false;
     glowDark.visible = false;
 
-    confirmAtlas = new FlxAtlasSprite(5, 55, Paths.animateAtlas("freeplay/backingCards/pico/pico-confirm"));
     confirmAtlas.visible = false;
     add(confirmAtlas);
 
@@ -151,65 +159,66 @@ class PicoCard extends BackingCard
     confirmAtlas.visible = true;
     confirmAtlas.anim.play("");
 
-    FlxTween.color(instance.backingImage, 10 / 24, 0xFFFFFFFF, 0xFF8A8A8A,
+    // instance may be constantly null, brrr....
+    if (instance != null) FlxTween.color(instance.backingImage, 10 / 24, 0xFFFFFFFF, 0xFF8A8A8A,
       {
         ease: FlxEase.expoOut,
         onUpdate: function(_) {
-          instance.angleMaskShader.extraColor = instance.backingImage.color;
+          if (instance != null) instance.angleMaskShader.extraColor = instance.backingImage.color;
         }
       });
 
     new FlxTimer().start(10 / 24, function(_) {
       // shoot
-      FlxTween.color(instance.backingImage, 3 / 24, 0xFF343036, 0xFF696366,
+      if (instance != null) FlxTween.color(instance.backingImage, 3 / 24, 0xFF343036, 0xFF696366,
         {
           ease: FlxEase.expoOut,
           onUpdate: function(_) {
-            instance.angleMaskShader.extraColor = instance.backingImage.color;
+            if (instance != null) instance.angleMaskShader.extraColor = instance.backingImage.color;
           }
         });
     });
 
     new FlxTimer().start(14 / 24, function(_) {
       // shoot
-      FlxTween.color(instance.backingImage, 3 / 24, 0xFF27292D, 0xFF686A6F,
+      if (instance != null) FlxTween.color(instance.backingImage, 3 / 24, 0xFF27292D, 0xFF686A6F,
         {
           ease: FlxEase.expoOut,
           onUpdate: function(_) {
-            instance.angleMaskShader.extraColor = instance.backingImage.color;
+            if (instance != null) instance.angleMaskShader.extraColor = instance.backingImage.color;
           }
         });
     });
 
     new FlxTimer().start(18 / 24, function(_) {
       // shoot
-      FlxTween.color(instance.backingImage, 3 / 24, 0xFF2D282D, 0xFF676164,
+      if (instance != null) FlxTween.color(instance.backingImage, 3 / 24, 0xFF2D282D, 0xFF676164,
         {
           ease: FlxEase.expoOut,
           onUpdate: function(_) {
-            instance.angleMaskShader.extraColor = instance.backingImage.color;
+            if (instance != null) instance.angleMaskShader.extraColor = instance.backingImage.color;
           }
         });
     });
 
     new FlxTimer().start(21 / 24, function(_) {
       // shoot
-      FlxTween.color(instance.backingImage, 3 / 24, 0xFF29292F, 0xFF62626B,
+      if (instance != null) FlxTween.color(instance.backingImage, 3 / 24, 0xFF29292F, 0xFF62626B,
         {
           ease: FlxEase.expoOut,
           onUpdate: function(_) {
-            instance.angleMaskShader.extraColor = instance.backingImage.color;
+            if (instance != null) instance.angleMaskShader.extraColor = instance.backingImage.color;
           }
         });
     });
 
     new FlxTimer().start(24 / 24, function(_) {
       // shoot
-      FlxTween.color(instance.backingImage, 3 / 24, 0xFF29232C, 0xFF808080,
+      if (instance != null) FlxTween.color(instance.backingImage, 3 / 24, 0xFF29232C, 0xFF808080,
         {
           ease: FlxEase.expoOut,
           onUpdate: function(_) {
-            instance.angleMaskShader.extraColor = instance.backingImage.color;
+            if (instance != null) instance.angleMaskShader.extraColor = instance.backingImage.color;
           }
         });
     });


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
Contribution towards https://github.com/FunkinCrew/Funkin/issues/4303
<!-- Briefly describe the issue(s) fixed. -->
## Description
This PR adds null-safety to the following classes:
* `funkin.ui.freeplay.backcards.BackingCard`
* `funkin.ui.freeplay.backcards.BoyfriendCard`
* `funkin.ui.freeplay.backcards.NewCharacterCard`
* `funkin.ui.freeplay.backcards.PicoCard`
