### PR TITLE
[BUGFIX] Fix Freeplay Rank Animation when switching songs

### DIFF
--- a/source/funkin/ui/freeplay/FreeplayState.hx
+++ b/source/funkin/ui/freeplay/FreeplayState.hx
@@ -2304,7 +2304,7 @@ class FreeplayState extends MusicBeatSubState
       intendedCompletion = Math.max(0, Scoring.tallyCompletion(songScore?.tallies));
       rememberedDifficulty = currentDifficulty;
       if (!capsuleAnim) generateSongList(currentFilter, false, true, true);
-      currentCapsule.refreshDisplay(!prepForNewRank);
+      if (change != 0) currentCapsule.refreshDisplay(!prepForNewRank);
     }
     else
     {
@@ -2808,7 +2808,7 @@ class FreeplayState extends MusicBeatSubState
     changeDiff();
     if (currentCapsule.freeplayData == null) currentCapsule.refreshDisplay();
     else
-      currentCapsule.refreshDisplay(!prepForNewRank);
+      currentCapsule.refreshDisplay(false);
 
     for (index => capsule in grpCapsules.members)
     {


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
Fixes https://github.com/FunkinCrew/Funkin/issues/4530

Redo of #4533
<!-- Briefly describe the issue(s) fixed. -->
## Description
The rank animation in Freeplay plays whenever you switch songs. To fix this I made the call to `refreshDisplay` in `changeSelection` always pass in a value of `false` over the default `true`.

I also changed the `changeDiff` function to only refresh the capsule display if the current difficulty has changed. (This is different from my previous PR. I found that I could do this instead of adding a new parameter to the `changeDiff` function).
<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos

Before:

https://github.com/user-attachments/assets/643d740a-2d23-44bb-8acf-0da8e47ac303

After:

https://github.com/user-attachments/assets/fa39bda3-d969-4559-bd1a-6c7d04d6bfc3