### PR TITLE
[CHORE] Add Null Safety to 5 classes in funkin.ui

### DIFF
--- a/source/funkin/ui/freeplay/DifficultyDot.hx
+++ b/source/funkin/ui/freeplay/DifficultyDot.hx
@@ -23,6 +23,7 @@ enum DotState
   SELECTED;
 }
 
+@:nullSafety
 class DifficultyDot extends FlxSpriteGroup
 {
   /**
@@ -41,8 +42,8 @@ class DifficultyDot extends FlxSpriteGroup
 
   var pulseColor = false;
 
-  public var dot:FlxSprite;
-  public var pulse:FlxSprite;
+  public var dot:FlxSprite = new FlxSprite().loadGraphic(Paths.image('freeplay/seperator'));
+  public var pulse:FlxSprite = new FlxSprite(0, 0);
 
   // var newColors:Array<FlxColor> = [0xFFE86D09, 0xFFE54400, 0xFFE83509, 0xFFF3D48A, 0xFFFAF269, 0xFFF9F0C2];
 
@@ -52,12 +53,9 @@ class DifficultyDot extends FlxSpriteGroup
 
     difficultyId = id;
 
-    dot = new FlxSprite().loadGraphic(Paths.image('freeplay/seperator'));
     add(dot);
-
     dot.alpha = 0;
 
-    pulse = new FlxSprite(0, 0);
     pulse.frames = Paths.getSparrowAtlas('freeplay/dotPulse');
     pulse.animation.addByPrefix('pulse', 'pulse', 12, true);
     pulse.animation.play('pulse', true, false, FlxMath.wrap(num * -2, 0, 11));
@@ -69,8 +67,8 @@ class DifficultyDot extends FlxSpriteGroup
     });
   }
 
-  var colorTween:FlxTween;
-  var fadeTween:FlxTween;
+  var colorTween:Null<FlxTween>;
+  var fadeTween:Null<FlxTween>;
 
   /**
    * Interpolates between 2 colors to make the dot pulse in time with the pulse's animation.
@@ -146,7 +144,7 @@ class DifficultyDot extends FlxSpriteGroup
     switch (type)
     {
       case NORMAL:
-        if (fadeTween?.finished) dot.alpha = 1;
+        if (fadeTween != null && fadeTween?.finished) dot.alpha = 1;
 
         switch (state)
         {
@@ -164,7 +162,7 @@ class DifficultyDot extends FlxSpriteGroup
         }
 
       case ERECT:
-        if (fadeTween?.finished) dot.alpha = 1;
+        if (fadeTween != null && fadeTween?.finished) dot.alpha = 1;
 
         switch (state)
         {
@@ -183,7 +181,7 @@ class DifficultyDot extends FlxSpriteGroup
 
       case INACTIVE:
         color = 0xFF121212;
-        if (fadeTween?.finished) dot.alpha = 0.33;
+        if (fadeTween != null && fadeTween?.finished) dot.alpha = 0.33;
 
       default:
         trace('freeplay dot type is invalid!');

--- a/source/funkin/ui/story/LevelTitle.hx
+++ b/source/funkin/ui/story/LevelTitle.hx
@@ -5,16 +5,17 @@ import flixel.group.FlxSpriteGroup;
 import flixel.util.FlxColor;
 import funkin.util.MathUtil;
 
+@:nullSafety
 class LevelTitle extends FlxSpriteGroup
 {
   static final LOCK_PAD:Int = 4;
 
-  public final level:Level;
+  public final level:Null<Level>;
 
-  public var targetY:Float;
+  public var targetY:Float = 0.00;
 
-  var title:FlxSprite;
-  var lock:FlxSprite;
+  var title:FlxSprite = new FlxSprite();
+  var lock:Null<FlxSprite>;
 
   public function new(x:Int, y:Int, level:Level)
   {
@@ -32,13 +33,18 @@ class LevelTitle extends FlxSpriteGroup
   {
     if (length == 0) return 0;
 
-    if (lock.visible)
+    if (lock != null && lock.visible)
     {
       return title.width + lock.width + LOCK_PAD;
     }
     else
     {
-      return title.width;
+      if (title != null)
+      {
+        return title.width;
+      } else {
+        return 0;
+      }
     }
   }
 
@@ -57,27 +63,36 @@ class LevelTitle extends FlxSpriteGroup
       if (flashTick >= 1 / flashFramerate)
       {
         flashTick %= 1 / flashFramerate;
-        title.color = (title.color == FlxColor.WHITE) ? 0xFF33ffff : FlxColor.WHITE;
+        title.color = (title?.color == FlxColor.WHITE) ? 0xFF33ffff : FlxColor.WHITE;
       }
     }
   }
 
   public function showLock():Void
   {
-    lock.visible = true;
-    this.x -= (lock.width + LOCK_PAD) / 2;
+    if (lock != null)
+    {
+      lock.visible = true;
+      this.x -= (lock.width + LOCK_PAD) / 2;
+    } 
   }
 
   public function hideLock():Void
   {
-    lock.visible = false;
-    this.x += (lock.width + LOCK_PAD) / 2;
+    if (lock != null) 
+    {
+      lock.visible = false;
+      this.x += (lock.width + LOCK_PAD) / 2;
+    }
   }
 
   function buildLevelTitle():Void
   {
-    title = level.buildTitleGraphic();
-    add(title);
+    if (title != null && level != null) 
+    {
+      title = level.buildTitleGraphic();
+      add(title);
+    }
   }
 
   function buildLevelLock():Void

--- a/source/funkin/ui/title/AttractState.hx
+++ b/source/funkin/ui/title/AttractState.hx
@@ -22,6 +22,7 @@ import flixel.addons.display.FlxPieDial;
  * In the current version, this just plays the ~~Kickstarter trailer~~ Erect teaser, but this can be changed to
  * gameplay footage, a generic game trailer, or something more elaborate.
  */
+@:nullSafety
 class AttractState extends MusicBeatState
 {
   #if html5
@@ -32,7 +33,7 @@ class AttractState extends MusicBeatState
   static final ATTRACT_VIDEO_PATH:String = Paths.videos('toyCommercial');
   #end
 
-  var pie:FlxPieDial;
+  var pie:FlxPieDial = new FlxPieDial(0, 0, 40, FlxColor.WHITE, 45, CIRCLE, true, 20);
   var holdDelta:Float = 0;
   var holdTime:Float = 1.5;
 
@@ -42,7 +43,6 @@ class AttractState extends MusicBeatState
     if (FlxG.sound.music != null)
     {
       FlxG.sound.music.destroy();
-      FlxG.sound.music = null;
     }
 
     #if html5
@@ -55,7 +55,6 @@ class AttractState extends MusicBeatState
     playVideoNative(ATTRACT_VIDEO_PATH);
     #end
 
-    pie = new FlxPieDial(0, 0, 40, FlxColor.WHITE, 45, CIRCLE, true, 20);
     pie.x = FlxG.width - ((pie.width * 1.5) + FullScreenScaleMode.gameNotchSize.x);
     pie.y = FlxG.height - (pie.height * 1.5);
     pie.amount = 0;
@@ -64,12 +63,11 @@ class AttractState extends MusicBeatState
   }
 
   #if html5
-  var vid:FlxVideo;
+  var vid:Null<FlxVideo> = new FlxVideo(filePath);
 
   function playVideoHTML5(filePath:String):Void
   {
     // Video displays OVER the FlxState.
-    vid = new FlxVideo(filePath);
     if (vid != null)
     {
       vid.zIndex = 0;
@@ -86,14 +84,13 @@ class AttractState extends MusicBeatState
   #end
 
   #if hxvlc
-  var vid:FunkinVideoSprite;
+  var vid:Null<FunkinVideoSprite> = new FunkinVideoSprite(0, 0);
 
   function playVideoNative(filePath:String):Void
   {
     // Video displays OVER the FlxState.
-    vid = new FunkinVideoSprite(0, 0);
 
-    if (vid != null)
+    if (vid != null && vid.bitmap != null)
     {
       vid.zIndex = 0;
       vid.active = false;
@@ -104,9 +101,9 @@ class AttractState extends MusicBeatState
       });
       vid.bitmap.onEndReached.add(onAttractEnd);
       vid.bitmap.onFormatSetup.add(() -> {
-        vid.setGraphicSize(FlxG.initialWidth, FlxG.initialHeight);
-        vid.updateHitbox();
-        vid.screenCenter();
+        vid?.setGraphicSize(FlxG.initialWidth, FlxG.initialHeight);
+        vid?.updateHitbox();
+        vid?.screenCenter();
       });
 
       add(vid);
@@ -165,8 +162,7 @@ class AttractState extends MusicBeatState
     #end
 
     #if (html5 || hxvlc)
-    vid.destroy();
-    vid = null;
+    vid?.destroy();
     #end
 
     FlxG.switchState(() -> new TitleState());

--- a/source/funkin/ui/title/FlxSpriteOverlay.hx
+++ b/source/funkin/ui/title/FlxSpriteOverlay.hx
@@ -7,18 +7,16 @@ import flixel.FlxCamera;
 import flixel.FlxG;
 import flixel.graphics.frames.FlxFrame.FlxFrameAngle;
 
+@:nullSafety
 class FlxSpriteOverlay extends FlxSprite
 {
-  var blendShader:BlendModesShader;
-  var dipshitBitmap:BitmapData;
-  var temp:FlxSprite;
+  var blendShader:BlendModesShader = new BlendModesShader();
+  var dipshitBitmap:BitmapData = new BitmapData(2180, 1720, true, 0xFFCC00CC);
+  var temp:FlxSprite = new FlxSprite().makeGraphic(FlxG.width, FlxG.height, 0xFF000000);
 
   public function new(x:Float, y:Float)
   {
     super(x, y);
-    temp = new FlxSprite().makeGraphic(FlxG.width, FlxG.height, 0xFF000000);
-    blendShader = new BlendModesShader();
-    dipshitBitmap = new BitmapData(2180, 1720, true, 0xFFCC00CC);
   }
 
   override function drawComplex(camera:FlxCamera):Void

--- a/source/funkin/ui/title/TitleState.hx
+++ b/source/funkin/ui/title/TitleState.hx
@@ -38,6 +38,7 @@ import funkin.util.TouchUtil;
 import funkin.util.SwipeUtil;
 #end
 
+@:nullSafety
 class TitleState extends MusicBeatState
 {
   /**
@@ -45,19 +46,18 @@ class TitleState extends MusicBeatState
    */
   public static var initialized:Bool = false;
 
-  var blackScreen:FlxSprite;
-  var credGroup:FlxGroup;
-  var textGroup:FlxGroup;
-  var ngSpr:FlxSprite;
+  var blackScreen:Null<FlxSprite>;
+  var credGroup:Null<FlxGroup>;
+  var textGroup:Null<FlxGroup>;
+  var ngSpr:FlxSprite = new FlxSprite(0, FlxG.height * 0.52);
 
   var curWacky:Array<String> = [];
   var lastBeat:Int = 0;
-  var swagShader:ColorSwap;
+  var swagShader:ColorSwap = new ColorSwap();
 
   override public function create():Void
   {
     super.create();
-    swagShader = new ColorSwap();
 
     curWacky = FlxG.random.getObject(getIntroTextShit());
     funkin.FunkinMemory.cacheSound(Paths.music('girlfriendsRingtone/girlfriendsRingtone'));
@@ -71,12 +71,12 @@ class TitleState extends MusicBeatState
       startIntro();
   }
 
-  var logoBl:FlxSprite;
-  var outlineShaderShit:TitleOutline;
+  var logoBl:Null<FlxSprite>;
+  var outlineShaderShit:Null<TitleOutline>;
 
-  var gfDance:FlxSpriteOverlay;
+  var gfDance:Null<FlxSpriteOverlay>;
   var danceLeft:Bool = false;
-  var titleText:FlxSprite;
+  var titleText:FlxSprite = new FlxSprite();
   var maskShader = new LeftMaskShader();
 
   function startIntro():Void
@@ -146,8 +146,6 @@ class TitleState extends MusicBeatState
       credGroup.add(blackScreen);
       credGroup.add(textGroup);
     }
-
-    ngSpr = new FlxSprite(0, FlxG.height * 0.52);
 
     if (FlxG.random.bool(1))
     {
@@ -282,7 +280,7 @@ class TitleState extends MusicBeatState
 
     if (gamepad != null)
     {
-      if (gamepad.justPressed.START || gamepad.justPressed.ACCEPT) pressedEnter = true;
+      if (gamepad.justPressed.START) pressedEnter = true;
     }
 
     // If you spam Enter, we should skip the transition.
@@ -294,7 +292,6 @@ class TitleState extends MusicBeatState
 
     if (pressedEnter && !transitioning && skippedIntro)
     {
-      if (FlxG.sound.music != null) FlxG.sound.music.onComplete = null;
       // netStream.play(Paths.file('music/kickstarterTrailer.mp4'));
       titleText.animation.play('press');
       FlxG.camera.flash(FlxColor.WHITE, 1);


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
No linked issues.
<!-- Briefly describe the issue(s) fixed. -->
## Description
This Pull Request adds Null Safety to the following classes in `funkin.ui.title`:
- TitleState.hx
- AttractState.hx
- FlxSpriteOverlay.hx

This Pull Request adds Null Safety to the following classes in `funkin.ui.freeplay`:
- DifficultyDot.hx

This Pull Request adds Null Safety to the following classes in `funkin.ui.story`:
- LevelTitle.hx

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos
<img width="316" height="41" alt="image" src="https://github.com/user-attachments/assets/dd99148f-3433-4381-8cc0-f56469013d12" />
<img width="325" height="41" alt="image" src="https://github.com/user-attachments/assets/6a702d8f-6833-43a7-857e-f5d7ff70f9b1" />
<img width="317" height="42" alt="image" src="https://github.com/user-attachments/assets/3b0e9ad9-5819-4280-aa70-5a723fc7842e" />
<img width="331" height="43" alt="image" src="https://github.com/user-attachments/assets/319b9de1-6444-447d-abd7-cc047dec6535" />
<img width="314" height="43" alt="image" src="https://github.com/user-attachments/assets/db80c9cb-dcc0-4aa4-9bb6-fef061ad3a92" />