### PR TITLE
[ENHANCEMENT] Increase Freeplay Preview Volume To 80% To Match Random's Preview Volume

### DIFF
--- a/source/funkin/ui/freeplay/FreeplayState.hx
+++ b/source/funkin/ui/freeplay/FreeplayState.hx
@@ -2795,7 +2795,7 @@ class FreeplayState extends MusicBeatSubState
               end: 0.2
             },
           onLoad: function() {
-            FlxG.sound.music.fadeIn(2, 0, 0.4);
+            FlxG.sound.music.fadeIn(2, 0, 0.8);
           }
         });
       if (songDifficulty != null)


### PR DESCRIPTION
<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
None
<!-- Briefly describe the issue(s) fixed. -->
## Description
Increases the volume of freeplay previews to 80%. They were previously 40% while Random was at 80% making it inconsistent. I think it's better to make the preview volume 80% instead of decreasing them to 40% since some people (including me) like listening to the previews once in a while, and it's a bit inconvenient to have to increase/decrease volume.
<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos
Nah I'm good