### PR TITLE
[BUGFIX] Freeplay - Intro callback running twice fix

### DIFF
--- a/source/funkin/ui/freeplay/FreeplayState.hx
+++ b/source/funkin/ui/freeplay/FreeplayState.hx
@@ -636,15 +636,6 @@ class FreeplayState extends MusicBeatSubState
       }
     };
 
-    if (dj != null)
-    {
-      dj.onIntroDone.add(onDJIntroDone);
-    }
-    else
-    {
-      onDJIntroDone();
-    }
-
     allDifficulties = SongRegistry.instance.listAllDifficulties(currentCharacterId);
 
     // Generates song list with the starter params (who our current character is, last remembered difficulty, etc.)
@@ -680,6 +671,17 @@ class FreeplayState extends MusicBeatSubState
     {
       enterFromCharSel();
       onDJIntroDone();
+    }
+    else
+    {
+      if (dj != null)
+      {
+        dj.onIntroDone.add(onDJIntroDone);
+      }
+      else
+      {
+        onDJIntroDone();
+      }
     }
   }
 


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
Fixes #5246
<!-- Briefly describe the issue(s) fixed. -->
## Description
When you enter freeplay from character select, `onDJIntroDone` is called immediately, but it's also still called by the dj when they finish their intro animation.
<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos

https://github.com/user-attachments/assets/63d511c1-2991-4c3a-8d2a-5b2b9ea40c2d

