### PR TITLE
[ENHANCEMENT] Chart Editor - Modify individual events in selection

### DIFF
--- a/source/funkin/data/event/SongEventSchema.hx
+++ b/source/funkin/data/event/SongEventSchema.hx
@@ -76,6 +76,12 @@ abstract SongEventSchema(SongEventSchemaRaw)
     return this[k] = v;
   }
 
+  @:arrayAccess
+  public inline function push(v:SongEventSchemaField)
+  {
+    this.push(v);
+  }
+
   /**
    * For a given song event field, retrieve its default value.
    * @param name The name of the field to retrieve.

--- a/source/funkin/data/event/SongEventSchema.hx
+++ b/source/funkin/data/event/SongEventSchema.hx
@@ -75,6 +75,12 @@ abstract SongEventSchema(SongEventSchemaRaw)
     return this[k] = v;
   }
 
+  @:arrayAccess
+  public inline function push(v:SongEventSchemaField)
+  {
+    this.push(v);
+  }
+
   /**
    * For a given song event field, retrieve its default value.
    * @param name The name of the field to retrieve.

--- a/source/funkin/data/song/SongData.hx
+++ b/source/funkin/data/song/SongData.hx
@@ -1091,9 +1091,27 @@ class SongEventDataRaw implements ICloneable<SongEventDataRaw>
     var eventHandler = getHandler();
     var eventSchema = getSchema();
 
-    if (eventSchema == null) return 'Unknown Event: ${this.eventKind}';
+    var result = 'Unknown Event: ${this.eventKind}';
 
-    var result = '${eventHandler.getTitle()}';
+    if (eventSchema == null)
+    {
+      // Build a tooltip out of the value map instead.
+      var valueStruct:haxe.DynamicAccess<Dynamic> = valueAsStruct();
+
+      for (pair in valueStruct.keyValueIterator())
+      {
+        var key = pair.key;
+        var value = pair.value;
+
+        var title = pair.key ?? 'UnknownField';
+
+        result += '\n- ${title}: ${value}';
+      }
+
+      return result;
+    }
+
+    result = '${eventHandler.getTitle()}';
 
     var valueStruct:haxe.DynamicAccess<Dynamic> = valueAsStruct();
 

--- a/source/funkin/data/song/SongData.hx
+++ b/source/funkin/data/song/SongData.hx
@@ -891,9 +891,27 @@ class SongEventDataRaw implements ICloneable<SongEventDataRaw>
     var eventHandler = getHandler();
     var eventSchema = getSchema();
 
-    if (eventSchema == null) return 'Unknown Event: ${this.eventKind}';
+    var result = 'Unknown Event: ${this.eventKind}';
 
-    var result = '${eventHandler.getTitle()}';
+    if (eventSchema == null)
+    {
+      // Build a tooltip out of the value map instead.
+      var valueStruct:haxe.DynamicAccess<Dynamic> = valueAsStruct('value');
+
+      for (pair in valueStruct.keyValueIterator())
+      {
+        var key = pair.key;
+        var value = pair.value;
+
+        var title = pair.key ?? 'UnknownField';
+
+        result += '\n- ${title}: ${value}';
+      }
+
+      return result;
+    }
+
+    result = '${eventHandler.getTitle()}';
 
     var defaultKey = eventSchema.getFirstField()?.name;
     var valueStruct:haxe.DynamicAccess<Dynamic> = valueAsStruct(defaultKey);

--- a/source/funkin/ui/debug/charting/commands/AddEventsCommand.hx
+++ b/source/funkin/ui/debug/charting/commands/AddEventsCommand.hx
@@ -47,6 +47,8 @@ class AddEventsCommand implements ChartEditorCommand
 
     state.playSound(Paths.sound('ui/editors/chart-editor/charting-sounds/note-place'));
 
+    state.refreshToolbox(ChartEditorState.CHART_EDITOR_TOOLBOX_EVENT_DATA_LAYOUT);
+
     state.saveDataDirty = true;
     state.noteDisplayDirty = true;
     state.notePreviewDirty = true;
@@ -67,6 +69,8 @@ class AddEventsCommand implements ChartEditorCommand
     state.currentNoteSelection = [];
     state.currentEventSelection = [];
     state.playSound(Paths.sound('ui/editors/chart-editor/charting-sounds/undo'));
+
+    state.refreshToolbox(ChartEditorState.CHART_EDITOR_TOOLBOX_EVENT_DATA_LAYOUT);
 
     state.saveDataDirty = true;
     state.noteDisplayDirty = true;

--- a/source/funkin/ui/debug/charting/commands/AddEventsCommand.hx
+++ b/source/funkin/ui/debug/charting/commands/AddEventsCommand.hx
@@ -38,6 +38,8 @@ class AddEventsCommand implements ChartEditorCommand
 
     state.playSound(Paths.sound('chartingSounds/noteLay'));
 
+    state.refreshToolbox(ChartEditorState.CHART_EDITOR_TOOLBOX_EVENT_DATA_LAYOUT);
+
     state.saveDataDirty = true;
     state.noteDisplayDirty = true;
     state.notePreviewDirty = true;
@@ -53,6 +55,8 @@ class AddEventsCommand implements ChartEditorCommand
     state.currentNoteSelection = [];
     state.currentEventSelection = [];
     state.playSound(Paths.sound('chartingSounds/undo'));
+
+    state.refreshToolbox(ChartEditorState.CHART_EDITOR_TOOLBOX_EVENT_DATA_LAYOUT);
 
     state.saveDataDirty = true;
     state.noteDisplayDirty = true;

--- a/source/funkin/ui/debug/charting/commands/CutItemsCommand.hx
+++ b/source/funkin/ui/debug/charting/commands/CutItemsCommand.hx
@@ -41,6 +41,8 @@ class CutItemsCommand implements ChartEditorCommand
     state.currentNoteSelection = [];
     state.currentEventSelection = [];
 
+    state.refreshToolbox(ChartEditorState.CHART_EDITOR_TOOLBOX_EVENT_DATA_LAYOUT);
+
     state.saveDataDirty = true;
     state.noteDisplayDirty = true;
     state.notePreviewDirty = true;
@@ -62,6 +64,8 @@ class CutItemsCommand implements ChartEditorCommand
 
     state.currentNoteSelection = notes;
     state.currentEventSelection = events;
+
+    state.refreshToolbox(ChartEditorState.CHART_EDITOR_TOOLBOX_EVENT_DATA_LAYOUT);
 
     state.saveDataDirty = true;
     state.noteDisplayDirty = true;

--- a/source/funkin/ui/debug/charting/commands/CutItemsCommand.hx
+++ b/source/funkin/ui/debug/charting/commands/CutItemsCommand.hx
@@ -35,6 +35,8 @@ class CutItemsCommand implements ChartEditorCommand
     state.currentNoteSelection = [];
     state.currentEventSelection = [];
 
+    state.refreshToolbox(ChartEditorState.CHART_EDITOR_TOOLBOX_EVENT_DATA_LAYOUT);
+
     state.saveDataDirty = true;
     state.noteDisplayDirty = true;
     state.notePreviewDirty = true;
@@ -51,6 +53,8 @@ class CutItemsCommand implements ChartEditorCommand
 
     state.currentNoteSelection = notes;
     state.currentEventSelection = events;
+
+    state.refreshToolbox(ChartEditorState.CHART_EDITOR_TOOLBOX_EVENT_DATA_LAYOUT);
 
     state.saveDataDirty = true;
     state.noteDisplayDirty = true;

--- a/source/funkin/ui/debug/charting/commands/DeselectAllItemsBetweenTimeCommand.hx
+++ b/source/funkin/ui/debug/charting/commands/DeselectAllItemsBetweenTimeCommand.hx
@@ -109,6 +109,8 @@ class DeselectAllItemsBetweenTimeCommand implements ChartEditorCommand
     state.currentNoteSelection = SongDataUtils.subtractNotes(state.currentNoteSelection, this.notes);
     state.currentEventSelection = SongDataUtils.subtractEvents(state.currentEventSelection, this.events);
 
+    state.refreshToolbox(ChartEditorState.CHART_EDITOR_TOOLBOX_EVENT_DATA_LAYOUT);
+
     state.noteDisplayDirty = true;
     state.notePreviewDirty = true;
   }
@@ -129,6 +131,8 @@ class DeselectAllItemsBetweenTimeCommand implements ChartEditorCommand
     {
       state.currentEventSelection.pushUnique(event);
     }
+
+    state.refreshToolbox(ChartEditorState.CHART_EDITOR_TOOLBOX_EVENT_DATA_LAYOUT);
 
     state.noteDisplayDirty = true;
     state.notePreviewDirty = true;

--- a/source/funkin/ui/debug/charting/commands/DeselectAllItemsBetweenTimeCommand.hx
+++ b/source/funkin/ui/debug/charting/commands/DeselectAllItemsBetweenTimeCommand.hx
@@ -90,6 +90,8 @@ class DeselectAllItemsBetweenTimeCommand implements ChartEditorCommand
     state.currentNoteSelection = SongDataUtils.subtractNotes(state.currentNoteSelection, this.notes);
     state.currentEventSelection = SongDataUtils.subtractEvents(state.currentEventSelection, this.events);
 
+    state.refreshToolbox(ChartEditorState.CHART_EDITOR_TOOLBOX_EVENT_DATA_LAYOUT);
+
     state.noteDisplayDirty = true;
     state.notePreviewDirty = true;
   }
@@ -105,6 +107,8 @@ class DeselectAllItemsBetweenTimeCommand implements ChartEditorCommand
     {
       state.currentEventSelection.push(event);
     }
+
+    state.refreshToolbox(ChartEditorState.CHART_EDITOR_TOOLBOX_EVENT_DATA_LAYOUT);
 
     state.noteDisplayDirty = true;
     state.notePreviewDirty = true;

--- a/source/funkin/ui/debug/charting/commands/DeselectAllItemsCommand.hx
+++ b/source/funkin/ui/debug/charting/commands/DeselectAllItemsCommand.hx
@@ -31,6 +31,8 @@ class DeselectAllItemsCommand implements ChartEditorCommand
     state.currentNoteSelection = [];
     state.currentEventSelection = [];
 
+    state.refreshToolbox(ChartEditorState.CHART_EDITOR_TOOLBOX_EVENT_DATA_LAYOUT);
+
     state.noteDisplayDirty = true;
     state.editButtonsDirty = true;
   }
@@ -44,6 +46,8 @@ class DeselectAllItemsCommand implements ChartEditorCommand
   {
     state.currentNoteSelection = previousNoteSelection;
     state.currentEventSelection = previousEventSelection;
+
+    state.refreshToolbox(ChartEditorState.CHART_EDITOR_TOOLBOX_EVENT_DATA_LAYOUT);
 
     state.noteDisplayDirty = true;
     state.editButtonsDirty = true;

--- a/source/funkin/ui/debug/charting/commands/DeselectAllItemsCommand.hx
+++ b/source/funkin/ui/debug/charting/commands/DeselectAllItemsCommand.hx
@@ -25,6 +25,8 @@ class DeselectAllItemsCommand implements ChartEditorCommand
     state.currentNoteSelection = [];
     state.currentEventSelection = [];
 
+    state.refreshToolbox(ChartEditorState.CHART_EDITOR_TOOLBOX_EVENT_DATA_LAYOUT);
+
     state.noteDisplayDirty = true;
     state.editButtonsDirty = true;
   }
@@ -33,6 +35,8 @@ class DeselectAllItemsCommand implements ChartEditorCommand
   {
     state.currentNoteSelection = previousNoteSelection;
     state.currentEventSelection = previousEventSelection;
+
+    state.refreshToolbox(ChartEditorState.CHART_EDITOR_TOOLBOX_EVENT_DATA_LAYOUT);
 
     state.noteDisplayDirty = true;
     state.editButtonsDirty = true;

--- a/source/funkin/ui/debug/charting/commands/DeselectItemsCommand.hx
+++ b/source/funkin/ui/debug/charting/commands/DeselectItemsCommand.hx
@@ -31,6 +31,8 @@ class DeselectItemsCommand implements ChartEditorCommand
     state.currentNoteSelection = SongDataUtils.subtractNotes(state.currentNoteSelection, this.notes);
     state.currentEventSelection = SongDataUtils.subtractEvents(state.currentEventSelection, this.events);
 
+    state.refreshToolbox(ChartEditorState.CHART_EDITOR_TOOLBOX_EVENT_DATA_LAYOUT);
+
     state.noteDisplayDirty = true;
     state.notePreviewDirty = true;
     state.editButtonsDirty = true;
@@ -52,6 +54,8 @@ class DeselectItemsCommand implements ChartEditorCommand
     {
       state.currentEventSelection.pushUnique(event);
     }
+
+    state.refreshToolbox(ChartEditorState.CHART_EDITOR_TOOLBOX_EVENT_DATA_LAYOUT);
 
     state.noteDisplayDirty = true;
     state.notePreviewDirty = true;

--- a/source/funkin/ui/debug/charting/commands/DeselectItemsCommand.hx
+++ b/source/funkin/ui/debug/charting/commands/DeselectItemsCommand.hx
@@ -25,6 +25,8 @@ class DeselectItemsCommand implements ChartEditorCommand
     state.currentNoteSelection = SongDataUtils.subtractNotes(state.currentNoteSelection, this.notes);
     state.currentEventSelection = SongDataUtils.subtractEvents(state.currentEventSelection, this.events);
 
+    state.refreshToolbox(ChartEditorState.CHART_EDITOR_TOOLBOX_EVENT_DATA_LAYOUT);
+
     state.noteDisplayDirty = true;
     state.notePreviewDirty = true;
     state.editButtonsDirty = true;
@@ -41,6 +43,8 @@ class DeselectItemsCommand implements ChartEditorCommand
     {
       state.currentEventSelection.push(event);
     }
+
+    state.refreshToolbox(ChartEditorState.CHART_EDITOR_TOOLBOX_EVENT_DATA_LAYOUT);
 
     state.noteDisplayDirty = true;
     state.notePreviewDirty = true;

--- a/source/funkin/ui/debug/charting/commands/InvertSelectedItemsCommand.hx
+++ b/source/funkin/ui/debug/charting/commands/InvertSelectedItemsCommand.hx
@@ -33,6 +33,8 @@ class InvertSelectedItemsCommand implements ChartEditorCommand
     state.currentNoteSelection = SongDataUtils.subtractNotes(state.currentSongChartNoteData, previousNoteSelection);
     state.currentEventSelection = SongDataUtils.subtractEvents(state.currentSongChartEventData, previousEventSelection);
 
+    state.refreshToolbox(ChartEditorState.CHART_EDITOR_TOOLBOX_EVENT_DATA_LAYOUT);
+
     state.noteDisplayDirty = true;
     state.editButtonsDirty = true;
   }
@@ -46,6 +48,8 @@ class InvertSelectedItemsCommand implements ChartEditorCommand
   {
     state.currentNoteSelection = previousNoteSelection;
     state.currentEventSelection = previousEventSelection;
+
+    state.refreshToolbox(ChartEditorState.CHART_EDITOR_TOOLBOX_EVENT_DATA_LAYOUT);
 
     state.noteDisplayDirty = true;
     state.editButtonsDirty = true;

--- a/source/funkin/ui/debug/charting/commands/InvertSelectedItemsCommand.hx
+++ b/source/funkin/ui/debug/charting/commands/InvertSelectedItemsCommand.hx
@@ -27,6 +27,8 @@ class InvertSelectedItemsCommand implements ChartEditorCommand
     state.currentNoteSelection = SongDataUtils.subtractNotes(state.currentSongChartNoteData, previousNoteSelection);
     state.currentEventSelection = SongDataUtils.subtractEvents(state.currentSongChartEventData, previousEventSelection);
 
+    state.refreshToolbox(ChartEditorState.CHART_EDITOR_TOOLBOX_EVENT_DATA_LAYOUT);
+
     state.noteDisplayDirty = true;
     state.editButtonsDirty = true;
   }
@@ -35,6 +37,8 @@ class InvertSelectedItemsCommand implements ChartEditorCommand
   {
     state.currentNoteSelection = previousNoteSelection;
     state.currentEventSelection = previousEventSelection;
+
+    state.refreshToolbox(ChartEditorState.CHART_EDITOR_TOOLBOX_EVENT_DATA_LAYOUT);
 
     state.noteDisplayDirty = true;
     state.editButtonsDirty = true;

--- a/source/funkin/ui/debug/charting/commands/PasteItemsCommand.hx
+++ b/source/funkin/ui/debug/charting/commands/PasteItemsCommand.hx
@@ -66,6 +66,8 @@ class PasteItemsCommand implements ChartEditorCommand
     state.currentNoteSelection = addedNotes.copy();
     state.currentEventSelection = addedEvents.copy();
 
+    state.refreshToolbox(ChartEditorState.CHART_EDITOR_TOOLBOX_EVENT_DATA_LAYOUT);
+
     state.saveDataDirty = true;
     state.noteDisplayDirty = true;
     state.notePreviewDirty = true;
@@ -114,6 +116,8 @@ class PasteItemsCommand implements ChartEditorCommand
     state.currentSongChartEventData = SongDataUtils.subtractEvents(state.currentSongChartEventData, addedEvents);
     state.currentEventSelection = [];
     state.performCommand(new SelectItemsCommand(removedNotes.copy()), false);
+
+    state.refreshToolbox(ChartEditorState.CHART_EDITOR_TOOLBOX_EVENT_DATA_LAYOUT);
 
     state.saveDataDirty = true;
     state.noteDisplayDirty = true;

--- a/source/funkin/ui/debug/charting/commands/PasteItemsCommand.hx
+++ b/source/funkin/ui/debug/charting/commands/PasteItemsCommand.hx
@@ -60,6 +60,8 @@ class PasteItemsCommand implements ChartEditorCommand
     state.currentNoteSelection = addedNotes.copy();
     state.currentEventSelection = addedEvents.copy();
 
+    state.refreshToolbox(ChartEditorState.CHART_EDITOR_TOOLBOX_EVENT_DATA_LAYOUT);
+
     state.saveDataDirty = true;
     state.noteDisplayDirty = true;
     state.notePreviewDirty = true;
@@ -96,6 +98,8 @@ class PasteItemsCommand implements ChartEditorCommand
     state.currentSongChartEventData = SongDataUtils.subtractEvents(state.currentSongChartEventData, addedEvents);
     state.currentEventSelection = [];
     state.performCommand(new SelectItemsCommand(removedNotes.copy()), false);
+
+    state.refreshToolbox(ChartEditorState.CHART_EDITOR_TOOLBOX_EVENT_DATA_LAYOUT);
 
     state.saveDataDirty = true;
     state.noteDisplayDirty = true;

--- a/source/funkin/ui/debug/charting/commands/RemoveEventsCommand.hx
+++ b/source/funkin/ui/debug/charting/commands/RemoveEventsCommand.hx
@@ -32,6 +32,8 @@ class RemoveEventsCommand implements ChartEditorCommand
 
     state.playSound(Paths.sound('ui/editors/chart-editor/charting-sounds/note-erase'));
 
+    state.refreshToolbox(ChartEditorState.CHART_EDITOR_TOOLBOX_EVENT_DATA_LAYOUT);
+
     state.saveDataDirty = true;
     state.noteDisplayDirty = true;
     state.notePreviewDirty = true;
@@ -55,6 +57,8 @@ class RemoveEventsCommand implements ChartEditorCommand
     }
     state.currentEventSelection = events;
     state.playSound(Paths.sound('ui/editors/chart-editor/charting-sounds/undo'));
+
+    state.refreshToolbox(ChartEditorState.CHART_EDITOR_TOOLBOX_EVENT_DATA_LAYOUT);
 
     state.saveDataDirty = true;
     state.noteDisplayDirty = true;

--- a/source/funkin/ui/debug/charting/commands/RemoveEventsCommand.hx
+++ b/source/funkin/ui/debug/charting/commands/RemoveEventsCommand.hx
@@ -27,6 +27,8 @@ class RemoveEventsCommand implements ChartEditorCommand
 
     state.playSound(Paths.sound('chartingSounds/noteErase'));
 
+    state.refreshToolbox(ChartEditorState.CHART_EDITOR_TOOLBOX_EVENT_DATA_LAYOUT);
+
     state.saveDataDirty = true;
     state.noteDisplayDirty = true;
     state.notePreviewDirty = true;
@@ -45,6 +47,8 @@ class RemoveEventsCommand implements ChartEditorCommand
     }
     state.currentEventSelection = events;
     state.playSound(Paths.sound('chartingSounds/undo'));
+
+    state.refreshToolbox(ChartEditorState.CHART_EDITOR_TOOLBOX_EVENT_DATA_LAYOUT);
 
     state.saveDataDirty = true;
     state.noteDisplayDirty = true;

--- a/source/funkin/ui/debug/charting/commands/RemoveItemsCommand.hx
+++ b/source/funkin/ui/debug/charting/commands/RemoveItemsCommand.hx
@@ -38,6 +38,8 @@ class RemoveItemsCommand implements ChartEditorCommand
 
     state.playSound(Paths.sound('ui/editors/chart-editor/charting-sounds/note-erase'));
 
+    state.refreshToolbox(ChartEditorState.CHART_EDITOR_TOOLBOX_EVENT_DATA_LAYOUT);
+
     state.saveDataDirty = true;
     state.noteDisplayDirty = true;
     state.notePreviewDirty = true;
@@ -67,6 +69,8 @@ class RemoveItemsCommand implements ChartEditorCommand
 
     state.currentNoteSelection = notes;
     state.currentEventSelection = events;
+
+    state.refreshToolbox(ChartEditorState.CHART_EDITOR_TOOLBOX_EVENT_DATA_LAYOUT);
 
     state.playSound(Paths.sound('ui/editors/chart-editor/charting-sounds/undo'));
 

--- a/source/funkin/ui/debug/charting/commands/RemoveItemsCommand.hx
+++ b/source/funkin/ui/debug/charting/commands/RemoveItemsCommand.hx
@@ -33,6 +33,8 @@ class RemoveItemsCommand implements ChartEditorCommand
 
     state.playSound(Paths.sound('chartingSounds/noteErase'));
 
+    state.refreshToolbox(ChartEditorState.CHART_EDITOR_TOOLBOX_EVENT_DATA_LAYOUT);
+
     state.saveDataDirty = true;
     state.noteDisplayDirty = true;
     state.notePreviewDirty = true;
@@ -57,6 +59,8 @@ class RemoveItemsCommand implements ChartEditorCommand
 
     state.currentNoteSelection = notes;
     state.currentEventSelection = events;
+
+    state.refreshToolbox(ChartEditorState.CHART_EDITOR_TOOLBOX_EVENT_DATA_LAYOUT);
 
     state.playSound(Paths.sound('chartingSounds/undo'));
 

--- a/source/funkin/ui/debug/charting/commands/SelectAllItemsBetweenTimeCommand.hx
+++ b/source/funkin/ui/debug/charting/commands/SelectAllItemsBetweenTimeCommand.hx
@@ -117,8 +117,8 @@ class SelectAllItemsBetweenTimeCommand implements ChartEditorCommand
       state.currentEventSelection.pushUnique(event);
     }
 
-    // I don't think it's necessary to copy this code in, but someone will make an issue out of this if I don't, I'm sure.
-    // If we just selected one or more events (and no notes), then we should make the event data toolbox display the event data for the selected event.
+    // I don't think it's neccesary to copy this code in, but someone will make an issue out of this if I don't, I'm sure.
+    // If we just selected one event (and no notes), then we should make the event data toolbox display the event data for the selected event.
     if (this.notes.length == 0 && this.events.length == 1)
     {
       var eventSelected = this.events[0];
@@ -128,11 +128,9 @@ class SelectAllItemsBetweenTimeCommand implements ChartEditorCommand
       var eventData = eventSelected.valueAsStruct();
 
       state.eventDataToPlace = eventData;
-
-      state.refreshToolbox(ChartEditorState.CHART_EDITOR_TOOLBOX_EVENT_DATA_LAYOUT);
     }
 
-    // If we just selected one or more notes (and no events), then we should make the note data toolbox display the note data for the selected note.
+    // If we just selected one note (and no events), then we should make the note data toolbox display the note data for the selected note.
     if (this.events.length == 0 && this.notes.length == 1)
     {
       var noteSelected = this.notes[0];
@@ -142,6 +140,8 @@ class SelectAllItemsBetweenTimeCommand implements ChartEditorCommand
       // This code is here to parse note data that's not built as a struct for some reason.
       state.refreshToolbox(ChartEditorState.CHART_EDITOR_TOOLBOX_NOTE_DATA_LAYOUT);
     }
+
+    state.refreshToolbox(ChartEditorState.CHART_EDITOR_TOOLBOX_EVENT_DATA_LAYOUT);
 
     state.noteDisplayDirty = true;
     state.notePreviewDirty = true;
@@ -156,6 +156,8 @@ class SelectAllItemsBetweenTimeCommand implements ChartEditorCommand
   {
     state.currentNoteSelection = SongDataUtils.subtractNotes(state.currentNoteSelection, this.notes);
     state.currentEventSelection = SongDataUtils.subtractEvents(state.currentEventSelection, this.events);
+
+    state.refreshToolbox(ChartEditorState.CHART_EDITOR_TOOLBOX_EVENT_DATA_LAYOUT);
 
     state.noteDisplayDirty = true;
     state.notePreviewDirty = true;

--- a/source/funkin/ui/debug/charting/commands/SelectAllItemsBetweenTimeCommand.hx
+++ b/source/funkin/ui/debug/charting/commands/SelectAllItemsBetweenTimeCommand.hx
@@ -99,7 +99,7 @@ class SelectAllItemsBetweenTimeCommand implements ChartEditorCommand
     }
 
     // I don't think it's neccesary to copy this code in, but someone will make an issue out of this if I don't, I'm sure.
-    // If we just selected one or more events (and no notes), then we should make the event data toolbox display the event data for the selected event.
+    // If we just selected one event (and no notes), then we should make the event data toolbox display the event data for the selected event.
     if (this.notes.length == 0 && this.events.length == 1)
     {
       var eventSelected = this.events[0];
@@ -121,11 +121,9 @@ class SelectAllItemsBetweenTimeCommand implements ChartEditorCommand
       var eventData = eventSelected.valueAsStruct(defaultKey);
 
       state.eventDataToPlace = eventData;
-
-      state.refreshToolbox(ChartEditorState.CHART_EDITOR_TOOLBOX_EVENT_DATA_LAYOUT);
     }
 
-    // If we just selected one or more notes (and no events), then we should make the note data toolbox display the note data for the selected note.
+    // If we just selected one note (and no events), then we should make the note data toolbox display the note data for the selected note.
     if (this.events.length == 0 && this.notes.length == 1)
     {
       var noteSelected = this.notes[0];
@@ -136,6 +134,8 @@ class SelectAllItemsBetweenTimeCommand implements ChartEditorCommand
       state.refreshToolbox(ChartEditorState.CHART_EDITOR_TOOLBOX_NOTE_DATA_LAYOUT);
     }
 
+    state.refreshToolbox(ChartEditorState.CHART_EDITOR_TOOLBOX_EVENT_DATA_LAYOUT);
+
     state.noteDisplayDirty = true;
     state.notePreviewDirty = true;
   }
@@ -144,6 +144,8 @@ class SelectAllItemsBetweenTimeCommand implements ChartEditorCommand
   {
     state.currentNoteSelection = SongDataUtils.subtractNotes(state.currentNoteSelection, this.notes);
     state.currentEventSelection = SongDataUtils.subtractEvents(state.currentEventSelection, this.events);
+
+    state.refreshToolbox(ChartEditorState.CHART_EDITOR_TOOLBOX_EVENT_DATA_LAYOUT);
 
     state.noteDisplayDirty = true;
     state.notePreviewDirty = true;

--- a/source/funkin/ui/debug/charting/commands/SelectAllItemsCommand.hx
+++ b/source/funkin/ui/debug/charting/commands/SelectAllItemsCommand.hx
@@ -35,6 +35,8 @@ class SelectAllItemsCommand implements ChartEditorCommand
     state.currentNoteSelection = shouldSelectNotes ? state.currentSongChartNoteData : [];
     state.currentEventSelection = shouldSelectEvents ? state.currentSongChartEventData : [];
 
+    state.refreshToolbox(ChartEditorState.CHART_EDITOR_TOOLBOX_EVENT_DATA_LAYOUT);
+
     state.noteDisplayDirty = true;
     state.editButtonsDirty = true;
   }
@@ -48,6 +50,8 @@ class SelectAllItemsCommand implements ChartEditorCommand
   {
     state.currentNoteSelection = previousNoteSelection;
     state.currentEventSelection = previousEventSelection;
+
+    state.refreshToolbox(ChartEditorState.CHART_EDITOR_TOOLBOX_EVENT_DATA_LAYOUT);
 
     state.noteDisplayDirty = true;
     state.editButtonsDirty = true;

--- a/source/funkin/ui/debug/charting/commands/SelectAllItemsCommand.hx
+++ b/source/funkin/ui/debug/charting/commands/SelectAllItemsCommand.hx
@@ -29,6 +29,8 @@ class SelectAllItemsCommand implements ChartEditorCommand
     state.currentNoteSelection = shouldSelectNotes ? state.currentSongChartNoteData : [];
     state.currentEventSelection = shouldSelectEvents ? state.currentSongChartEventData : [];
 
+    state.refreshToolbox(ChartEditorState.CHART_EDITOR_TOOLBOX_EVENT_DATA_LAYOUT);
+
     state.noteDisplayDirty = true;
     state.editButtonsDirty = true;
   }
@@ -37,6 +39,8 @@ class SelectAllItemsCommand implements ChartEditorCommand
   {
     state.currentNoteSelection = previousNoteSelection;
     state.currentEventSelection = previousEventSelection;
+
+    state.refreshToolbox(ChartEditorState.CHART_EDITOR_TOOLBOX_EVENT_DATA_LAYOUT);
 
     state.noteDisplayDirty = true;
     state.editButtonsDirty = true;

--- a/source/funkin/ui/debug/charting/commands/SelectItemsCommand.hx
+++ b/source/funkin/ui/debug/charting/commands/SelectItemsCommand.hx
@@ -39,7 +39,7 @@ class SelectItemsCommand implements ChartEditorCommand
       state.currentEventSelection.pushUnique(event);
     }
 
-    // If we just selected one or more events (and no notes), then we should make the event data toolbox display the event data for the selected event.
+    // If we just selected one event (and no notes), then we should make the event data toolbox display the event data for the selected event.
     if (this.notes.length == 0 && this.events.length == 1)
     {
       var eventSelected = this.events[0];
@@ -49,11 +49,9 @@ class SelectItemsCommand implements ChartEditorCommand
       var eventData = eventSelected.valueAsStruct();
 
       state.eventDataToPlace = eventData;
-
-      state.refreshToolbox(ChartEditorState.CHART_EDITOR_TOOLBOX_EVENT_DATA_LAYOUT);
     }
 
-    // If we just selected one or more notes (and no events), then we should make the note data toolbox display the note data for the selected note.
+    // If we just selected one note (and no events), then we should make the note data toolbox display the note data for the selected note.
     if (this.events.length == 0 && this.notes.length == 1)
     {
       var noteSelected = this.notes[0];
@@ -63,6 +61,8 @@ class SelectItemsCommand implements ChartEditorCommand
       // This code is here to parse note data that's not built as a struct for some reason.
       state.refreshToolbox(ChartEditorState.CHART_EDITOR_TOOLBOX_NOTE_DATA_LAYOUT);
     }
+
+    state.refreshToolbox(ChartEditorState.CHART_EDITOR_TOOLBOX_EVENT_DATA_LAYOUT);
 
     state.noteDisplayDirty = true;
     state.notePreviewDirty = true;
@@ -78,6 +78,8 @@ class SelectItemsCommand implements ChartEditorCommand
   {
     state.currentNoteSelection = SongDataUtils.subtractNotes(state.currentNoteSelection, this.notes);
     state.currentEventSelection = SongDataUtils.subtractEvents(state.currentEventSelection, this.events);
+
+    state.refreshToolbox(ChartEditorState.CHART_EDITOR_TOOLBOX_EVENT_DATA_LAYOUT);
 
     state.noteDisplayDirty = true;
     state.notePreviewDirty = true;

--- a/source/funkin/ui/debug/charting/commands/SelectItemsCommand.hx
+++ b/source/funkin/ui/debug/charting/commands/SelectItemsCommand.hx
@@ -33,7 +33,7 @@ class SelectItemsCommand implements ChartEditorCommand
       state.currentEventSelection.push(event);
     }
 
-    // If we just selected one or more events (and no notes), then we should make the event data toolbox display the event data for the selected event.
+    // If we just selected one event (and no notes), then we should make the event data toolbox display the event data for the selected event.
     if (this.notes.length == 0 && this.events.length == 1)
     {
       var eventSelected = this.events[0];
@@ -55,11 +55,9 @@ class SelectItemsCommand implements ChartEditorCommand
       var eventData = eventSelected.valueAsStruct(defaultKey);
 
       state.eventDataToPlace = eventData;
-
-      state.refreshToolbox(ChartEditorState.CHART_EDITOR_TOOLBOX_EVENT_DATA_LAYOUT);
     }
 
-    // If we just selected one or more notes (and no events), then we should make the note data toolbox display the note data for the selected note.
+    // If we just selected one note (and no events), then we should make the note data toolbox display the note data for the selected note.
     if (this.events.length == 0 && this.notes.length == 1)
     {
       var noteSelected = this.notes[0];
@@ -70,6 +68,8 @@ class SelectItemsCommand implements ChartEditorCommand
       state.refreshToolbox(ChartEditorState.CHART_EDITOR_TOOLBOX_NOTE_DATA_LAYOUT);
     }
 
+    state.refreshToolbox(ChartEditorState.CHART_EDITOR_TOOLBOX_EVENT_DATA_LAYOUT);
+
     state.noteDisplayDirty = true;
     state.notePreviewDirty = true;
     state.editButtonsDirty = true;
@@ -79,6 +79,8 @@ class SelectItemsCommand implements ChartEditorCommand
   {
     state.currentNoteSelection = SongDataUtils.subtractNotes(state.currentNoteSelection, this.notes);
     state.currentEventSelection = SongDataUtils.subtractEvents(state.currentEventSelection, this.events);
+
+    state.refreshToolbox(ChartEditorState.CHART_EDITOR_TOOLBOX_EVENT_DATA_LAYOUT);
 
     state.noteDisplayDirty = true;
     state.notePreviewDirty = true;

--- a/source/funkin/ui/debug/charting/commands/SetItemSelectionCommand.hx
+++ b/source/funkin/ui/debug/charting/commands/SetItemSelectionCommand.hx
@@ -36,7 +36,7 @@ class SetItemSelectionCommand implements ChartEditorCommand
     state.currentNoteSelection = notes;
     state.currentEventSelection = events;
 
-    // If we just selected one or more events (and no notes), then we should make the event data toolbox display the event data for the selected event.
+    // If we just selected one event (and no notes), then we should make the event data toolbox display the event data for the selected event.
     if (this.notes.length == 0 && this.events.length == 1)
     {
       var eventSelected = this.events[0];
@@ -59,11 +59,9 @@ class SetItemSelectionCommand implements ChartEditorCommand
       {
         state.eventDataToPlace = eventDataClone;
       }
-
-      state.refreshToolbox(ChartEditorState.CHART_EDITOR_TOOLBOX_EVENT_DATA_LAYOUT);
     }
 
-    // IF we just selected one or more notes (and no events), then we should make the note data toolbox display the note data for the selected note.
+    // IF we just selected one note (and no events), then we should make the note data toolbox display the note data for the selected note.
     if (this.events.length == 0 && this.notes.length == 1)
     {
       var noteSelected = this.notes[0];
@@ -72,6 +70,8 @@ class SetItemSelectionCommand implements ChartEditorCommand
 
       state.refreshToolbox(ChartEditorState.CHART_EDITOR_TOOLBOX_NOTE_DATA_LAYOUT);
     }
+
+    state.refreshToolbox(ChartEditorState.CHART_EDITOR_TOOLBOX_EVENT_DATA_LAYOUT);
 
     state.noteDisplayDirty = true;
     state.editButtonsDirty = true;
@@ -86,6 +86,8 @@ class SetItemSelectionCommand implements ChartEditorCommand
   {
     state.currentNoteSelection = previousNoteSelection;
     state.currentEventSelection = previousEventSelection;
+
+    state.refreshToolbox(ChartEditorState.CHART_EDITOR_TOOLBOX_EVENT_DATA_LAYOUT);
 
     state.noteDisplayDirty = true;
     state.editButtonsDirty = true;

--- a/source/funkin/ui/debug/charting/commands/SetItemSelectionCommand.hx
+++ b/source/funkin/ui/debug/charting/commands/SetItemSelectionCommand.hx
@@ -30,7 +30,7 @@ class SetItemSelectionCommand implements ChartEditorCommand
     state.currentNoteSelection = notes;
     state.currentEventSelection = events;
 
-    // If we just selected one or more events (and no notes), then we should make the event data toolbox display the event data for the selected event.
+    // If we just selected one event (and no notes), then we should make the event data toolbox display the event data for the selected event.
     if (this.notes.length == 0 && this.events.length == 1)
     {
       var eventSelected = this.events[0];
@@ -65,11 +65,9 @@ class SetItemSelectionCommand implements ChartEditorCommand
       {
         state.eventDataToPlace = eventDataClone;
       }
-
-      state.refreshToolbox(ChartEditorState.CHART_EDITOR_TOOLBOX_EVENT_DATA_LAYOUT);
     }
 
-    // IF we just selected one or more notes (and no events), then we should make the note data toolbox display the note data for the selected note.
+    // IF we just selected one note (and no events), then we should make the note data toolbox display the note data for the selected note.
     if (this.events.length == 0 && this.notes.length == 1)
     {
       var noteSelected = this.notes[0];
@@ -79,6 +77,8 @@ class SetItemSelectionCommand implements ChartEditorCommand
       state.refreshToolbox(ChartEditorState.CHART_EDITOR_TOOLBOX_NOTE_DATA_LAYOUT);
     }
 
+    state.refreshToolbox(ChartEditorState.CHART_EDITOR_TOOLBOX_EVENT_DATA_LAYOUT);
+
     state.noteDisplayDirty = true;
     state.editButtonsDirty = true;
   }
@@ -87,6 +87,8 @@ class SetItemSelectionCommand implements ChartEditorCommand
   {
     state.currentNoteSelection = previousNoteSelection;
     state.currentEventSelection = previousEventSelection;
+
+    state.refreshToolbox(ChartEditorState.CHART_EDITOR_TOOLBOX_EVENT_DATA_LAYOUT);
 
     state.noteDisplayDirty = true;
     state.editButtonsDirty = true;

--- a/source/funkin/ui/debug/charting/toolboxes/ChartEditorEventDataToolbox.hx
+++ b/source/funkin/ui/debug/charting/toolboxes/ChartEditorEventDataToolbox.hx
@@ -36,8 +36,13 @@ import openfl.geom.Rectangle;
 @:build(haxe.ui.ComponentBuilder.build('assets/exclude/ui/editors/chart-editor/toolboxes/event-data.xml'))
 class ChartEditorEventDataToolbox extends ChartEditorBaseToolbox
 {
-  var toolboxEventsEventKind:DropDown;
+  var toolboxEventsModifyAllEvents:CheckBox;
   var toolboxEventsDataBox:VBox;
+  var toolboxEventsSelectedEvents:DropDown;
+  var selectedEventDropdownItemRenderer:haxe.ui.core.ItemRenderer;
+  var toolboxEventsCustomKindLabel:Label;
+  var toolboxEventsCustomKind:TextField;
+
   var easeGraphImage:Image;
   var easeDotImage:Image;
   var _easeGraphSprite:Null<flixel.FlxSprite> = null;
@@ -50,6 +55,7 @@ class ChartEditorEventDataToolbox extends ChartEditorBaseToolbox
   static var _loopPause:Float = 0.15;
 
   var _initializing:Bool = true;
+  var populateSelectedEventsDropDown:Bool = true;
 
   /**
    * If `true`, changing the value of the Event Kind dropdown will trigger the `onEventKindChanged` callback,
@@ -78,6 +84,8 @@ class ChartEditorEventDataToolbox extends ChartEditorBaseToolbox
   {
     super(chartEditorState2);
 
+    selectedEventDropdownItemRenderer = toolboxEventsSelectedEvents.findComponent(haxe.ui.core.ItemRenderer);
+
     initialize();
 
     this.onDialogClosed = onClose;
@@ -95,6 +103,65 @@ class ChartEditorEventDataToolbox extends ChartEditorBaseToolbox
     toolboxEventsEventKind.onChange = onEventKindChanged;
     shouldTriggerOnEventKindChanged = false;
 
+    toolboxEventsCustomKind.onChange = function(event:UIEvent)
+    {
+      var customKind:Null<String> = event?.target?.text;
+      if (customKind == null) return;
+
+      var prevEventKindToPlace = chartEditorState.eventKindToPlace;
+      chartEditorState.eventKindToPlace = customKind;
+      if (!_initializing && chartEditorState.currentEventSelection.length > 0)
+      {
+        if (toolboxEventsModifyAllEvents.selected)
+        {
+          trace(' CHART EDITOR '.bold().bg_bright_yellow() + 'Event toolbox MODIFYING events to kind "${chartEditorState.eventKindToPlace}"');
+          // Edit the event data of any existing events of the same type.
+          for (event in chartEditorState.currentEventSelection)
+          {
+            if (event.eventKind == prevEventKindToPlace)
+            {
+              event.eventKind = chartEditorState.eventKindToPlace;
+              event.value = Reflect.copy(chartEditorState.eventDataToPlace);
+            }
+          }
+        }
+        else
+        {
+          // Find the currently selected event and update it's values.
+          var event = chartEditorState.currentEventSelection[toolboxEventsSelectedEvents.selectedIndex - 1];
+          if (event != null)
+          {
+            event.eventKind = chartEditorState.eventKindToPlace;
+            event.value = Reflect.copy(chartEditorState.eventDataToPlace);
+          }
+        }
+        chartEditorState.saveDataDirty = true;
+        chartEditorState.noteDisplayDirty = true;
+        chartEditorState.notePreviewDirty = true;
+        chartEditorState.noteTooltipsDirty = true;
+      }
+    }
+
+    toolboxEventsSelectedEvents.onChange = function(event:UIEvent)
+    {
+      if (event.target.value == null) return;
+      var selectedEvent = chartEditorState.currentEventSelection[toolboxEventsSelectedEvents.selectedIndex - 1];
+      if (selectedEvent != null && chartEditorState.eventDataToPlace != selectedEvent.value)
+      {
+        chartEditorState.eventKindToPlace = selectedEvent.eventKind;
+        chartEditorState.eventDataToPlace = selectedEvent.value;
+        if (shouldTriggerOnEventKindChanged) // only refresh if there isn't one already taking place.
+        {
+          populateSelectedEventsDropDown = false;
+
+          refresh();
+
+          populateSelectedEventsDropDown = true;
+        }
+      }
+    };
+    refreshSelectedEvents(toolboxEventsSelectedEvents.selectedIndex);
+
     var startingEventValue = ChartEditorDropdowns.populateDropdownWithSongEvents(toolboxEventsEventKind, chartEditorState.eventKindToPlace);
     toolboxEventsEventKind.value = startingEventValue;
 
@@ -108,6 +175,7 @@ class ChartEditorEventDataToolbox extends ChartEditorBaseToolbox
       return;
     }
 
+    var prevEventKindToPlace = chartEditorState.eventKindToPlace;
     var eventKind:String = event.data.id;
     var sameEvent:Bool = (eventKind == chartEditorState.eventKindToPlace);
 
@@ -118,31 +186,64 @@ class ChartEditorEventDataToolbox extends ChartEditorBaseToolbox
 
     var schema:SongEventSchema = SongEventRegistry.getEventSchema(eventKind);
 
+    if (!sameEvent) chartEditorState.eventDataToPlace = {};
     if (schema == null)
     {
       chartEditorState.warning('Invalid Event Kind', 'Event toolbox tried to use unknown event kind "$eventKind", did you define a schema?');
-      return;
+      toolboxEventsCustomKindLabel.hidden = false;
+      toolboxEventsCustomKind.hidden = false;
+      buildEventDataFormFromSchema(toolboxEventsDataBox, buildSchemaFromEventData(), chartEditorState.eventKindToPlace);
     }
-
-    if (!sameEvent) chartEditorState.eventDataToPlace = {};
-    buildEventDataFormFromSchema(toolboxEventsDataBox, schema, chartEditorState.eventKindToPlace);
+    else
+    {
+      toolboxEventsCustomKindLabel.hidden = true;
+      toolboxEventsCustomKind.hidden = true;
+      buildEventDataFormFromSchema(toolboxEventsDataBox, schema, chartEditorState.eventKindToPlace);
+    }
 
     if (!_initializing && chartEditorState.currentEventSelection.length > 0)
     {
-      // Edit the event data of any selected events.
-      chartEditorState.success(
-        'Modified Events',
-        'Switching ${chartEditorState.currentEventSelection.length} events to "${chartEditorState.eventKindToPlace}"'
-      );
-      for (event in chartEditorState.currentEventSelection)
+      if (toolboxEventsModifyAllEvents.selected)
       {
-        event.eventKind = chartEditorState.eventKindToPlace;
-        event.value = chartEditorState.eventDataToPlace;
+        chartEditorState.success(
+          'Modified Events',
+          'Switching ${chartEditorState.currentEventSelection.length} events to "${chartEditorState.eventKindToPlace}"'
+        );
+        // Edit the event data of any selected events of the same type.
+        for (event in chartEditorState.currentEventSelection)
+        {
+          if (event.eventKind == prevEventKindToPlace)
+          {
+            event.eventKind = chartEditorState.eventKindToPlace;
+            event.value = Reflect.copy(chartEditorState.eventDataToPlace);
+          }
+        }
+      }
+      else
+      {
+        // Find the currently selected event and update it's values.
+        var event = chartEditorState.currentEventSelection[toolboxEventsSelectedEvents.selectedIndex - 1];
+        if (event != null)
+        {
+          event.eventKind = chartEditorState.eventKindToPlace;
+          event.value = Reflect.copy(chartEditorState.eventDataToPlace);
+        }
       }
       chartEditorState.saveDataDirty = true;
       chartEditorState.noteDisplayDirty = true;
       chartEditorState.notePreviewDirty = true;
+      chartEditorState.noteTooltipsDirty = true;
     }
+  }
+
+  function refreshSelectedEvents(startingChartEvent:Int = 0):Void
+  {
+    toolboxEventsSelectedEvents.pauseEvent(UIEvent.CHANGE, true);
+    var startingSelectedEvent = ChartEditorDropdowns.populateDropdownWithChartEvents(toolboxEventsSelectedEvents, chartEditorState, startingChartEvent);
+    toolboxEventsSelectedEvents.selectedIndex = Std.parseInt(startingSelectedEvent.id);
+    toolboxEventsSelectedEvents.value = startingSelectedEvent;
+    selectedEventDropdownItemRenderer.data = startingSelectedEvent;
+    toolboxEventsSelectedEvents.resumeEvent(UIEvent.CHANGE, true, true);
   }
 
   override public function refresh():Void
@@ -151,24 +252,37 @@ class ChartEditorEventDataToolbox extends ChartEditorBaseToolbox
 
     shouldTriggerOnEventKindChanged = false;
 
+    if (populateSelectedEventsDropDown) refreshSelectedEvents(toolboxEventsSelectedEvents.selectedIndex);
+
     var newDropdownElement = ChartEditorDropdowns.findDropdownElement(chartEditorState.eventKindToPlace, toolboxEventsEventKind);
 
     if (newDropdownElement == null)
     {
       trace(' WARNING '.bold().bg_yellow() + ' CHART EDITOR - Event kind "${chartEditorState.eventKindToPlace}" not found in dropdown lookup. Attempting to proceed...');
-      newDropdownElement = toolboxEventsEventKind.dataSource.get(0);
+      newDropdownElement = ChartEditorDropdowns.findDropdownElement('unknown', toolboxEventsEventKind);
+      toolboxEventsCustomKindLabel.hidden = false;
+      toolboxEventsCustomKind.hidden = false;
+      toolboxEventsCustomKind.value = chartEditorState.eventKindToPlace;
     }
-    else if (toolboxEventsEventKind.value != newDropdownElement || lastEventKind != toolboxEventsEventKind.value.id)
+    else
+    {
+      toolboxEventsCustomKindLabel.hidden = true;
+      toolboxEventsCustomKind.hidden = true;
+    }
+
+    if (toolboxEventsEventKind.value != newDropdownElement || lastEventKind != toolboxEventsEventKind.value.id)
     {
       toolboxEventsEventKind.value = newDropdownElement;
 
       var schema:SongEventSchema = SongEventRegistry.getEventSchema(chartEditorState.eventKindToPlace);
       if (schema == null)
       {
+        // Build the event schema using the selected unknown event's value instead.
         chartEditorState.warning(
           'Invalid Event Kind',
           'Event toolbox tried to use unknown event kind "${chartEditorState.eventKindToPlace}", did you define a schema?'
         );
+        buildEventDataFormFromSchema(toolboxEventsDataBox, buildSchemaFromEventData(), chartEditorState.eventKindToPlace);
       }
       else
       {
@@ -190,7 +304,6 @@ class ChartEditorEventDataToolbox extends ChartEditorBaseToolbox
       if (field != null)
       {
         field.pauseEvent(UIEvent.CHANGE, true);
-
         switch (Type.getClass(field))
         {
           case NumberStepper:
@@ -216,8 +329,81 @@ class ChartEditorEventDataToolbox extends ChartEditorBaseToolbox
       }
     }
 
-    shouldTriggerOnEventKindChanged = true;
     updateEasePreview();
+
+    shouldTriggerOnEventKindChanged = true;
+  }
+
+  function buildSchemaFromEventData():SongEventSchema
+  {
+    var schema:SongEventSchema = new SongEventSchema([]);
+
+    for (pair in chartEditorState.eventDataToPlace.keyValueIterator())
+    {
+      var fieldId:String = pair.key;
+      var value:Null<Dynamic> = pair.value;
+
+      switch (value)
+      {
+        case Std.isOfType(_, Int) => true:
+          schema.push(
+            {
+              name: '$fieldId',
+              title: '$fieldId',
+              defaultValue: value,
+              step: 1,
+              type: SongEventFieldType.INTEGER,
+            });
+        case Std.isOfType(_, Float) => true:
+          schema.push(
+            {
+              name: '$fieldId',
+              title: '$fieldId',
+              defaultValue: value,
+              step: 0.1,
+              type: SongEventFieldType.FLOAT,
+            });
+        case Std.isOfType(_, Bool) => true:
+          schema.push(
+            {
+              name: '$fieldId',
+              title: '$fieldId',
+              type: SongEventFieldType.BOOL,
+              defaultValue: value,
+            });
+        case Std.isOfType(_, String) => true:
+          schema.push(
+            {
+              name: '$fieldId',
+              title: '$fieldId',
+              type: SongEventFieldType.STRING,
+              defaultValue: '$value',
+            });
+        default:
+          throw 'ChartEditorEventDataToolbox - Field "${fieldId}" is of unknown type "${Type.getClassName(Type.getClass(value))}".';
+      }
+    }
+
+    if (schema.getFirstField() == null)
+    {
+      // Fine, here's some useless values for the psychic in you.
+      schema = new SongEventSchema([
+        {
+          name: 'value1',
+          title: 'value1',
+          type: SongEventFieldType.STRING,
+          defaultValue: '',
+        },
+        {
+          name: 'value2',
+          title: 'value2',
+          type: SongEventFieldType.STRING,
+          defaultValue: '',
+        },
+      ]);
+    }
+
+    return schema;
   }
 
   var lastEventKind:String = 'unknown';
@@ -365,16 +551,6 @@ class ChartEditorEventDataToolbox extends ChartEditorBaseToolbox
 
       hbox.addComponent(field.type == FRAME ? input : inputBox);
 
-      // Ensure chartEditorState.eventDataToPlace reflects default UI values so preview is correct on first open
-      if (field.defaultValue != null)
-      {
-        // Only set if not already present (don't overwrite existing selection data)
-        if (chartEditorState.eventDataToPlace.get(field.name) == null)
-        {
-          chartEditorState.eventDataToPlace.set(field.name, field.defaultValue);
-        }
-      }
-
       // Update the value of the event data without modifying
       input.pauseEvent(UIEvent.CHANGE, true);
       input.onChange = function(event:UIEvent)
@@ -404,14 +580,26 @@ class ChartEditorEventDataToolbox extends ChartEditorBaseToolbox
           chartEditorState.eventDataToPlace.set(event.target.id, value);
         }
 
-        // Edit the event data of any existing events.
         if (!_initializing && chartEditorState.currentEventSelection.length > 0)
         {
-          // chartEditorState.success('Modified Events', 'Edited ${chartEditorState.currentEventSelection.length} selected events')
-          for (songEvent in chartEditorState.currentEventSelection)
+          if (toolboxEventsModifyAllEvents.selected)
           {
-            songEvent.eventKind = chartEditorState.eventKindToPlace;
-            songEvent.value = Reflect.copy(chartEditorState.eventDataToPlace);
+            // Edit the event data of any existing events of the same type.
+            trace(' CHART EDITOR '.bold().bg_bright_yellow() + 'Event Toolbox MODIFYING all selected events...');
+            for (event in chartEditorState.currentEventSelection)
+            {
+              if (event.eventKind == chartEditorState.eventKindToPlace) event.value = chartEditorState.eventDataToPlace;
+            }
+          }
+          else
+          {
+            // Find the currently selected event and update it's values.
+            var event = chartEditorState.currentEventSelection[toolboxEventsSelectedEvents.selectedIndex - 1];
+            if (event != null)
+            {
+              event.eventKind = chartEditorState.eventKindToPlace;
+              event.value = Reflect.copy(chartEditorState.eventDataToPlace);
+            }
           }
           chartEditorState.saveDataDirty = true;
           chartEditorState.noteDisplayDirty = true;

--- a/source/funkin/ui/debug/charting/toolboxes/ChartEditorEventDataToolbox.hx
+++ b/source/funkin/ui/debug/charting/toolboxes/ChartEditorEventDataToolbox.hx
@@ -34,8 +34,13 @@ import flixel.FlxG;
 @:access(funkin.ui.debug.charting.ChartEditorState) @:build(haxe.ui.ComponentBuilder.build('assets/exclude/data/ui/chart-editor/toolboxes/event-data.xml'))
 class ChartEditorEventDataToolbox extends ChartEditorBaseToolbox
 {
-  var toolboxEventsEventKind:DropDown;
+  var toolboxEventsModifyAllEvents:CheckBox;
   var toolboxEventsDataBox:VBox;
+  var toolboxEventsSelectedEvents:DropDown;
+  var selectedEventDropdownItemRenderer:haxe.ui.core.ItemRenderer;
+  var toolboxEventsCustomKindLabel:Label;
+  var toolboxEventsCustomKind:TextField;
+
   var easeGraphImage:Image;
   var easeDotImage:Image;
   var _easeGraphSprite:Null<flixel.FlxSprite> = null;
@@ -48,6 +53,7 @@ class ChartEditorEventDataToolbox extends ChartEditorBaseToolbox
   static var _loopPause:Float = 0.15;
 
   var _initializing:Bool = true;
+  var populateSelectedEventsDropDown:Bool = true;
 
   /**
    * If `true`, changing the value of the Event Kind dropdown will trigger the `onEventKindChanged` callback,
@@ -76,6 +82,8 @@ class ChartEditorEventDataToolbox extends ChartEditorBaseToolbox
   {
     super(chartEditorState2);
 
+    selectedEventDropdownItemRenderer = toolboxEventsSelectedEvents.findComponent(haxe.ui.core.ItemRenderer);
+
     initialize();
 
     this.onDialogClosed = onClose;
@@ -93,6 +101,65 @@ class ChartEditorEventDataToolbox extends ChartEditorBaseToolbox
     toolboxEventsEventKind.onChange = onEventKindChanged;
     shouldTriggerOnEventKindChanged = false;
 
+    toolboxEventsCustomKind.onChange = function(event:UIEvent)
+    {
+      var customKind:Null<String> = event?.target?.text;
+      if (customKind == null) return;
+
+      var prevEventKindToPlace = chartEditorState.eventKindToPlace;
+      chartEditorState.eventKindToPlace = customKind;
+      if (!_initializing && chartEditorState.currentEventSelection.length > 0)
+      {
+        if (toolboxEventsModifyAllEvents.selected)
+        {
+          trace(' CHART EDITOR '.bold().bg_bright_yellow() + 'Event toolbox MODIFYING events to kind "${chartEditorState.eventKindToPlace}"');
+          // Edit the event data of any existing events of the same type.
+          for (event in chartEditorState.currentEventSelection)
+          {
+            if (event.eventKind == prevEventKindToPlace)
+            {
+              event.eventKind = chartEditorState.eventKindToPlace;
+              event.value = Reflect.copy(chartEditorState.eventDataToPlace);
+            }
+          }
+        }
+        else
+        {
+          // Find the currently selected event and update it's values.
+          var event = chartEditorState.currentEventSelection[toolboxEventsSelectedEvents.selectedIndex - 1];
+          if (event != null)
+          {
+            event.eventKind = chartEditorState.eventKindToPlace;
+            event.value = Reflect.copy(chartEditorState.eventDataToPlace);
+          }
+        }
+        chartEditorState.saveDataDirty = true;
+        chartEditorState.noteDisplayDirty = true;
+        chartEditorState.notePreviewDirty = true;
+        chartEditorState.noteTooltipsDirty = true;
+      }
+    }
+
+    toolboxEventsSelectedEvents.onChange = function(event:UIEvent)
+    {
+      if (event.target.value == null) return;
+      var selectedEvent = chartEditorState.currentEventSelection[toolboxEventsSelectedEvents.selectedIndex - 1];
+      if (selectedEvent != null && chartEditorState.eventDataToPlace != selectedEvent.value)
+      {
+        chartEditorState.eventKindToPlace = selectedEvent.eventKind;
+        chartEditorState.eventDataToPlace = selectedEvent.value;
+        if (shouldTriggerOnEventKindChanged) // only refresh if there isn't one already taking place.
+        {
+          populateSelectedEventsDropDown = false;
+
+          refresh();
+
+          populateSelectedEventsDropDown = true;
+        }
+      }
+    };
+    refreshSelectedEvents(toolboxEventsSelectedEvents.selectedIndex);
+
     var startingEventValue = ChartEditorDropdowns.populateDropdownWithSongEvents(toolboxEventsEventKind, chartEditorState.eventKindToPlace);
     trace(' CHART EDITOR '.bold().bg_bright_yellow() + 'Building Event toolbox with kind "${startingEventValue}"');
     toolboxEventsEventKind.value = startingEventValue;
@@ -108,6 +175,7 @@ class ChartEditorEventDataToolbox extends ChartEditorBaseToolbox
       return;
     }
 
+    var prevEventKindToPlace = chartEditorState.eventKindToPlace;
     var eventKind:String = event.data.id;
     var sameEvent:Bool = (eventKind == chartEditorState.eventKindToPlace);
 
@@ -118,28 +186,59 @@ class ChartEditorEventDataToolbox extends ChartEditorBaseToolbox
 
     var schema:SongEventSchema = SongEventRegistry.getEventSchema(eventKind);
 
+    if (!sameEvent) chartEditorState.eventDataToPlace = {};
     if (schema == null)
     {
-      trace(' WARNING '.bold().bg_yellow() + ' Event toolbox attempted to use unknown event kind "$eventKind"');
-      return;
+      trace(' WARNING '.bold().bg_yellow() + ' Event toolbox - unknown event kind "$eventKind"');
+      toolboxEventsCustomKindLabel.hidden = false;
+      toolboxEventsCustomKind.hidden = false;
+      buildEventDataFormFromSchema(toolboxEventsDataBox, buildSchemaFromEventData(), chartEditorState.eventKindToPlace);
     }
-
-    if (!sameEvent) chartEditorState.eventDataToPlace = {};
-    buildEventDataFormFromSchema(toolboxEventsDataBox, schema, chartEditorState.eventKindToPlace);
+    else
+    {
+      toolboxEventsCustomKindLabel.hidden = true;
+      toolboxEventsCustomKind.hidden = true;
+      buildEventDataFormFromSchema(toolboxEventsDataBox, schema, chartEditorState.eventKindToPlace);
+    }
 
     if (!_initializing && chartEditorState.currentEventSelection.length > 0)
     {
-      // Edit the event data of any selected events.
-      trace(' CHART EDITOR '.bold().bg_bright_yellow() + 'Event toolbox MODIFYING events to kind "${chartEditorState.eventKindToPlace}"');
-      for (event in chartEditorState.currentEventSelection)
+      if (toolboxEventsModifyAllEvents.selected)
       {
-        event.eventKind = chartEditorState.eventKindToPlace;
-        event.value = chartEditorState.eventDataToPlace;
+        trace(' CHART EDITOR '.bold().bg_bright_yellow() + 'Event toolbox MODIFYING events to kind "${chartEditorState.eventKindToPlace}"');
+        // Edit the event data of any existing events of the same type.
+        for (event in chartEditorState.currentEventSelection)
+        {
+          if (event.eventKind == prevEventKindToPlace)
+          {
+            event.eventKind = chartEditorState.eventKindToPlace;
+            event.value = Reflect.copy(chartEditorState.eventDataToPlace);
+          }
+        }
+      }
+      else
+      {
+        // Find the currently selected event and update it's values.
+        var event = chartEditorState.currentEventSelection[toolboxEventsSelectedEvents.selectedIndex - 1];
+        if (event != null)
+        {
+          event.eventKind = chartEditorState.eventKindToPlace;
+          event.value = Reflect.copy(chartEditorState.eventDataToPlace);
+        }
       }
       chartEditorState.saveDataDirty = true;
       chartEditorState.noteDisplayDirty = true;
       chartEditorState.notePreviewDirty = true;
+      chartEditorState.noteTooltipsDirty = true;
     }
+  }
+
+  function refreshSelectedEvents(startingChartEvent:Int = 0):Void
+  {
+    var startingSelectedEvent = ChartEditorDropdowns.populateDropdownWithChartEvents(toolboxEventsSelectedEvents, chartEditorState, startingChartEvent);
+    toolboxEventsSelectedEvents.selectedIndex = Std.parseInt(startingSelectedEvent.id);
+    toolboxEventsSelectedEvents.value = startingSelectedEvent;
+    selectedEventDropdownItemRenderer.data = startingSelectedEvent;
   }
 
   override public function refresh():Void
@@ -148,20 +247,34 @@ class ChartEditorEventDataToolbox extends ChartEditorBaseToolbox
 
     shouldTriggerOnEventKindChanged = false;
 
+    if (populateSelectedEventsDropDown) refreshSelectedEvents(toolboxEventsSelectedEvents.selectedIndex);
+
     var newDropdownElement = ChartEditorDropdowns.findDropdownElement(chartEditorState.eventKindToPlace, toolboxEventsEventKind);
 
     if (newDropdownElement == null)
     {
-      throw 'CHART EDITOR - In Event Toolbox, event kind "${chartEditorState.eventKindToPlace}" not in dropdown!';
+      trace('CHART EDITOR - Event kind "${chartEditorState.eventKindToPlace}" not in dropdown!');
+      newDropdownElement = ChartEditorDropdowns.findDropdownElement('unknown', toolboxEventsEventKind);
+      toolboxEventsCustomKindLabel.hidden = false;
+      toolboxEventsCustomKind.hidden = false;
+      toolboxEventsCustomKind.value = chartEditorState.eventKindToPlace;
     }
-    else if (toolboxEventsEventKind.value != newDropdownElement || lastEventKind != toolboxEventsEventKind.value.id)
+    else
+    {
+      toolboxEventsCustomKindLabel.hidden = true;
+      toolboxEventsCustomKind.hidden = true;
+    }
+
+    if (toolboxEventsEventKind.value != newDropdownElement || lastEventKind != toolboxEventsEventKind.value.id)
     {
       toolboxEventsEventKind.value = newDropdownElement;
 
       var schema:SongEventSchema = SongEventRegistry.getEventSchema(chartEditorState.eventKindToPlace);
       if (schema == null)
       {
+        // Build the event schema using the selected unknown event's value instead.
         trace(' CHART EDITOR '.bold().bg_bright_yellow() + 'Event kind "${chartEditorState.eventKindToPlace}" has no schema for Event toolbox!');
+        buildEventDataFormFromSchema(toolboxEventsDataBox, buildSchemaFromEventData(), chartEditorState.eventKindToPlace);
       }
       else
       {
@@ -180,7 +293,6 @@ class ChartEditorEventDataToolbox extends ChartEditorBaseToolbox
       var value:Null<Dynamic> = pair.value;
 
       var field:Component = toolboxEventsDataBox.findComponent(fieldId);
-      field.pauseEvent(UIEvent.CHANGE, true);
 
       if (field == null)
       {
@@ -188,6 +300,7 @@ class ChartEditorEventDataToolbox extends ChartEditorBaseToolbox
       }
       else
       {
+        field.pauseEvent(UIEvent.CHANGE, true);
         switch (field)
         {
           case Std.isOfType(_, NumberStepper) => true:
@@ -211,6 +324,78 @@ class ChartEditorEventDataToolbox extends ChartEditorBaseToolbox
 
     shouldTriggerOnEventKindChanged = true;
     updateEasePreview();
+  }
+
+  function buildSchemaFromEventData():SongEventSchema
+  {
+    var schema:SongEventSchema = new SongEventSchema([]);
+
+    for (pair in chartEditorState.eventDataToPlace.keyValueIterator())
+    {
+      var fieldId:String = pair.key;
+      var value:Null<Dynamic> = pair.value;
+
+      switch (value)
+      {
+        case Std.isOfType(_, Int) => true:
+          schema.push(
+            {
+              name: '$fieldId',
+              title: '$fieldId',
+              defaultValue: value,
+              step: 1,
+              type: SongEventFieldType.INTEGER,
+            });
+        case Std.isOfType(_, Float) => true:
+          schema.push(
+            {
+              name: '$fieldId',
+              title: '$fieldId',
+              defaultValue: value,
+              step: 0.1,
+              type: SongEventFieldType.FLOAT,
+            });
+        case Std.isOfType(_, Bool) => true:
+          schema.push(
+            {
+              name: '$fieldId',
+              title: '$fieldId',
+              type: SongEventFieldType.BOOL,
+              defaultValue: value,
+            });
+        case Std.isOfType(_, String) => true:
+          schema.push(
+            {
+              name: '$fieldId',
+              title: '$fieldId',
+              type: SongEventFieldType.STRING,
+              defaultValue: '$value',
+            });
+        default:
+          throw 'ChartEditorEventDataToolbox - Field "${fieldId}" is of unknown type "${Type.getClassName(Type.getClass(value))}".';
+      }
+    }
+
+    if (schema.getFirstField() == null)
+    {
+      // Fine, here's some useless values for the psychic in you.
+      schema = new SongEventSchema([
+        {
+          name: 'value1',
+          title: 'value1',
+          type: SongEventFieldType.STRING,
+          defaultValue: '',
+        },
+        {
+          name: 'value2',
+          title: 'value2',
+          type: SongEventFieldType.STRING,
+          defaultValue: '',
+        },
+      ]);
+    }
+
+    return schema;
   }
 
   var lastEventKind:String = 'unknown';
@@ -395,14 +580,26 @@ class ChartEditorEventDataToolbox extends ChartEditorBaseToolbox
           chartEditorState.eventDataToPlace.set(event.target.id, value);
         }
 
-        // Edit the event data of any existing events.
         if (!_initializing && chartEditorState.currentEventSelection.length > 0)
         {
-          trace(' CHART EDITOR '.bold().bg_bright_yellow() + 'Event Toolbox MODIFYING all selected events...');
-          for (songEvent in chartEditorState.currentEventSelection)
+          if (toolboxEventsModifyAllEvents.selected)
           {
-            songEvent.eventKind = chartEditorState.eventKindToPlace;
-            songEvent.value = Reflect.copy(chartEditorState.eventDataToPlace);
+            // Edit the event data of any existing events of the same type.
+            trace(' CHART EDITOR '.bold().bg_bright_yellow() + 'Event Toolbox MODIFYING all selected events...');
+            for (event in chartEditorState.currentEventSelection)
+            {
+              if (event.eventKind == chartEditorState.eventKindToPlace) event.value = chartEditorState.eventDataToPlace;
+            }
+          }
+          else
+          {
+            // Find the currently selected event and update it's values.
+            var event = chartEditorState.currentEventSelection[toolboxEventsSelectedEvents.selectedIndex - 1];
+            if (event != null)
+            {
+              event.eventKind = chartEditorState.eventKindToPlace;
+              event.value = Reflect.copy(chartEditorState.eventDataToPlace);
+            }
           }
           chartEditorState.saveDataDirty = true;
           chartEditorState.noteDisplayDirty = true;

--- a/source/funkin/ui/debug/charting/util/ChartEditorDropdowns.hx
+++ b/source/funkin/ui/debug/charting/util/ChartEditorDropdowns.hx
@@ -168,6 +168,47 @@ class ChartEditorDropdowns
 
     dropDown.dataSource.sort('text', ASCENDING);
 
+    dropDown.dataSource.add({id: 'unknown', text: 'Unknown Event'});
+
+    return returnValue;
+  }
+
+  /**
+   * Populate a dropdown with the current event selection.
+   */
+  public static function populateDropdownWithChartEvents(dropDown:DropDown, state:ChartEditorState, startingChartEvent:Int = 0):DropDownEntry
+  {
+    dropDown.dataSource.clear();
+
+    var events = state.currentEventSelection;
+
+    var returnValue:DropDownEntry =
+      {
+        id: "0",
+        text: (events[0] != null) ? (events[0].time + ' : ' + events[0].buildTooltip()) : ('No Event Selected!')
+      };
+
+    for (index in 0...events.length)
+    {
+      var value =
+        {
+          id: '$index',
+          text: '${events[index].time} : ${events[index].buildTooltip()}'
+        };
+      if (startingChartEvent == index) returnValue = value;
+      dropDown.dataSource.add(value);
+    }
+
+    if (events.length > 0) dropDown.dataSource.insert(0,
+      {
+      id: "0",
+        text: 'No Selected Event'
+      });
+    else
+      dropDown.dataSource.insert(0, returnValue);
+
+    dropDown.dataSource.sort('id', ASCENDING);
+
     return returnValue;
   }
 

