### PR TITLE
[BUGFIX] Fix attempting to login while the login process is ongoing causing a crash

### DIFF
--- a/source/funkin/api/newgrounds/NewgroundsClient.hx
+++ b/source/funkin/api/newgrounds/NewgroundsClient.hx
@@ -102,6 +102,12 @@ class NewgroundsClient
       return;
     }
 
+    if (NG.core.attemptingLogin)
+    {
+      trace("[NEWGROUNDS] Login attempt ongoing, will not login until finished.");
+      return;
+    }
+
     if (onSuccess != null && onError != null)
     {
       NG.core.requestLogin(onLoginResolvedWithCallbacks.bind(_, onSuccess, onError));


### PR DESCRIPTION
## Linked Issues
Closes https://github.com/FunkinCrew/Funkin/issues/5814

## Description
The newgrounds library throws an error if you were to initiate a login while one is previously ongoing....even though it has a variable inside to track ongoing login attempts. This PR does something Geokureli can't and actually prevents the code from running if that variable is set to True...
Never letting Geokureli touch newgrounds library again like what kind of fucked up formatting did he even do to it

## Screenshots/Videos

https://github.com/user-attachments/assets/ba2f9861-0369-47dc-93bc-3cf053f1a488
