### PR TITLE
[BUGFIX+REFACTOR] Fix two issues with chart editor sussy(amongggggggfgg…………..us……..) trails

### DIFF
--- a/source/funkin/ui/debug/charting/ChartEditorState.hx
+++ b/source/funkin/ui/debug/charting/ChartEditorState.hx
@@ -3601,30 +3601,16 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
       {
         if (holdNoteSprite == null || holdNoteSprite.noteData == null || !holdNoteSprite.exists || !holdNoteSprite.visible) continue;
 
-        // Fixes an issue where dragging an hold note too far would hide its sustain trail
+        // Fixes an issue where dragging a hold note too far would hide its sustain trail
         var isSelectedAndDragged = currentNoteSelection.fastContains(holdNoteSprite.noteData) && (dragTargetCurrentStep != 0);
 
-        if (holdNoteSprite.noteData == currentPlaceNoteData)
+        if (!isSelectedAndDragged
+          && (holdNoteSprite.noteData == currentPlaceNoteData // Being dragged, displayed by gridGhostHoldNoteSprite instead.
+            || !holdNoteSprite.isHoldNoteVisible(viewAreaBottomPixels, viewAreaTopPixels) // Off-screen.
+            || !currentSongChartNoteData.fastContains(holdNoteSprite.noteData) // Deleted.
+            || holdNoteSprite.noteData.length == 0 // Also deleted.
+          ))
         {
-          // This hold note is for the note we are currently dragging.
-          // It will be displayed by gridGhostHoldNoteSprite instead.
-          holdNoteSprite.kill();
-        }
-        else if (!holdNoteSprite.isHoldNoteVisible(viewAreaBottomPixels, viewAreaTopPixels) && !isSelectedAndDragged)
-        {
-          // This hold note is off-screen.
-          // Kill the hold note sprite and recycle it.
-          holdNoteSprite.kill();
-        }
-        else if (!currentSongChartNoteData.fastContains(holdNoteSprite.noteData) || holdNoteSprite.noteData.length == 0)
-        {
-          // This hold note was deleted.
-          // Kill the hold note sprite and recycle it.
-          holdNoteSprite.kill();
-        }
-        else if (displayedHoldNoteData.fastContains(holdNoteSprite.noteData))
-        {
-          // This hold note is a duplicate.
           // Kill the hold note sprite and recycle it.
           holdNoteSprite.kill();
         }
@@ -3632,8 +3618,8 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
         {
           displayedHoldNoteData.push(holdNoteSprite.noteData);
           // Update the hold note sprite's height and position.
-          // var holdNoteHeight = holdNoteSprite.noteData.getStepLength() * GRID_SIZE;
-          // holdNoteSprite.setHeightDirectly(holdNoteHeight);
+          var holdNoteHeight = holdNoteSprite.noteData.getStepLength() * GRID_SIZE;
+          holdNoteSprite.setHeightDirectly(holdNoteHeight);
           holdNoteSprite.updateHoldNotePosition(renderedHoldNotes);
         }
       }
@@ -3800,8 +3786,6 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
         holdNoteSprite.noteStyle = NoteKindManager.getNoteStyleId(noteData.kind, currentSongNoteStyle) ?? currentSongNoteStyle;
 
         holdNoteSprite.updateHoldNotePosition(renderedHoldNotes);
-
-        displayedHoldNoteData.push(noteData);
       }
 
       // Destroy all existing selection squares.


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
Fixes https://github.com/FunkinCrew/Funkin/issues/4796
<!-- Briefly describe the issue(s) fixed. -->
## Description
* Fixes the sustain height not being updated when undoing/redoing length commands (there was commented out code that fixed it, I re-enabled it and it didn't seem to cause any issues)
* Fixes an instance of "hanging" duplicate sustain trails when dragging the notes, which was being caused by `displayedHoldNotes` being pushed with duplicate notes.
* Refactored the displayed hold note sprite kill checks and removed an unnecessary check.

<details><summary>Click for 0.7.0</summary>
<p>

![SUSYSYYSUSUSYSYSUASYDUSIADYSAIUD](https://i.imgflip.com/54970b.jpg)

</p>
</details> 
<!-- Include any relevant screenshots or videos. -->

## Screenshots/Videos

https://github.com/user-attachments/assets/323a5aa7-685a-4c53-a78e-0fad30fadf92

