### PR TITLE
[feat/flixel-animate] Apply some lossless quality settings

### DIFF
--- a/source/funkin/graphics/adobeanimate/FlxAtlasSprite.hx
+++ b/source/funkin/graphics/adobeanimate/FlxAtlasSprite.hx
@@ -97,7 +97,7 @@ class FlxAtlasSprite extends FlxAnimate
       {
         swfMode: settings?.swfMode ?? false,
         cacheOnLoad: settings?.cacheOnLoad ?? false,
-        filterQuality: settings?.filterQuality ?? HIGH,
+        filterQuality: settings?.filterQuality ?? MEDIUM,
         spritemaps: settings?.spritemaps ?? null,
         metadataJson: settings?.metadataJson ?? null,
         cacheKey: settings?.cacheKey ?? null,

--- a/source/funkin/ui/charSelect/CharSelectAtlasHandler.hx
+++ b/source/funkin/ui/charSelect/CharSelectAtlasHandler.hx
@@ -18,7 +18,7 @@ class CharSelectAtlasHandler
     var result:FlxAnimateFrames = FlxAnimateFrames.fromAnimate(path,
       {
         swfMode: settings?.swfMode ?? true,
-        filterQuality: settings?.filterQuality ?? HIGH,
+        filterQuality: settings?.filterQuality ?? MEDIUM,
         cacheOnLoad: settings?.cacheOnLoad ?? false
       });
 

--- a/source/funkin/ui/charSelect/CharSelectSubState.hx
+++ b/source/funkin/ui/charSelect/CharSelectSubState.hx
@@ -135,7 +135,7 @@ class CharSelectSubState extends MusicBeatSubState
     }
 
     // Mr. Static also needs some caching...
-    CharSelectAtlasHandler.loadAtlas(Paths.animateAtlas('charSelect/lockedChill'));
+    CharSelectAtlasHandler.loadAtlas(Paths.animateAtlas('charSelect/lockedChill'), {filterQuality: LOW});
   }
 
   override public function create():Void

--- a/source/funkin/ui/freeplay/FreeplayDJ.hx
+++ b/source/funkin/ui/freeplay/FreeplayDJ.hx
@@ -42,7 +42,7 @@ class FreeplayDJ extends FlxAtlasSprite
     super(x, y, playableCharData?.getAtlasPath(),
       {
         swfMode: true,
-        filterQuality: HIGH
+        filterQuality: MEDIUM
       });
 
     onAnimationFrame.add(function(name, number) {


### PR DESCRIPTION
<!-- Briefly describe the issue(s) fixed. -->
## Description
I've noticed that in the new branch the quality setting ``HIGH`` has been stablished as the default quality setting. I believe it should be knocked down to ``MEDIUM``, as it is the recommended quality setting for flixel-animate. (Even ``LOW`` quality could be used in some instances, such as the Mr.Locked character, since their use of filters is pretty easy to optimize). This is because, specially on blur filters, some optimization techniques are added to use way smaller bitmaps without any obvious visual differences.

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos
Here's screenshots of some characters that use filters with these changes, and no visual quality loss.
NOTE: On these screenshots the blur strength may seem lower than before. This isnt because of the lower quality use. This is because flixel-animate applies blur filters closer to how theyre displayed in Flash (as FlxAnimate had overly blurred blur filters).
| MEDIUM | LOW | MEDIUM |
|---------|---------|---------|
| <img width="404" height="409" alt="Image 1" src="https://github.com/user-attachments/assets/3fbdb7cf-e04f-45bc-ac12-46b53aafd654" /> | <img width="295" height="411" alt="Image 2" src="https://github.com/user-attachments/assets/23950efa-0bc8-4192-a55c-ccf377acb526" /> | <img width="465" height="419" alt="Image 3" src="https://github.com/user-attachments/assets/914f7ae5-56da-4551-886d-56e8910d8403" /> |




