### PR TITLE
[BUGFIX] Use the actual character ID for `currentCharacterId`

### DIFF
--- a/source/funkin/ui/freeplay/FreeplayState.hx
+++ b/source/funkin/ui/freeplay/FreeplayState.hx
@@ -207,11 +207,11 @@ class FreeplayState extends MusicBeatSubState
     };
 
     currentCharacter = fetchPlayableCharacter();
-    currentCharacterId = currentCharacter.getFreeplayStyleID();
+    currentCharacterId = currentCharacter.id;
 
     currentVariation = rememberedVariation;
     currentDifficulty = rememberedDifficulty;
-    styleData = FreeplayStyleRegistry.instance.fetchEntry(currentCharacterId);
+    styleData = FreeplayStyleRegistry.instance.fetchEntry(currentCharacter.getFreeplayStyleID());
     rememberedCharacterId = currentCharacter?.id ?? Constants.DEFAULT_CHARACTER;
 
     fromCharSelect = params?.fromCharSelect ?? false;


### PR DESCRIPTION

<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
<!-- ## Linked Issues --> <!-- Don't think so?? -->

<!-- Briefly describe the issue(s) fixed. -->
## Description
Recently, a PR merged in `develop` made it so `currentCharacterId` would be the Freeplay Style ID, making it so it doesn't use the character specified directly. This PR fixes that issue by making `currentCharacterId` is the actual ID of the character.

<!-- Include any relevant screenshots or videos. -->
<!-- ## Screenshots/Videos  --> <!-- maybe later -->
