### PR TITLE
[BUGFIX] Fix Chart Editor crash

### DIFF
--- a/source/funkin/ui/debug/charting/ChartEditorState.hx
+++ b/source/funkin/ui/debug/charting/ChartEditorState.hx
@@ -1293,7 +1293,7 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
    * - Keys are the variation IDs. At least one (`default`) must exist.
    * - Values are the relevant chart data, ready to be serialized to JSON.
    */
-  var songChartData:Map<String, SongChartData> = [];
+  var songChartData:Map<String, SongChartData> = new Map<String, SongChartData>();
 
   /**
    * Convenience property to get the chart data for the current variation.


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
no
<!-- Briefly describe the issue(s) fixed. -->
## Description
For some reason the develop chart editor crashes unless I change the `songChartData` map to equal `new Map<String, SongChartData>()` rather than `[]`, so idk.
<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos
![Screenshot 2025-06-17 214124](https://github.com/user-attachments/assets/cdbc89fb-fc8f-48fb-9a9c-b75b99027670)
