### PR TITLE
[ENHANCEMENT] Make both Start and Accept buttons work on Title Menu

### DIFF
--- a/source/funkin/ui/title/TitleState.hx
+++ b/source/funkin/ui/title/TitleState.hx
@@ -282,7 +282,7 @@ class TitleState extends MusicBeatState
 
     if (gamepad != null)
     {
-      if (gamepad.justPressed.START) pressedEnter = true;
+      if (gamepad.justPressed.START || gamepad.justPressed.ACCEPT) pressedEnter = true;
     }
 
     // If you spam Enter, we should skip the transition.


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues

No

<!-- Briefly describe the issue(s) fixed. -->
## Description

The title menu only worked with the start button on a gamepad, which is ok, but too many people would try to use the South button, notice that it doesn't work, and end up confused. This PR makes it so both the Start and South buttons work

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos

https://github.com/user-attachments/assets/79cd266c-d5a5-4129-b985-7bfec49365db

