### PR TITLE
[BUGFIX] Fix Stress (Pico Mix) bricks moving when restarting

### DIFF
--- a/source/funkin/play/PlayState.hx
+++ b/source/funkin/play/PlayState.hx
@@ -972,6 +972,8 @@ class PlayState extends MusicBeatSubState
 
       previousDifficulty = currentDifficulty;
 
+      currentStage?.resetStage();
+
       dispatchEvent(retryEvent);
 
       resetCamera();
@@ -1015,8 +1017,6 @@ class PlayState extends MusicBeatSubState
         vocals.playerVolume = 1;
         vocals.opponentVolume = 1;
       }
-
-      currentStage?.resetStage();
 
       if (!fromDeathState)
       {


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
Fixes #5595

<!-- Briefly describe the issue(s) fixed. -->
## Description
When playing Stress (Pico Mix), restarting the song will cause the bricks to move slightly. I moved the stage reset function to be before the `onSongRetry` event so that the bricks could be repositioned in the stage script without the bricks resetting its position afterwards.

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos

Stage reset before:

<img width="363" height="186" alt="Screenshot 2025-09-01 190529" src="https://github.com/user-attachments/assets/d8800c83-5490-47c9-8fd9-28b157ef586d" />

Stage reset after:
Yay the bricks are no longer like Bonnie from FNAF 1!!

<img width="279" height="175" alt="Screenshot 2025-09-01 190604" src="https://github.com/user-attachments/assets/38ec58ab-0b94-4230-959c-2bd5d03d2787" />

