### PR TITLE
[ENHANCEMENT] WIP: Animation Priority system

### DIFF
--- a/source/funkin/data/animation/AnimationData.hx
+++ b/source/funkin/data/animation/AnimationData.hx
@@ -137,4 +137,12 @@ typedef UnnamedAnimationData =
   @:default([])
   @:optional
   var frameIndices:Null<Array<Int>>;
+
+  /**
+   * The priority value for this animation.
+   * Higher values will be prioritized when playing animations.
+   */
+  @:default([0])
+  @:optional
+  var priority:Null<Int>;
 }

--- a/source/funkin/data/animation/AnimationData.hx
+++ b/source/funkin/data/animation/AnimationData.hx
@@ -142,7 +142,7 @@ typedef UnnamedAnimationData =
    * The priority value for this animation.
    * Higher values will be prioritized when playing animations.
    */
-  @:default([0])
+  @:default(0)
   @:optional
   var priority:Null<Int>;
 }

--- a/source/funkin/graphics/adobeanimate/FlxAtlasSprite.hx
+++ b/source/funkin/graphics/adobeanimate/FlxAtlasSprite.hx
@@ -114,8 +114,6 @@ class FlxAtlasSprite extends FlxAnimate
 
   var looping:Bool = false;
 
-  public var ignoreExclusionPref:Array<String> = [];
-
   /**
    * Plays an animation.
    * @param id A string ID of the animation to play.

--- a/source/funkin/graphics/adobeanimate/FlxAtlasSprite.hx
+++ b/source/funkin/graphics/adobeanimate/FlxAtlasSprite.hx
@@ -125,27 +125,6 @@ class FlxAtlasSprite extends FlxAnimate
    */
   public function playAnimation(id:String, restart:Bool = false, ignoreOther:Bool = false, loop:Bool = false, startFrame:Int = 0):Void
   {
-    // Skip if not allowed to play animations.
-    if ((!canPlayOtherAnims))
-    {
-      if (this.currentAnimation == id && restart) {}
-      else if (ignoreExclusionPref != null && ignoreExclusionPref.length > 0)
-      {
-        var detected:Bool = false;
-        for (entry in ignoreExclusionPref)
-        {
-          if (StringTools.startsWith(id, entry))
-          {
-            detected = true;
-            break;
-          }
-        }
-        if (!detected) return;
-      }
-      else
-        return;
-    }
-
     if (anim == null) return;
 
     if (id == null || id == '') id = this.currentAnimation;

--- a/source/funkin/play/character/AnimateAtlasCharacter.hx
+++ b/source/funkin/play/character/AnimateAtlasCharacter.hx
@@ -176,8 +176,6 @@ class AnimateAtlasCharacter extends BaseCharacter
 
     this.mainSprite = sprite;
 
-    mainSprite.ignoreExclusionPref = ["sing"];
-
     // This forces the atlas to recalcuate its width and height
     this.mainSprite.alpha = 0.0001;
     this.mainSprite.draw();

--- a/source/funkin/play/character/AnimateAtlasCharacter.hx
+++ b/source/funkin/play/character/AnimateAtlasCharacter.hx
@@ -13,6 +13,7 @@ import funkin.graphics.FunkinSprite;
 import flixel.system.FlxAssets.FlxGraphicAsset;
 import flixel.util.FlxColor;
 import flixel.util.FlxDestroyUtil;
+import funkin.data.animation.AnimationData;
 import funkin.graphics.adobeanimate.FlxAtlasSprite;
 import funkin.modding.events.ScriptEvent;
 import funkin.play.character.CharacterData.CharacterRenderType;
@@ -102,6 +103,15 @@ class AnimateAtlasCharacter extends BaseCharacter
     if (correctName == null)
     {
       trace('$characterName Could not find Atlas animation: ' + name);
+      return;
+    }
+
+    var animationPriority = priorityMap.get(correctName);
+    var currentAnimationPriority = priorityMap.get(getCurrentAnimation());
+
+    if (currentAnimationPriority > animationPriority && !isAnimationFinished())
+    {
+      trace('Bopper tried to play animation "$name" that has a lower priority than the current animation\'s (${getCurrentAnimation()}) priority! ($currentAnimationPriority)');
       return;
     }
 
@@ -214,6 +224,8 @@ class AnimateAtlasCharacter extends BaseCharacter
       animations.set(anim.name, anim);
       trace('[ATLASCHAR] - Successfully loaded animation ${anim.name} to ${characterId}');
     }
