### PR TITLE
[BUGFIX] Fix Preferences Camera Position Upon Enter

### DIFF
--- a/source/funkin/ui/options/PreferencesMenu.hx
+++ b/source/funkin/ui/options/PreferencesMenu.hx
@@ -65,7 +65,6 @@ class PreferencesMenu extends Page<OptionsState.OptionsMenuPageName>
     createPrefDescription();
 
     camFollow = new FlxObject(FlxG.width / 2, 0, 140, 70);
-    if (items != null) camFollow.y = items.selectedItem.y;
 
     menuCamera.follow(camFollow, null, 0.085);
     var margin = 160;
@@ -73,7 +72,6 @@ class PreferencesMenu extends Page<OptionsState.OptionsMenuPageName>
     menuCamera.minScrollY = 0;
 
     items.onChange.add(function(selected) {
-      camFollow.y = selected.y;
       itemDesc.text = preferenceDesc[items.selectedIndex];
     });
 
@@ -203,6 +201,9 @@ class PreferencesMenu extends Page<OptionsState.OptionsMenuPageName>
   override function update(elapsed:Float):Void
   {
     super.update(elapsed);
+
+    // Positions the camera to the selected item.
+    if (items != null) camFollow.y = items.selectedItem.y;
 
     // Indent the selected item.
     items.forEach(function(daItem:TextMenuItem) {


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
I couldn't find any issues about this bug.

<!-- Briefly describe the issue(s) fixed. -->
## Description
There's a bug where if you exit the preferences menu, the position of the camera resets when you reenter it. This causes the camera to be in its default position even if the selected preference item is at the way bottom.

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos

Before:

https://github.com/user-attachments/assets/26a33d88-dd13-4fd7-93fb-554fb29fa1fb

After:

https://github.com/user-attachments/assets/f73868f0-bd45-4da2-88cd-116e7bbf37e3

As you can see in the before, the camera position isn't right when you reenter the preferences menu as it should be positioned near the bottom where the selected preference item was. The after video shows exactly how it should look after reentering the preferences menu.