### PR TITLE
[ENHANCEMENT] Forced stage camera positions. Add stages custom camera points.

### DIFF
--- a/source/funkin/data/stage/StageData.hx
+++ b/source/funkin/data/stage/StageData.hx
@@ -42,7 +42,7 @@ class StageData
           zIndex: 0,
           scale: 1,
           position: [0, 0],
-          stageCamPos: null,
+          forceCameraPos: false,
           cameraOffsets: [-100, -100]
         },
       dad:
@@ -50,7 +50,7 @@ class StageData
           zIndex: 0,
           scale: 1,
           position: [0, 0],
-          stageCamPos: null,
+          forceCameraPos: false,
           cameraOffsets: [100, -100]
         },
       gf:
@@ -58,7 +58,7 @@ class StageData
           zIndex: 0,
           scale: 1,
           position: [0, 0],
-          stageCamPos: null,
+          forceCameraPos: false,
           cameraOffsets: [0, 0]
         }
     };
@@ -263,12 +263,12 @@ typedef StageDataCharacter =
   var scale:Float;
 
   /**
-   * The forced character's camera position.
-   * @default null
+   * Will force camera position to `cameraOffsets`, excluding character's position.
+   * @default false
    */
   @:optional
-  @:default(null)
-  var stageCamPos:Array<Float>;
+  @:default(false)
+  var forceCameraPos:Bool;
 
   /**
    * The camera offsets to apply when focusing on the character on this stage.

--- a/source/funkin/data/stage/StageData.hx
+++ b/source/funkin/data/stage/StageData.hx
@@ -24,6 +24,10 @@ class StageData
   @:optional
   public var directory:Null<String>;
 
+  @:optional
+  @:default([])
+  public var cameraPoints:Null<Array<StageCameraPoint>>;
+
   public function new()
   {
     this.version = StageRegistry.STAGE_DATA_VERSION;
@@ -38,6 +42,7 @@ class StageData
           zIndex: 0,
           scale: 1,
           position: [0, 0],
+          stageCamPos: null,
           cameraOffsets: [-100, -100]
         },
       dad:
@@ -45,6 +50,7 @@ class StageData
           zIndex: 0,
           scale: 1,
           position: [0, 0],
+          stageCamPos: null,
           cameraOffsets: [100, -100]
         },
       gf:
@@ -52,6 +58,7 @@ class StageData
           zIndex: 0,
           scale: 1,
           position: [0, 0],
+          stageCamPos: null,
           cameraOffsets: [0, 0]
         }
     };
@@ -256,6 +263,14 @@ typedef StageDataCharacter =
   var scale:Float;
 
   /**
+   * The forced character's camera position.
+   * @default null
+   */
+  @:optional
+  @:default(null)
+  var stageCamPos:Array<Float>;
+
+  /**
    * The camera offsets to apply when focusing on the character on this stage.
    * @default [-100, -100] for BF, [100, -100] for DAD/OPPONENT, [0, 0] for GF
    */
@@ -290,3 +305,10 @@ typedef StageDataCharacter =
   @:default(0.0)
   var angle:Float;
 };
+
+typedef StageCameraPoint =
+{
+  var name:String;
+  var x:Float;
+  var y:Float;
+}

--- a/source/funkin/play/PlayState.hx
+++ b/source/funkin/play/PlayState.hx
@@ -2113,7 +2113,7 @@ class PlayState extends MusicBeatSubState
       {
         currentStage.addCharacter(dad, DAD);
         // Camera starts at dad.
-        cameraFollowPoint.setPosition(dad.cameraFocusPoint.x, dad.cameraFocusPoint.y);
+        cameraFollowPoint.setPosition(dad.requiredCameraPos.x, dad.requiredCameraPos.y);
 
         #if FEATURE_DEBUG_FUNCTIONS
         FlxG.console.registerObject('dad', dad);

--- a/source/funkin/play/character/BaseCharacter.hx
+++ b/source/funkin/play/character/BaseCharacter.hx
@@ -154,6 +154,17 @@ class BaseCharacter extends Bopper
     return super.set_y(value);
   }
 
