### PR TITLE
[BUGFIX] Fix Chart Editor forgetting Notes when changing to a Song with different Variations

### DIFF
--- a/source/funkin/ui/debug/charting/handlers/ChartEditorImportExportHandler.hx
+++ b/source/funkin/ui/debug/charting/handlers/ChartEditorImportExportHandler.hx
@@ -117,12 +117,13 @@ class ChartEditorImportExportHandler
   {
     state.songMetadata = newSongMetadata;
     state.songChartData = newSongChartData;
-    state.selectedDifficulty = state.availableDifficulties[0];
 
     if (!newSongMetadata.exists(state.selectedVariation))
     {
       state.selectedVariation = Constants.DEFAULT_VARIATION;
     }
+
+    state.selectedDifficulty = state.availableDifficulties[0];
 
     Conductor.instance.forceBPM(null); // Disable the forced BPM.
     Conductor.instance.instrumentalOffset = state.currentInstrumentalOffset; // Loads from the metadata.


### PR DESCRIPTION
## Linked Issues
Closes https://github.com/FunkinCrew/Funkin/issues/5206

## Description
Changing the difficulty causes the `noteDisplayDirty` variable to be set to True... and the note displays to be refreshed, however this doesn't get called properly because the valid variation is checked for AFTER the difficulty, not the other way around, which causes the notes to only be rearranged. This PR fixes it.

## Screenshots/Videos

https://github.com/user-attachments/assets/846aa621-c85c-45a2-93ee-5b5d31646448
