### PR TITLE
[ENHANCEMENT]: CoolColors Array Removal from `FreeplayState.hx`

### DIFF
--- a/source/funkin/ui/freeplay/FreeplayState.hx
+++ b/source/funkin/ui/freeplay/FreeplayState.hx
@@ -169,17 +169,6 @@ class FreeplayState extends MusicBeatSubState
     return grpCapsules.members[curSelected];
   }
 
-  var coolColors:Array<Int> = [
-    0xFF9271FD,
-    0xFF9271FD,
-    0xFF223344,
-    0xFF941653,
-    0xFFFC96D7,
-    0xFFA0D1FF,
-    0xFFFF78BF,
-    0xFFF6B604
-  ];
-
   var grpCapsules:FlxTypedGroup<SongMenuItem>;
 
   var dj:Null<FreeplayDJ> = null;


### PR DESCRIPTION
<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
No Linked Issues.
<!-- Briefly describe the issue(s) fixed. -->
## Description
Removes an unused array from `FreeplayState.hx`. Saving a few lines. This was added long ago, ever since Week 7. But has not been used since then, due to the overhaul of the Freeplay menu.
<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos
<img width="1153" height="435" alt="image" src="https://github.com/user-attachments/assets/f387c526-f9a6-40b8-aacc-fec3b3ec0a96" />
