### PR TITLE
[BUGFIX] Make NoteKinds receive events last in PlayState

### DIFF
--- a/source/funkin/play/PlayState.hx
+++ b/source/funkin/play/PlayState.hx
@@ -1424,9 +1424,6 @@ class PlayState extends MusicBeatSubState
     // super.dispatchEvent(event) dispatches event to module scripts.
     super.dispatchEvent(event);
 
-    // Dispatch event to note kind scripts
-    NoteKindManager.callEvent(event);
-
     // Dispatch event to stage script.
     ScriptEventDispatcher.callEvent(currentStage, event);
 
@@ -1438,6 +1435,9 @@ class PlayState extends MusicBeatSubState
 
     // Dispatch event to conversation script.
     ScriptEventDispatcher.callEvent(currentConversation, event);
+
+    // Dispatch event to note kind scripts
+    NoteKindManager.callEvent(event);
   }
 
   /**


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues

<!-- Briefly describe the issue(s) fixed. -->
## Description
Rearranges the order in which events are dispatched to scripts in PlayState, making NoteKinds receive events last, following the order of a comment in the function.

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos
