### PR TITLE
[ENHANCEMENT] Pause Menu Enhancements

### DIFF
--- a/hmm.json
+++ b/hmm.json
@@ -46,7 +46,7 @@
       "type": "git",
       "dir": null,
       "ref": "08fc955ca87f192a971719a675f1d3b21709725d",
-      "url": "https://github.com/FunkinCrew/flixel-mobile"
+      "url": "https://github.com/FunkinCrew/flixel"
     },
     {
       "name": "flixel-addons",
@@ -171,7 +171,7 @@
       "type": "git",
       "dir": null,
       "ref": "0f1193c37761f1a80a888fb84e752490b5d0b656",
-      "url": "https://github.com/FunkinCrew/lime-mobile"
+      "url": "https://github.com/FunkinCrew/lime"
     },
     {
       "name": "mconsole",
@@ -213,7 +213,7 @@
       "type": "git",
       "dir": null,
       "ref": "a0df7c3afe360c9af59a76e45007dbf4e53b5131",
-      "url": "https://github.com/FunkinCrew/openfl-mobile"
+      "url": "https://github.com/FunkinCrew/openfl"
     },
     {
       "name": "polymod",

--- a/source/funkin/play/PauseSubState.hx
+++ b/source/funkin/play/PauseSubState.hx
@@ -199,6 +199,11 @@ class PauseSubState extends MusicBeatSubState
   var metadataArtist:FlxText;
 
   /**
+  * A text object that displays if you are currently using botplay.
+  */
+  var metadataBotplay:FlxText;
+
+  /**
    * A text object that displays the current global offset.
    */
   var offsetText:FlxText;
@@ -213,11 +218,6 @@ class PauseSubState extends MusicBeatSubState
    */
   var menuEntryText:FlxTypedSpriteGroup<AtlasText>;
 
-  /**
-   * Callback that gets called once substate gets open.
-   */
-  var onPause:Void->Void;
-
   // ===============
   // Audio Variables
   // ===============
@@ -227,11 +227,10 @@ class PauseSubState extends MusicBeatSubState
   // Constructor
   // ===============
 
-  public function new(?params:PauseSubStateParams, ?onPause:Void->Void)
+  public function new(?params:PauseSubStateParams)
   {
     super();
     this.currentMode = params?.mode ?? Standard;
-    this.onPause = onPause;
   }
 
   // ===============
@@ -249,8 +248,6 @@ class PauseSubState extends MusicBeatSubState
 
     AdMobUtil.addBanner(extension.admob.AdmobBannerSize.BANNER, extension.admob.AdmobBannerAlign.TOP_LEFT);
     #end
-
-    if (onPause != null) onPause();
 
     super.create();
 
@@ -294,7 +291,6 @@ class PauseSubState extends MusicBeatSubState
     hapticTimer.cancel();
     hapticTimer = null;
     pauseMusic.stop();
-    onPause = null;
   }
 
   // ===============
@@ -428,7 +424,7 @@ class PauseSubState extends MusicBeatSubState
     metadata.add(metadataDifficulty);
 
     metadataDeaths = new FlxText(20, metadataDifficulty.y + 32, camera.width - Math.max(40, funkin.ui.FullScreenScaleMode.gameNotchSize.x),
-      '${PlayState.instance?.deathCounter} Blue Balls');
+      '${PlayState.instance?.deathCounter} ${Preferences.naughtyness ? 'Blue Ball' : 'Death'}${PlayState.instance?.deathCounter == 1 ? '' : 's'}');
     metadataDeaths.setFormat(Paths.font('vcr.ttf'), 32, FlxColor.WHITE, FlxTextAlign.RIGHT);
     metadataDeaths.scrollFactor.set(0, 0);
     metadata.add(metadataDeaths);
@@ -438,6 +434,12 @@ class PauseSubState extends MusicBeatSubState
     metadataPractice.visible = PlayState.instance?.isPracticeMode ?? false;
     metadataPractice.scrollFactor.set(0, 0);
     metadata.add(metadataPractice);
