### PR TITLE
[ENHANCEMENT] Make Android Back button close the game in Title screen

### DIFF
--- a/source/funkin/ui/title/TitleState.hx
+++ b/source/funkin/ui/title/TitleState.hx
@@ -228,11 +228,11 @@ class TitleState extends MusicBeatState
   {
     FlxG.bitmapLog.add(FlxG.camera.buffer);
 
-    #if desktop
+    #if (desktop || android)
     // Pressing BACK on the title screen should close the game.
     // This lets you exit without leaving fullscreen mode.
-    // Only applicable on desktop.
-    if (controls.BACK)
+    // Only applicable on desktop and Android.
+    if (#if android FlxG.android.justReleased.BACK || #end controls.BACK)
     {
       openfl.Lib.application.window.close();
     }


### PR DESCRIPTION
<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
Closes #5349 
<!-- Briefly describe the issue(s) fixed. -->
## Description
My first mobile PR :D and I guess the second ever public mobile PR.
Just a lil' QOL change I suggested that's easily replaceable by an in-game Exit button that I decided to do anyway.
<!-- Include any relevant screenshots or videos. -->

~TODO: There appears to be a small issue where you may have to touch on it more than once for it to work for some reason.~
Turns out that it's 'cause `justPressed` doesn't work too well in this case. Managed to fix it by replacing with `justReleased`.
## Screenshots/Videos
https://github.com/user-attachments/assets/f55c4129-0edc-47c9-ad9c-947c4d82f5cc