+
+    setAnimationPriorities(_data.animations);
 
     trace('[ATLASCHAR] Loaded ${animations.size()} animations for ${characterId}');
   }

--- a/source/funkin/play/character/BaseCharacter.hx
+++ b/source/funkin/play/character/BaseCharacter.hx
@@ -152,8 +152,6 @@ class BaseCharacter extends Bopper
 
     this.characterId = id;
 
-    ignoreExclusionPref = ["sing"];
-
     _data = CharacterDataParser.fetchCharacterData(this.characterId);
     if (_data == null)
     {

--- a/source/funkin/play/character/MultiSparrowCharacter.hx
+++ b/source/funkin/play/character/MultiSparrowCharacter.hx
@@ -122,6 +122,8 @@ class MultiSparrowCharacter extends BaseCharacter
       }
     }
 
+    setAnimationPriorities(_data.animations);
+
     var animNames = this.animation.getNameList();
     trace('[MULTISPARROWCHAR] Successfully loaded ${animNames.length} animations for ${characterId}');
   }

--- a/source/funkin/play/character/PackerCharacter.hx
+++ b/source/funkin/play/character/PackerCharacter.hx
@@ -76,6 +76,8 @@ class PackerCharacter extends BaseCharacter
       }
     }
 
+    setAnimationPriorities(_data.animations);
+
     var animNames = this.animation.getNameList();
     trace('[PACKERCHAR] Successfully loaded ${animNames.length} animations for ${characterId}');
   }

--- a/source/funkin/play/character/SparrowCharacter.hx
+++ b/source/funkin/play/character/SparrowCharacter.hx
@@ -79,6 +79,8 @@ class SparrowCharacter extends BaseCharacter
       }
     }
 
+    setAnimationPriorities(_data.animations);
+
     var animNames = this.animation.getNameList();
     trace('[SPARROWCHAR] Successfully loaded ${animNames.length} animations for ${characterId}');
   }

--- a/source/funkin/play/stage/Bopper.hx
+++ b/source/funkin/play/stage/Bopper.hx
@@ -6,6 +6,8 @@ import flixel.util.FlxTimer;
 import funkin.modding.IScriptedClass.IPlayStateScriptedClass;
 import funkin.modding.events.ScriptEvent;
 
+using StringTools;
+
 typedef AnimationFrameCallback = String->Int->Int->Void;
 typedef AnimationFinishedCallback = String->Void;
 
@@ -54,6 +56,11 @@ class Bopper extends StageProp implements IPlayStateScriptedClass
     if (isPixel == value) return value;
     return isPixel = value;
   }
+
+  /**
+   * A map of animation names with their priority values.
+   */
+  public var priorityMap:Map<String, Int> = new Map<String, Int>();
 
   /**
    * Whether this bopper should bop every beat. By default it's true, but when used
@@ -253,8 +260,6 @@ class Bopper extends StageProp implements IPlayStateScriptedClass
 
   public var canPlayOtherAnims:Bool = true;
 
-  public var ignoreExclusionPref:Array<String> = [];
-
   /**
    * @param name The name of the animation to play.
    * @param restart Whether to restart the animation if it is already playing.
@@ -263,38 +268,29 @@ class Bopper extends StageProp implements IPlayStateScriptedClass
    */
   public function playAnimation(name:String, restart:Bool = false, ignoreOther:Bool = false, reversed:Bool = false):Void
   {
-    if ((!canPlayOtherAnims))
-    {
-      var id = name;
-      if (getCurrentAnimation() == id && restart) {}
-      else if (ignoreExclusionPref != null && ignoreExclusionPref.length > 0)
-      {
-        var detected:Bool = false;
-        for (entry in ignoreExclusionPref)
-        {
-          if (StringTools.startsWith(id, entry))
-          {
-            detected = true;
-            break;
-          }
-        }
-        if (!detected) return;
-      }
-      else
-        return;
-    }
-
     var correctName = correctAnimationName(name);
     if (correctName == null) return;
 
-    this.animation.play(correctName, restart, reversed, 0);
+    var animationPriority = priorityMap.get(correctName);
+    var currentAnimationPriority = priorityMap.get(getCurrentAnimation());
 
-    if (ignoreOther)
+    if (currentAnimationPriority > animationPriority)
     {
-      canPlayOtherAnims = false;
+      FlxG.log.warn('Bopper tried to play animation "$name" that has a lower priority than the current animation\'s (${getCurrentAnimation()}) priority! ($currentAnimationPriority)');
+      return;
     }
 
+    this.animation.play(correctName, restart, reversed, 0);
+
     applyAnimationOffsets(correctName);
+  }
+
+  function setAnimationPriorities(animations:Array<AnimationData>):Void
+  {
+    for (anim in animations)
+    {
+      priorityMap.set(anim.name, anim.priority ?? 0);
+    }
   }
 
   var forceAnimationTimer:FlxTimer = new FlxTimer();

