### PR TITLE
[CRASH-FIX] Fix Game Crashing After Spamming Through Letter Selection

### DIFF
--- a/source/funkin/ui/freeplay/LetterSort.hx
+++ b/source/funkin/ui/freeplay/LetterSort.hx
@@ -148,18 +148,22 @@ class LetterSort extends FlxSpriteGroup
 
   public function changeSelection(diff:Int = 0, playSound:Bool = true):Void
   {
-    doLetterChangeAnims(diff);
+    @:privateAccess
+    if (instance.controls.active)
+    {
+      doLetterChangeAnims(diff);
 
-    var multiPosOrNeg:Float = diff > 0 ? 1 : -1;
+      var multiPosOrNeg:Float = diff > 0 ? 1 : -1;
 
-    // if we're moving left (diff < 0), we want control of the right arrow, and vice versa
-    var arrowToMove:FlxSprite = diff < 0 ? leftArrow : rightArrow;
-    arrowToMove.offset.x = 3 * multiPosOrNeg;
+      // if we're moving left (diff < 0), we want control of the right arrow, and vice versa
+      var arrowToMove:FlxSprite = diff < 0 ? leftArrow : rightArrow;
+      arrowToMove.offset.x = 3 * multiPosOrNeg;
 
-    new FlxTimer().start(2 / 24, function(_) {
-      arrowToMove.offset.x = 0;
-    });
-    if (playSound && diff != 0) FunkinSound.playOnce(Paths.sound('scrollMenu'), 0.4);
+      new FlxTimer().start(2 / 24, function(_) {
+        arrowToMove.offset.x = 0;
+      });
+      if (playSound && diff != 0) FunkinSound.playOnce(Paths.sound('scrollMenu'), 0.4);
+    }
   }
 
   /**


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
#5567

<!-- Briefly describe the issue(s) fixed. -->
## Description
When the player would spam the letter sorting keybinds (Q&E by default), and try to leave at the same time, the game would crash. This is due `LetterSort.hx` not checking if the controls were active, meaning you could still spam during the leaving transition of the freeplay menu. This would cause it to crash, and this P.R is here to check if the controls are on/off.

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos
Please wait patiently!