### PR TITLE
[BUGFIX] Fix exiting to Main Menu while callibrating/testing Offsets causing a softlock

### DIFF
--- a/source/funkin/ui/options/OffsetMenu.hx
+++ b/source/funkin/ui/options/OffsetMenu.hx
@@ -975,4 +975,10 @@ class OffsetMenu extends Page<OptionsState.OptionsMenuPageName>
     preferenceItems.add(item.lefthandText);
     return item;
   }
+
+  override public function destroy()
+  {
+    MenuTypedList.pauseInput = false;
+    super.destroy();
+  }
 }


### PR DESCRIPTION
## Linked Issues
Fixes https://github.com/FunkinCrew/Funkin/issues/5712

## Description
Adds an override for the `destroy` function in `OffsetMenu`, which then sets `MenuTypedList.pauseInput` to ~~kralse~~ false. Considering this is a static variable, you'd get softlocked even by hot-reloading.

## Screenshots/Videos

https://github.com/user-attachments/assets/e6d972f1-3f89-427a-ba60-30a38cc9da02