+  // Returns _stageCamPos or cameraFocusPoint for FocusCamera event.
+  public var requiredCameraPos(get, never):FlxPoint;
+
+  inline function get_requiredCameraPos():FlxPoint
+  {
+    return (_stageCamPos ?? cameraFocusPoint);
+  }
+
+  // Forced stage-specific camera position.
+  public var _stageCamPos:FlxPoint = null;
+
   public function new(id:String, renderType:CharacterRenderType)
   {
     super(CharacterDataParser.DEFAULT_DANCEEVERY);

--- a/source/funkin/play/event/FocusCameraSongEvent.hx
+++ b/source/funkin/play/event/FocusCameraSongEvent.hx
@@ -144,6 +144,7 @@ class FocusCameraSongEvent extends SongEvent
 
   private function getStageCameraPoints()
   {
+    _cameraPoints?.clear();
     _cameraPoints ??= new Map();
     @:privateAccess
     final stage = funkin.data.stage.StageRegistry.instance.fetchEntry(funkin.ui.debug.charting.ChartEditorState.instance.currentSongStage);

--- a/source/funkin/play/event/FocusCameraSongEvent.hx
+++ b/source/funkin/play/event/FocusCameraSongEvent.hx
@@ -69,7 +69,7 @@ class FocusCameraSongEvent extends SongEvent
 
     var easeDir:String = data.getString('easeDir') ?? SongEvent.DEFAULT_EASE_DIR;
     if (SongEvent.EASE_TYPE_DIR_REGEX.match(ease) || ease == "linear") easeDir = "";
-    
+
     if (stagePoint != null && stagePoint != "NONE" && customPoints != null)
     {
       final point = customPoints.exists(stagePoint) ? customPoints.get(stagePoint) : null;
@@ -93,7 +93,7 @@ class FocusCameraSongEvent extends SongEvent
         return;
     }
 
-    applyCameraTween(targetX, targetY, duration, ease);
+    applyCameraTween(targetX, targetY, duration, ease, easeDir);
   }
 
   function getCharacterPoint(char:Int):Null<flixel.math.FlxPoint>
@@ -109,7 +109,7 @@ class FocusCameraSongEvent extends SongEvent
     }
   }
 
