### PR TITLE
[ENHANCEMENT] Add Song Fade In Transition

### DIFF
--- a/source/funkin/modding/IScriptedClass.hx
+++ b/source/funkin/modding/IScriptedClass.hx
@@ -151,6 +151,11 @@ interface IPlayStateScriptedClass extends INoteScriptedClass extends IBPMSyncedS
   public function onSongRetry(event:SongRetryEvent):Void;
 
   /**
+   * Called when the song's fade in transition starts.
+   */
+  public function onSongFadeIn(event:ScriptEvent):Void;
+
+  /**
    * Called when the player presses a key when no note is on the strumline.
    */
   public function onNoteGhostMiss(event:GhostMissNoteScriptEvent):Void;

--- a/source/funkin/modding/events/ScriptEventDispatcher.hx
+++ b/source/funkin/modding/events/ScriptEventDispatcher.hx
@@ -142,6 +142,9 @@ class ScriptEventDispatcher
         case SONG_EVENT:
           t.onSongEvent(cast event);
           return;
+        case SONG_FADE_IN:
+          t.onSongFadeIn(cast event);
+          return;
         case COUNTDOWN_START:
           t.onCountdownStart(cast event);
           return;

--- a/source/funkin/modding/events/ScriptEventType.hx
+++ b/source/funkin/modding/events/ScriptEventType.hx
@@ -51,6 +51,14 @@ enum abstract ScriptEventType(String) from String to String
   var RESUME = 'RESUME';
 
   /**
+   * Called when a song fade in transition starts.
+   *
+   * This event IS cancelable! Canceling the event will skip the fade in
+   * transition from occurring.
+   */
+  var SONG_FADE_IN = 'SONG_FADE_IN';
+
+  /**
    * Called once per step in the song. This happens 4 times per measure.
    *
    * This event is not cancelable.

--- a/source/funkin/modding/module/Module.hx
+++ b/source/funkin/modding/module/Module.hx
@@ -234,4 +234,9 @@ class Module implements IPlayStateScriptedClass implements IStateChangingScripte
    * Called when the song has been restarted.
    */
   public function onSongRetry(event:SongRetryEvent) {}
+
+  /**
+   * Called when the song's fade in transition starts.
+   */
+  public function onSongFadeIn(event:ScriptEvent) {}
 }

--- a/source/funkin/play/PlayState.hx
+++ b/source/funkin/play/PlayState.hx
@@ -896,6 +896,9 @@ class PlayState extends MusicBeatSubState
     // This step ensures z-indexes are applied properly,
     // and it's important to call it last so all elements get affected.
     refresh();
+
+    // Fades the camera in
+    startCameraFadeIn();
   }
 
   public function togglePauseButton(visible:Bool = false):Void
@@ -1849,6 +1852,28 @@ class PlayState extends MusicBeatSubState
       previousCameraFollowPoint = null;
     }
     add(cameraFollowPoint);
+  }
+
+  /**
+     * Fades the camera in to give a nice transition.
+     */
+  function startCameraFadeIn():Void
+  {
+    var event = new ScriptEvent(SONG_FADE_IN, true);
+    dispatchEvent(event);
+
+    // Winter Horrorland's cutscene is hard coded so this has to be done
+    if ((currentSong.id ?? '').toLowerCase() == 'winter-horrorland')
+    {
+      event.cancel();
+    }
+
+    if (event.eventCanceled) return;
+
+    if (!isMinimalMode && !isChartingMode && (!PlayStatePlaylist.isStoryMode || PlayStatePlaylist.isFirstSongInCampaign))
+    {
+      FlxG.camera.fade(FlxColor.BLACK, 1, true);
+    }
   }
 
   /**
@@ -3337,6 +3362,7 @@ class PlayState extends MusicBeatSubState
       isNewHighscore = false;
 
       PlayStatePlaylist.campaignScore += songScore;
+      PlayStatePlaylist.isFirstSongInCampaign = false;
 
       // Pop the next song ID from the list.
       // Returns null if the list is empty.

--- a/source/funkin/play/PlayStatePlaylist.hx
+++ b/source/funkin/play/PlayStatePlaylist.hx
@@ -14,6 +14,11 @@ class PlayStatePlaylist
   public static var isStoryMode:Bool = false;
 
   /**
+   * Whether the game is currently in the first song of the campaign.
+   */
+  public static var isFirstSongInCampaign:Bool = true;
+
+  /**
    * The loist of upcoming songs to be played.
    * When the user completes a song in Story Mode, the first entry in this list is played.
    * When this list is empty, move to the Results screen instead.

--- a/source/funkin/play/song/Song.hx
+++ b/source/funkin/play/song/Song.hx
@@ -636,6 +636,8 @@ class Song implements IPlayStateScriptedClass implements IRegistryEntry<SongMeta
 
   public function onSongRetry(event:SongRetryEvent):Void {};
 
+  public function onSongFadeIn(event:ScriptEvent):Void {};
+
   public function onNoteIncoming(event:NoteScriptEvent) {};
 
   public function onNoteHit(event:HitNoteScriptEvent) {};

--- a/source/funkin/play/stage/Bopper.hx
+++ b/source/funkin/play/stage/Bopper.hx
@@ -388,4 +388,6 @@ class Bopper extends StageProp implements IPlayStateScriptedClass
   public function onSongLoaded(event:SongLoadScriptEvent) {}
 
   public function onSongRetry(event:SongRetryEvent) {}
+
+  public function onSongFadeIn(event:ScriptEvent) {}
 }

--- a/source/funkin/play/stage/Stage.hx
+++ b/source/funkin/play/stage/Stage.hx
@@ -896,4 +896,6 @@ class Stage extends FlxSpriteGroup implements IPlayStateScriptedClass implements
   public function onSongLoaded(event:SongLoadScriptEvent) {}
 
   public function onSongRetry(event:SongRetryEvent) {}
+
+  public function onSongFadeIn(event:ScriptEvent) {}
 }

--- a/source/funkin/ui/story/StoryMenuState.hx
+++ b/source/funkin/ui/story/StoryMenuState.hx
@@ -362,7 +362,7 @@ class StoryMenuState extends MusicBeatState
           changeLevel(-levelList.length);
           changeDifficulty(0);
         }
-        
+
         #if !html5
         if (FlxG.mouse.wheel != 0)
         {
@@ -598,6 +598,7 @@ class StoryMenuState extends MusicBeatState
 
     PlayStatePlaylist.playlistSongIds = currentLevel.getSongs();
     PlayStatePlaylist.isStoryMode = true;
+    PlayStatePlaylist.isFirstSongInCampaign = true;
     PlayStatePlaylist.campaignScore = 0;
 
     var targetSongId:String = PlayStatePlaylist.playlistSongIds.shift();


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
Implements #5779

<!-- Briefly describe the issue(s) fixed. -->
## Description
This pr adds a fade in for whenever a song starts. The fade in will only occur either if you are playing a song from freeplay, or if you are playing the first song in a level. The fade in does not run if you are playing the song in charting mode (or if you're minimal mode) A new cancelable script event was also added called ``onSongFadeIn()`` due to some songs having cutscenes or if any modded songs have unique transitions. Below is a list of songs that do not have the fade in.

- Senpai (Storymode or Pico)
- Roses (Storymode or Pico)
- Thorns (Storymode)
- Ugh (Storymode)
- Guns (Storymode)
- Stress (Storymode or Pico)
- Darnell (Storymode)
- Winter Horrorland

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos

https://github.com/user-attachments/assets/3b466207-5be4-479b-96d8-2cd0f3560a36

