### PR TITLE
[feat/flixel-animate] Fix cached CharSelect atlases not being destroyed when pressing F4

### DIFF
--- a/source/funkin/ui/charSelect/CharSelectSubState.hx
+++ b/source/funkin/ui/charSelect/CharSelectSubState.hx
@@ -451,6 +451,12 @@ class CharSelectSubState extends MusicBeatSubState
     });
   }
 
+  override public function destroy():Void
+  {
+    CharSelectAtlasHandler.clearAtlasCache();
+    super.destroy();
+  }
+
   function checkNewChar():Void
   {
     if (nonLocks.length > 0) selectTimer.start(2, (_) -> {
@@ -711,7 +717,6 @@ class CharSelectSubState extends MusicBeatSubState
       {
         ease: FlxEase.backIn,
         onComplete: function(_) {
-          CharSelectAtlasHandler.clearAtlasCache();
           FlxG.switchState(() -> FreeplayState.build(
             {
               {


### PR DESCRIPTION
## Description
Turns out pressing F4 to eject yourself from the character select sub-state causes some unforeseen consequences when you decide to go back to it and switch characters.....