### PR TITLE
[BUGFIX] Fix Freeplay capsules not playing jump-in animation after returning from stickers

### DIFF
--- a/source/funkin/ui/freeplay/FreeplayState.hx
+++ b/source/funkin/ui/freeplay/FreeplayState.hx
@@ -830,6 +830,7 @@ class FreeplayState extends MusicBeatSubState
     {
       if (fromCharSelect) enterFromCharSel();
       onDJIntroDone();
+      forceSkipIntro = false;
     }
     else
     {

--- a/source/funkin/ui/freeplay/FreeplayState.hx
+++ b/source/funkin/ui/freeplay/FreeplayState.hx
@@ -2829,9 +2829,7 @@ class FreeplayState extends MusicBeatSubState
     if (currentCapsule.freeplayData == null) albumRoll.albumId = null;
 
     changeDiff();
-    if (currentCapsule.freeplayData == null) currentCapsule.refreshDisplay();
-    else
-      currentCapsule.refreshDisplay(false);
+    currentCapsule.refreshDisplay(currentCapsule.freeplayData == null);
 
     for (index => capsule in grpCapsules.members)
     {


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
None.
<!-- Briefly describe the issue(s) fixed. -->
## Description
Recent changes to `develop` made the Freeplay intro animations not play when you're returning from a song, this fixes those changes inadvertently making the capsule jump-in animation never play again after that.

Also did an unrelated tiny adjustment to the code cuz why not
<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos
[Gravar a tela_20250911_163538.webm](https://github.com/user-attachments/assets/71498669-a6b8-4f06-a3ae-07a121ca36fe)
