### PR TITLE
[BUGFIX] Cancel Tweens and Timers upon exiting PlayState

### DIFF
--- a/source/funkin/play/PlayState.hx
+++ b/source/funkin/play/PlayState.hx
@@ -3223,6 +3223,9 @@ class PlayState extends MusicBeatSubState
 
     forEachPausedSound((s) -> s.destroy());
 
+    FlxTween.globalManager.clear();
+    FlxTimer.globalManager.clear();
+
     // Remove reference to stage and remove sprites from it to save memory.
     if (currentStage != null)
     {


### PR DESCRIPTION
## Linked Issues
Fixes #5277 

## Description
View title

## Screenshots/Videos

https://github.com/user-attachments/assets/3ece1a4b-33bb-4f07-87f7-fd7e11a36215
