### PR TITLE
``[feat/flixel-animate]`` New stage matrix migration

### DIFF
--- a/hmm.json
+++ b/hmm.json
@@ -59,7 +59,7 @@
       "name": "flixel-animate",
       "type": "git",
       "dir": null,
-      "ref": "87972f8981cbb0f37a94bbb204d4ae4246f2dcff",
+      "ref": "723b77457056bb793a5d37f5915ab86cccd80ad4",
       "url": "https://github.com/MaybeMaru/flixel-animate"
     },
     {

--- a/source/funkin/data/freeplay/player/PlayerData.hx
+++ b/source/funkin/data/freeplay/player/PlayerData.hx
@@ -105,7 +105,7 @@ class PlayerFreeplayDJData
 
   @:optional
   @:default(false)
-  var legacyBoundsPosition:Bool;
+  var applyStageMatrix:Bool;
 
   @:optional
   @:default("BOYFRIEND")
@@ -158,9 +158,9 @@ class PlayerFreeplayDJData
     return assetPath;
   }
 
-  public function useLegacyBoundsPosition():Bool
+  public function useApplyStageMatrix():Bool
   {
-    return legacyBoundsPosition;
+    return applyStageMatrix;
   }
 
   public function getFreeplayDJText(index:Int):String
@@ -345,7 +345,7 @@ typedef PlayerResultsAnimationData =
 
   @:optional
   @:default(false)
-  var legacyBoundsPosition:Bool;
+  var applyStageMatrix:Bool;
 
   @:optional
   var assetPath:Null<String>;

--- a/source/funkin/play/ResultState.hx
+++ b/source/funkin/play/ResultState.hx
@@ -231,9 +231,9 @@ class ResultState extends MusicBeatSubState
 
           if (animation == null) continue;
 
-          if (animData?.legacyBoundsPosition ?? false)
+          if (animData?.applyStageMatrix ?? false)
           {
-            animation.legacyBoundsPosition = true;
+            animation.applyStageMatrix = true;
           }
 
           animation.zIndex = animData.zIndex ?? 500;

--- a/source/funkin/ui/charSelect/CharSelectGF.hx
+++ b/source/funkin/ui/charSelect/CharSelectGF.hx
@@ -78,14 +78,6 @@ class CharSelectGF extends FunkinSprite implements IBPMSyncedScriptedClass
     }
   }
 
