### PR TITLE
Fix stutter issue with multi-sparrow characters (and probably cached graphics in general)

### DIFF
--- a/source/funkin/FunkinMemory.hx
+++ b/source/funkin/FunkinMemory.hx
@@ -177,6 +177,7 @@ class FunkinMemory
     var sprite = new flixel.FlxSprite();
     sprite.loadGraphic(graphic);
     sprite.draw(); // Draw sprite and load it into game's memory.
+    graphic.bitmap?.getTexture(FlxG.stage.context3D); // Just in case that didn't work...
     sprite.destroy();
   }
 


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
Closes #4467 
<!-- Briefly describe the issue(s) fixed. -->
## Description
Despite another contributor's effort to force textures to be uploaded to the GPU, turns out it wasn't enough...
In Stress (Pico Mix), since bloody Tankman's texture is so fucking massive for a Funkin' game some GPUs piss themselves when trying to load it for the first time (even if it's cached), causing the stutter when the "Ugh, redheads." animation plays.
<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos

https://github.com/user-attachments/assets/e96e65a1-dd70-4530-95ed-8054d12df09e


