### PR TITLE
[BUGFIX] Fix DJ Flicker After New Rank

### DIFF
--- a/source/funkin/ui/freeplay/FreeplayDJ.hx
+++ b/source/funkin/ui/freeplay/FreeplayDJ.hx
@@ -81,8 +81,6 @@ class FreeplayDJ extends FlxAtlasSprite
 
   public override function update(elapsed:Float):Void
   {
-    super.update(elapsed);
-
     switch (currentState)
     {
       case Intro:
@@ -185,6 +183,8 @@ class FreeplayDJ extends FlxAtlasSprite
       default:
         // I shit myself.
     }
+
+    super.update(elapsed);
   }
 
   function onFinishAnim(name:String):Void


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
Closes #3162

<!-- Briefly describe the issue(s) fixed. -->
## Description
Whenever you complete a song and you get a new rank for that song, the DJ would flicker or become invisible for a frame after transitioning from their new rank animation to their idle.

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos

Before:

https://github.com/user-attachments/assets/11c5c3be-46ad-40c9-b1ea-d50696362698

After:

https://github.com/user-attachments/assets/9f075b48-c3fc-42b0-b449-cd9377763074
