### PR TITLE
Fix a bug where holding down a note after dropping the previous one would sometimes make its cover over not show.

### DIFF
--- a/source/funkin/play/notes/NoteHoldCover.hx
+++ b/source/funkin/play/notes/NoteHoldCover.hx
@@ -71,6 +71,8 @@ class NoteHoldCover extends FlxTypedSpriteGroup<FlxSprite>
 
     this.visible = false;
 
+    holdNote.cover = null;
+
     if (glow != null) glow.visible = false;
     if (sparks != null) sparks.visible = false;
   }


### PR DESCRIPTION
This fixes [Issue #3772](https://github.com/FunkinCrew/Funkin/issues/3772)

I was able to fix this while adding hold covers to DnB 3.5 so I thought I'd submit a PR fixing it here.

Essentially, sometimes if you drop a hold note, and then you hit one right after (from my friends and I's experience, the hold note has to be RIGHT after the dropped one), the one you just hit doesn't give a cover. 

This bug happens periodically, (which is why I say _sometimes_), from my experience it takes a couple tries to get it but when you do end up getting it the first time it happens all the time.

I tested it with Lit Up (BF Mix) and Bopeebo since it was most easily debuggable, and it didn't appear to happen anymore.

**BEFORE (Bug happens at 0:15):**
https://github.com/user-attachments/assets/48cf9821-ad4e-46b6-89b3-9781e4f16033

**AFTER:**
https://github.com/user-attachments/assets/ed7ac8cd-bbc4-4ad4-a7a1-8c93e79a3d91