### PR TITLE
[BUGFIX] Fix the Freeplay Difficulty Stars not showing up correctly upon song completion

### DIFF
--- a/source/funkin/ui/freeplay/FreeplayState.hx
+++ b/source/funkin/ui/freeplay/FreeplayState.hx
@@ -2179,7 +2179,7 @@ class FreeplayState extends MusicBeatSubState
    */
   function changeDiff(change:Int = 0, force:Bool = false, capsuleAnim:Bool = false):Void
   {
-    if (!controls.active) return;
+    if (!controls.active && !force) return;
 
     if (capsuleAnim)
     {
@@ -2701,7 +2701,7 @@ class FreeplayState extends MusicBeatSubState
       intendedCompletion = songScore == null ? 0.0 : ((songScore.tallies.sick +
         songScore.tallies.good - songScore.tallies.missed) / songScore.tallies.totalNotes);
       rememberedSongId = daSongCapsule.freeplayData.data.id;
-      changeDiff();
+      changeDiff(0, true);
       daSongCapsule.refreshDisplay((prepForNewRank == true) ? false : true);
     }
     else
@@ -2710,7 +2710,7 @@ class FreeplayState extends MusicBeatSubState
       intendedCompletion = 0.0;
       rememberedSongId = null;
       albumRoll.albumId = null;
-      changeDiff();
+      changeDiff(0, true);
       daSongCapsule.refreshDisplay();
     }
 


### PR DESCRIPTION
## Linked Issues
Fixes https://github.com/FunkinCrew/Funkin/issues/5398

## Description
Recent update made it so that `changeDiff` wasn't being called when controls aren't active.....however upon state init, controls are set to inactive, meaning that `changeDiff` wasn't being called for state initialization, which means that upon entering into freeplay, many things tied to the difficulty but most noticably the difficulty stars didn't get updated.

## Screenshots/Videos

https://github.com/user-attachments/assets/a193c952-9d2b-41dc-8fb5-3fe813db65e8
