### PR TITLE
[BUGFIX] Fix regression of capsule rank disappearing when switching variations

### DIFF
--- a/source/funkin/ui/freeplay/FreeplayState.hx
+++ b/source/funkin/ui/freeplay/FreeplayState.hx
@@ -2360,7 +2360,7 @@ class FreeplayState extends MusicBeatSubState
       // Update the song capsules to reflect the new difficulty info.
       for (songCapsule in grpCapsules.members)
       {
-        if (songCapsule == null) continue;
+        if (songCapsule == null || !songCapsule.alive) continue;
 
         if (songCapsule.freeplayData != null)
         {


### PR DESCRIPTION
<!-- Briefly describe the issue(s) fixed. -->
## Description
Every time the capsules are refreshed on a difficulty change, even the killed ones are reinitialized. This causes their ranking's visibility to be changed, but since the capsule is dead the ranking's child sprites do not update accordingly, which means the next time that capsule is revived and the ranking is updated Flixel will think the sprites already have the intended visibility state and won't update them, leading to the invisible rank. Now it'll only initialize alive capsules.

No idea why it only seems to affect Ugh in my case (and Darnell in my first attempt to reproduce the issue) but if I were to guess it's probably because of the order they're loaded.

## Screenshots/Videos
<img width="250" height="250" alt="We were good once but I fucked up now..." src="https://github.com/user-attachments/assets/ca6f98ef-41aa-4ec7-8d03-e72190815ea6" />

[Gravar a tela_20250825_233013.webm](https://github.com/user-attachments/assets/c10a1fdb-d8f4-4c26-8c68-29e90b75d646)
