### PR TITLE
[BUGFIX] Fix Blazin' Death When Pressing Reset and Pause Button

### DIFF
--- a/source/funkin/play/PlayState.hx
+++ b/source/funkin/play/PlayState.hx
@@ -1230,7 +1230,7 @@ class PlayState extends MusicBeatSubState
 
   function pause(?mode:PauseMode = Standard):Void
   {
-    if (!mayPauseGame || justUnpaused || isGamePaused) return;
+    if (!mayPauseGame || justUnpaused || isGamePaused || isPlayerDying) return;
 
     switch (mode)
     {


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
Fixes #3168
Fixes #2385

<!-- Briefly describe the issue(s) fixed. -->
## Description
In Blazin', whenever you press the reset button and the pause button at the same time (press reset first), you'll experience the death animation, but instead how it looks in the screenshot below. This was fixed by checking if the player isn't dead when trying to pausing.

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos

<img width="1280" height="720" alt="screenshot-2025-08-02-19-13-10" src="https://github.com/user-attachments/assets/b1d5dd58-7d0b-45b9-b417-28aebb4c32ef" />

