### PR TITLE
[ENHANCEMENT] Split GF characters from their Speakers

### DIFF
--- a/source/funkin/play/boombox/Boombox.hx
+++ b/source/funkin/play/boombox/Boombox.hx
@@ -1,0 +1,71 @@
+package funkin.play.boombox;
+
+import flixel.group.FlxSpriteGroup;
+import flixel.math.FlxPoint;
+import flixel.util.FlxSort;
+import funkin.modding.IScriptedClass.IPlayStateScriptedClass;
+import funkin.modding.events.ScriptEvent;
+import funkin.play.character.BaseCharacter;
+import funkin.util.SortUtil;
+
+/**
+ * A Boombox represents the speakers that the gf characters sit on.
+ * It's an `FlxSpriteGroup` in case your boomboxes contain multiple elements (such as for Nene's A-Bot).
+ * It doesn't do anything on its own though.
+ */
+@:nullSafety
+class Boombox extends FlxSpriteGroup implements IPlayStateScriptedClass
+{
+  public var parentCharacter:Null<BaseCharacter> = null;
+
+  public function refresh():Void
+  {
+    sort(SortUtil.byZIndex, FlxSort.ASCENDING);
+  }
+
+  public function onAdd(event:ScriptEvent):Void {}
+
+  public function onScriptEvent(event:ScriptEvent) {}
+
+  public function onCreate(event:ScriptEvent) {}
+
+  public function onDestroy(event:ScriptEvent) {}
+
+  public function onUpdate(event:UpdateScriptEvent) {}
+
+  public function onStepHit(event:SongTimeScriptEvent) {}
+
+  public function onBeatHit(event:SongTimeScriptEvent):Void {}
+
+  public function onPause(event:PauseScriptEvent) {}
+
+  public function onResume(event:ScriptEvent) {}
+
+  public function onSongStart(event:ScriptEvent) {}
+
+  public function onSongEnd(event:ScriptEvent) {}
+
+  public function onGameOver(event:ScriptEvent) {}
+
+  public function onNoteIncoming(event:NoteScriptEvent) {}
+
+  public function onNoteHit(event:HitNoteScriptEvent) {}
+
+  public function onNoteHoldDrop(event:HoldNoteScriptEvent) {}
+
+  public function onNoteMiss(event:NoteScriptEvent) {}
+
+  public function onSongEvent(event:SongEventScriptEvent) {}
+
+  public function onNoteGhostMiss(event:GhostMissNoteScriptEvent) {}
+
+  public function onCountdownStart(event:CountdownScriptEvent) {}
+
+  public function onCountdownStep(event:CountdownScriptEvent) {}
+
+  public function onCountdownEnd(event:CountdownScriptEvent) {}
+
+  public function onSongLoaded(event:SongLoadScriptEvent) {}
+
+  public function onSongRetry(event:SongRetryEvent) {}
+}

--- a/source/funkin/play/boombox/ScriptedBoombox.hx
+++ b/source/funkin/play/boombox/ScriptedBoombox.hx
@@ -1,0 +1,8 @@
+package funkin.play.boombox;
+
+/**
+ * A script that can be tied to a Bopper.
+ * Create a scripted class that extends Bopper to use this.
+ */
+@:hscriptClass
+class ScriptedBoombox extends funkin.play.boombox.Boombox implements polymod.hscript.HScriptedClass {}

--- a/source/funkin/play/character/BaseCharacter.hx
+++ b/source/funkin/play/character/BaseCharacter.hx
@@ -2,6 +2,10 @@ package funkin.play.character;
 
 import flixel.math.FlxPoint;
 import funkin.modding.events.ScriptEvent;
+import funkin.modding.events.ScriptEventDispatcher;
+import funkin.play.boombox.Boombox;
+import funkin.play.boombox.ScriptedBoombox;
+import funkin.play.character.CharacterData.BoomboxData;
 import funkin.play.character.CharacterData.CharacterDataParser;
 import funkin.play.character.CharacterData.CharacterRenderType;
 import funkin.play.stage.Bopper;
@@ -344,6 +348,31 @@ class BaseCharacter extends Bopper
       }
       PlayState.instance.iconP2.configure(_data?.healthIcon);
     }
+  }
+
+  public function fetchBoombox():Boombox
+  {
+    var dataToUse:Null<BoomboxData> = _data?.boombox;
+    if (dataToUse?.scriptClass == null)
+    {
+      return null;
+    }
+
+    var output:Boombox = ScriptedBoombox.init(dataToUse.scriptClass);
+    output.parentCharacter = this;
+
+    ScriptEventDispatcher.callEvent(output, new ScriptEvent(CREATE));
+    return output;
+  }
+
+  public function getBoomboxOffsets():Array<Float>
+  {
+    return _data?.boombox?.offsets ?? [0.0, 0.0];
+  }
+
+  public function getBoomboxZIndex():Int
+  {
+    return _data?.boombox?.zIndex ?? 0;
   }
 
   public override function onUpdate(event:UpdateScriptEvent):Void

--- a/source/funkin/play/character/CharacterData.hx
+++ b/source/funkin/play/character/CharacterData.hx
@@ -680,6 +680,12 @@ typedef CharacterData =
    */
   var healthIcon:Null<HealthIconData>;
 
+  /**
+   * Optional data about the boombox for the character.
+   * Used only if the character is loaded in the GF slot.
+   */
+  var boombox:Null<BoomboxData>;
+
   var death:Null<DeathData>;
 
   /**
@@ -775,6 +781,30 @@ typedef HealthIconData =
    * @default [0, 25]
    */
   var offsets:Null<Array<Float>>;
+}
+
+/**
+ * The JSON data schema used to define the boombox for a character, if used on GF's position.
+ */
+typedef BoomboxData =
+{
+  /**
+   * The scripted class' name for the boombox.
+   * @default `null`
+   */
+  var scriptClass:Null<String>;
+
+  /**
+   * The offset of the boombox, in pixels.
+   * @default [0, 0]
+   */
+  var offsets:Null<Array<Float>>;
+
+  /**
+   * The z-Index offset of the boom box.
+   * For example, using the offset `-5` while your character has z-Index `100` will make the boombox have its z-Index be `95`.
+   */
+  var zIndex:Null<Int>;
 }
 
 typedef DeathData =


### PR DESCRIPTION
## Linked Issues
Closes https://github.com/FunkinCrew/Funkin/issues/5111

## Description
This PR introduces a new scriptable class, `Boombox`. (the name `Speaker` was already occupied by the dialogue speaker) It's essentially just an `FlxSpriteGroup` with a support for the same events as the characters. It only works on GF and receives event calls before GF. The position of the Boombx depends on the stage json's position for the girlfriend and the offsets defined in the character json.

At the moment I have only done this for the default versions of Nene and A-Bot, though I'd like to update this at some point to include other versions of A-Bot and Nene.
GF will take a bit though considering the back side of her hair would need to be separated from the rest of her body (hence the branch name `bald-gf`).

~~also can you guys merge the latest changes from the main assets branch onto develop please i swear i didn't touch the labeller files i just pulled from main to have an assets submod base okay thanks~~

## Screenshots/Videos
<details>
<summary><a>Video Preview</a></summary>

https://github.com/user-attachments/assets/551e3d9c-c125-4c10-95c1-ce1d79aec47b

</details>
<details>
<summary><a>Character Boombox Configuration</a></summary>

![image](https://github.com/user-attachments/assets/9f414068-4fd2-44f9-a4e6-76a8889d9fd9)

</details>
