### PR TITLE
[Enhancement] Add Camera Fade To Selecting Songs and Weeks

### DIFF
--- a/source/funkin/ui/freeplay/FreeplayState.hx
+++ b/source/funkin/ui/freeplay/FreeplayState.hx
@@ -2599,7 +2599,7 @@ class FreeplayState extends MusicBeatSubState
     new FlxTimer().start(styleData?.getStartDelay(), function(tmr:FlxTimer) {
       FunkinSound.emptyPartialQueue();
 
-      funnyCam.fade(FlxColor.BLACK, 0.1, false, function() {
+      funnyCam.fade(FlxColor.BLACK, 0.2, false, function() {
         Paths.setCurrentLevel(cap?.freeplayData?.levelId);
         LoadingState.loadPlayState(
           {

--- a/source/funkin/ui/freeplay/FreeplayState.hx
+++ b/source/funkin/ui/freeplay/FreeplayState.hx
@@ -2599,26 +2599,28 @@ class FreeplayState extends MusicBeatSubState
     new FlxTimer().start(styleData?.getStartDelay(), function(tmr:FlxTimer) {
       FunkinSound.emptyPartialQueue();
 
-      Paths.setCurrentLevel(cap?.freeplayData?.levelId);
-      LoadingState.loadPlayState(
-        {
-          targetSong: targetSong,
-          targetDifficulty: currentDifficulty,
-          targetVariation: currentVariation,
-          targetInstrumental: targetInstId,
-          practiceMode: false,
-          minimalMode: false,
+      funnyCam.fade(FlxColor.BLACK, 0.1, false, function() {
+        Paths.setCurrentLevel(cap?.freeplayData?.levelId);
+        LoadingState.loadPlayState(
+          {
+            targetSong: targetSong,
+            targetDifficulty: currentDifficulty,
+            targetVariation: currentVariation,
+            targetInstrumental: targetInstId,
+            practiceMode: false,
+            minimalMode: false,
 
-          #if FEATURE_DEBUG_FUNCTIONS
-          botPlayMode: FlxG.keys.pressed.SHIFT,
-          #else
-          botPlayMode: false,
-          #end
-          // TODO: Make these an option! It's currently only accessible via chart editor.
-          // startTimestamp: 0.0,
-          // playbackRate: 0.5,
-          // botPlayMode: true,
-        }, true);
+            #if FEATURE_DEBUG_FUNCTIONS
+            botPlayMode: FlxG.keys.pressed.SHIFT,
+            #else
+            botPlayMode: false,
+            #end
+            // TODO: Make these an option! It's currently only accessible via chart editor.
+            // startTimestamp: 0.0,
+            // playbackRate: 0.5,
+            // botPlayMode: true,
+          }, true);
+      });
     });
   }
 

--- a/source/funkin/ui/story/StoryMenuState.hx
+++ b/source/funkin/ui/story/StoryMenuState.hx
@@ -604,12 +604,14 @@ class StoryMenuState extends MusicBeatState
 
       var targetVariation:String = targetSong.getFirstValidVariation(PlayStatePlaylist.campaignDifficulty);
 
-      LoadingState.loadPlayState(
-        {
-          targetSong: targetSong,
-          targetDifficulty: PlayStatePlaylist.campaignDifficulty,
-          targetVariation: targetVariation
-        }, true);
+      FlxG.camera.fade(FlxColor.BLACK, 0.1, false, function() {
+        LoadingState.loadPlayState(
+          {
+            targetSong: targetSong,
+            targetDifficulty: PlayStatePlaylist.campaignDifficulty,
+            targetVariation: targetVariation
+          }, true);
+      });
     });
   }
 

--- a/source/funkin/ui/story/StoryMenuState.hx
+++ b/source/funkin/ui/story/StoryMenuState.hx
@@ -604,7 +604,7 @@ class StoryMenuState extends MusicBeatState
 
       var targetVariation:String = targetSong.getFirstValidVariation(PlayStatePlaylist.campaignDifficulty);
 
-      FlxG.camera.fade(FlxColor.BLACK, 0.1, false, function() {
+      FlxG.camera.fade(FlxColor.BLACK, 0.2, false, function() {
         LoadingState.loadPlayState(
           {
             targetSong: targetSong,


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
I checked, couldn't find anything.

<!-- Briefly describe the issue(s) fixed. -->
## Description
What this PR adds is a quick camera fade that occurs after selecting a song in freeplay or selecting a week in the story menu. This makes it a way better transition from the menu you're in to the actual game, rather than the menu freezing for a few seconds just for it to immediately switch to the game. I also tested this on web and it looks good.

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos

Freeplay:

https://github.com/user-attachments/assets/52fd7d06-5a15-4727-a58c-de01b31cdf2d

Story Menu:

https://github.com/user-attachments/assets/e040b01b-c13b-485f-8219-9fca8aedc5ae
