### PR TITLE
[BUGFIX] Chart Editor - Fix sus trails disappearing when dragging

### DIFF
--- a/source/funkin/ui/debug/charting/ChartEditorState.hx
+++ b/source/funkin/ui/debug/charting/ChartEditorState.hx
@@ -3590,13 +3590,16 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
       {
         if (holdNoteSprite == null || holdNoteSprite.noteData == null || !holdNoteSprite.exists || !holdNoteSprite.visible) continue;
 
+        // Fixes an issue where dragging an hold note too far would hide its sustain trail
+        var isSelectedAndDragged = currentNoteSelection.fastContains(holdNoteSprite.noteData) && (dragTargetCurrentStep != 0);
+
         if (holdNoteSprite.noteData == currentPlaceNoteData)
         {
           // This hold note is for the note we are currently dragging.
           // It will be displayed by gridGhostHoldNoteSprite instead.
           holdNoteSprite.kill();
         }
-        else if (!holdNoteSprite.isHoldNoteVisible(viewAreaBottomPixels, viewAreaTopPixels))
+        else if (!holdNoteSprite.isHoldNoteVisible(viewAreaBottomPixels, viewAreaTopPixels) && !isSelectedAndDragged)
         {
           // This hold note is off-screen.
           // Kill the hold note sprite and recycle it.
@@ -3617,7 +3620,7 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
         else
         {
           displayedHoldNoteData.push(holdNoteSprite.noteData);
-          // Update the event sprite's height and position.
+          // Update the hold note sprite's height and position.
           // var holdNoteHeight = holdNoteSprite.noteData.getStepLength() * GRID_SIZE;
           // holdNoteSprite.setHeightDirectly(holdNoteHeight);
           holdNoteSprite.updateHoldNotePosition(renderedHoldNotes);


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
N/A
<!-- Briefly describe the issue(s) fixed. -->
## Description
Fixes an issue in the `develop` branch where dragging a hold note too far would cause its trail to disappear
<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos
(yes, the after gif is laggy at the end that's not just you)
| Before / After |
|--------|
| ![this-fucking-bug-that-i-hate](https://github.com/user-attachments/assets/43d6fc0f-1d22-41dd-97ca-b6111254121c) |
| ![this-fucking-bug-that-i-hate-but-it-fucking-died](https://github.com/user-attachments/assets/235851b4-47e6-46a1-b9e8-b953f6b8f673) | 