### PR TITLE
[BUGFIX] Fix Video Cutscenes persisting between songs

### DIFF
--- a/source/funkin/play/PlayState.hx
+++ b/source/funkin/play/PlayState.hx
@@ -3534,6 +3534,8 @@ class PlayState extends MusicBeatSubState
 
     forEachPausedSound((s) -> s.destroy());
 
+    if (VideoCutscene.isPlaying()) VideoCutscene.destroyVideo();
+
     FlxTween.globalManager.clear();
     FlxTimer.globalManager.clear();
 

--- a/source/funkin/play/cutscene/VideoCutscene.hx
+++ b/source/funkin/play/cutscene/VideoCutscene.hx
@@ -347,6 +347,38 @@ class VideoCutscene
         // throw "Not implemented!";
     }
   }
+
+  /**
+   * Destroy the active cutscene, if any. Separate from finishVideo() so that it doesn't trigger onCutsceneFinish().
+   */
+  public static function destroyVideo()
+  {
+    #if html5
+    if (vid != null) PlayState.instance.remove(vid);
+    #end
+
+    #if hxvlc
+    if (vid != null)
+    {
+      vid.stop();
+      PlayState.instance.remove(vid);
+    }
+    #end
+
+    #if (html5 || hxvlc)
+    if (vid != null)
+    {
+      vid?.destroy();
+      vid = null;
+    }
+    #end
+
+    if (blackScreen != null)
+    {
+      PlayState.instance.remove(blackScreen);
+      blackScreen = null;
+    }
+  }
 }
 
 enum CutsceneType


### PR DESCRIPTION
## Linked Issues
Closes #5872 

## Description
Upon destroying PlayState, any playing video cutscenes are not destroyed. Hence why entering a song without videos would make the game assume that you still have a video playing even when not.

## Screenshots/Videos

https://github.com/user-attachments/assets/b0747ce2-90d8-4266-9eee-a16c73805161
