### PR TITLE
[BUGFIX] Fix text field related chart editor crash

### DIFF
--- a/source/funkin/ui/debug/charting/ChartEditorState.hx
+++ b/source/funkin/ui/debug/charting/ChartEditorState.hx
@@ -5710,6 +5710,8 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
       return;
     }
 
+    this.hideAllToolboxes();
+
     stopWelcomeMusic();
     // TODO: PR Flixel to make onComplete nullable.
     if (audioInstTrack != null) audioInstTrack.onComplete = null;


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
Closes #5953 
<!-- Briefly describe the issue(s) fixed. -->
## Description
Fixes a crash with previously focused text fields and the user trying to exit via the confirmation dialog. ~What a clusterfuck~
<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos
[Gravar a tela_20250912_210733.webm](https://github.com/user-attachments/assets/70ba0d59-9746-462c-b6aa-69d2b6436852)
