### PR TITLE
[BUGFIX] Only destroy paused sounds on restart if they have `autoDestroy` enabled

### DIFF
--- a/source/funkin/play/PlayState.hx
+++ b/source/funkin/play/PlayState.hx
@@ -1502,7 +1502,9 @@ class PlayState extends MusicBeatSubState
         musicPausedBySubState = false;
       }
 
-      forEachPausedSound((s) -> needsReset ? s.destroy() : s.resume());
+      // The logic here is that if this sound doesn't auto-destroy
+      // then it's gonna be reused somewhere, so we just stop it instead.
+      forEachPausedSound(s -> needsReset ? (s.autoDestroy ? s.destroy() : s.stop()) : s.resume());
 
       // Resume camera tweens if we paused any.
       for (camTween in cameraTweensPausedBySubState)


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
Fixes #5371
<!-- Briefly describe the issue(s) fixed. -->
## Description
I've realized the train sounds on Philly Train stages were broken, sometimes working, sometimes not. Turns out it was because the stages reuse the sound, and the sounds pause system was destroying it. I had failed to notice this when I originally coded this system lol. So this makes it so the sounds are only destroyed if they also auto-destroy.

~I feel like this might solve #5371 although I'm not really able to reproduce it on the `develop` branch, though I did seem to experience the same bug on Philly Erect (thought that was apparently because of an oversight when I was coding this PR where I was stopping the auto-destroying sounds and not the other way around lel)~
## Screenshots/Videos
~I don't think a video would suffice~