--- a/source/funkin/ui/debug/charting/util/ChartEditorDropdowns.hx
+++ b/source/funkin/ui/debug/charting/util/ChartEditorDropdowns.hx
@@ -140,6 +140,47 @@ class ChartEditorDropdowns
 
     dropDown.dataSource.sort('text', ASCENDING);
 
+    dropDown.dataSource.add({id: 'unknown', text: 'Unknown Event'});
+
+    return returnValue;
+  }
+
+  /**
+   * Populate a dropdown with the current event selection.
+   */
+  public static function populateDropdownWithChartEvents(dropDown:DropDown, state:ChartEditorState, startingChartEvent:Int = 0):DropDownEntry
+  {
+    dropDown.dataSource.clear();
+
+    var events = state.currentEventSelection;
+
+    var returnValue:DropDownEntry =
+      {
+        id: "0",
+        text: (events[0] != null) ? (events[0].time + ' : ' + events[0].buildTooltip()) : ('No Event Selected!')
+      };
+
+    for (index in 0...events.length)
+    {
+      var value =
+        {
+          id: '$index',
+          text: '${events[index].time} : ${events[index].buildTooltip()}'
+        };
+      if (startingChartEvent == index) returnValue = value;
+      dropDown.dataSource.add(value);
+    }
+
+    if (events.length > 0) dropDown.dataSource.insert(0,
+      {
+      id: "0",
+        text: 'No Selected Event'
+      });
+    else
+      dropDown.dataSource.insert(0, returnValue);
+
+    dropDown.dataSource.sort('id', ASCENDING);
+
     return returnValue;
   }
 


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
Closes #4192, fixes #5109, fixes #5028
<!-- Briefly describe the issue(s) fixed. -->
## Description

This PR adds a dropdown of the currently selected events to the event data toolbox, allowing you to modify the data of the selected events separately.

It also adds an option to enable the previous functionality (editing the entire event selection at the same time), but modifies it slightly to only apply to events of the same type. Selecting a event kind with the option enabled will set the entire selection to that type, however.

Also adds support for unknown events (aka, psycho users who can't be bothered to make events properly in mod ports to new FNF).

> [!IMPORTANT]
> Requires https://github.com/FunkinCrew/funkin.assets/pull/330

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos

https://github.com/user-attachments/assets/d51f7040-a7b8-4dac-920e-b1bc62f9ef27

Unknown events support:
![Screenshot 2025-05-23 212612](https://github.com/user-attachments/assets/4461050b-eb0b-40b8-97b5-533aabe6066b)
![Screenshot 2025-05-23 214809](https://github.com/user-attachments/assets/477b2621-279d-4cf8-b7db-de0cff6fc34c)
![Screenshot 2025-05-23 225204](https://github.com/user-attachments/assets/3c11a649-86fd-46ea-a702-507ea9424fd2)

