### PR TITLE
[ENHANCEMENT] Softcoded Freeplay Capsule Week Labels

### DIFF
--- a/source/funkin/ui/freeplay/SongItemGroup.hx
+++ b/source/funkin/ui/freeplay/SongItemGroup.hx
@@ -4,6 +4,7 @@ import flixel.FlxCamera;
 import flixel.FlxSprite;
 import flixel.group.FlxGroup.FlxTypedGroup;
 import funkin.graphics.shaders.GaussianBlurShader;
+import openfl.filters.GlowFilter;
 
 /**
  * A FlxTypedGroup for capsules that does drawing in batches. This prevents memory leaks due to too many assets being rendered.
@@ -13,6 +14,7 @@ class SongItemGroup extends FlxTypedGroup<SongMenuItem>
 {
   var rankBlurredShader:GaussianBlurShader = new GaussianBlurShader(1);
   var favIconBlurredShader:GaussianBlurShader = new GaussianBlurShader(1.2);
+  var weekTextFilter:GlowFilter = new GlowFilter(0xFF1A1C24, 1, 5, 5, 3.13, 1, true, true);
 
   override function recycle(?cls:Class<SongMenuItem>, ?factory:Void->SongMenuItem, force:Bool = false, revive:Bool = true):SongMenuItem
   {
@@ -22,6 +24,8 @@ class SongItemGroup extends FlxTypedGroup<SongMenuItem>
     capsule.fakeBlurredRanking.shader = rankBlurredShader;
     capsule.blurredRanking.shader = rankBlurredShader;
     capsule.favIconBlurred.shader = favIconBlurredShader;
+
+    capsule.weekText.filters = [weekTextFilter];
 
     return capsule;
   }

--- a/source/funkin/ui/freeplay/SongMenuItem.hx
+++ b/source/funkin/ui/freeplay/SongMenuItem.hx
@@ -2,9 +2,12 @@ package funkin.ui.freeplay;
 
 import funkin.ui.FullScreenScaleMode;
 import funkin.ui.freeplay.FreeplayState.FreeplaySongData;
+import funkin.data.story.level.LevelRegistry;
 import funkin.graphics.shaders.HSVShader;
 import funkin.graphics.shaders.GaussianBlurShader;
+import funkin.graphics.FlxFilteredSprite;
 import flixel.group.FlxGroup;
+import flixel.text.FlxText;
 import flixel.FlxSprite;
 import flixel.group.FlxSpriteGroup;
 import flixel.math.FlxPoint;
@@ -20,6 +23,7 @@ import flixel.tweens.FlxTween;
 import flixel.addons.effects.FlxTrail;
 import funkin.play.scoring.Scoring.ScoringRank;
 import flixel.util.FlxColor;
+import funkin.ui.story.Level;
 import funkin.ui.PixelatedIcon;
 import funkin.util.TouchUtil;
 import funkin.util.SwipeUtil;
@@ -66,13 +70,12 @@ class SongMenuItem extends FlxSpriteGroup
   // var diffRatingSprite:FlxSprite;
   public var bpmText:FlxSprite;
   public var difficultyText:FlxSprite;
-  public var weekType:FlxSprite;
+  public var weekText:FlxFilteredSprite;
 
   public var newText:FlxSprite;
 
   var difficultyNumbers:Array<CapsuleNumber> = []; // referred to as "bignumbers" in the .fla file!
   var bpmNumbers:Array<CapsuleNumber> = []; // referred to as "smallnumbers" in the .fla file!
-  var weekNumbers:Array<CapsuleNumber> = [];
 
   var impactThing:FunkinSprite;
 
@@ -105,14 +108,11 @@ class SongMenuItem extends FlxSpriteGroup
     difficultyText.setGraphicSize(Std.int(difficultyText.width * 0.9));
     add(difficultyText);
 
-    weekType = new FlxSprite(291, 87);
-    weekType.frames = Paths.getSparrowAtlas('freeplay/freeplayCapsule/weektypes');
-
-    weekType.animation.addByPrefix('WEEK', 'WEEK text instance 1', 24, false);
-    weekType.animation.addByPrefix('WEEKEND', 'WEEKEND text instance 1', 24, false);
-
-    weekType.setGraphicSize(Std.int(weekType.width * 0.9));
-    add(weekType);
+    weekText = new FlxFilteredSprite(291, 88);
+    weekText.scale.set(0.9, 0.9);
+    weekText.visible = false;
+    weekText.active = false;
+    add(weekText);
 
     newText = new FlxSprite(454, 9);
     newText.frames = Paths.getSparrowAtlas('freeplay/freeplayCapsule/new');
@@ -228,11 +228,6 @@ class SongMenuItem extends FlxSpriteGroup
     favIcon.blend = BlendMode.ADD;
     add(favIcon);
 
-    var weekNumber:CapsuleNumber = new CapsuleNumber(355, 88.5, false, 0);
-    add(weekNumber);
-
-    weekNumbers.push(weekNumber);
-
     setVisibleGrp(false);
 
     theActualHitbox = new FlxObject(capsule.x + 160, capsule.y - 20, Math.round(capsule.width / 1.4), Math.round(capsule.height / 1.4));
@@ -247,55 +242,51 @@ class SongMenuItem extends FlxSpriteGroup
     sparkleTimer = new FlxTimer().start(FlxG.random.float(1.2, 4.5), sparkleEffect);
   }
 
-  // no way to grab weeks rn, so this needs to be done :/
-  // negative values mean weekends
-  function checkWeek(name:String):Void
+  function checkWeek():Void
   {
-    // trace(name);
-    var weekNum:Int = 0;
-    switch (name)
+    if (this.freeplayData?.levelId == null)
     {
-      case 'bopeebo' | 'fresh' | 'dadbattle':
-        weekNum = 1;
-      case 'spookeez' | 'south' | 'monster':
-        weekNum = 2;
-      case 'pico' | 'philly-nice' | 'blammed':
-        weekNum = 3;
-      case "satin-panties" | 'high' | 'milf':
-        weekNum = 4;
-      case "cocoa" | 'eggnog' | 'winter-horrorland':
-        weekNum = 5;
-      case 'senpai' | 'roses' | 'thorns':
-        weekNum = 6;
-      case 'ugh' | 'guns' | 'stress':
-        weekNum = 7;
-      case 'darnell' | 'lit-up' | '2hot' | 'blazin':
-        weekNum = -1;
-      default:
-        weekNum = 0;
+      // Make the text invisible for random levels.
+      weekText.visible = false;
+      return;
     }
 
-    weekNumbers[0].digit = Std.int(Math.abs(weekNum));
+    weekText.visible = true;
 
-    if (weekNum == 0)
+    // Format the level id to contain a space between differently capitalized letters and numbers.
+    // E.g. "bonusWeek2" -> "bonus Week 2"
+    var levelId:String = this.freeplayData.levelId;
+    var levelIdClean:String = "";
+    for (i in 0...levelId.length)
     {
-      weekType.visible = false;
-      weekNumbers[0].visible = false;
+      if (i == 0)
+      {
+        levelIdClean += levelId.charAt(i);
+        continue;
+      }
+
+      var previousChar:String = levelId.charAt(i - 1);
+      var currentChar:String = levelId.charAt(i);
+
+      if (previousChar.toLowerCase() == previousChar && currentChar.toLowerCase() != currentChar) levelIdClean += " ";
+      if (Std.parseInt(previousChar) == null && Std.parseInt(currentChar) != null) levelIdClean += " ";
+      if (Std.parseInt(previousChar) != null && Std.parseInt(currentChar) == null) levelIdClean += " ";
+
+      levelIdClean += currentChar;
     }
-    else
-    {
-      weekType.visible = true;
-      weekNumbers[0].visible = true;
-    }
-    if (weekNum > 0)
-    {
-      weekType.animation.play('WEEK', true);
-    }
-    else
-    {
-      weekType.animation.play('WEEKEND', true);
-      weekNumbers[0].offset.x -= 35;
-    }
+
+    createWeekTextGraphic(levelIdClean);
+    weekText.loadGraphic(FlxG.bitmap.get(levelIdClean));
+  }
+
+  function createWeekTextGraphic(text:String)
+  {
+    if (FlxG.bitmap.checkCache(text)) return;
+
+    var weekTextBase:FlxText = new FlxText(0, 0, 0, text).setFormat(Paths.font("Youre-Gone.otf"), 20, 0xFF21242E);
+    @:privateAccess weekTextBase.regenGraphic();
+
+    FlxG.bitmap.add(weekTextBase.pixels.clone(), false, text);
   }
 
   /**
@@ -573,7 +564,7 @@ class SongMenuItem extends FlxSpriteGroup
 
     refreshDisplay();
 
-    checkWeek(freeplayData?.data.id);
+    checkWeek();
   }
 
   public function initRandom(?styleData:FreeplayStyle = null):Void


### PR DESCRIPTION
## Linked Issues
N/A

## Description
Makes the little text on the Freeplay Song Capsule for the Song's Week softcodable, considering modded weeks aren't currently able to add them. This PR utilizes FlxTexts and openfl's GlowFilter to achieve this effect.

## Screenshots/Videos

<img width="497" height="131" alt="image" src="https://github.com/user-attachments/assets/625d5569-3875-4f54-968f-82c1c7ef7718" />
