### PR TITLE
[BUGFIX] Fix PureColor shader antialiasing

### DIFF
--- a/source/funkin/graphics/shaders/PureColor.hx
+++ b/source/funkin/graphics/shaders/PureColor.hx
@@ -17,7 +17,7 @@ class PureColor extends FlxShader
 
   function set_col(val:FlxColor):FlxColor
   {
-    funnyColor.value = [val.red, val.green, val.blue, val.alpha];
+    funnyColor.value = [val.redFloat, val.greenFloat, val.blueFloat, val.alphaFloat];
 
     return val;
   }
@@ -33,7 +33,7 @@ class PureColor extends FlxShader
             vec4 color = flixel_texture2D(bitmap, openfl_TextureCoordv);
 
             if (color.a > 0.0 && colSet)
-                color = vec4(funnyColor.r, funnyColor.g, funnyColor.b, color.a);
+                color = funnyColor * color.a;
 
             gl_FragColor = color;
         }


### PR DESCRIPTION
<!-- Briefly describe the issue(s) fixed. -->
## Description
Pretty basic fix, a incorrect value for the color was being added. Tested to work correctly both on web and desktop.
As a side note for the future, I believe in some instances where this shader is used, it should be replaced with color transform.

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos
| Before | After |
| ------------- | ------------- |
| <img width="647" height="281" alt="image" src="https://github.com/user-attachments/assets/d83540ff-381b-4e7a-9e32-2955109f0dc3" /> | <img width="626" height="268" alt="image" src="https://github.com/user-attachments/assets/8523c1fc-3133-4722-8f9b-119505bd4156" /> |