### PR TITLE
[FIX] Fix random double notes in Lag Adjustment test menu

### DIFF
--- a/source/funkin/ui/options/OffsetMenu.hx
+++ b/source/funkin/ui/options/OffsetMenu.hx
@@ -736,12 +736,6 @@ class OffsetMenu extends Page<OptionsState.OptionsMenuPageName>
         var data:SongNoteData = new SongNoteData(arrowBeat * msPerBeat, _lastDirection, 0, null, null);
         testStrumline.addNoteData(data, false);
 
-        if (Math.floor(arrowBeat % 8) == 0)
-        {
-          var data:SongNoteData = new SongNoteData(arrowBeat * msPerBeat, 2, 0, null, null);
-          testStrumline.addNoteData(data, false);
-        }
-
         _lastDirection = (_lastDirection + 1) % 4; // Cycle through directions 0-3
       }
       if (b >= 124 && _lastDirection != 0) _lastDirection = 0; // reset direction on loop


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
https://github.com/FunkinCrew/Funkin/issues/5741
<!-- Briefly describe the issue(s) fixed. -->
## Description
* Before this PR, for some reason there was left out code that was adding note data for UP direction for no apparent reason. Either it was for testing and forgot to be removed, or it was just a strange decision, who knows?
