### PR TITLE
[CHORE] Fix Typo In MusicBeatState

### DIFF
--- a/source/funkin/ui/MusicBeatState.hx
+++ b/source/funkin/ui/MusicBeatState.hx
@@ -189,7 +189,7 @@ class MusicBeatState extends FlxTransitionableState implements IEventHandler
   {
     // Both have an xPos of 0, but a width equal to the full screen.
     // The rightWatermarkText is right aligned, which puts the text in the correct spot.
-    // Their xPos is only changed when there's a notch on the device so it doesn't get covered byt it.
+    // Their xPos is only changed when there's a notch on the device so it doesn't get covered by it.
     leftWatermarkText = new FlxText(funkin.ui.FullScreenScaleMode.gameNotchSize.x, FlxG.height - 18, FlxG.width, '', 12);
     rightWatermarkText = new FlxText(-(funkin.ui.FullScreenScaleMode.gameNotchSize.x), FlxG.height - 18, FlxG.width, '', 12);
 


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues

<!-- Briefly describe the issue(s) fixed. -->
## Description

Changes the documentation in `MusicBeatState.hx` as there was a typo in it. The word "byt" has now been changed to "by"

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos
<img width="516" height="31" alt="image" src="https://github.com/user-attachments/assets/50dd838d-5fb2-46fb-890b-9084db79366f" />

