### PR TITLE
[ENHANCEMENT] Change Animation Editor save shortcuts

### DIFF
--- a/source/funkin/ui/debug/anim/DebugBoundingState.hx
+++ b/source/funkin/ui/debug/anim/DebugBoundingState.hx
@@ -347,6 +347,16 @@ class DebugBoundingState extends FlxState
 
   function offsetControls():Void
   {
+    // CTRL + S = Save Character Data
+    // CTRL + SHIFT + S = Save Offsets
+    // "WINDOWS" key code is the same keycode as COMMAND on mac
+    if ((FlxG.keys.pressed.CONTROL || FlxG.keys.pressed.WINDOWS) && FlxG.keys.justPressed.S)
+    {
+      var outputString = FlxG.keys.pressed.SHIFT ? buildOutputStringOld() : buildOutputStringNew();
+      saveOffsets(outputString, FlxG.keys.pressed.SHIFT ? swagChar.characterId + "Offsets.txt" : swagChar.characterId + ".json");
+      return;
+    }
+
     if (FlxG.keys.justPressed.RBRACKET || FlxG.keys.justPressed.E)
     {
       if (offsetAnimationDropdown.selectedIndex + 1 <= offsetAnimationDropdown.dataSource.size)
@@ -456,12 +466,6 @@ class DebugBoundingState extends FlxState
       txtOffsetShit.y = FlxG.height - 20 - txtOffsetShit.height;
 
       trace(animName);
-    }
-
-    if (FlxG.keys.justPressed.ESCAPE)
-    {
-      var outputString = FlxG.keys.pressed.CONTROL ? buildOutputStringOld() : buildOutputStringNew();
-      saveOffsets(outputString, FlxG.keys.pressed.CONTROL ? swagChar.characterId + "Offsets.txt" : swagChar.characterId + ".json");
     }
   }
 


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
Closes #5931

<!-- Briefly describe the issue(s) fixed. -->
## Description
The current shortcut for saving offsets in the Animation Editor is Ctrl+Esc, but on Windows, this shortcut opens the start menu.

This PR changes the shortcuts for saving files in the Animation Editor to Ctrl+S and Ctrl+Shift+S. (Ctrl+S for saving character data, Ctrl+Shift+S for saving offsets)

I chose these shortcuts for consistency as both the chart editor and stage editor use these shortcuts for saving files.

## Associated Funkin Assets PR
https://github.com/FunkinCrew/funkin.assets/pull/253

This PR is necessary to change the labels to the new shortcuts in the dialog that lists all of the shortcuts.