--- a/source/funkin/play/stage/Bopper.hx
+++ b/source/funkin/play/stage/Bopper.hx
@@ -277,7 +277,7 @@ class Bopper extends StageProp implements IPlayStateScriptedClass
 
     if (currentAnimationPriority > animationPriority && !isAnimationFinished())
     {
-      FlxG.log.warn('Bopper tried to play animation "$name" that has a lower priority than the current animation\'s (${getCurrentAnimation()}) priority! ($currentAnimationPriority)');
+      trace('Bopper tried to play animation "$name" that has a lower priority than the current animation\'s (${getCurrentAnimation()}) priority! ($currentAnimationPriority)');
       return;
     }
 
@@ -286,7 +286,7 @@ class Bopper extends StageProp implements IPlayStateScriptedClass
     applyAnimationOffsets(correctName);
   }
 
-  function setAnimationPriorities(animations:Array<AnimationData>):Void
+  public function setAnimationPriorities(animations:Array<AnimationData>):Void
   {
     for (anim in animations)
     {

--- a/source/funkin/play/stage/Bopper.hx
+++ b/source/funkin/play/stage/Bopper.hx
@@ -3,6 +3,7 @@ package funkin.play.stage;
 import flixel.FlxCamera;
 import flixel.math.FlxPoint;
 import flixel.util.FlxTimer;
+import funkin.data.animation.AnimationData;
 import funkin.modding.IScriptedClass.IPlayStateScriptedClass;
 import funkin.modding.events.ScriptEvent;
 
@@ -274,7 +275,7 @@ class Bopper extends StageProp implements IPlayStateScriptedClass
     var animationPriority = priorityMap.get(correctName);
     var currentAnimationPriority = priorityMap.get(getCurrentAnimation());
 
-    if (currentAnimationPriority > animationPriority)
+    if (currentAnimationPriority > animationPriority && !isAnimationFinished())
     {
       FlxG.log.warn('Bopper tried to play animation "$name" that has a lower priority than the current animation\'s (${getCurrentAnimation()}) priority! ($currentAnimationPriority)');
       return;

--- a/source/funkin/play/stage/Stage.hx
+++ b/source/funkin/play/stage/Stage.hx
@@ -166,15 +166,7 @@ class Stage extends FlxSpriteGroup implements IPlayStateScriptedClass implements
       var isSolidColor = dataProp.assetPath.startsWith('#');
       var isAnimated = dataProp.animations.length > 0;
 
-      var propSprite:StageProp;
-      if (dataProp.danceEvery != 0)
-      {
-        propSprite = new Bopper(dataProp.danceEvery);
-      }
-      else
-      {
-        propSprite = new StageProp();
-      }
+      var propSprite:Bopper = new Bopper(dataProp.danceEvery);
 
       if (isAnimated)
       {
@@ -186,6 +178,8 @@ class Stage extends FlxSpriteGroup implements IPlayStateScriptedClass implements
           default: // 'sparrow'
             propSprite.loadSparrow(dataProp.assetPath);
         }
+
+        propSprite.setAnimationPriorities(dataProp.animations);
       }
       else if (isSolidColor)
       {


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
Fixes #3491, fixes #2367 (for real this time).

<!-- Briefly describe the issue(s) fixed. -->
## Description
This PR adds a new animation priority system, replacing `ignoreExclusionPref`.
`priority` acts like `zIndex` for characters, where the higher the value is, the higher the animation is prioritized!

<!-- Tasks that still need to be completed. -->
## TODO
- [x] Animate Atlas character support
- [x] Stage prop support
- [ ] Default priorities for `sing` and `idle`/`dance`
- [ ] Set priorities for existing animations
- [ ] Figure out how to do forced animations