### PR TITLE
[OPTIMIZATION?] Prevent script classes from being registered twice after hot-reloading

### DIFF
--- a/source/funkin/modding/PolymodHandler.hx
+++ b/source/funkin/modding/PolymodHandler.hx
@@ -557,11 +557,9 @@ class PolymodHandler
     Polymod.clearScripts();
 
     // Forcibly reload Polymod so it finds any new files.
+    // This will also register all scripts.
     // TODO: Replace this with loadEnabledMods().
     funkin.modding.PolymodHandler.loadAllMods();
-
-    // Reload scripted classes so stages and modules will update.
-    Polymod.registerAllScriptClasses();
 
     // Reload everything that is cached.
     // Currently this freezes the game for a second but I guess that's tolerable?


### PR DESCRIPTION
## Linked Issues
N/A

## Description
Hot-reloading causes the function `forceReloadAssets` of `PolymodHandler` to be called, which loads back all mods and their script classes. This PR removes the line to register scripted classes.
On the surface, this change seems preposterous. However, reloading mods triggers the function `Polymod.init();` which already contains the line that is deleted in this PR. This means that this PR mitigates this monstrocity from occuring upon hot-reloading:
<img width="1890" height="848" alt="image" src="https://github.com/user-attachments/assets/27b350b4-55d9-4020-9605-a5841f49991c" />

