### PR TITLE
[VULNERABILITY PATCH] Blacklist `hscript.Interp`

### DIFF
--- a/source/funkin/modding/PolymodHandler.hx
+++ b/source/funkin/modding/PolymodHandler.hx
@@ -304,6 +304,10 @@ class PolymodHandler
     // Can load native processes on the host operating system.
     Polymod.blacklistImport('openfl.desktop.NativeProcess');
 
+    // `hscript.Interp`
+    // The `cnew` function allows for instantiating blacklisted classes (such as `sys.io.Process`).
+    Polymod.blacklistImport('hscript.Interp');
+
     // `funkin.api.*`
     // Contains functions which may allow for cheating and such.
     for (cls in ClassMacro.listClassesInPackage('funkin.api'))


### PR DESCRIPTION
## Linked Issues
N/A

## Description
Interp's `cnew` function allows for instantiating blacklisted classes, such as `sys.io.Process`.
Note that it's also technically possible to access Polymod's `_interp` field considering scripted classes have the `_asc` field, which contains `_interp`.

Evil and fucked up script example:
```
var interp = new Interp();
var proc = interp.cnew("sys.io.Process", ['echo "HELLO WORLD" > FUCKKKKK']);
proc.close();
```

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos
N/A