### PR TITLE
[DOCUMENTATION/CHORE] Fix typo in NoteStyleData

### DIFF
--- a/source/funkin/data/notestyle/NoteStyleData.hx
+++ b/source/funkin/data/notestyle/NoteStyleData.hx
@@ -165,7 +165,7 @@ typedef NoteStyleAssetData<T> =
   var assetPath:String;
 
   /**
-   * The scale to render the prop at.
+   * The scale to render the note at.
    * @default 1.0
    */
   @:default(1.0)
@@ -181,7 +181,7 @@ typedef NoteStyleAssetData<T> =
   var offsets:Null<Array<Float>>;
 
   /**
-   * If true, the prop is a pixel sprite, and will be rendered without anti-aliasing.
+   * If true, the note is a pixel sprite, and will be rendered without anti-aliasing.
    */
   @:default(false)
   @:optional


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Briefly describe the issue(s) fixed. -->
## Description
* Fixes notes being called props in `NoteStyleData.hx`.

*P.S. I realized while making this PR that I myself made a typo in the branch name. It's so over.*