### PR TITLE
[BUGFIX] Fix the softlock caused by "Fix Playtesting While `Are you sure?` dialog is open"

### DIFF
--- a/source/funkin/ui/debug/charting/ChartEditorState.hx
+++ b/source/funkin/ui/debug/charting/ChartEditorState.hx
@@ -95,9 +95,6 @@ import haxe.ui.components.Button;
 import haxe.ui.components.DropDown;
 import haxe.ui.components.Label;
 import haxe.ui.components.Slider;
-import haxe.ui.containers.dialogs.Dialogs;
-import haxe.ui.containers.dialogs.Dialog.DialogButton;
-import haxe.ui.containers.dialogs.MessageBox.MessageBoxType;
 import haxe.ui.containers.dialogs.CollapsibleDialog;
 import haxe.ui.containers.menus.Menu;
 import haxe.ui.containers.menus.MenuBar;
@@ -5675,19 +5672,8 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
   {
     if (saveDataDirty)
     {
-      this.isHaxeUIDialogOpen = true;
-      var dialog = Dialogs.messageBox("You are about to leave the editor without saving.\n\nAre you sure?", "Leave Editor", MessageBoxType.TYPE_YESNO, true,
-        function(button:DialogButton) {
-          if (button == DialogButton.YES)
-          {
-            autoSave();
-            quitChartEditor();
-          }
-        });
-
+      this.openLeaveConfirmationDialog();
       return;
-
-      dialog.onDialogClosed = (_) -> this.isHaxeUIDialogOpen = false;
     }
 
     stopWelcomeMusic();

--- a/source/funkin/ui/debug/charting/handlers/ChartEditorDialogHandler.hx
+++ b/source/funkin/ui/debug/charting/handlers/ChartEditorDialogHandler.hx
@@ -32,6 +32,7 @@ import haxe.ui.containers.Box;
 import haxe.ui.containers.dialogs.Dialog;
 import haxe.ui.containers.dialogs.Dialog.DialogButton;
 import haxe.ui.containers.dialogs.Dialogs;
+import haxe.ui.containers.dialogs.MessageBox.MessageBoxType;
 import haxe.ui.containers.Form;
 import haxe.ui.containers.menus.Menu;
 import haxe.ui.core.Component;
@@ -1311,6 +1312,37 @@ class ChartEditorDialogHandler
 
       dialog.hideDialog(DialogButton.APPLY);
     }
+
+    return dialog;
+  }
+
+  /**
+   * Builds and opens a dialog where the user can confirm to leave the chart editor if they have unsaved changes.
+   * @param state The current chart editor state.
+   * @return The dialog that was opened.
+   */
+  public static function openLeaveConfirmationDialog(state:ChartEditorState):Dialog
+  {
+    var dialog:Null<Dialog> = Dialogs.messageBox("You are about to leave the editor without saving.\n\nAre you sure?", "Leave Editor", MessageBoxType.TYPE_YESNO, true,
+      function(button:DialogButton)
+      {
+        state.isHaxeUIDialogOpen = false;
+        if (button == DialogButton.YES)
+        {
+          state.autoSave();
+          state.quitChartEditor();
+        }
+      }
+    );
+
+    dialog.destroyOnClose = true;
+    state.isHaxeUIDialogOpen = true;
+
+    dialog.onDialogClosed = function(event:UIEvent) {
+      state.isHaxeUIDialogOpen = false;
+    };
+
+    dialog.zIndex = 1000;
 
     return dialog;
   }


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Briefly describe the issue(s) fixed. -->
## Description
* My dumbass forgot to add `this.isHaxeUIDialogOpen = false;` when the user promptly decides NOT to leave the chart editor. Also for some reason I was making the dialog in the `ChartEditorState` class itself instead of the appropriate `ChartEditorDialogHandler` class. Both of these issues are thankfully gone now.
<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos

https://github.com/user-attachments/assets/5e7bb484-a967-428a-aeea-215c03239977

