### PR TITLE
[BUGFIX] Fix Legacy Chart Import Not Applying Scroll Speed

### DIFF
--- a/source/funkin/data/song/importer/FNFLegacyImporter.hx
+++ b/source/funkin/data/song/importer/FNFLegacyImporter.hx
@@ -95,8 +95,8 @@ class FNFLegacyImporter
     switch (songData.song.speed)
     {
       case Left(speed):
-        // All difficulties will use the one scroll speed.
-        songChartData.scrollSpeed.set('default', speed);
+        // Sets the scroll speed for the difficulty.
+        songChartData.scrollSpeed.set(difficulty, speed);
       case Right(speeds):
         if (speeds.easy != null) songChartData.scrollSpeed.set('easy', speeds.easy);
         if (speeds.normal != null) songChartData.scrollSpeed.set('normal', speeds.normal);


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
Fixes #5535

<!-- Briefly describe the issue(s) fixed. -->
## Description
When you go into the chart editor and you import a legacy chart, the scroll speed doesn't get applied properly and this pr fixes that so that instead of the scroll speed defaulting to 1, it gets set to the legacy chart's proper scroll speed.

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos

A screenshot of what the scroll speed should be when importing a legacy chart such as Philly (Hard).

<img width="269" height="121" alt="Screenshot 2025-08-03 184839" src="https://github.com/user-attachments/assets/f8df98a3-c81a-4649-80db-1bfc524d5c2a" />
