### PR TITLE
[ENHANCEMENT] Make Checkbox Items in Preferences Instantly Update (RECOVERY)

### DIFF
--- a/source/funkin/ui/MenuList.hx
+++ b/source/funkin/ui/MenuList.hx
@@ -283,7 +283,12 @@ class MenuTypedList<T:MenuListItem> extends FlxTypedGroup<T>
 
     onAcceptPress.dispatch(selected);
 
-    if (selected.fireInstantly) selected.callback();
+    if (selected.fireInstantly)
+    {
+      FunkinSound.playOnce(Paths.sound('confirmMenu'));
+      selected.callback();
+      FlxFlicker.flicker(selected, 1, 0.06, true, false);
+    }
     else
     {
       busy = true;

--- a/source/funkin/ui/options/PreferencesMenu.hx
+++ b/source/funkin/ui/options/PreferencesMenu.hx
@@ -255,7 +255,7 @@ class PreferencesMenu extends Page<OptionsState.OptionsMenuPageName>
       var value = !checkbox.currentValue;
       onChange(value);
       checkbox.currentValue = value;
-    }, false, available);
+    }, true, available);
 
     preferenceItems.add(checkbox);
     preferenceDesc.push(prefDesc);


### PR DESCRIPTION
<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
None
<!-- Briefly describe the issue(s) fixed. -->
## Description
Recovery of #2368 with some extra changes by me. Makes checkbox items in preferences menu automatically update, allowing you to enable/disable a preference without needing to wait for the animation to finish playing.
<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos

https://github.com/user-attachments/assets/71b65abb-00f2-40ad-93b1-4fe22a25a84a

