### PR TITLE
[BUGFIX] Fix hot-reloading after getting a new rank causing a crash

### DIFF
--- a/source/funkin/ui/freeplay/FreeplayState.hx
+++ b/source/funkin/ui/freeplay/FreeplayState.hx
@@ -353,6 +353,14 @@ class FreeplayState extends MusicBeatSubState
       stickerSubState.degenStickers();
     }
 
+    if (fromResultsParams != null)
+    {
+      @:privateAccess
+      this._parentState._constructor = () -> {
+        return FreeplayState.build(null, null);
+      }
+    }
+
     #if FEATURE_DISCORD_RPC
     // Updating Discord Rich Presence
     DiscordClient.instance.setPresence({state: 'In the Menus', details: null});


### PR DESCRIPTION
## Linked Issues
Closes https://github.com/FunkinCrew/Funkin/issues/5956

## Description
I deadass have no idea whats up with the bug, I just replaced the state's `_constructor` variable when the player moved after getting a new rank.

## Screenshots/Videos

https://github.com/user-attachments/assets/c93fccae-eaef-4c3b-af1d-5213df36912f
