### PR TITLE
[GITHUB] Add *the* checkbox to the Crash Template

### DIFF
--- a/.github/ISSUE_TEMPLATE/crash.yml
+++ b/.github/ISSUE_TEMPLATE/crash.yml
@@ -15,6 +15,7 @@ body:
         - label: I have read the [Contributing Guide](https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md)
         - label: I have checked the Issues/Discussions pages to see if my issue has already been reported
         - label: I have properly titled my issue
+        - label: I did not have any mods installed when I encountered this issue
 
   - type: dropdown
     attributes:


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

#5678 for the crash template. If a mod can cause a bug, it could also cause a crash. I believe this checkbox should be added to the crash template too.