### PR TITLE
Clear key from correct map

### DIFF
--- a/source/funkin/FunkinMemory.hx
+++ b/source/funkin/FunkinMemory.hx
@@ -350,7 +350,7 @@ class FunkinMemory
       if (sound != null)
       {
         Assets.cache.removeSound(key);
-        previousCachedTextures.remove(key);
+        previousCachedSounds.remove(key);
       }
     }
     Assets.cache.clear("songs");


### PR DESCRIPTION
<!-- Briefly describe the issue(s) fixed. -->
## Description

Just clear sound asset keys from the sounds map instead of textures, not sure if this was causing any real world issue *but* it seems like it would be good to properly clear everything anyways.