### PR TITLE
[BUGFIX] Fixes funkVis & grig.audio memory leak

### DIFF
--- a/project.hxp
+++ b/project.hxp
@@ -942,10 +942,10 @@ class Project extends HXProject
 
     setHaxedef("safeMode");
 
-    // If we aren't using the Flixel debugger, strip it out.
     if (FEATURE_DEBUG_FUNCTIONS.isDisabled(this))
     {
-      setHaxedef("FLX_NO_DEBUG");
+      setHaxedef("FLX_NO_DEBUG"); // If we aren't using the Flixel debugger, strip it out.
+      setHaxedef("analyzer-optimize"); // Optimize haxe code when not in debug to improve performance.
     }
 
     if (FEATURE_LOG_TRACE.isDisabled(this))

--- a/source/funkin/audio/visualize/ABotVis.hx
+++ b/source/funkin/audio/visualize/ABotVis.hx
@@ -14,6 +14,7 @@ class ABotVis extends FlxTypedSpriteGroup<FlxSprite>
 {
   // public var vis:VisShit;
   var analyzer:Null<SpectralAnalyzer> = null;
+  var analyzerLevelsCache:Array<Bar> = new Array<Bar>();
 
   var volumes:Array<Float> = [];
 
@@ -112,11 +113,11 @@ class ABotVis extends FlxTypedSpriteGroup<FlxSprite>
    */
   function drawFFT():Void
   {
-    var levels = (analyzer != null) ? analyzer.getLevels() : getDefaultLevels();
+    analyzerLevelsCache = (analyzer != null) ? analyzer.getLevels(analyzerLevelsCache) : getDefaultLevels();
 
-    for (i in 0...min(group.members.length, levels.length))
+    for (i in 0...min(group.members.length, analyzerLevelsCache.length))
     {
-      var animFrame:Int = (FlxG.sound.volume == 0 || FlxG.sound.muted) ? 0 : Math.round(levels[i].value * 6);
+      var animFrame:Int = (FlxG.sound.volume == 0 || FlxG.sound.muted) ? 0 : Math.round(analyzerLevelsCache[i].value * 6);
 
       // don't display if we're at 0 volume from the level
       group.members[i].visible = animFrame > 0;

--- a/source/funkin/ui/charSelect/CharSelectGF.hx
+++ b/source/funkin/ui/charSelect/CharSelectGF.hx
@@ -24,6 +24,7 @@ class CharSelectGF extends FlxAtlasSprite implements IBPMSyncedScriptedClass
   var list:Array<String> = [];
 
   var analyzer:SpectralAnalyzer;
+  var analyzerLevelsCache:Array<Bar> = new Array<Bar>();
 
   var currentGFPath:Null<String>;
   var enableVisualizer:Bool = false;
@@ -84,14 +85,14 @@ class CharSelectGF extends FlxAtlasSprite implements IBPMSyncedScriptedClass
   {
     if (enableVisualizer)
     {
-      var levels = analyzer.getLevels();
+      analyzerLevelsCache = analyzer.getLevels(analyzerLevelsCache);
       var frame = anim.curSymbol.timeline.get("VIZ_bars").get(anim.curFrame);
       var elements = frame.getList();
       var len:Int = cast Math.min(elements.length, 7);
 
       for (i in 0...len)
       {
-        var animFrame:Int = (FlxG.sound.volume == 0 || FlxG.sound.muted) ? 0 : Math.round(levels[i].value * 12);
+        var animFrame:Int = (FlxG.sound.volume == 0 || FlxG.sound.muted) ? 0 : Math.round(analyzerLevelsCache[i].value * 12);
 
         #if sys
         // Web version scales with the Flixel volume level.

--- a/source/funkin/ui/freeplay/FreeplayState.hx
+++ b/source/funkin/ui/freeplay/FreeplayState.hx
@@ -1672,10 +1672,6 @@ class FreeplayState extends MusicBeatSubState
   {
     if (!controls.active) return;
 
-    final upP:Bool = controls.UI_UP_P;
-    final downP:Bool = controls.UI_DOWN_P;
-    final accepted:Bool = controls.ACCEPT;
-
     #if FEATURE_TOUCH_CONTROLS
     handleTouchCapsuleClick();
     handleTouchFavoritesAndDifficulties();
@@ -1714,7 +1710,7 @@ class FreeplayState extends MusicBeatSubState
       goBack();
     }
 
-    if (accepted && controls.active)
+    if (controls.ACCEPT && controls.active)
     {
       currentCapsule.onConfirm();
     }


### PR DESCRIPTION
## Description
This Pull Request Fixes Memory Leaks related to funkVis and grig.audio due to them allocating a new array every frame instead of using the same array being cached and changing values

This PR depends on 2 other pr's on funkVis and grig.audio in the FunkinCrew org (linked below)
funkVis PR: https://github.com/FunkinCrew/funkVis/pull/16
grig.audio PR: https://github.com/FunkinCrew/grig.audio/pull/2 (uses the `refactor/fft-cam-version` branch instead of `funkin` due to changes in funkVis)
(these pr fixes the memory leak at its core too)

## Screenshots/Videos
https://github.com/user-attachments/assets/943a6ed0-4e43-4f75-8f6e-5e778aa84033
(notice how the memory doesn't leak anymore when previewing pico in the character selector)

## Notice
The libraries has to be updated in `hmm.json` so it works as expected