### PR TITLE
`[feat/flixel-animate]` Screen bounds fixes

### DIFF
--- a/hmm.json
+++ b/hmm.json
@@ -59,7 +59,7 @@
       "name": "flixel-animate",
       "type": "git",
       "dir": null,
-      "ref": "6e1e2e48a27921be220c647f8cc49f2dcbf599ab",
+      "ref": "9959ab5eba4ef6959fbf35bcc06e1d6a558955cf",
       "url": "https://github.com/MaybeMaru/flixel-animate"
     },
     {

--- a/source/funkin/graphics/FunkinSprite.hx
+++ b/source/funkin/graphics/FunkinSprite.hx
@@ -110,7 +110,14 @@ class FunkinSprite extends FlxAnimate
    * Turning this on is not recommended, only use this if you know what you're doing.
    * It's also worth noting that not all atlases will react correctly, some may need position tweaks.
    */
-  public var legacyBoundsPosition:Bool = false;
+  public var legacyBoundsPosition(default, set):Bool = false;
+
+  function set_legacyBoundsPosition(v:Bool):Bool
+  {
+    if (!isAnimate) return false;
+    if (v) applyStageMatrix = true;
+    return this.legacyBoundsPosition = v;
+  }
 
   /**
    * @param x Starting X position
@@ -658,12 +665,12 @@ class FunkinSprite extends FlxAnimate
 
     if (this.isAnimate)
     {
-      if (this.applyStageMatrix || legacyBoundsPosition)
+      if (this.applyStageMatrix)
       {
         result.add(this.library.matrix.tx, this.library.matrix.ty);
       }
 
-      if (legacyBoundsPosition)
+      if (this.legacyBoundsPosition)
       {
         var point = this.timeline.getBoundsOrigin(FlxPoint.get(), true);
         result.add(point.x, point.y);
@@ -672,6 +679,24 @@ class FunkinSprite extends FlxAnimate
     }
 
     return result.subtract(camera.scroll.x * scrollFactor.x, camera.scroll.y * scrollFactor.y);
+  }
+
+  override function getScreenBounds(?newRect:FlxRect, ?camera:FlxCamera):FlxRect
+  {
+    var bounds = super.getScreenBounds(newRect, camera);
+
+    if (this.isAnimate)
+    {
+      if (this.legacyBoundsPosition)
+      {
+        var point = this.timeline.getBoundsOrigin(FlxPoint.get(), true);
+        bounds.x += point.x;
+        bounds.y += point.y;
+        point.put();
+      }
+    }
+
+    return bounds;
   }
 
   override function drawSimple(camera:FlxCamera):Void


### PR DESCRIPTION
<!-- Briefly describe the issue(s) fixed. -->
## Description
Continuation of https://github.com/FunkinCrew/Funkin/pull/5847
In the last PR I completely missed adding the extra necessary logic so flixel could check if the sprite was inside the camera bounds when using ``applyStageMatrix`` and/or ``legacyBoundsPosition``. Also bumped a bit the flixel-animate version since the library also had a small oversight related to the calculation of those.
It should be now completely fixed, but extra testing would be appreciated!
