### PR TITLE
[BUGFIX] Fix TitleState Shader Crash

### DIFF
--- a/source/funkin/ui/title/TitleState.hx
+++ b/source/funkin/ui/title/TitleState.hx
@@ -240,12 +240,20 @@ class TitleState extends MusicBeatState
       }
           }
      */
-    if (FlxG.keys.justPressed.I)
+    if (outlineShaderShit != null)
     {
-      FlxTween.tween(outlineShaderShit, {funnyX: 50, funnyY: 50}, 0.6, {ease: FlxEase.quartOut});
+      if (FlxG.keys.justPressed.I)
+      {
+        FlxTween.tween(outlineShaderShit, {funnyX: 50, funnyY: 50}, 0.6, {ease: FlxEase.quartOut});
+      }
+
+      if (FlxG.keys.pressed.D)
+      {
+        outlineShaderShit.funnyX += 1;
+      }
+
+      // outlineShaderShit.xPos.value[0] += 1;
     }
-    if (FlxG.keys.pressed.D) outlineShaderShit.funnyX += 1;
-    // outlineShaderShit.xPos.value[0] += 1;
 
     if (FlxG.keys.justPressed.Y)
     {


### PR DESCRIPTION
## Linked Issues
Closes #5159 

## Description
This fixes a crash when spamming or holding d or i on title state before the outline shader is called.

## Screenshots/Videos

### BEFORE:
https://github.com/user-attachments/assets/7d96d5d0-c86e-46c8-ad19-cf3e35a2d4ac

### AFTER:
https://github.com/user-attachments/assets/8f07f841-aa98-4301-8417-24b137a6b67d

