### PR TITLE
[OPTIMIZATION] Improve note batching

### DIFF
--- a/source/funkin/play/notes/NoteSprite.hx
+++ b/source/funkin/play/notes/NoteSprite.hx
@@ -167,8 +167,6 @@ class NoteSprite extends FunkinSprite
   {
     noteStyle.buildNoteSprite(this);
 
-    this.shader = hsvShader;
-
     // `false` disables the update() function for performance.
     this.active = noteStyle.isNoteAnimated();
   }
@@ -221,11 +219,13 @@ class NoteSprite extends FunkinSprite
   public function desaturate():Void
   {
     this.hsvShader.saturation = 0.2;
+    this.shader = this.hsvShader;
   }
 
   public function setHue(hue:Float):Void
   {
     this.hsvShader.hue = hue;
+    this.shader = (hue != 1.0) ? this.hsvShader : null;
   }
 
   public override function revive():Void
@@ -239,6 +239,9 @@ class NoteSprite extends FunkinSprite
     this.mayHit = false;
     this.hasMissed = false;
 
+    // The hsvShader should only be applied when it's necessary.
+    // Otherwise, it should be turned off to keep note batching.
+    this.shader = null;
     this.hsvShader.hue = 1.0;
     this.hsvShader.saturation = 1.0;
     this.hsvShader.value = 1.0;

--- a/source/funkin/play/notes/NoteSprite.hx
+++ b/source/funkin/play/notes/NoteSprite.hx
@@ -225,7 +225,7 @@ class NoteSprite extends FunkinSprite
   public function setHue(hue:Float):Void
   {
     this.hsvShader.hue = hue;
-    this.shader = (hue != 1.0) ? this.hsvShader : null;
+    if (hue != 1.0) this.shader = this.hsvShader;
   }
 
   public override function revive():Void


### PR DESCRIPTION
<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues

<!-- Briefly describe the issue(s) fixed. -->
## Description
Flixel batches quads when they all share the same rendering values (color, antialiasing, shader, etc). The problem with this is that, with each note having it's own hsv shader instance, batching is unavailable. Which can be pretty harmful for performance in instances with many notes on screen. To fix this I made it so the shader is disabled by default and only applied when neccesary (miss desaturation or hue changes).

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos
Here's the difference in draw calls needed checked through Nvidia Nsight.
| Before  | After |
| ------------- | ------------- |
| <video src="https://github.com/user-attachments/assets/fddddd8b-2d3d-4d28-857a-503b6b51b709" width="320" height="240" controls></video> | <video src="https://github.com/user-attachments/assets/4636800e-b052-4873-8bdd-cc2ac2cd0907" width="320" height="240" controls></video> |



