### PR TITLE
[FIX] Don't check for outdated libraries on `display`

### DIFF
--- a/project.hxp
+++ b/project.hxp
@@ -510,7 +510,10 @@ class Project extends HXProject
       configureIOS();
     }
 
-    checkLibraries();
+    if (!isDisplay())
+    {
+      checkLibraries();
+    }
   }
 
   /**


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
None
<!-- Briefly describe the issue(s) fixed. -->
## Description
The recent changes that check for diverging libraries break the Haxe language server because it's stupid and thinks the printed text is part of the command line or something like that.
<img width="416" height="128" alt="image" src="https://github.com/user-attachments/assets/3b3262da-56df-401f-8c79-3e806d815997" />

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos
