### PR TITLE
[BUGFIX] Disabled Inputs During Freeplay Transition After Exiting Character Select

### DIFF
--- a/source/funkin/ui/freeplay/FreeplayState.hx
+++ b/source/funkin/ui/freeplay/FreeplayState.hx
@@ -1215,21 +1215,18 @@ class FreeplayState extends MusicBeatSubState
   {
     busy = true;
     FlxG.keys.enabled = false;
-
     if (_parentState != null) _parentState.persistentDraw = false;
 
     var transitionGradient = new FlxSprite(0, 720).loadGraphic(Paths.image('freeplay/transitionGradient'));
     transitionGradient.scale.set(1280, 1);
     transitionGradient.updateHitbox();
     transitionGradient.cameras = [rankCamera];
-
     exitMoversCharSel.set([transitionGradient],
       {
         y: -720,
         speed: 1.5,
         wait: 0.1
       });
-
     add(transitionGradient);
     // FlxTween.tween(transitionGradient, {alpha: 0}, 1, {ease: FlxEase.circIn});
     // for (index => capsule in grpCapsules.members)
@@ -1247,7 +1244,6 @@ class FreeplayState extends MusicBeatSubState
     //   }
     // }
     fadeShader.fade(0.0, 1.0, 0.8, {ease: FlxEase.quadIn});
-
     for (grpSpr in exitMoversCharSel.keys())
     {
       var moveData:Null<MoveData> = exitMoversCharSel.get(grpSpr);
@@ -1264,7 +1260,6 @@ class FreeplayState extends MusicBeatSubState
         var moveDataWait = funnyMoveShit.wait ?? 0.0;
 
         spr.y += moveDataY;
-
         FlxTween.tween(spr, {y: spr.y - moveDataY}, moveDataSpeed * 1.2,
         {
           ease: FlxEase.expoOut,
@@ -1273,7 +1268,6 @@ class FreeplayState extends MusicBeatSubState
             {
               capsule.doLerp = true;
             }
-
             fromCharSelect = false;
             busy = false;
             FlxG.keys.enabled = true;

--- a/source/funkin/ui/freeplay/FreeplayState.hx
+++ b/source/funkin/ui/freeplay/FreeplayState.hx
@@ -1214,18 +1214,22 @@ class FreeplayState extends MusicBeatSubState
   function enterFromCharSel():Void
   {
     busy = true;
+    FlxG.keys.enabled = false;
+
     if (_parentState != null) _parentState.persistentDraw = false;
 
     var transitionGradient = new FlxSprite(0, 720).loadGraphic(Paths.image('freeplay/transitionGradient'));
     transitionGradient.scale.set(1280, 1);
     transitionGradient.updateHitbox();
     transitionGradient.cameras = [rankCamera];
+
     exitMoversCharSel.set([transitionGradient],
       {
         y: -720,
         speed: 1.5,
         wait: 0.1
       });
+
     add(transitionGradient);
     // FlxTween.tween(transitionGradient, {alpha: 0}, 1, {ease: FlxEase.circIn});
     // for (index => capsule in grpCapsules.members)
@@ -1243,6 +1247,7 @@ class FreeplayState extends MusicBeatSubState
     //   }
     // }
     fadeShader.fade(0.0, 1.0, 0.8, {ease: FlxEase.quadIn});
+
     for (grpSpr in exitMoversCharSel.keys())
     {
       var moveData:Null<MoveData> = exitMoversCharSel.get(grpSpr);
@@ -1259,18 +1264,21 @@ class FreeplayState extends MusicBeatSubState
         var moveDataWait = funnyMoveShit.wait ?? 0.0;
 
         spr.y += moveDataY;
+
         FlxTween.tween(spr, {y: spr.y - moveDataY}, moveDataSpeed * 1.2,
-          {
-            ease: FlxEase.expoOut,
-            onComplete: function(_) {
-              for (index => capsule in grpCapsules.members)
-              {
-                capsule.doLerp = true;
-                fromCharSelect = false;
-                busy = false;
-              }
+        {
+          ease: FlxEase.expoOut,
+          onComplete: function(_) {
+            for (index => capsule in grpCapsules.members)
+            {
+              capsule.doLerp = true;
             }
-          });
+
+            fromCharSelect = false;
+            busy = false;
+            FlxG.keys.enabled = true;
+          }
+        });
       }
     }
   }


### PR DESCRIPTION
<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
None
<!-- Briefly describe the issue(s) fixed. -->
## Description
Pressing ESC during the transition from character select to freeplay causes some weird behavior. I was inspired to fix this because of #5244. The bug shown in this issue was fixed, but I still think that exiting the freeplay menu during its transition from character select is unintended because of how weird/buggy it looks, so I disabled inputs all together.

NOTE: ChatGPT helped me make this fix, I do not take full credit for this.
## Screenshots/Videos
### Before Fix:

https://github.com/user-attachments/assets/66b401a9-8a52-4e42-b94a-0ff4efc8c905

### After Fix:

https://github.com/user-attachments/assets/b9d93a0a-ab1c-4e55-990b-3622a1454e34
