### PR TITLE
[ENHANCEMENT] Display an Indicator for Note Kinds in Chart Editor

### DIFF
--- a/source/funkin/data/song/SongData.hx
+++ b/source/funkin/data/song/SongData.hx
@@ -1117,6 +1117,30 @@ class SongNoteDataRaw implements ICloneable<SongNoteDataRaw>
     return 'SongNoteData(${this.time}ms, ' + (this.length > 0 ? '[${this.length}ms hold]' : '') + ' ${this.data}'
       + (this.kind != '' ? ' [kind: ${this.kind}])' : ')');
   }
+
+  public function buildTooltip():String
+  {
+    var result:String = "Kind: ";
+
+    if ((this.kind?.length ?? 0) == 0)
+    {
+      result += "Default";
+      return result;
+    }
+
+    result += this.kind;
+
+    if (this.params.length == 0) return result;
+
+    result += "\nParams:";
+
+    for (param in params)
+    {
+      result += '\n- ${param.name}: ${param.value}';
+    }
+
+    return result;
+  }
 }
 
 /**

--- a/source/funkin/data/song/SongData.hx
+++ b/source/funkin/data/song/SongData.hx
@@ -1120,16 +1120,9 @@ class SongNoteDataRaw implements ICloneable<SongNoteDataRaw>
 
   public function buildTooltip():String
   {
-    var result:String = "Kind: ";
+    if ((this.kind?.length ?? 0) == 0) return "";
 
-    if ((this.kind?.length ?? 0) == 0)
-    {
-      result += "Default";
-      return result;
-    }
-
-    result += this.kind;
-
+    var result:String = 'Kind: ${this.kind}';
     if (this.params.length == 0) return result;
 
     result += "\nParams:";

--- a/source/funkin/save/Save.hx
+++ b/source/funkin/save/Save.hx
@@ -187,6 +187,7 @@ class Save
           theme: ChartEditorTheme.Light,
           playtestStartTime: false,
           downscroll: false,
+          showNoteKinds: true,
           metronomeVolume: 1.0,
           hitsoundVolumePlayer: 1.0,
           hitsoundVolumeOpponent: 1.0,
@@ -356,6 +357,23 @@ class Save
     data.optionsChartEditor.downscroll = value;
     flush();
     return data.optionsChartEditor.downscroll;
+  }
+
+  public var chartEditorShowNoteKinds(get, set):Bool;
+
+  function get_chartEditorShowNoteKinds():Bool
+  {
+    if (data.optionsChartEditor.showNoteKinds == null) data.optionsChartEditor.showNoteKinds = true;
+
+    return data.optionsChartEditor.showNoteKinds;
+  }
+
+  function set_chartEditorShowNoteKinds(value:Bool):Bool
+  {
+    // Set and apply.
+    data.optionsChartEditor.showNoteKinds = value;
+    flush();
+    return data.optionsChartEditor.showNoteKinds;
   }
 
   public var chartEditorPlaytestStartTime(get, set):Bool;
@@ -1843,6 +1861,12 @@ typedef SaveDataChartEditorOptions =
    * @default `false`
    */
   var ?downscroll:Bool;
+
+  /**
+   * Show Note Kind Indicator in the Chart Editor.
+   * @default `true`
+   */
+  var ?showNoteKinds:Bool;
 
   /**
    * Metronome volume in the Chart Editor.

--- a/source/funkin/ui/debug/charting/ChartEditorState.hx
+++ b/source/funkin/ui/debug/charting/ChartEditorState.hx
@@ -2522,7 +2522,7 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
     add(gridTiledSprite);
     gridTiledSprite.zIndex = 10;
 
-    gridGhostNote = new ChartEditorNoteSprite(this);
+    gridGhostNote = new ChartEditorNoteSprite(this, true);
     gridGhostNote.alpha = 0.6;
     gridGhostNote.noteData = new SongNoteData(0, 0, 0, "", []);
     gridGhostNote.visible = false;
@@ -3924,6 +3924,9 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
           selectionSquare.width = selectionSquare.height = GRID_SIZE;
           selectionSquare.color = FlxColor.RED;
         }
+
+        // Additional cleanup on notes.
+        if (noteTooltipsDirty) noteSprite.updateTooltipText();
       }
 
       for (eventSprite in renderedEvents.members)

--- a/source/funkin/ui/debug/charting/ChartEditorState.hx
+++ b/source/funkin/ui/debug/charting/ChartEditorState.hx
@@ -635,6 +635,11 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
   }
 
   /**
+   * Whether to show an indicator if a note is of a non-default kind.
+   */
+  var showNoteKindIndicators:Bool = false;
+
+  /**
    * The current theme used by the editor.
    * Dictates the appearance of many UI elements.
    * Currently hardcoded to just Light and Dark.
@@ -1859,6 +1864,11 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
   var menubarItemDownscroll:MenuCheckBox;
 
   /**
+   * The `View -> Note Kind Indicator` menu item.
+   */
+  var menubarItemViewIndicators:MenuCheckBox;
+
+  /**
    * The `View -> Increase Difficulty` menu item.
    */
   var menubarItemDifficultyUp:MenuItem;