+
+    metadataBotplay = new FlxText(20, metadataDeaths.y + 32, camera.width - Math.max(40, funkin.ui.FullScreenScaleMode.gameNotchSize.x),
+      '${PlayState.instance?.isBotPlayMode ? 'Bot Play Enabled' : ''}');
+    metadataBotplay.setFormat(Paths.font('vcr.ttf'), 32, FlxColor.WHITE, FlxTextAlign.RIGHT);
+    metadataBotplay.scrollFactor.set(0, 0);
+    metadata.add(metadataBotplay);
 
     // Right side
     offsetText = new FlxText(20, metadataSong.y - 12, (camera.width + 10) - Math.max(40, funkin.ui.FullScreenScaleMode.gameNotchSize.x),
@@ -453,7 +455,7 @@ class PauseSubState extends MusicBeatSubState
     offsetText.y = FlxG.height - (offsetText.height + offsetText.height + 40);
     offsetTextInfo.y = offsetText.y + offsetText.height + 4;
 
-    #if (!mobile && FEATURE_LAG_ADJUSTMENT)
+    #if !mobile
     metadata.add(offsetText);
     metadata.add(offsetTextInfo);
     #end
@@ -463,6 +465,7 @@ class PauseSubState extends MusicBeatSubState
     metadataSong.alpha = 0;
     metadataDifficulty.alpha = 0;
     metadataDeaths.alpha = 0;
+    metadataBotplay.alpha = 0;
     offsetText.alpha = 0;
     offsetTextInfo.alpha = 0;
 
@@ -879,6 +882,8 @@ class PauseSubState extends MusicBeatSubState
   function updateMetadataText():Void
   {
     metadataPractice.visible = PlayState.instance?.isPracticeMode ?? false;
+    metadataBotplay.y = PlayState.instance?.isPracticeMode ? metadataPractice.y + 32 : metadataDeaths.y + 32;
+    
 
     #if mobile
     if (metadata.members[0].y != camera.height - 185 && metadataPractice.visible)
@@ -893,7 +898,7 @@ class PauseSubState extends MusicBeatSubState
     switch (this.currentMode)
     {
       case Standard | Difficulty:
-        metadataDeaths.text = '${PlayState.instance?.deathCounter} Blue Balls';
+        metadataDeaths.text = '${PlayState.instance?.deathCounter} ${Preferences.naughtyness ? 'Blue Ball' : 'Death'}${PlayState.instance?.deathCounter == 1 ? '' : 's'}';
       case Charting:
         metadataDeaths.text = 'Chart Editor Preview';
       case Conversation:

--- a/source/funkin/ui/freeplay/FreeplayState.hx
+++ b/source/funkin/ui/freeplay/FreeplayState.hx
@@ -2599,7 +2599,7 @@ class FreeplayState extends MusicBeatSubState
     new FlxTimer().start(styleData?.getStartDelay(), function(tmr:FlxTimer) {
       FunkinSound.emptyPartialQueue();
 
-      funnyCam.fade(FlxColor.BLACK, 0.1, false, function() {
+      funnyCam.fade(FlxColor.BLACK, 0.2, false, function() {
         Paths.setCurrentLevel(cap?.freeplayData?.levelId);
         LoadingState.loadPlayState(
           {

--- a/source/funkin/ui/freeplay/FreeplayState.hx
+++ b/source/funkin/ui/freeplay/FreeplayState.hx
@@ -2599,26 +2599,28 @@ class FreeplayState extends MusicBeatSubState
     new FlxTimer().start(styleData?.getStartDelay(), function(tmr:FlxTimer) {
       FunkinSound.emptyPartialQueue();
 
-      Paths.setCurrentLevel(cap?.freeplayData?.levelId);
-      LoadingState.loadPlayState(
-        {
-          targetSong: targetSong,
-          targetDifficulty: currentDifficulty,
-          targetVariation: currentVariation,
-          targetInstrumental: targetInstId,
-          practiceMode: false,
-          minimalMode: false,
+      funnyCam.fade(FlxColor.BLACK, 0.1, false, function() {
+        Paths.setCurrentLevel(cap?.freeplayData?.levelId);
+        LoadingState.loadPlayState(
+          {
+            targetSong: targetSong,
+            targetDifficulty: currentDifficulty,
+            targetVariation: currentVariation,
+            targetInstrumental: targetInstId,
+            practiceMode: false,
+            minimalMode: false,
 
-          #if FEATURE_DEBUG_FUNCTIONS
-          botPlayMode: FlxG.keys.pressed.SHIFT,
-          #else
-          botPlayMode: false,
-          #end
-          // TODO: Make these an option! It's currently only accessible via chart editor.
-          // startTimestamp: 0.0,
-          // playbackRate: 0.5,
-          // botPlayMode: true,
-        }, true);
+            #if FEATURE_DEBUG_FUNCTIONS
+            botPlayMode: FlxG.keys.pressed.SHIFT,
+            #else
+            botPlayMode: false,
+            #end
+            // TODO: Make these an option! It's currently only accessible via chart editor.
+            // startTimestamp: 0.0,
+            // playbackRate: 0.5,
+            // botPlayMode: true,
+          }, true);
+      });
     });
   }
 

--- a/source/funkin/ui/story/StoryMenuState.hx
+++ b/source/funkin/ui/story/StoryMenuState.hx
@@ -604,12 +604,14 @@ class StoryMenuState extends MusicBeatState
 
       var targetVariation:String = targetSong.getFirstValidVariation(PlayStatePlaylist.campaignDifficulty);
 
-      LoadingState.loadPlayState(
-        {
-          targetSong: targetSong,
-          targetDifficulty: PlayStatePlaylist.campaignDifficulty,
-          targetVariation: targetVariation
-        }, true);
+      FlxG.camera.fade(FlxColor.BLACK, 0.1, false, function() {
+        LoadingState.loadPlayState(
+          {
+            targetSong: targetSong,
+            targetDifficulty: PlayStatePlaylist.campaignDifficulty,
+            targetVariation: targetVariation
+          }, true);
+      });
     });
   }
 

--- a/source/funkin/ui/story/StoryMenuState.hx
+++ b/source/funkin/ui/story/StoryMenuState.hx
@@ -604,7 +604,7 @@ class StoryMenuState extends MusicBeatState
 
       var targetVariation:String = targetSong.getFirstValidVariation(PlayStatePlaylist.campaignDifficulty);
 
-      FlxG.camera.fade(FlxColor.BLACK, 0.1, false, function() {
+      FlxG.camera.fade(FlxColor.BLACK, 0.2, false, function() {
         LoadingState.loadPlayState(
           {
             targetSong: targetSong,


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
No linked issues.

<!-- Briefly describe the issue(s) fixed. -->
## Description
This adds enhancements to the pause menu, the enhancements in specific are grammar correction for the `metadataDeaths` text, and if you have Naughtyness off, it will say "Deaths" instead of "Blue Balls". It also adds another metadata text called `metadataBotplay`, which indicates if you are using botplay to beat a song in the pause menu, along with it being offset depending on if you have practice mode on/off.

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos
<img width="1280" height="720" alt="screenshot-2025-07-29-10-43-43" src="https://github.com/user-attachments/assets/29cceb72-79bf-440d-abb8-e163ebb43477" />
<img width="1280" height="720" alt="screenshot-2025-07-29-10-43-53" src="https://github.com/user-attachments/assets/abada084-02ba-4ab8-9a14-9679504fc1d7" />
<img width="1280" height="720" alt="screenshot-2025-07-29-10-44-00" src="https://github.com/user-attachments/assets/ab1c1e5c-128c-4962-a3f5-9292ffda0255" />
<img width="1280" height="720" alt="screenshot-2025-07-29-11-57-33" src="https://github.com/user-attachments/assets/1cf24e88-4e52-476d-a444-f6c9ded5a8d1" />

## Checklist:
 * [x] Botplay Text In The Pause Menu
 * [x] Naughtyness Patch (NAUGHTYNESS = Blue Balls) (NO NAUGHTYNESS = Deaths) 
 * [x] Blue Balls Grammar Fixing
 * [x] BotPlay Text POS Fix (if practice is disabled and only botplay, there will be a gap, so remove it.) 
