### PR TITLE
[BUGFIX] Fix Chart Editor's Playbar using incorrect Style Data when switching Editors

### DIFF
--- a/source/funkin/ui/debug/DebugMenuSubState.hx
+++ b/source/funkin/ui/debug/DebugMenuSubState.hx
@@ -71,6 +71,9 @@ class DebugMenuSubState extends MusicBeatSubState
     #end
     onMenuChange(items.members[0]);
     FlxG.camera.focusOn(new FlxPoint(camFocusPoint.x, camFocusPoint.y + 500));
+
+    // Remove the "user" stylesheet to prevent components using incorrect style data when entering an editor.
+    haxe.ui.Toolkit.styleSheet.clear("user");
   }
 
   function onMenuChange(selected:TextMenuItem)


### PR DESCRIPTION
## Linked Issues
Fixes https://github.com/FunkinCrew/Funkin/issues/5252

## Description
Every time an editor is entered, a styleSheet "user" is created, which persists throughout the entire play session. This PR removes that styleSheet so that a new one is generated upon entering any editor.

## Screenshots/Videos

https://github.com/user-attachments/assets/77f51e93-403d-4b69-b984-8b72c02937a7