-  function applyCameraTween(targetX:Float, targetY:Float, duration:Float, ease:String):Void
+  function applyCameraTween(targetX:Float, targetY:Float, duration:Float, ease:String, easeDir:String):Void
   {
     final playState = PlayState.instance;
 

--- a/source/funkin/play/event/FocusCameraSongEvent.hx
+++ b/source/funkin/play/event/FocusCameraSongEvent.hx
@@ -143,11 +143,11 @@ class FocusCameraSongEvent extends SongEvent
   private function getStageCameraPoints()
   {
     var cameraPoints:Map<String, String> = new Map();
-    cameraPoints.set("NONE", "NONE");
     @:privateAccess
-    if (funkin.ui.debug.charting.ChartEditorState.instance != null)
-      for (point in funkin.data.stage.StageRegistry.instance.fetchEntry(funkin.ui.debug.charting.ChartEditorState.instance.currentSongStage)
-      ._data.cameraPoints)
+    var stage = funkin.data.stage.StageRegistry.instance.fetchEntry(funkin.ui.debug.charting.ChartEditorState.instance.currentSongStage);
+    cameraPoints.set("NONE", "NONE");
+    if (stage == null) return cameraPoints;
+    if (funkin.ui.debug.charting.ChartEditorState.instance != null) for (point in stage?._data?.cameraPoints ?? [])
       cameraPoints.set(point.name, point.name);
 
     return cameraPoints;

--- a/source/funkin/play/event/FocusCameraSongEvent.hx
+++ b/source/funkin/play/event/FocusCameraSongEvent.hx
@@ -59,7 +59,7 @@ class FocusCameraSongEvent extends SongEvent
     if (playState == null || playState.currentStage == null || playState.isMinimalMode) return;
 
     final stagePoint = data.getString('stagePoint') ?? 'NONE';
-    final customPoints = playState.currentStage.customCameraPoints;
+    final customPoints = playState.currentStage?.customCameraPoints ?? [];
 
     var targetX:Float = data.getFloat('x') ?? 0.0;
     var targetY:Float = data.getFloat('y') ?? 0.0;
@@ -140,17 +140,19 @@ class FocusCameraSongEvent extends SongEvent
     return 'Focus Camera';
   }
 
+  var _cameraPoints:Map<String, String> = new Map();
+
   private function getStageCameraPoints()
   {
-    var cameraPoints:Map<String, String> = new Map();
+    _cameraPoints ??= new Map();
     @:privateAccess
-    var stage = funkin.data.stage.StageRegistry.instance.fetchEntry(funkin.ui.debug.charting.ChartEditorState.instance.currentSongStage);
-    cameraPoints.set("NONE", "NONE");
-    if (stage == null) return cameraPoints;
+    final stage = funkin.data.stage.StageRegistry.instance.fetchEntry(funkin.ui.debug.charting.ChartEditorState.instance.currentSongStage);
+    _cameraPoints.set("NONE", "NONE");
+    if (stage == null) return _cameraPoints;
     if (funkin.ui.debug.charting.ChartEditorState.instance != null) for (point in stage?._data?.cameraPoints ?? [])
-      cameraPoints.set(point.name, point.name);
+      _cameraPoints.set(point.name, point.name);
 
-    return cameraPoints;
+    return _cameraPoints;
   }
 
   /**

--- a/source/funkin/play/event/FocusCameraSongEvent.hx
+++ b/source/funkin/play/event/FocusCameraSongEvent.hx
@@ -96,12 +96,12 @@ class FocusCameraSongEvent extends SongEvent
     applyCameraTween(targetX, targetY, duration, ease);
   }
 
-  function getCharacterPoint(char:Int):Null<FlxPoint>
+  function getCharacterPoint(char:Int):Null<flixel.math.FlxPoint>
   {
     final currentStage = PlayState.instance.currentStage;
     return switch (char)
     {
-      case -1: FlxPoint.get(); // Manual position
+      case -1: flixel.math.FlxPoint.get(); // Manual position
       case 0: currentStage.getBoyfriend()?.requiredCameraPos;
       case 1: currentStage.getDad()?.requiredCameraPos;
       case 2: currentStage.getGirlfriend()?.requiredCameraPos;
@@ -145,7 +145,9 @@ class FocusCameraSongEvent extends SongEvent
     var cameraPoints:Map<String, String> = new Map();
     cameraPoints.set("NONE", "NONE");
     @:privateAccess
-    if (ChartEditorState.instance != null) for (point in StageRegistry.instance.fetchEntry(ChartEditorState.instance.currentSongStage)._data.cameraPoints)
+    if (funkin.ui.debug.charting.ChartEditorState.instance != null)
+      for (point in funkin.data.stage.StageRegistry.instance.fetchEntry(funkin.ui.debug.charting.ChartEditorState.instance.currentSongStage)
+      ._data.cameraPoints)
       cameraPoints.set(point.name, point.name);
 
     return cameraPoints;

--- a/source/funkin/play/event/FocusCameraSongEvent.hx
+++ b/source/funkin/play/event/FocusCameraSongEvent.hx
@@ -46,6 +46,8 @@ import funkin.data.event.SongEventSchema.SongEventFieldType;
  */
 class FocusCameraSongEvent extends SongEvent
 {
+  static final CHARACTER_TARGETS = ["Position" => -1, "Player" => 0, "Opponent" => 1, "Girlfriend" => 2];
+
   public function new()
   {
     super('FocusCamera');
@@ -53,101 +55,100 @@ class FocusCameraSongEvent extends SongEvent
 
   public override function handleEvent(data:SongEventData):Void
   {
-    // Does nothing if there is no PlayState camera or stage.
-    if (PlayState.instance == null || PlayState.instance.currentStage == null) return;
+    final playState = PlayState.instance;
+    if (playState == null || playState.currentStage == null || playState.isMinimalMode) return;
 
-    // Does nothing if we are minimal mode.
-    if (PlayState.instance.isMinimalMode) return;
+    final stagePoint = data.getString('stagePoint') ?? 'NONE';
+    final customPoints = playState.currentStage.customCameraPoints;
 
-    var posX:Null<Float> = data.getFloat('x');
-    if (posX == null) posX = 0.0;
-    var posY:Null<Float> = data.getFloat('y');
-    if (posY == null) posY = 0.0;
-
-    var char:Null<Int> = data.getInt('char');
-
-    if (char == null) char = cast data.value;
-
-    var duration:Null<Float> = data.getFloat('duration');
-    if (duration == null) duration = 4.0;
-    var ease:Null<String> = data.getString('ease');
-    if (ease == null) ease = 'CLASSIC'; // No linear in defaults lol
+    var targetX:Float = data.getFloat('x') ?? 0.0;
+    var targetY:Float = data.getFloat('y') ?? 0.0;
+    var char:Null<Int> = data.getInt('char') ?? cast data.value ?? 0;
+    var duration:Null<Float> = data.getFloat('duration') ?? 4.0;
+    var ease:Null<String> = data.getString('ease') ?? 'CLASSIC';
 
     var easeDir:String = data.getString('easeDir') ?? SongEvent.DEFAULT_EASE_DIR;
     if (SongEvent.EASE_TYPE_DIR_REGEX.match(ease) || ease == "linear") easeDir = "";
-
-    var currentStage = PlayState.instance.currentStage;
-
-    // Get target position based on char.
-    var targetX:Float = posX;
-    var targetY:Float = posY;
-
-    switch (char)
+    
+    if (stagePoint != null && stagePoint != "NONE" && customPoints != null)
     {
-      case -1: // Position ("focus" on origin)
-        trace('Focusing camera on static position.');
-
-      case 0: // Boyfriend (focus on player)
-        if (currentStage.getBoyfriend() == null)
-        {
-          trace('No BF to focus on.');
-          return;
-        }
-        trace('Focusing camera on player.');
-        var bfPoint = currentStage.getBoyfriend().cameraFocusPoint;
-        targetX += bfPoint.x;
-        targetY += bfPoint.y;
-
-      case 1: // Dad (focus on opponent)
-        if (currentStage.getDad() == null)
-        {
-          trace('No dad to focus on.');
-          return;
-        }
-        trace('Focusing camera on opponent.');
-        var dadPoint = currentStage.getDad().cameraFocusPoint;
-        targetX += dadPoint.x;
-        targetY += dadPoint.y;
-
-      case 2: // Girlfriend (focus on girlfriend)
-        if (currentStage.getGirlfriend() == null)
-        {
-          trace('No GF to focus on.');
-          return;
-        }
-        trace('Focusing camera on girlfriend.');
-        var gfPoint = currentStage.getGirlfriend().cameraFocusPoint;
-        targetX += gfPoint.x;
-        targetY += gfPoint.y;
-
-      default:
-        trace('Unknown camera focus: ' + data);
+      final point = customPoints.exists(stagePoint) ? customPoints.get(stagePoint) : null;
+      if (point != null)
+      {
+        targetX += point.x;
+        targetY += point.y;
+      }
+      else
+        return;
+    }
+    else
+    {
+      final charPoint = getCharacterPoint(char);
+      if (charPoint != null)
+      {
+        targetX += charPoint.x;
+        targetY += charPoint.y;
+      }
+      else
+        return;
     }
 
-    // Apply tween based on ease.
+    applyCameraTween(targetX, targetY, duration, ease);
+  }
+
+  function getCharacterPoint(char:Int):Null<FlxPoint>
+  {
+    final currentStage = PlayState.instance.currentStage;
+    return switch (char)
+    {
+      case -1: FlxPoint.get(); // Manual position
+      case 0: currentStage.getBoyfriend()?.requiredCameraPos;
+      case 1: currentStage.getDad()?.requiredCameraPos;
+      case 2: currentStage.getGirlfriend()?.requiredCameraPos;
+      default: null;
+    }
+  }
+
+  function applyCameraTween(targetX:Float, targetY:Float, duration:Float, ease:String):Void
+  {
+    final playState = PlayState.instance;
+
     switch (ease)
     {
-      case 'CLASSIC': // Old-school. No ease. Just set follow point.
-        PlayState.instance.resetCamera(false, false, false);
-        PlayState.instance.cancelCameraFollowTween();
-        PlayState.instance.cameraFollowPoint.setPosition(targetX, targetY);
-      case 'INSTANT': // Instant ease. Duration is automatically 0.
-        PlayState.instance.tweenCameraToPosition(targetX, targetY, 0);
+      case 'CLASSIC':
+        playState.resetCamera(false, false, false);
+        playState.cancelCameraFollowTween();
+        playState.cameraFollowPoint.setPosition(targetX, targetY);
+
+      case 'INSTANT':
+        playState.tweenCameraToPosition(targetX, targetY, 0);
+
       default:
-        var durSeconds = Conductor.instance.stepLengthMs * duration / 1000;
         var easeFunction:Null<Float->Float> = Reflect.field(FlxEase, ease + easeDir);
         if (easeFunction == null)
         {
           trace('Invalid ease function: $ease');
           return;
         }
-        PlayState.instance.tweenCameraToPosition(targetX, targetY, durSeconds, easeFunction);
+        var durSeconds = Conductor.instance.stepLengthMs * duration / 1000;
+        playState.tweenCameraToPosition(targetX, targetY, durSeconds, easeFunction);
     }
   }
 
   public override function getTitle():String
   {
     return 'Focus Camera';
+  }
+
+  private function getStageCameraPoints()
+  {
+    var cameraPoints:Map<String, String> = new Map();
+    cameraPoints.set("NONE", "NONE");
+    @:privateAccess
+    if (ChartEditorState.instance != null) for (point in StageRegistry.instance.fetchEntry(ChartEditorState.instance.currentSongStage)._data.cameraPoints)
+      cameraPoints.set(point.name, point.name);
+
+    return cameraPoints;
   }
 
   /**
@@ -167,7 +168,14 @@ class FocusCameraSongEvent extends SongEvent
         title: "Target",
         defaultValue: 0,
         type: SongEventFieldType.ENUM,
-        keys: ["Position" => -1, "Player" => 0, "Opponent" => 1, "Girlfriend" => 2]
+        keys: CHARACTER_TARGETS
+      },
+      {
+        name: "stagePoint",
+        title: "Stage Point",
+        defaultValue: "NONE",
+        type: ENUM,
+        keys: getStageCameraPoints()
       },
       {
         name: "x",
@@ -197,7 +205,7 @@ class FocusCameraSongEvent extends SongEvent
       {
         name: 'ease',
         title: 'Easing Type',
-        defaultValue: 'linear',
+        defaultValue: 'CLASSIC',
         type: SongEventFieldType.ENUM,
         keys: [
           'Linear' => 'linear',

--- a/source/funkin/play/stage/Stage.hx
+++ b/source/funkin/play/stage/Stage.hx
@@ -457,9 +457,9 @@ class Stage extends FlxSpriteGroup implements IPlayStateScriptedClass implements
       character.setScale(finalScale); // Don't use scale.set for characters!
       character.cameraFocusPoint.x += stageCharData.cameraOffsets[0];
       character.cameraFocusPoint.y += stageCharData.cameraOffsets[1];
-
-      if (stageCharData.stageCamera != null) character._stageCamPos = FlxPoint.get(stageCharData.stageCamera[0] + stageCharData.cameraOffsets[0],
-        stageCharData.stageCamera[1] + stageCharData.cameraOffsets[1]);
+      @:privateAccess
+      if (stageCharData.stageCamPos != null) character._stageCamPos = FlxPoint.get(stageCharData.stageCamPos[0] + character.characterCameraOffsets[0],
+        stageCharData.stageCamPos[1] + character.characterCameraOffsets[1]);
 
       character.scrollFactor.x = stageCharData.scroll[0];
       character.scrollFactor.y = stageCharData.scroll[1];

--- a/source/funkin/play/stage/Stage.hx
+++ b/source/funkin/play/stage/Stage.hx
@@ -55,6 +55,8 @@ class Stage extends FlxSpriteGroup implements IPlayStateScriptedClass implements
   var characters:Map<String, BaseCharacter> = new Map<String, BaseCharacter>();
   var boppers:Array<Bopper> = new Array<Bopper>();
 
+  public var customCameraPoints:Null<Map<String, FlxPoint>> = new Map();
+
   /**
    * The Stage elements get initialized at the beginning of the game.
    * They're used to cache the data needed to build the stage,
@@ -156,6 +158,13 @@ class Stage extends FlxSpriteGroup implements IPlayStateScriptedClass implements
   function buildStage():Void
   {
     trace('Building stage for display: ${this.id}');
+
+    if (_data.cameraPoints.length > 0)
+    {
+      trace('Generating ${_data.cameraPoints.length} custom camera points.');
+      for (point in _data.cameraPoints)
+        customCameraPoints.set(point.name, FlxPoint.get(point.x, point.y));
+    }
 
     this.debugIconGroup = new FlxSpriteGroup();
 
@@ -448,6 +457,9 @@ class Stage extends FlxSpriteGroup implements IPlayStateScriptedClass implements
       character.setScale(finalScale); // Don't use scale.set for characters!
       character.cameraFocusPoint.x += stageCharData.cameraOffsets[0];
       character.cameraFocusPoint.y += stageCharData.cameraOffsets[1];
+
+      if (stageCharData.stageCamera != null) character._stageCamPos = FlxPoint.get(stageCharData.stageCamera[0] + stageCharData.cameraOffsets[0],
+        stageCharData.stageCamera[1] + stageCharData.cameraOffsets[1]);
 
       character.scrollFactor.x = stageCharData.scroll[0];
       character.scrollFactor.y = stageCharData.scroll[1];

--- a/source/funkin/play/stage/Stage.hx
+++ b/source/funkin/play/stage/Stage.hx
@@ -458,8 +458,11 @@ class Stage extends FlxSpriteGroup implements IPlayStateScriptedClass implements
       character.cameraFocusPoint.x += stageCharData.cameraOffsets[0];
       character.cameraFocusPoint.y += stageCharData.cameraOffsets[1];
       @:privateAccess
-      if (stageCharData.stageCamPos != null) character._stageCamPos = FlxPoint.get(stageCharData.stageCamPos[0] + character.characterCameraOffsets[0],
-        stageCharData.stageCamPos[1] + character.characterCameraOffsets[1]);
+      if (stageCharData.forceCameraPos)
+      {
+        character._stageCamPos = FlxPoint.get(stageCharData.cameraOffsets[0] + character.characterCameraOffsets[0],
+          stageCharData.cameraOffsets[1] + character.characterCameraOffsets[1]);
+      }
 
       character.scrollFactor.x = stageCharData.scroll[0];
       character.scrollFactor.y = stageCharData.scroll[1];

--- a/source/funkin/ui/debug/charting/ChartEditorState.hx
+++ b/source/funkin/ui/debug/charting/ChartEditorState.hx
@@ -129,6 +129,8 @@ using Lambda;
 @:build(haxe.ui.ComponentBuilder.build("assets/exclude/data/ui/chart-editor/main-view.xml"))
 class ChartEditorState extends UIState // UIState derives from MusicBeatState
 {
+  public static var instance:ChartEditorState = null;
+
   /**
    * CONSTANTS
    */
@@ -2352,6 +2354,7 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
 
   override function create():Void
   {
+    instance = this;
     // super.create() must be called first, the HaxeUI components get created here.
     super.create();
     // Set the z-index of the HaxeUI.
@@ -6996,6 +6999,8 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
 
   override function destroy():Void
   {
+    instance = null;
+
     super.destroy();
 
     cleanupAutoSave();


### PR DESCRIPTION
## Linked Issues
_Hypothetically_ #5592 

## Description
* Adds new parameter to FORCE camera positions from cameraOffsets for characters (Bypasses the character's position on the screen and is set by the player).
* Adds new system for custom stage camera points, so user can select custom point on stage to focus on, instread of Dad, Bf, Gf (YES, THIS IS BETTER than position focus event, because all values are written in stage AND for pos changes user need to change this once in stage's json, instread of EVERY focus event used for it)

* Uhh, ChartEditorState instance...

## Screenshots/Videos
<img width="541" height="394" alt="image" src="https://github.com/user-attachments/assets/1ea2e4cd-d2e4-466d-9acd-aa240319fe6b" />
<img width="1313" height="681" alt="image" src="https://github.com/user-attachments/assets/b8ceb9d5-b35e-4185-93ef-9e5b7d9e14f9" />
<img width="519" height="150" alt="image" src="https://github.com/user-attachments/assets/75098583-3b7c-4140-8821-815437107d18" />
<img width="405" height="225" alt="image" src="https://github.com/user-attachments/assets/2d10da4e-b101-45e3-af29-cc5b656fc3a4" />

<img width="128" height="105" alt="a" src="https://github.com/user-attachments/assets/15ad24ea-fcdc-4f69-95ee-90cd5ccfdfd1" />
