### PR TITLE
[BUGFIX] Make slamming rank visible

### DIFF
--- a/source/funkin/ui/freeplay/FreeplayState.hx
+++ b/source/funkin/ui/freeplay/FreeplayState.hx
@@ -1090,9 +1090,10 @@ class FreeplayState extends MusicBeatSubState
 
   function rankDisplayNew(fromResults:Null<FromResultsParams>, capsuleToRank:SongMenuItem):Void
   {
-    capsuleToRank.ranking.visible = false;
-    capsuleToRank.fakeRanking.visible = false;
+    capsuleToRank.ranking.visible = true;
+    capsuleToRank.fakeRanking.visible = true;
     capsuleToRank.ranking.scale.set(20, 20);
+    capsuleToRank.ranking.updateHitbox();
 
     if (fromResults != null && fromResults.newRank != null)
     {


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
https://github.com/FunkinCrew/Funkin/issues/5905

<!-- Briefly describe the issue(s) fixed. -->
## Description
Makes the rank visible while slamming

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos
I couldn't make any. The animation is too fast
