### PR TITLE
[BUGFIX] Fix crash in Animation Editor after saving a character

### DIFF
--- a/source/funkin/ui/debug/anim/DebugBoundingState.hx
+++ b/source/funkin/ui/debug/anim/DebugBoundingState.hx
@@ -100,6 +100,7 @@ class DebugBoundingState extends FlxState
     offsetAnimationDropdown = offsetEditorDialog.findComponent("animationDropdown", DropDown);
 
     offsetEditorDialog.cameras = [hudCam];
+    offsetEditorDialog.closable = false;
 
     add(offsetEditorDialog);
     offsetEditorDialog.showDialog(false);


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
https://github.com/FunkinCrew/Funkin/issues/5493
<!-- Briefly describe the issue(s) fixed. -->
## Description
* Before this PR, once a user has pressed `ESCAPE` button, the Dialog which displayed all of the information (including the modes, offsets, shortcuts, etc.) would close without having a proper ability to open it back. If a user tries to move or click on anything, it would crash the game. Now the issue is fixed.
<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos
(TBA)