### PR TITLE
Vulnerability Patch: Blacklist `funkin.util.macro.*`

### DIFF
--- a/source/funkin/modding/PolymodHandler.hx
+++ b/source/funkin/modding/PolymodHandler.hx
@@ -348,6 +348,16 @@ class PolymodHandler
       var className:String = Type.getClassName(cls);
       Polymod.blacklistImport(className);
     }
+
+    // `funkin.util.macro.*`
+    // CompiledClassList's get function allows access to sys and Newgrounds classes
+    // None of the classes are suitable for mods anyway
+    for (cls in ClassMacro.listClassesInPackage('funkin.util.macro'))
+    {
+      if (cls == null) continue;
+      var className:String = Type.getClassName(cls);
+      Polymod.blacklistImport(className);
+    }
   }
 
   /**


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
N/A
<!-- Briefly describe the issue(s) fixed. -->
## Description
Not only it has `CompiledClassList` from which you can retrieve `sys` and Newgrounds classes, it has nothing of use to mods.
Credits to @KoloInDaCrib for discovering the security vulnerability.

Delightfully Devilish Script Example:
```haxe
var classLists = [
  CompiledClassList.get("package~funkin.api.newgrounds~recursive"),
  CompiledClassList.get("package~sys~recursive")
];

for (list in classLists)
{
  for (class in list)
  {
    var className = Reflect.getClassName(class);
    if (className == "sys.io.Process")
    {
      var proc = new class('echo "HELLO WORLD" > FUCKKKKK');
      proc.close();
    }

    if (className == "funkin.api.newgrounds.Medals")
    {
      class.awardStoryLevel('weekend1');
    }
  }
}
```
<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos
N/A