@@ -2361,6 +2371,7 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
     noteSnapQuantIndex = save.chartEditorNoteQuant;
     currentLiveInputStyle = save.chartEditorLiveInputStyle;
     isViewDownscroll = save.chartEditorDownscroll;
+    showNoteKindIndicators = save.chartEditorShowNoteKinds;
     playtestStartTime = save.chartEditorPlaytestStartTime;
     currentTheme = save.chartEditorTheme;
     metronomeVolume = save.chartEditorMetronomeVolume;
@@ -2390,6 +2401,7 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
     save.chartEditorNoteQuant = noteSnapQuantIndex;
     save.chartEditorLiveInputStyle = currentLiveInputStyle;
     save.chartEditorDownscroll = isViewDownscroll;
+    save.chartEditorShowNoteKinds = showNoteKindIndicators;
     save.chartEditorPlaytestStartTime = playtestStartTime;
     save.chartEditorTheme = currentTheme;
     save.chartEditorMetronomeVolume = metronomeVolume;
@@ -3091,6 +3103,9 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
 
     menubarItemDownscroll.onClick = event -> isViewDownscroll = event.value;
     menubarItemDownscroll.selected = isViewDownscroll;
+
+    menubarItemViewIndicators.onClick = event -> showNoteKindIndicators = menubarItemViewIndicators.selected;
+    menubarItemViewIndicators.selected = showNoteKindIndicators;
 
     menubarItemDifficultyUp.onClick = _ -> incrementDifficulty(1);
     menubarItemDifficultyDown.onClick = _ -> incrementDifficulty(-1);
@@ -6313,7 +6328,8 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
   {
     currentScrollEase = Math.max(0, targetScrollPosition);
     currentScrollEase = Math.min(currentScrollEase, songLengthInPixels);
-    scrollPositionInPixels = MathUtil.snap(MathUtil.smoothLerpPrecision(scrollPositionInPixels, currentScrollEase, FlxG.elapsed, SCROLL_EASE_DURATION, 1 / 1000), currentScrollEase, 1 / 1000);
+    scrollPositionInPixels = MathUtil.snap(MathUtil.smoothLerpPrecision(scrollPositionInPixels, currentScrollEase, FlxG.elapsed, SCROLL_EASE_DURATION,
+      1 / 1000), currentScrollEase, 1 / 1000);
     moveSongToScrollPosition();
   }
 

--- a/source/funkin/ui/debug/charting/components/ChartEditorNoteSprite.hx
+++ b/source/funkin/ui/debug/charting/components/ChartEditorNoteSprite.hx
@@ -10,6 +10,9 @@ import funkin.data.song.SongData.SongNoteData;
 import funkin.data.notestyle.NoteStyleRegistry;
 import funkin.play.notes.notestyle.NoteStyle;
 import funkin.play.notes.NoteDirection;
