### PR TITLE
Chart Editor variation crash fix but better this time

### DIFF
--- a/source/funkin/ui/debug/charting/handlers/ChartEditorImportExportHandler.hx
+++ b/source/funkin/ui/debug/charting/handlers/ChartEditorImportExportHandler.hx
@@ -62,13 +62,25 @@ class ChartEditorImportExportHandler
 
     for (variation in state.availableVariations)
     {
-      if (variation == Constants.DEFAULT_VARIATION)
+      var instId:String = '';
+      var firstDiff:Null<SongDifficulty> = song.getDifficulty(null, variation);
+      if (firstDiff != null && firstDiff.characters != null)
       {
-        state.loadInstFromAsset(Paths.inst(songId));
+        // Load the instrumental based on the metadata's instrumental ID.
+        instId = firstDiff.characters.instrumental;
+        state.loadInstFromAsset(firstDiff.getInstPath(instId), variation);
       }
       else
       {
-        state.loadInstFromAsset(Paths.inst(songId, '-$variation'), variation);
+        // Revert to the old behavior.
+        if (variation == Constants.DEFAULT_VARIATION)
+        {
+          state.loadInstFromAsset(Paths.inst(songId));
+        }
+        else
+        {
+          state.loadInstFromAsset(Paths.inst(songId, '-$variation'), variation);
+        }
       }
 
       for (difficultyId in song.listDifficulties(variation, true, true))
@@ -76,17 +88,17 @@ class ChartEditorImportExportHandler
         var diff:Null<SongDifficulty> = song.getDifficulty(difficultyId, variation);
         if (diff == null) continue;
 
-        var instId:String = diff.variation == Constants.DEFAULT_VARIATION ? '' : diff.variation;
+        var vocalId:String = diff.variation == Constants.DEFAULT_VARIATION ? '' : diff.variation;
         var voiceList:Array<String> = diff.buildVoiceList(); // SongDifficulty accounts for variation already.
 
         if (voiceList.length == 2)
         {
-          state.loadVocalsFromAsset(voiceList[0], diff.characters.player, instId);
-          state.loadVocalsFromAsset(voiceList[1], diff.characters.opponent, instId);
+          state.loadVocalsFromAsset(voiceList[0], diff.characters.player, vocalId);
+          state.loadVocalsFromAsset(voiceList[1], diff.characters.opponent, vocalId);
         }
         else if (voiceList.length == 1)
         {
-          state.loadVocalsFromAsset(voiceList[0], diff.characters.player, instId);
+          state.loadVocalsFromAsset(voiceList[0], diff.characters.player, vocalId);
         }
         else
         {


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
None

<!-- Briefly describe the issue(s) fixed. -->
## Description
Currently, the Chart Editor ignores `playData.characters.instrumental` in the metadata when loading a song's instrumental. This PR points it in the right direction.

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos
In this video, I test out base game variations as well as two variations that have no `instrumental` value and therefore use the default instrumental.
https://github.com/user-attachments/assets/25f95579-3b44-43b5-9943-92e7261d9a3b