### PR TITLE
[BUGFIX] Fix the offsets causing choppy note behaviour

### DIFF
--- a/source/funkin/play/PlayState.hx
+++ b/source/funkin/play/PlayState.hx
@@ -1082,7 +1082,7 @@ class PlayState extends MusicBeatSubState
       // And it was frame dependant which we don't like!!
       if (FlxG.sound.music.playing)
       {
-        final audioDiff:Float = Math.round(Math.abs(Conductor.instance.songPosition - FlxG.sound.music.time));
+        final audioDiff:Float = Math.round(Math.abs(FlxG.sound.music.time - (Conductor.instance.songPosition - Conductor.instance.combinedOffset)));
         if (audioDiff <= RESYNC_THRESHOLD)
         {
           // Only do neat & smooth lerps as long as the lerp doesn't fuck up and go WAY behind the music time triggering false resyncs


### PR DESCRIPTION
## Linked Issues
N/A

## Description
Damn you Karim you forgot to account for offsets grrrrrrrrrrrrrrrrrrrr
This PR updates the audioDiff check to match the one from `beatHit`, you know, the one that's responsible for `resyncVocals`. Yeah that one.

## Screenshots/Videos
<img width="782" height="121" alt="image" src="https://github.com/user-attachments/assets/bdba3b8f-3d4f-4dd4-b77c-38af5aadacbe" />
