### PR TITLE
[BUGFIX] Fix New Rank being bigger than original ones

### DIFF
--- a/source/funkin/ui/freeplay/FreeplayState.hx
+++ b/source/funkin/ui/freeplay/FreeplayState.hx
@@ -1098,7 +1098,7 @@ class FreeplayState extends MusicBeatSubState
       capsuleToRank.ranking.playAnimationEach(fromResults.newRank.getFreeplayRankIconAsset(), true);
     }
 
-    FlxTween.tween(capsuleToRank.ranking, {"scale.x": 1, "scale.y": 1}, 0.1);
+    FlxTween.tween(capsuleToRank.ranking, {"scale.x": 0.9, "scale.y": 0.9}, 0.1);
 
     new FlxTimer().start(0.1, _ -> {
       capsuleToRank.ranking.visible = true;
@@ -3117,7 +3117,7 @@ class FreeplaySongData
   {
     return Save.instance.isSongFavorited(idAndVariation);
   }
-  
+
   public function isDifficultyNew(difficulty:String):Bool
   {
     // grabs a specific difficulty's new status. used for the difficulty dots.


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Briefly describe the issue(s) fixed. -->
## Description
* Before this PR, whenever you got a new rank on a specific song, the new rank would be a bit bigger than the ones that were already there. The problem was that in the original code each rank have a scale of `0.9`, but the new ranks got a scale of `1`. Now this is fixed.

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos

<div align='center'>
<table>
  <tr>
    <th>BEFORE (look at bopeebo rank)</th>
    <th>AFTER</th>
  </tr>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/dc0268ce-c07e-4784-b434-beef2cac3a39" alt="BEFORE" width="1000"/></td>
    <td><video src="https://github.com/user-attachments/assets/248d0fe5-7d21-488d-bcc7-ddd77cff8aaa" alt="AFTER" width="250"/></td>
  </tr>
</table>
</div>