### PR TITLE
[ENHANCEMENT] [MODDING] Scoped Modules

### DIFF
--- a/source/funkin/modding/module/Module.hx
+++ b/source/funkin/modding/module/Module.hx
@@ -40,15 +40,26 @@ class Module implements IPlayStateScriptedClass implements IStateChangingScripte
   }
 
   /**
+   * The state this module is associated with.
+   * If set, this module will only receive events when the game is in this state.
+   */
+  public var state:Null<Class<Dynamic>> = null;
+
+  /**
    * Called when the module is initialized.
    * It may not be safe to reference other modules here since they may not be loaded yet.
    *
    * NOTE: To make the module start inactive, call `this.active = false` in the constructor.
    */
-  public function new(moduleId:String, priority:Int = 1000):Void
+  public function new(moduleId:String, priority:Int = 1000, state:Null<Class<Dynamic>> = null):Void
   {
     this.moduleId = moduleId;
     this.priority = priority;
+
+    if (state != null)
+    {
+      this.state = state;
+    }
   }
 
   public function toString()

--- a/source/funkin/modding/module/Module.hx
+++ b/source/funkin/modding/module/Module.hx
@@ -5,6 +5,18 @@ import funkin.modding.IScriptedClass.IStateChangingScriptedClass;
 import funkin.modding.events.ScriptEvent;
 
 /**
+ * Parameters used to initialize a module.
+ */
+typedef ModuleParams =
+{
+  /**
+   * The state this module is associated with.
+   * If set, this module will only receive events when the game is in this state.
+   */
+  ?state:Class<Dynamic>
+}
+
+/**
  * A module is a scripted class which receives all events without requiring a specific context.
  * You may have the module active at all times, or only when another script enables it.
  */
@@ -51,14 +63,14 @@ class Module implements IPlayStateScriptedClass implements IStateChangingScripte
    *
    * NOTE: To make the module start inactive, call `this.active = false` in the constructor.
    */
-  public function new(moduleId:String, priority:Int = 1000, state:Null<Class<Dynamic>> = null):Void
+  public function new(moduleId:String, priority:Int = 1000, ?params:ModuleParams):Void
   {
     this.moduleId = moduleId;
     this.priority = priority;
 
-    if (state != null)
+    if (params != null)
     {
-      this.state = state;
+      this.state = params.state ?? null;
     }
   }
 

--- a/source/funkin/modding/module/ModuleHandler.hx
+++ b/source/funkin/modding/module/ModuleHandler.hx
@@ -6,6 +6,7 @@ import funkin.modding.events.ScriptEvent;
 import funkin.modding.events.ScriptEventDispatcher;
 import funkin.modding.module.Module;
 import funkin.modding.module.ScriptedModule;
+import flixel.FlxG;
 
 /**
  * Utility functions for loading and manipulating active modules.
@@ -145,6 +146,14 @@ class ModuleHandler
       // The module needs to be active to receive events.
       if (module != null && module.active)
       {
+        if (module.state != null)
+        {
+          // Only call the event if the current state is what the module's state is.
+          if (!(Type.getClass(FlxG.state) == module.state) && !(Type.getClass(FlxG.state?.subState) == module.state))
+          {
+            continue;
+          }
+        }
         ScriptEventDispatcher.callEvent(module, event);
       }
     }


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
N/A

<!-- Briefly describe the issue(s) fixed. -->
## Description
This PR adds a brand new `params` parameter to the Module constructor with a `state` parameter to go along with it.
This allows modules that can only run in a specific state, making it easier to make modules that only run in `PlayState` for example!
```haxe
import funkin.modding.module.Module;
import funkin.play.PlayState;

class SomePlayStateThing extends Module {
    public function new() {
        super("AAAAAAAAAAAAAAAAA", 1, {
          state: PlayState
        });
    }

    override function onUpdate(event:UpdateScriptEvent):Void {
        super.onUpdate();

        trace('IN PLAYSTATE!!!');
        PlayState.instance.currentStage.getBoyfriend().angle += 360 * event.elapsed;
    }
}
```

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos
![image](https://github.com/user-attachments/assets/e6f01cf3-1550-4457-ab7a-768b817e570b)