### PR TITLE
[ENHANCEMENT] Zero out visualizers when volume is muted

### DIFF
--- a/source/funkin/audio/visualize/ABotVis.hx
+++ b/source/funkin/audio/visualize/ABotVis.hx
@@ -116,7 +116,7 @@ class ABotVis extends FlxTypedSpriteGroup<FlxSprite>
 
     for (i in 0...min(group.members.length, levels.length))
     {
-      var animFrame:Int = Math.round(levels[i].value * 6);
+      var animFrame:Int = (FlxG.sound.volume == 0 || FlxG.sound.muted) ? 0 : Math.round(levels[i].value * 6);
 
       // don't display if we're at 0 volume from the level
       group.members[i].visible = animFrame > 0;

--- a/source/funkin/ui/charSelect/CharSelectGF.hx
+++ b/source/funkin/ui/charSelect/CharSelectGF.hx
@@ -91,7 +91,7 @@ class CharSelectGF extends FlxAtlasSprite implements IBPMSyncedScriptedClass
 
       for (i in 0...len)
       {
-        var animFrame:Int = Math.round(levels[i].value * 12);
+        var animFrame:Int = (FlxG.sound.volume == 0 || FlxG.sound.muted) ? 0 : Math.round(levels[i].value * 12);
 
         #if desktop
         // Web version scales with the Flixel volume level.


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
Based off this comment: https://github.com/FunkinCrew/Funkin/pull/3475#issuecomment-2888156905
<!-- Briefly describe the issue(s) fixed. -->
## Description
Muting the game now sets the bars to first frame, aka, nothing.

Only issue I've noticed is that when nene swaps in character select, the bars are all full for a frame.
<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos

https://github.com/user-attachments/assets/82dbb68c-08ca-4a2a-a767-27204c523ce1

<details>

https://github.com/user-attachments/assets/3f0a7246-fc0f-4ded-8e28-123de0167352

</details>

