### PR TITLE
Add Charter field to New Chart dialog

### DIFF
--- a/source/funkin/ui/debug/charting/handlers/ChartEditorDialogHandler.hx
+++ b/source/funkin/ui/debug/charting/handlers/ChartEditorDialogHandler.hx
@@ -619,6 +619,23 @@ class ChartEditorDialogHandler
     };
     inputSongArtist.text = "";
 
+    var inputSongCharter:Null<TextField> = dialog.findComponent('inputSongCharter', TextField);
+    if (inputSongCharter == null) throw 'Could not locate inputSongCharter TextField in Song Metadata dialog';
+    inputSongCharter.onChange = function(event:UIEvent) {
+      var valid:Bool = event.target.text != null && event.target.text != '';
+
+      if (valid)
+      {
+        inputSongCharter.removeClass('invalid-value');
+        newSongMetadata.charter = event.target.text;
+      }
+      else
+      {
+        newSongMetadata.charter = "";
+      }
+    };
+    inputSongCharter.text = "";
+
     var inputStage:Null<DropDown> = dialog.findComponent('inputStage', DropDown);
     if (inputStage == null) throw 'Could not locate inputStage DropDown in Song Metadata dialog';
     inputStage.onChange = function(event:UIEvent) {


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
None
<!-- Briefly describe the issue(s) fixed. -->
## Description
> [!NOTE]
> Requires https://github.com/FunkinCrew/funkin.assets/pull/218

Adds a charter field to the song metadata dialog that shows up when you're creating a new chart.
This was only done for the add variation window in an earlier PR.
##### Also what the hell happened to the BPM field?
<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos
<img width="328" height="397" alt="image" src="https://github.com/user-attachments/assets/b31fee2d-f5aa-4a04-ae5f-63fd447b6b35" />

