### PR TITLE
[BUGFIX] Fix spamming Reser and Accept keybinds causing a softlock

### DIFF
--- a/source/funkin/play/GameOverSubState.hx
+++ b/source/funkin/play/GameOverSubState.hx
@@ -440,7 +440,7 @@ class GameOverSubState extends MusicBeatSubState
             #else
             resetPlaying();
             #end
-          });
+          }, true);
         }
       });
     }


### PR DESCRIPTION
## Linked Issues
Closes https://github.com/FunkinCrew/Funkin/issues/4417
Closes https://github.com/FunkinCrew/Funkin/issues/5705

## Description
After every confirm on gameover, a little fade tween is done for two seconds. However, by spamming R and Enter, you could enter the confirming phase of the game over while the tween is still classified as active. Due to the fact that the process of moving you back to playstate is tied to this tween and that you couldn't activate it more than once simultaneously, you'd be stuck here till the heat death of the universe. The only character spared from this was bf-pixel, as his camera tween stuff uses a different system.
This PR makes the fade forcefully happen.

## Screenshots/Videos

https://github.com/user-attachments/assets/e8cfc2cb-0163-453c-bec7-4e46d3f7e876