+import haxe.ui.tooltips.ToolTipRegionOptions;
+import funkin.util.HaxeUIUtil;
+import haxe.ui.tooltips.ToolTipManager;
 
 /**
  * A sprite that can be used to display a note in a chart.
@@ -63,11 +66,16 @@ class ChartEditorNoteSprite extends FlxSprite
     return overrideData;
   }
 
-  public function new(parent:ChartEditorState)
+  public var isGhost:Bool = false;
+  public var tooltip:ToolTipRegionOptions;
+
+  public function new(parent:ChartEditorState, isGhost:Bool = false)
   {
     super();
 
     this.parentState = parent;
+    this.isGhost = isGhost;
+    this.tooltip = HaxeUIUtil.buildTooltip('N/A');
 
     var entries:Array<String> = NoteStyleRegistry.instance.listEntryIds();
 
@@ -156,6 +164,7 @@ class ChartEditorNoteSprite extends FlxSprite
     if (this.noteData == null)
     {
       this.kill();
+      updateTooltipPosition();
       return this.noteData;
     }
 
@@ -167,7 +176,7 @@ class ChartEditorNoteSprite extends FlxSprite
 
     // Update the position to match the note data.
     updateNotePosition();
-
+    updateTooltipText();
     return this.noteData;
   }
 
@@ -193,6 +202,38 @@ class ChartEditorNoteSprite extends FlxSprite
     {
       this.x += origin.x;
       this.y += origin.y;
+    }
+
+    this.updateTooltipPosition();
+  }
+
+  public function updateTooltipText():Void
+  {
+    if (this.noteData == null) return;
+    if (this.isGhost) return;
+    this.tooltip.tipData = {text: this.noteData.buildTooltip()};
+  }
+
+  public function updateTooltipPosition():Void
+  {
+    // No tooltip for ghost sprites.
+    if (this.isGhost) return;
+
+    if (this.noteData == null)
+    {
+      // Disable the tooltip.
+      ToolTipManager.instance.unregisterTooltipRegion(this.tooltip);
+    }
+    else
+    {
+      // Update the position.
+      this.tooltip.left = this.x;
+      this.tooltip.top = this.y;
+      this.tooltip.width = this.width;
+      this.tooltip.height = this.height;
+
+      // Enable the tooltip.
+      ToolTipManager.instance.registerTooltipRegion(this.tooltip);
     }
   }
 

--- a/source/funkin/ui/debug/charting/components/ChartEditorNoteSprite.hx
+++ b/source/funkin/ui/debug/charting/components/ChartEditorNoteSprite.hx
@@ -1,5 +1,7 @@
 package funkin.ui.debug.charting.components;
 
+import flixel.text.FlxText;
+import flixel.util.FlxColor;
 import flixel.FlxObject;
 import flixel.FlxSprite;
 import flixel.graphics.frames.FlxFramesCollection;
@@ -69,6 +71,11 @@ class ChartEditorNoteSprite extends FlxSprite
   public var isGhost:Bool = false;
   public var tooltip:ToolTipRegionOptions;
 
+  /**
+   * An indicator if the note is a note kind different than Default ("").
+   */
+  public var kindIndicator:FlxText = new FlxText(5, 5, 100, '*', 16);
+
   public function new(parent:ChartEditorState, isGhost:Bool = false)
   {
     super();
@@ -97,6 +104,8 @@ class ChartEditorNoteSprite extends FlxSprite
     {
       addNoteStyleAnimations(fetchNoteStyle(entry));
     }
+
+    kindIndicator.setFormat("VCR OSD Mono", 24, FlxColor.YELLOW, LEFT, FlxTextBorderStyle.OUTLINE, FlxColor.BLACK);
   }
 
   static var noteFrameCollection:Null<FlxFramesCollection> = null;
@@ -219,7 +228,7 @@ class ChartEditorNoteSprite extends FlxSprite
     // No tooltip for ghost sprites.
     if (this.isGhost) return;
 
-    if (this.noteData == null)
+    if (this.noteData == null || (this.tooltip.tipData?.text ?? "").length == 0)
     {
       // Disable the tooltip.
       ToolTipManager.instance.unregisterTooltipRegion(this.tooltip);
@@ -235,6 +244,18 @@ class ChartEditorNoteSprite extends FlxSprite
       // Enable the tooltip.
       ToolTipManager.instance.registerTooltipRegion(this.tooltip);
     }
+  }
+
+  override public function draw()
+  {
+    super.draw();
+
+    if (!parentState.showNoteKindIndicators) return;
+    if ((this.noteData?.kind ?? "").length == 0) return; // Do not render the note kind indicator if the note kind is default.
+
+    kindIndicator.x = this.x;
+    kindIndicator.y = this.y;
+    kindIndicator.draw();
   }
 
   function get_noteStyle():Null<String>


### PR DESCRIPTION
## Linked Issues
Closes https://github.com/FunkinCrew/Funkin/issues/5271

## Description
Adds a new toggle under `View`, `Note Kind Indicator` which is on by default. With this enabled, notes with custom notekinds will have a little star next to them to separate them from the normal notes. To add to this change, I added tooltip support for notes so that the user knows exactly which notekind the note is (tooltip is disabled if the note is the of the default kind.)

## Screenshots/Videos

https://github.com/user-attachments/assets/78a2173d-71e9-438f-83f2-09039cfb171e

