### PR TITLE
[BUGFIX] Add Enter/Exit Animation For Character Select Nametags

### DIFF
--- a/source/funkin/ui/charSelect/CharSelectSubState.hx
+++ b/source/funkin/ui/charSelect/CharSelectSubState.hx
@@ -271,6 +271,12 @@ class CharSelectSubState extends MusicBeatSubState
     nametag.midpointX += cutoutSize;
     add(nametag);
 
+    @:privateAccess
+    {
+      nametag.midpointY += 200;
+      FlxTween.tween(nametag, {midpointY: nametag.midpointY - 200}, 1, {ease: FlxEase.expoOut});
+    }
+
     nametag.scrollFactor.set();
 
     FlxG.debugger.addTrackerProfile(new TrackerProfile(FlxSprite, ["x", "y", "alpha", "scale", "blend"]));
@@ -739,6 +745,7 @@ class CharSelectSubState extends MusicBeatSubState
     FlxTween.tween(cursorConfirmed, {alpha: 0}, 0.8, {ease: FlxEase.expoOut});
 
     FlxTween.tween(barthing, {y: barthing.y + 80}, 0.8, {ease: FlxEase.backIn});
+    FlxTween.tween(nametag, {y: nametag.y + 80}, 0.8, {ease: FlxEase.backIn});
     FlxTween.tween(dipshitBacking, {y: dipshitBacking.y + 210}, 0.8, {ease: FlxEase.backIn});
     FlxTween.tween(chooseDipshit, {y: chooseDipshit.y + 200}, 0.8, {ease: FlxEase.backIn});
     FlxTween.tween(dipshitBlur, {y: dipshitBlur.y + 220}, 0.8, {ease: FlxEase.backIn});


### PR DESCRIPTION
<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
Fixes #5259 

<!-- Briefly describe the issue(s) fixed. -->
## Description
Makes the character select nametags move with the rest of the transition. Works with both entering and exiting.
<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos

https://github.com/user-attachments/assets/7fd32b45-eff2-476b-96ba-99caa08cbfab

