### PR TITLE
[ENHANCEMENT] Pressing BACK on Character Selector menu now goes to the Freeplay menu

### DIFF
--- a/source/funkin/ui/charSelect/CharSelectSubState.hx
+++ b/source/funkin/ui/charSelect/CharSelectSubState.hx
@@ -906,6 +906,14 @@ class CharSelectSubState extends MusicBeatSubState
         holdTmrRight = 0;
         selectSound.play(true);
       }
+
+      if (controls.BACK)
+      {
+        wentBackToFreeplay = true;
+        FunkinSound.playOnce(Paths.sound('cancelMenu'));
+        FlxTween.tween(FlxG.sound.music, {volume: 0.0}, 0.7, {ease: FlxEase.quadInOut});
+        goToFreeplay();
+      }
     }
 
     if (cursorX < -1)
@@ -923,14 +931,6 @@ class CharSelectSubState extends MusicBeatSubState
     if (cursorY > 1)
     {
       cursorY = -1;
-    }
-
-    if (controls.BACK && !pressedSelect && allowInput)
-    {
-      wentBackToFreeplay = true;
-      FunkinSound.playOnce(Paths.sound('cancelMenu'));
-      FlxTween.tween(FlxG.sound.music, {volume: 0.0}, 0.7, {ease: FlxEase.quadInOut});
-      goToFreeplay();
     }
 
     if (availableChars.exists(getCurrentSelected()) && PlayerRegistry.instance.isCharacterSeen(availableChars[getCurrentSelected()]))


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
No
<!-- Briefly describe the issue(s) fixed. -->
## Description
This PR lets you go back to the Freeplay menu from the Character Selector menu pressing back instead of being forced to select the same character if you want to go back
<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos

https://github.com/user-attachments/assets/e2c1884f-2dda-4599-b7b3-f70b13ce0a13

