### PR TITLE
[ENHANCEMENT] Stage Editor - New stage keybind + exit hotkey change + Stage Editor/Builder build presets

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -151,6 +151,16 @@
       "args": ["-debug", "-DRESULTS"]
     },
     {
+      "label": "Windows / Debug (Straight to Stage Editor)",
+      "target": "windows",
+      "args": ["-debug", "-DSTAGING", "-DFEATURE_DEBUG_FUNCTIONS"]
+    },
+    {
+      "label": "Windows / Debug (Straight to Stage Builder)",
+      "target": "windows",
+      "args": ["-debug", "-DSTAGEBUILD", "-DFEATURE_DEBUG_FUNCTIONS"]
+    },
+    {
       "label": "Windows / Debug (Straight to Animation Editor)",
       "target": "windows",
       "args": ["-debug", "-DANIMDEBUG", "-DFEATURE_DEBUG_FUNCTIONS"]

--- a/source/funkin/InitState.hx
+++ b/source/funkin/InitState.hx
@@ -242,6 +242,9 @@ class InitState extends FlxState
     #elseif CHARTING
     // -DCHARTING
     FlxG.switchState(() -> new funkin.ui.debug.charting.ChartEditorState());
+    #elseif STAGING
+    // -DSTAGING
+    FlxG.switchState(() -> new funkin.ui.debug.stageeditor.StageEditorState());
     #elseif STAGEBUILD
     // -DSTAGEBUILD
     FlxG.switchState(() -> new funkin.ui.debug.stage.StageBuilderState());

--- a/source/funkin/ui/debug/stageeditor/StageEditorState.hx
+++ b/source/funkin/ui/debug/stageeditor/StageEditorState.hx
@@ -633,6 +633,7 @@ class StageEditorState extends UIState
         if (FlxG.keys.justPressed.S) FlxG.keys.pressed.SHIFT ? onMenuItemClick("save stage as") : onMenuItemClick("save stage");
         if (FlxG.keys.justPressed.F) onMenuItemClick("find object");
         if (FlxG.keys.justPressed.O) onMenuItemClick("open stage");
+        if (FlxG.keys.justPressed.N) onMenuItemClick("new stage");
       }
 
       if (FlxG.keys.justPressed.TAB) onMenuItemClick("switch mode");

--- a/source/funkin/ui/debug/stageeditor/StageEditorState.hx
+++ b/source/funkin/ui/debug/stageeditor/StageEditorState.hx
@@ -1270,7 +1270,7 @@ class StageEditorState extends UIState
         CrashHandler.criticalErrorSignal.remove(autosavePerCrash);
 
         Cursor.hide();
-        FlxG.switchState(() -> new DebugMenuSubState());
+        FlxG.switchState(() -> new MainMenuState());
         FlxG.sound.music.stop();
 
       case "switch mode":

--- a/source/funkin/ui/debug/stageeditor/StageEditorState.hx
+++ b/source/funkin/ui/debug/stageeditor/StageEditorState.hx
@@ -23,6 +23,7 @@ import haxe.ui.containers.menus.MenuBar;
 import haxe.ui.containers.menus.MenuOptionBox;
 import haxe.ui.containers.menus.MenuCheckBox;
 import funkin.util.FileUtil;
+import funkin.ui.mainmenu.MainMenuState;
 import funkin.ui.debug.stageeditor.handlers.AssetDataHandler;
 import funkin.ui.debug.stageeditor.handlers.AssetDataHandler.StageEditorObjectData;
 import funkin.ui.debug.stageeditor.handlers.StageDataHandler;
@@ -634,6 +635,7 @@ class StageEditorState extends UIState
         if (FlxG.keys.justPressed.F) onMenuItemClick("find object");
         if (FlxG.keys.justPressed.O) onMenuItemClick("open stage");
         if (FlxG.keys.justPressed.N) onMenuItemClick("new stage");
+        if (FlxG.keys.justPressed.Q) onMenuItemClick("exit");
       }
 
       if (FlxG.keys.justPressed.TAB) onMenuItemClick("switch mode");


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
Closes #4811, fixes #4808
<!-- Briefly describe the issue(s) fixed. -->
## Description

Ctrl+N -> new stage dialog

Also adds windows target configuration preset for straight to stage editor (and the stage _builder_ too). 

Also also makes the stage editor exit to the _main_ menu, like every other editor.

Also also also changes the exit hotkey to Ctrl + Q (and the text), to match the chart editor.

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos

https://github.com/user-attachments/assets/63e1d6bc-113f-43b2-8643-120227526c3a
