### PR TITLE
[OPTIMIZATION] Small Freeplay rendering optimizations

### DIFF
--- a/source/funkin/ui/freeplay/BGScrollingText.hx
+++ b/source/funkin/ui/freeplay/BGScrollingText.hx
@@ -4,70 +4,80 @@ import flixel.FlxObject;
 import flixel.group.FlxSpriteGroup;
 import flixel.text.FlxText;
 import flixel.util.FlxSort;
+import flixel.FlxSprite;
+import flixel.util.FlxDestroyUtil;
+import flixel.util.FlxColor;
 
 // its kinda like marqeee html lol!
 @:nullSafety
 class BGScrollingText extends FlxSpriteGroup
 {
-  var grpTexts:FlxTypedSpriteGroup<FlxText>;
+  var grpTexts:FlxTypedSpriteGroup<FlxSprite>;
+  var sourceText:FlxText;
 
   public var widthShit:Float = FlxG.width;
   public var placementOffset:Float = 20;
   public var speed:Float = 1;
   public var size(default, set):Int = 48;
 
-  public var funnyColor(default, set):Int = 0xFFFFFFFF;
+  public var funnyColor(default, set):FlxColor = 0xFFFFFFFF;
 
   public function new(x:Float, y:Float, text:String, widthShit:Float = 100, ?bold:Bool = false, ?size:Int = 48)
   {
     super(x, y);
 
-    grpTexts = new FlxTypedSpriteGroup<FlxText>();
-    add(grpTexts);
+    grpTexts = new FlxTypedSpriteGroup<FlxSprite>();
 
     this.widthShit = widthShit;
-    if (size != null) this.size = size;
 
-    var testText:FlxText = new FlxText(0, 0, 0, text, this.size);
-    testText.font = "5by7";
-    testText.bold = bold ?? false;
-    testText.updateHitbox();
-    grpTexts.add(testText);
+    // Only keep one FlxText graphic at a time for batching
+    sourceText = new FlxText(0, 0, 0, text, size ?? this.size);
+    sourceText.font = "5by7";
+    sourceText.bold = bold ?? false;
 
-    var needed:Int = Math.ceil(widthShit / testText.frameWidth) + 1;
+    @:privateAccess
+    sourceText.regenGraphic();
+
+    var needed:Int = Math.ceil(widthShit / sourceText.frameWidth) + 1;
 
     for (i in 0...needed)
     {
-      var lmfao:Int = i + 1;
-
-      var coolText:FlxText = new FlxText((lmfao * testText.frameWidth) + (lmfao * 20), 0, 0, text, this.size);
-
-      coolText.font = "5by7";
-      coolText.bold = bold ?? false;
-      coolText.updateHitbox();
+      var coolText = new FlxSprite((i * sourceText.frameWidth) + (i * 20), 0);
       grpTexts.add(coolText);
+    }
+
+    if (size != null) this.size = size;
+
+    add(grpTexts);
+  }
+
+  function reloadGraphics()
+  {
+    if (grpTexts != null)
+    {
+      @:privateAccess
+      sourceText.regenGraphic();
+      grpTexts.forEach(function(txt:FlxSprite) {
+        txt.loadGraphic(sourceText.graphic);
+        txt.updateHitbox();
+      });
     }
   }
 
   function set_size(value:Int):Int
   {
-    if (grpTexts != null)
-    {
-      grpTexts.forEach(function(txt:FlxText) {
-        txt.size = value;
-      });
-    }
+    sourceText.size = value;
+    reloadGraphics();
     this.size = value;
     return value;
   }
 
-  function set_funnyColor(col:Int):Int
+  function set_funnyColor(value:FlxColor):FlxColor
   {
-    grpTexts.forEach(function(txt) {
-      txt.color = col;
-    });
-
-    return col;
+    sourceText.color = value;
+    reloadGraphics();
+    this.funnyColor = value;
+    return value;
   }
 
   override public function update(elapsed:Float)
@@ -105,5 +115,11 @@ class BGScrollingText extends FlxSpriteGroup
     grpTexts.sort(function(Order:Int, Obj1:FlxObject, Obj2:FlxObject) {
       return FlxSort.byValues(Order, Obj1.x, Obj2.x);
     });
+  }
+
+  override function destroy():Void
+  {
+    super.destroy();
+    sourceText = FlxDestroyUtil.destroy(sourceText);
   }
 }

--- a/source/funkin/ui/freeplay/FreeplayState.hx
+++ b/source/funkin/ui/freeplay/FreeplayState.hx
@@ -503,7 +503,7 @@ class FreeplayState extends MusicBeatSubState
 
     if (fromCharSelect)
     {
-      blackOverlayBullshitLOLXD.x = backingImage.x;
+      blackOverlayBullshitLOLXD.visible = false;
       overhangStuff.y = -100;
       backingCard.skipIntroTween();
     }
@@ -703,6 +703,9 @@ class FreeplayState extends MusicBeatSubState
             ease: FlxEase.expoOut,
             onUpdate: function(_) {
               angleMaskShader.extraColor = backingImage.color;
+            },
+            onComplete: function(_) {
+              blackOverlayBullshitLOLXD.visible = false;
             }
           });
       }


### PR DESCRIPTION
<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues

<!-- Briefly describe the issue(s) fixed. -->
## Description
I've been testing around with Nvidia Nsight to have more clear rendering debugging and found some issues that affect FreeplayState both in loading and performance. The main problem I noticed was with ``BGScrollingText``, since by creating multiple FlxText instances it also created seperate bitmaps and draw calls for each object with no batching.

I fixed this by making only one instance of text and making the rest of the sprites just copy the graphic of the main text sprite.
Also fixed the black overlay from the freeplay intro never getting set invisible, which saves some performance both with running the shader and rendering it's bitmap.

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos
Here's a small sample of the draw calls produced by ``BGScrollingText`` before and after this change.

| Before | After |
|--------|-------|
| <video src="https://github.com/user-attachments/assets/db592d0d-35ca-409e-bc42-ca12110371d1" width="320" height="240" controls></video> | <video src="https://github.com/user-attachments/assets/eef386cf-47c2-44de-88e8-1c037ff22f95" width="320" height="240" controls></video> |