### PR TITLE
[OPTIMIZATION] Properly recycle note sprites

### DIFF
--- a/source/funkin/play/notes/Strumline.hx
+++ b/source/funkin/play/notes/Strumline.hx
@@ -946,7 +946,6 @@ class Strumline extends FlxSpriteGroup
   {
     if (note == null) return;
     note.visible = false;
-    notes.remove(note, false);
     note.kill();
 
     if (note.holdNoteSprite != null)
@@ -1120,6 +1119,7 @@ class Strumline extends FlxSpriteGroup
 
       noteSprite.direction = note.getDirection();
       noteSprite.noteData = note;
+      noteSprite.holdNoteSprite = null;
 
       noteSprite.x = this.x;
       noteSprite.x += getXPos(DIRECTIONS[note.getDirection() % KEY_COUNT]);


### PR DESCRIPTION
## Linked Issues
Closes https://github.com/FunkinCrew/Funkin/issues/5726

## Description
Upon setting the data for the new notes, the `holdNoteSprite` variable of a noteSprite was never reset. This PR resets the value to null, as it still remains in the game and is cleared later by the `holdNotes` group.

## Screenshots/Videos

https://github.com/user-attachments/assets/bbb83246-708b-40b3-8ffd-a0f17b717ba3
