### PR TITLE
[BUGFIX] Prevent crash when missing credits.json with `-D NO_HARDCODED_CREDITS`

### DIFF
--- a/project.hxp
+++ b/project.hxp
@@ -1385,6 +1385,11 @@ class Project extends HXProject
     addAssetLibrary("default", shouldEmbed, shouldPreloadDefault);
     addAssetPath("assets/preload", "assets", "default", ["*"], exclude, shouldEmbed, "assets");
 
+    if (!HARDCODED_CREDITS.isEnabled(this))
+    {
+      addAsset("assets/exclude/data/credits.json", "assets/data/credits.json", "default", shouldEmbed);
+    }
+
     if (!FEATURE_ANIMATION_EDITOR.isEnabled(this))
       removeAssetPath('assets/preload/data/ui/animation-editor', "default");
 


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
N/A

<!-- Briefly describe the issue(s) fixed. -->
## Description
When the game is compiled with the flag `-D NO_HARDCODED_CREDITS` the game will crash when trying to enter the credits state because of the missing credits json.

This is cause the credits json is in the excludes folder, I mean it would be hardcoded credits so I guess it makes sense? But there isn't any code or checks for un-hardcoded credits.

This PR fixes that.

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos

Before:

https://github.com/user-attachments/assets/24ed2c52-2f44-495b-b97e-402c0f8af197

After:

https://github.com/user-attachments/assets/22cd9c1d-2475-4f0d-b740-b65e19a47583