### PR TITLE
[BUGFIX] Fix Freeplay Backing Card Beat Hit

### DIFF
--- a/source/funkin/ui/freeplay/FreeplayState.hx
+++ b/source/funkin/ui/freeplay/FreeplayState.hx
@@ -1571,6 +1571,8 @@ class FreeplayState extends MusicBeatSubState
   {
     super.update(elapsed);
 
+    Conductor.instance.update(FlxG.sound?.music?.time ?? 0.0);
+
     #if FEATURE_TOUCH_CONTROLS
     if (backButton != null && !backTransitioning)
     {
@@ -2906,7 +2908,6 @@ class FreeplayState extends MusicBeatSubState
       if (songDifficulty != null)
       {
         Conductor.instance.mapTimeChanges(songDifficulty.timeChanges);
-        Conductor.instance.update(FlxG.sound?.music?.time ?? 0.0);
       }
     }
   }


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
None

<!-- Briefly describe the issue(s) fixed. -->
## Description
The backing card has a beat hit function that pretty much never runs because of the freeplay menu not properly updating the conductor. This PR changes it so that the conductor actually updates instead of only firing once like how it is currently. Due to this change, the backing card's beat hit function actually runs.

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos

Before

https://github.com/user-attachments/assets/8b38cdb1-8638-4de1-a280-e910f5ea3916

After

https://github.com/user-attachments/assets/855fbab9-4cf3-4bb2-9c6b-0b3e4f4282e2

Boyfriend also has the cool backing card flash thing as well. It's just that I have Pico selected because I love him a lot.
