### PR TITLE
[BUGFIX] Fix the Animation Editor onion skin having horrid offsets

### DIFF
--- a/source/funkin/ui/debug/anim/DebugBoundingState.hx
+++ b/source/funkin/ui/debug/anim/DebugBoundingState.hx
@@ -549,6 +549,7 @@ class DebugBoundingState extends FlxState
     {
       onionSkinChar.loadGraphicFromSprite(swagChar);
       onionSkinChar.frame = swagChar.frame;
+      onionSkinChar.animation.stop();
       onionSkinChar.alpha = 0.6;
       onionSkinChar.flipX = swagChar.flipX;
       onionSkinChar.offset.x = swagChar.animOffsets[0];


### PR DESCRIPTION
## Linked Issues
Closes https://github.com/FunkinCrew/Funkin/issues/5802

## Description
The onion skin was actually just drawing the frame on top of itself with no accounting for offsets or anything. This PR switches the method to use `loadGraphicFromSprite` and do some offset calc which is marginally better because I say so.

## Screenshots/Videos
| Before (eww yucky gross) | After (swag mm yummy) |
|--------|--------|
| https://github.com/user-attachments/assets/cbfbf88c-adc2-4b90-8bc2-ff593b767110 | https://github.com/user-attachments/assets/8dc9bf4e-7256-42fd-9dd6-92e097bf8d27 |
