### PR TITLE
[BUGFIX] Fix scrolling Diffs in the Chart Editor when multiple Variations have the same Diff Name

### DIFF
--- a/source/funkin/ui/debug/charting/ChartEditorState.hx
+++ b/source/funkin/ui/debug/charting/ChartEditorState.hx
@@ -5288,7 +5288,7 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
     if (playbarSongRemaining.value != songRemainingString) playbarSongRemaining.value = songRemainingString;
 
     playbarNoteSnap.text = '1/${noteSnapQuant}';
-    playbarDifficulty.text = '${selectedDifficulty.toTitleCase()} (${selectedVariation.toTitleCase()})';
+    playbarDifficulty.text = '${selectedDifficulty.toTitleCase()}${selectedVariation == Constants.DEFAULT_VARIATION ? '' : ' (${selectedVariation.toTitleCase()})'}';
     playbarBPM.text = 'BPM: ${(Conductor.instance.bpm ?? 0.0)}';
   }
 


### PR DESCRIPTION
## Linked Issues
N/A

## Description
Formats the current difficulty as `[difficulty]-[variation]` when running the check for the currently selected index for incrementing/decrementing current difficulty. Also makes the `playbarDifficulty` text show the current variation in parentheses, for clarity.

## Screenshots/Videos

https://github.com/user-attachments/assets/f8bb4005-2e18-4fd9-920b-06079dcff368
