### PR TITLE
[BUGFIX] Fix missing notes not working

### DIFF
--- a/source/funkin/play/notes/NoteSprite.hx
+++ b/source/funkin/play/notes/NoteSprite.hx
@@ -256,6 +256,7 @@ class NoteSprite extends FunkinSprite
     this.hasBeenHit = false;
     this.mayHit = false;
     this.hasMissed = false;
+    this.handledMiss = false;
     this.holdNoteSprite = null;
 
     this.hsvShader.hue = 1.0;


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues

<!-- Briefly describe the issue(s) fixed. -->
## Description
The issue is that this line in `PlayState` checks for two variables.
https://github.com/FunkinCrew/Funkin/blob/8cba81d2078477f17f915109a525dad3179c99ef/source/funkin/play/PlayState.hx#L2648

But when a note is revived it only resets one of those variables, which means it will never process its miss logic. This didn't use to be an issue before because notes were always created from scratch, but now that the notes are properly recycled this issue has been unveiled.

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos
![](https://media1.tenor.com/m/-YZhgoKexcwAAAAd/npesta-sped-up.gif)