### PR TITLE
[flixel-animate] Legacy bounds fixes

### DIFF
--- a/hmm.json
+++ b/hmm.json
@@ -59,7 +59,7 @@
       "name": "flixel-animate",
       "type": "git",
       "dir": null,
-      "ref": "11af0ffdff33c0a9f4a44167d1b19aed61e87a05",
+      "ref": "6e1e2e48a27921be220c647f8cc49f2dcbf599ab",
       "url": "https://github.com/MaybeMaru/flixel-animate"
     },
     {

--- a/source/funkin/graphics/FunkinSprite.hx
+++ b/source/funkin/graphics/FunkinSprite.hx
@@ -110,16 +110,7 @@ class FunkinSprite extends FlxAnimate
    * Turning this on is not recommended, only use this if you know what you're doing.
    * It's also worth noting that not all atlases will react correctly, some may need position tweaks.
    */
-  public var legacyBoundsPosition(default, set):Bool = false;
-
-  public function set_legacyBoundsPosition(value:Bool):Bool
-  {
-    if (!this.isAnimate) return false;
-
-    this.legacyBoundsPosition = value;
-    this.applyStageMatrix = value;
-    return value;
-  }
+  public var legacyBoundsPosition:Bool = false;
 
   /**
    * @param x Starting X position
@@ -643,10 +634,19 @@ class FunkinSprite extends FlxAnimate
       _rect.height = _rect.height * this.scale.y;
     }
 
-    if (legacyBoundsPosition && this.isAnimate)
+    if (this.isAnimate)
     {
-      result.x += this.timeline.getBoundsOrigin(this.applyStageMatrix).x;
-      result.y += this.timeline.getBoundsOrigin(this.applyStageMatrix).y;
+      if (this.applyStageMatrix || legacyBoundsPosition)
+      {
+        result.add(this.library.matrix.tx, this.library.matrix.ty);
+      }
+
+      if (legacyBoundsPosition)
+      {
+        var point = this.timeline.getBoundsOrigin(FlxPoint.get(), true);
+        result.add(point.x, point.y);
+        point.put();
+      }
     }
 
     return result.subtract(camera.scroll.x * scrollFactor.x, camera.scroll.y * scrollFactor.y);


### PR DESCRIPTION
## Description
Ran into some issues regarding the implementation of these bounds but I believe they should be fully fixed now.
Changed a bit the behaviour too so if ``legacyBoundsPosition`` is turned on itll override the check for ``applyStageMatrix `` too, for accuracy.
This PR also bumps the version of flixel-animate as the method it used to list assets wasnt playing nice with polymod, but now it should be fully fixed and working both for base game and modded assets.
