### PR TITLE
[BUGFIX] Fallback to default if voices defined in the metadata don't exist

### DIFF
--- a/source/funkin/play/song/Song.hx
+++ b/source/funkin/play/song/Song.hx
@@ -846,61 +846,91 @@ class SongDifficulty
   {
     var suffix:String = (variation != null && variation != '' && variation != 'default') ? '-$variation' : '';
 
-    // Automatically resolve voices by removing suffixes.
-    // For example, if `Voices-bf-car-erect.ogg` does not exist, check for `Voices-bf-erect.ogg`.
-    // Then, check for  `Voices-bf-car.ogg`, then `Voices-bf.ogg`.
-
-    if (characters.playerVocals == null)
-    {
-      var playerId:String = characters.player;
-      var playerVoice:String = Paths.voices(this.song.id, '-${playerId}$suffix');
-
-      while (playerVoice != null && !Assets.exists(playerVoice))
-      {
-        // Remove the last suffix.
-        // For example, bf-car becomes bf.
-        playerId = playerId.split('-').slice(0, -1).join('-');
-        // Try again.
-        playerVoice = playerId == '' ? null : Paths.voices(this.song.id, '-${playerId}$suffix');
-      }
-      if (playerVoice == null)
-      {
-        // Try again without $suffix.
-        playerId = characters.player;
-        playerVoice = Paths.voices(this.song.id, '-${playerId}');
-        while (playerVoice != null && !Assets.exists(playerVoice))
-        {
-          // Remove the last suffix.
-          playerId = playerId.split('-').slice(0, -1).join('-');
-          // Try again.
-          playerVoice = playerId == '' ? null : Paths.voices(this.song.id, '-${playerId}$suffix');
-        }
-      }
-
-      return playerVoice != null ? [playerVoice] : [];
-    }
-    else
+    if (characters.playerVocals != null)
     {
       // The metadata explicitly defines the list of voices.
       var playerIds:Array<String> = characters?.playerVocals ?? [characters.player];
       var playerVoices:Array<String> = playerIds.map((id) -> Paths.voices(this.song.id, '-$id$suffix'));
+      var validVoices:Bool = true;
 
-      return playerVoices;
+      // Check if all voice paths exist before returning
+      // If not, fallback to the default method for resolving voices
+      for (voice in playerVoices)
+      {
+        if (voice == null || !Assets.exists(voice)) validVoices = false;
+      }
+      if (validVoices) return playerVoices;
     }
+
+    // Automatically resolve voices by removing suffixes.
+    // For example, if `Voices-bf-car-erect.ogg` does not exist, check for `Voices-bf-erect.ogg`.
+    // Then, check for  `Voices-bf-car.ogg`, then `Voices-bf.ogg`.
+    var playerId:String = characters.player;
+    var playerVoice:String = Paths.voices(this.song.id, '-${playerId}$suffix');
+
+    while (playerVoice != null && !Assets.exists(playerVoice))
+    {
+      // Remove the last suffix.
+      // For example, bf-car becomes bf.
+      playerId = playerId.split('-').slice(0, -1).join('-');
+      // Try again.
+      playerVoice = playerId == '' ? null : Paths.voices(this.song.id, '-${playerId}$suffix');
+    }
+    if (playerVoice == null)
+    {
+      // Try again without $suffix.
+      playerId = characters.player;
+      playerVoice = Paths.voices(this.song.id, '-${playerId}');
+      while (playerVoice != null && !Assets.exists(playerVoice))
+      {
+        // Remove the last suffix.
+        playerId = playerId.split('-').slice(0, -1).join('-');
+        // Try again.
+        playerVoice = playerId == '' ? null : Paths.voices(this.song.id, '-${playerId}$suffix');
+      }
+    }
+
+    return playerVoice != null ? [playerVoice] : [];
   }
 
   public function buildOpponentVoiceList():Array<String>
   {
     var suffix:String = (variation != null && variation != '' && variation != 'default') ? '-$variation' : '';
 
+    if (characters.opponentVocals != null)
+    {
+      // The metadata explicitly defines the list of voices.
+      var opponentIds:Array<String> = characters?.opponentVocals ?? [characters.opponent];
+      var opponentVoices:Array<String> = opponentIds.map((id) -> Paths.voices(this.song.id, '-$id$suffix'));
+      var validVoices:Bool = true;
+
+      // Check if all voice paths exist before returning
+      // If not, fallback to the default method for resolving voices
+      for (voice in opponentVoices)
+      {
+        if (voice == null || !Assets.exists(voice)) validVoices = false;
+      }
+      if (validVoices) return opponentVoices;
+    }
+
     // Automatically resolve voices by removing suffixes.
     // For example, if `Voices-bf-car-erect.ogg` does not exist, check for `Voices-bf-erect.ogg`.
     // Then, check for  `Voices-bf-car.ogg`, then `Voices-bf.ogg`.
 
-    if (characters.opponentVocals == null)
+    var opponentId:String = characters.opponent;
+    var opponentVoice:String = Paths.voices(this.song.id, '-${opponentId}$suffix');
+    while (opponentVoice != null && !Assets.exists(opponentVoice))
     {
-      var opponentId:String = characters.opponent;
-      var opponentVoice:String = Paths.voices(this.song.id, '-${opponentId}$suffix');
+      // Remove the last suffix.
+      opponentId = opponentId.split('-').slice(0, -1).join('-');
+      // Try again.
+      opponentVoice = opponentId == '' ? null : Paths.voices(this.song.id, '-${opponentId}$suffix');
+    }
+    if (opponentVoice == null)
+    {
+      // Try again without $suffix.
+      opponentId = characters.opponent;
+      opponentVoice = Paths.voices(this.song.id, '-${opponentId}');
       while (opponentVoice != null && !Assets.exists(opponentVoice))
       {
         // Remove the last suffix.
@@ -908,30 +938,9 @@ class SongDifficulty
         // Try again.
         opponentVoice = opponentId == '' ? null : Paths.voices(this.song.id, '-${opponentId}$suffix');
       }
-      if (opponentVoice == null)
-      {
-        // Try again without $suffix.
-        opponentId = characters.opponent;
-        opponentVoice = Paths.voices(this.song.id, '-${opponentId}');
-        while (opponentVoice != null && !Assets.exists(opponentVoice))
-        {
-          // Remove the last suffix.
-          opponentId = opponentId.split('-').slice(0, -1).join('-');
-          // Try again.
-          opponentVoice = opponentId == '' ? null : Paths.voices(this.song.id, '-${opponentId}$suffix');
-        }
-      }
-
-      return opponentVoice != null ? [opponentVoice] : [];
     }
-    else
-    {
-      // The metadata explicitly defines the list of voices.
-      var opponentIds:Array<String> = characters?.opponentVocals ?? [characters.opponent];
-      var opponentVoices:Array<String> = opponentIds.map((id) -> Paths.voices(this.song.id, '-$id$suffix'));
 
-      return opponentVoices;
-    }
+    return opponentVoice != null ? [opponentVoice] : [];
   }
 
   /**


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
#5910
<!-- Briefly describe the issue(s) fixed. -->
## Description
If a song's metadata explicitly defines the voices, the game will use them without checking if they actually exist which will cause a crash later. This PR fixes this issue by only using the voices defined in the metadata if their files exist. If they don't exist, it will fallback to the default method of resolving voices. 
<!-- Include any relevant screenshots or videos. -->
## Test

I tested this PR using this mod. All this mod does is replace the metadata file for Roses with the metadata file sent by the author of the linked issue:

[metadataTest.zip](https://github.com/user-attachments/files/22215133/metadataTest.zip)

If you use this mod on the release version, the game will crash when loading Roses. If you use it on a version compiled from this PR, the game will not crash.
