### PR TITLE
[BUGFIX] Fix selecting between two Sustail Trails causing visual errors

### DIFF
--- a/source/funkin/ui/debug/charting/ChartEditorState.hx
+++ b/source/funkin/ui/debug/charting/ChartEditorState.hx
@@ -4753,6 +4753,7 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
             gridGhostHoldNote.setHeightDirectly(dragLengthPixels, true);
             gridGhostHoldNote.noteStyle = NoteKindManager.getNoteStyleId(currentPlaceNoteData.kind, currentSongNoteStyle) ?? currentSongNoteStyle;
             gridGhostHoldNote.updateHoldNotePosition(renderedHoldNotes);
+            gridGhostHoldNote.updateHoldNoteGraphic();
           }
           else
           {


### PR DESCRIPTION
## Linked Issues
Closes https://github.com/FunkinCrew/Funkin/issues/5682

## Description
It was literally just one line. Just one line to update the `gridGhostHoldNote` graphic. That's it. Nothing else. I can't wrap my head around this, like, Eric, my man, between week 7 and weekend 1 you had THREE YEARS to perfect the chart editor, yet we keep finding flaws in it. Sure, nothing is flawless and all that, but we keep finding many and many imperfections that are easily solvable and it just boggles my mind. How did this blunder even happen? I'm sure this was playtested enough, hell, Cory and fabs must have spent more time in the editor than any of us combined so they should have noticed this at some point, no? I speak for everyone when I say that we, yes WE, will be using the legacy chart editor to chart. At least it didn't have horrible and unspeakable mistakes like this. 0/10, never touch a `.hx` file again.

## Screenshots/Videos

https://github.com/user-attachments/assets/d7526d7e-b31d-4cc2-bf06-4d10d42e1f9f
