### PR TITLE
[GITHUB] Bump docs to 0.7.5

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -48,19 +48,19 @@ body:
     attributes:
       label: Mobile Device Model
       description: (Mobile users only) What mobile device are you playing on?
-      placeholder: ex. iPhone 16, Galaxy S25, iPad 11th Gen
+      placeholder: ex. iPhone 17, Galaxy S25, iPad 11th Gen
 
   - type: input
     attributes:
       label: Mobile OS Version
       description: (Mobile users only) What version is your Operating System?
-      placeholder: ex. iOS 18.5, Android 15, iPadOS 18.5
+      placeholder: ex. iOS 26.0, Android 15, iPadOS 26.0
 
   - type: input
     attributes:
       label: Version
       description: Which version are you playing on? The game version is in the bottom left corner of the main menu.
-      placeholder: ex. 0.7.4
+      placeholder: ex. 0.7.5
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/charting.yml
+++ b/.github/ISSUE_TEMPLATE/charting.yml
@@ -36,7 +36,7 @@ body:
     attributes:
       label: Version
       description: Which version are you playing on? The game version is in the bottom left corner of the main menu.
-      placeholder: ex. 0.7.4
+      placeholder: ex. 0.7.5
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/compiling.yml
+++ b/.github/ISSUE_TEMPLATE/compiling.yml
@@ -36,7 +36,7 @@ body:
     attributes:
       label: Version
       description: Which version are you compiling? The game version is in the bottom left corner of the main menu or in the project.hxp file.
-      placeholder: ex. 0.7.4
+      placeholder: ex. 0.7.5
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/crash.yml
+++ b/.github/ISSUE_TEMPLATE/crash.yml
@@ -49,19 +49,19 @@ body:
     attributes:
       label: Mobile Device Model
       description: (Mobile users only) What mobile device are you playing on?
-      placeholder: ex. iPhone 16, Galaxy S25, iPad 11th Gen
+      placeholder: ex. iPhone 17, Galaxy S25, iPad 11th Gen
 
   - type: input
     attributes:
       label: Mobile OS Version
       description: (Mobile users only) What version is your Operating System?
-      placeholder: ex. iOS 18.5, Android 15, iPadOS 18.5
+      placeholder: ex. iOS 26.0, Android 15, iPadOS 26.0
 
   - type: input
     attributes:
       label: Version
       description: Which version are you playing on? The game version is in the bottom left corner of the main menu.
-      placeholder: ex. 0.7.4
+      placeholder: ex. 0.7.5
     validations:
       required: true
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -60,7 +60,7 @@ This section provides guidelines to follow when [opening an issue](https://githu
 
 ## Requirements
 Make sure you're playing:
-- the latest version of the game (currently v0.7.4)
+- the latest version of the game (currently v0.7.5)
 - without any mods
 - on [Newgrounds](https://www.newgrounds.com/portal/view/770371) or downloaded from [itch.io](https://ninja-muffin24.itch.io/funkin)
 


### PR DESCRIPTION
redo of #5968, but hopefully better

again I hope this works cause im so bad at github

bumps iOS versions from 18 to iOS 26, and iPhone 16 to iPhone 17.