### PR TITLE
[BUGFIX] Fix chart editor displaying incorrect waveforms

### DIFF
--- a/source/funkin/audio/FunkinSound.hx
+++ b/source/funkin/audio/FunkinSound.hx
@@ -551,6 +551,7 @@ class FunkinSound extends FlxSound implements ICloneable<FunkinSound>
     }
     FlxTween.cancelTweensOf(this);
     this._label = 'unknown';
+    this._waveformData = null;
   }
 
   @:access(openfl.media.Sound)


### PR DESCRIPTION
<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
Fixes #2653
<!-- Briefly describe the issue(s) fixed. -->
## Description
While messing around with waveforms for my other PR, I noticed this bug, and thought, "why not look into this one"?
My theory was that it was because `FunkinSound` recycles previously loaded sounds, but on the process of destroying one it never clears out the waveform data, the result: voice tracks with completely random waveform data. Turns out that was exactly what was going on. Easy fix!
<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos

https://github.com/user-attachments/assets/269496af-9c8b-4ddb-aa2e-9dd63e40cfb8

