### PR TITLE
`[feat/flixel-animate]` Nudge Character Select Objects to be consistent with pre-flixel-animate

### DIFF
--- a/source/funkin/ui/charSelect/CharSelectSubState.hx
+++ b/source/funkin/ui/charSelect/CharSelectSubState.hx
@@ -153,7 +153,7 @@ class CharSelectSubState extends MusicBeatSubState
     bg.scrollFactor.set(0.1, 0.1);
     add(bg);
 
-    var crowd:FunkinSprite = FunkinSprite.createTextureAtlas(cutoutSize, 0, "charSelect/crowd",
+    var crowd:FunkinSprite = FunkinSprite.createTextureAtlas(cutoutSize + -9, -5, "charSelect/crowd",
       {
         applyStageMatrix: true
       });
@@ -162,7 +162,7 @@ class CharSelectSubState extends MusicBeatSubState
     crowd.scrollFactor.set(0.3, 0.3);
     add(crowd);
 
-    var stageSpr:FunkinSprite = FunkinSprite.createTextureAtlas(cutoutSize + -2, 1, "charSelect/charSelectStage",
+    var stageSpr:FunkinSprite = FunkinSprite.createTextureAtlas(cutoutSize + -2, -27, "charSelect/charSelectStage",
       {
         applyStageMatrix: true
       });
@@ -186,8 +186,8 @@ class CharSelectSubState extends MusicBeatSubState
     barthing.scrollFactor.set(0, 0);
     add(barthing);
 
-    barthing.y += 80;
-    FlxTween.tween(barthing, {y: barthing.y - 80}, 1.3, {ease: FlxEase.expoOut});
+    barthing.y += 79;
+    FlxTween.tween(barthing, {y: barthing.y - 79}, 1.3, {ease: FlxEase.expoOut});
 
     var charLight:FunkinSprite = new FunkinSprite(cutoutSize + 800, 250);
     charLight.loadGraphic(Paths.image('charSelect/charLight'));
@@ -235,7 +235,8 @@ class CharSelectSubState extends MusicBeatSubState
       {
         applyStageMatrix: true
       });
-    speakers.x = cutoutSize - 10 + speakers.timeline.getBoundsOrigin().x;
+    speakers.x = cutoutSize - 11 + speakers.timeline.getBoundsOrigin().x;
+    speakers.y += 7;
     speakers.anim.play('');
     speakers.anim.curAnim.looped = true;
     speakers.scrollFactor.set(1.8, 1.8);


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
None yet!

<!-- Briefly describe the issue(s) fixed. -->
## Description
When Character Select had to be repositioned due how to flixel-animate makes atlases work, the entire process was eyeballed, leading to some object placement looking a tad bit off....

<img width="683" height="227" alt="image" src="https://github.com/user-attachments/assets/827d1f72-db79-47ce-92be-cf37c97815ec" />

This pull request repositions all those objects to 99% match how they were before the flixel-animate switch!

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos

https://github.com/user-attachments/assets/e565202f-3116-4b7c-ad9b-09e3695c1a1a

**SIDENOTE: I didn't change where the locks were positioned, the new one is way better/more centered**



