### PR TITLE
[FIX] Fix EnvironmentConfigMacro not parsing CRLF line endings properly

### DIFF
--- a/source/funkin/util/macro/EnvironmentConfigMacro.hx
+++ b/source/funkin/util/macro/EnvironmentConfigMacro.hx
@@ -59,6 +59,7 @@ class EnvironmentConfigMacro
 
     for (line in envFile.split('\n'))
     {
+      line = line.trim();
       if (line.length <= 0 || line.startsWith("#") || shouldExcludeKey(line)) continue;
 
       var index:Int = line.indexOf('=');


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
N/A
<!-- Briefly describe the issue(s) fixed. -->
## Description
This is caused by the fact the file content is simply split by a LF line ending, so in CRLF the carriage return would be included with the value. Fortunately a simple trim solves this.

This crash was being caused by it.
<img width="395" height="269" alt="image" src="https://github.com/user-attachments/assets/d225ebb7-db7f-47f6-a4c0-bc1da47fcb90" />


<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos
It would look like this in the code lel
<img width="266" height="33" alt="image" src="https://github.com/user-attachments/assets/6cc2fd95-b986-4384-b595-d37d63f2027e" />