-  public function updatePosition():Void
-  {
-    var bounds:FlxPoint = this.timeline.getBoundsOrigin(true);
-
-    x = bounds.x + FullScreenScaleMode.gameCutoutSize.x / 2;
-    y = bounds.y;
-  }
-
   /**
    * For switching between "GFs" such as gf, nene, etc
    * @param bf Which BF we are selecting, so that we know the accompyaning GF
@@ -119,8 +111,6 @@ class CharSelectGF extends FunkinSprite implements IBPMSyncedScriptedClass
     anim.play("idle", true);
 
     updateHitbox();
-
-    updatePosition();
   }
 
   public function onScriptEvent(event:ScriptEvent):Void {};

--- a/source/funkin/ui/charSelect/CharSelectPlayer.hx
+++ b/source/funkin/ui/charSelect/CharSelectPlayer.hx
@@ -63,15 +63,6 @@ class CharSelectPlayer extends FunkinSprite implements IBPMSyncedScriptedClass
     }
   };
 
-  public function updatePosition():Void
-  {
-    // offset the position such that it's positioned exactly like in Adobe Animate
-    var bounds:FlxPoint = this.timeline.getBoundsOrigin(true);
-
-    x = initialX + bounds.x;
-    y = initialY + bounds.y;
-  }
-
   public function switchChar(str:String):Void
   {
     frames = CharSelectAtlasHandler.loadAtlas('charSelect/${str}Chill');
@@ -79,8 +70,6 @@ class CharSelectPlayer extends FunkinSprite implements IBPMSyncedScriptedClass
     anim.play("slidein", true);
 
     updateHitbox();
-
-    updatePosition();
   }
 
   public function onScriptEvent(event:ScriptEvent):Void {};

--- a/source/funkin/ui/charSelect/CharSelectSubState.hx
+++ b/source/funkin/ui/charSelect/CharSelectSubState.hx
@@ -151,7 +151,7 @@ class CharSelectSubState extends MusicBeatSubState
     bg.scrollFactor.set(0.1, 0.1);
     add(bg);
 
-    var crowd:FunkinSprite = FunkinSprite.createTextureAtlas(cutoutSize + -9, -5, "charSelect/crowd",
+    var crowd:FunkinSprite = FunkinSprite.createTextureAtlas(cutoutSize, 0, "charSelect/crowd",
       {
         applyStageMatrix: true
       });
@@ -160,7 +160,7 @@ class CharSelectSubState extends MusicBeatSubState
     crowd.scrollFactor.set(0.3, 0.3);
     add(crowd);
 
-    var stageSpr:FunkinSprite = FunkinSprite.createTextureAtlas(cutoutSize + -2, -27, "charSelect/charSelectStage",
+    var stageSpr:FunkinSprite = FunkinSprite.createTextureAtlas(cutoutSize - 2, 1, "charSelect/charSelectStage",
       {
         applyStageMatrix: true
       });
@@ -184,8 +184,8 @@ class CharSelectSubState extends MusicBeatSubState
     barthing.scrollFactor.set(0, 0);
     add(barthing);
 
-    barthing.y += 79;
-    FlxTween.tween(barthing, {y: barthing.y - 79}, 1.3, {ease: FlxEase.expoOut});
+    barthing.y += 80;
+    FlxTween.tween(barthing, {y: barthing.y - 80}, 1.3, {ease: FlxEase.expoOut});
 
     var charLight:FunkinSprite = new FunkinSprite(cutoutSize + 800, 250);
     charLight.loadGraphic(Paths.image('charSelect/charLight'));
@@ -229,12 +229,10 @@ class CharSelectSubState extends MusicBeatSubState
     else
       setupPlayerChill(Constants.DEFAULT_CHARACTER);
 
-    var speakers:FunkinSprite = FunkinSprite.createTextureAtlas(0, 0, "charSelect/charSelectSpeakers",
+    var speakers:FunkinSprite = FunkinSprite.createTextureAtlas(cutoutSize - 10, 0, "charSelect/charSelectSpeakers",
       {
         applyStageMatrix: true
       });
-    speakers.x = cutoutSize - 11 + speakers.timeline.getBoundsOrigin().x;
-    speakers.y += 7;
     speakers.anim.play('');
     speakers.anim.curAnim.looped = true;
     speakers.scrollFactor.set(1.8, 1.8);

--- a/source/funkin/ui/freeplay/FreeplayDJ.hx
+++ b/source/funkin/ui/freeplay/FreeplayDJ.hx
@@ -52,9 +52,9 @@ class FreeplayDJ extends FunkinSprite
         filterQuality: HIGH
       });
 
-    if (playableCharData?.useLegacyBoundsPosition() ?? false)
+    if (playableCharData?.useApplyStageMatrix() ?? false)
     {
-      this.legacyBoundsPosition = true;
+      this.applyStageMatrix = true;
     }
 
     anim.onFrameChange.add(function(name, number, index) {
@@ -481,7 +481,7 @@ class FreeplayDJ extends FunkinSprite
       var finalOffsetX:Float = 0;
       var finalOffsetY:Float = 0;
 
-      if (this.legacyBoundsPosition)
+      if (this.applyStageMatrix)
       {
         finalOffsetX = animationOffsets[0];
         finalOffsetY = animationOffsets[1];


### PR DESCRIPTION
<!-- Briefly describe the issue(s) fixed. -->
## Description
After debating for a while and consulting with Abnormal, I made changes to how ``applyStageMatrix`` is handled in flixel-animate. Previously, the setting applied the matrix of the instance, but since it didn't apply the old animate bounds with it, it didn't produce the results a user would expect for the "Animate position in Flixel". With this new commit (https://github.com/MaybeMaru/flixel-animate/commit/723b77457056bb793a5d37f5915ab86cccd80ad4), having the setting turned off will result in Flixel-accurate bounds, as expected. And when turned on, it will now result in the same bounds as legacy FlxAnimate.

Think of this as a switch between "Flixel" bounds and "Animate" bounds. Using "Flixel" bounds should be the new standard for consistency with other packer types. However, if you want to position your texture atlases in Animate without additional work in Flixel, turning on the setting is for you.

With these changes, I've taken it upon myself to fix any bugs this update may cause to restore the previous state of the branch. This PR will remain a draft until I've addressed everything that needs fixing.

