### PR TITLE
[ENHANCEMENT] Recycle Combo and Rating Pop-ups + more

### DIFF
--- a/source/funkin/Paths.hx
+++ b/source/funkin/Paths.hx
@@ -143,7 +143,7 @@ class Paths
     return 'songs:assets/songs/${song.toLowerCase()}/Inst$suffix$ext';
   }
 
-  public static function image(key:String, ?library:String):String
+  public static function image(key:Null<String>, ?library:String):String
   {
     return getPath('images/$key.png', IMAGE, library);
   }

--- a/source/funkin/graphics/FunkinSprite.hx
+++ b/source/funkin/graphics/FunkinSprite.hx
@@ -80,7 +80,7 @@ class FunkinSprite extends FlxSprite
    * @param key The key of the texture to load.
    * @return This sprite, for chaining.
    */
-  public function loadTexture(key:String):FunkinSprite
+  public function loadTexture(key:Null<String>):FunkinSprite
   {
     var graphicKey:String = Paths.image(key);
     if (!isTextureCached(graphicKey)) FlxG.log.warn('Texture not cached, may experience stuttering! $graphicKey');

--- a/source/funkin/play/PlayState.hx
+++ b/source/funkin/play/PlayState.hx
@@ -733,7 +733,6 @@ class PlayState extends MusicBeatSubState
 
     // Combo & Pop Up
     comboPopUps = new PopUpStuff(noteStyle);
-    comboPopUps.setPosition(FlxG.width * 0.474, FlxG.camera.height * 0.45);
 
     // Pause sprites
     #if mobile
@@ -2182,6 +2181,7 @@ class PlayState extends MusicBeatSubState
   function initPopups():Void
   {
     // Initialize the judgements and combo meter.
+    comboPopUps.setPosition(FlxG.width * 0.474, FlxG.camera.height * 0.45);
     comboPopUps.zIndex = 900;
     add(comboPopUps);
     comboPopUps.cameras = [camHUD];

--- a/source/funkin/play/PlayState.hx
+++ b/source/funkin/play/PlayState.hx
@@ -733,6 +733,7 @@ class PlayState extends MusicBeatSubState
 
     // Combo & Pop Up
     comboPopUps = new PopUpStuff(noteStyle);
+    comboPopUps.setPosition(FlxG.width * 0.474, FlxG.camera.height * 0.45 - 60);
 
     // Pause sprites
     #if mobile

--- a/source/funkin/play/PlayState.hx
+++ b/source/funkin/play/PlayState.hx
@@ -733,7 +733,7 @@ class PlayState extends MusicBeatSubState
 
     // Combo & Pop Up
     comboPopUps = new PopUpStuff(noteStyle);
-    comboPopUps.setPosition(FlxG.width * 0.474, FlxG.camera.height * 0.45 - 60);
+    comboPopUps.setPosition(FlxG.width * 0.474, (FlxG.camera.height * 0.45) - 60);
 
     // Pause sprites
     #if mobile

--- a/source/funkin/play/PlayState.hx
+++ b/source/funkin/play/PlayState.hx
@@ -733,7 +733,7 @@ class PlayState extends MusicBeatSubState
 
     // Combo & Pop Up
     comboPopUps = new PopUpStuff(noteStyle);
-    comboPopUps.setPosition(FlxG.width * 0.474, (FlxG.camera.height * 0.45) - 60);
+    comboPopUps.setPosition(FlxG.width * 0.474, FlxG.camera.height * 0.45);
 
     // Pause sprites
     #if mobile

--- a/source/funkin/play/components/PopUpStuff.hx
+++ b/source/funkin/play/components/PopUpStuff.hx
@@ -96,7 +96,6 @@ class PopUpStuff extends FlxSpriteGroup
     rating.zIndex = latestRatingZIndex;
     latestRatingZIndex++;
     ratingGroup.sort(SortUtil.byZIndex, FlxSort.ASCENDING);
-    trace("rating Z index: " + rating.zIndex);
 
     rating.loadTexture(ratingInfo.assetPath);
 
@@ -107,7 +106,6 @@ class PopUpStuff extends FlxSpriteGroup
     rating.pixelPerfectPosition = ratingInfo.isPixel;
     rating.updateHitbox();
 
-    trace(ratingGroup.length);
     rating.x -= rating.width / 2;
     rating.y -= rating.height / 2;
 
@@ -128,7 +126,6 @@ class PopUpStuff extends FlxSpriteGroup
       {
         onComplete: function(tween:FlxTween) {
           rating.kill();
-          trace("Killed Rating!");
         },
         startDelay: Conductor.instance.beatLengthMs * 0.001,
         ease: fadeEase
@@ -185,8 +182,6 @@ class PopUpStuff extends FlxSpriteGroup
       numScore.pixelPerfectRender = comboInfo.isPixel;
       numScore.pixelPerfectPosition = comboInfo.isPixel;
       numScore.updateHitbox();
-
-      trace("Num Scores: " + numberGroup.length);
 
       numScore.x = numberGroup.x - (36 * (i + 1)) - 65;
       numScore.x += offsets[0];

--- a/source/funkin/play/components/PopUpStuff.hx
+++ b/source/funkin/play/components/PopUpStuff.hx
@@ -23,6 +23,8 @@ class PopUpStuff extends FlxSpriteGroup
    */
   var offsets:Array<Int> = [0, 0];
 
+  var numberGroup:FlxTypedSpriteGroup<Null<FunkinSprite>>;
+
   var ratingGroup:FlxTypedSpriteGroup<Null<FunkinSprite>>;
 
   override public function new(noteStyle:NoteStyle)
@@ -31,20 +33,25 @@ class PopUpStuff extends FlxSpriteGroup
 
     this.noteStyle = noteStyle;
 
+    numberGroup = new FlxTypedSpriteGroup<Null<FunkinSprite>>();
     ratingGroup = new FlxTypedSpriteGroup<Null<FunkinSprite>>();
 
+    add(numberGroup);
     add(ratingGroup);
   }
 
   /*
+    * Display the player's rating when hitting a note.
     @param daRating Null<String>
-    @return Null<String>
+    @return
    */
   public function displayRating(daRating:Null<String>)
   {
     if (daRating == null) daRating = "good";
 
     var rating:Null<FunkinSprite> = null;
+
+    rating = ratingGroup.getFirstDead();
 
     if (rating != null)
     {
@@ -55,7 +62,7 @@ class PopUpStuff extends FlxSpriteGroup
       rating = new FunkinSprite();
     }
 
-    // if (rating == null) return;
+    if (rating == null) return;
     var ratingInfo = noteStyle.buildJudgementSprite(daRating) ??
       {
         assetPath: null,
@@ -99,7 +106,6 @@ class PopUpStuff extends FlxSpriteGroup
     FlxTween.tween(rating, {alpha: 0}, 0.2,
       {
         onComplete: function(tween:FlxTween) {
-          // ratingGroup.remove(rating, true);
           rating.kill();
         },
         startDelay: Conductor.instance.beatLengthMs * 0.001,
@@ -120,8 +126,6 @@ class PopUpStuff extends FlxSpriteGroup
     while (seperatedScore.length < 3)
       seperatedScore.push(0);
 
-    // seperatedScore.reverse();
-
     var daLoop:Int = 1;
     for (digit in seperatedScore)
     {
@@ -141,14 +145,14 @@ class PopUpStuff extends FlxSpriteGroup
       numScore.velocity.y -= FlxG.random.int(130, 150);
       numScore.velocity.x = FlxG.random.float(-5, 5);
 
-      add(numScore);
+      numberGroup.add(numScore);
 
       var fadeEase = noteStyle.isComboNumSpritePixel(digit) ? EaseUtil.stepped(2) : null;
 
       FlxTween.tween(numScore, {alpha: 0}, 0.2,
         {
           onComplete: function(tween:FlxTween) {
-            remove(numScore, true);
+            numberGroup.remove(numScore, true);
             numScore.destroy();
           },
           startDelay: Conductor.instance.beatLengthMs * 0.002,

--- a/source/funkin/play/components/PopUpStuff.hx
+++ b/source/funkin/play/components/PopUpStuff.hx
@@ -53,8 +53,8 @@ class PopUpStuff extends FlxSpriteGroup
     ratingGroup.scrollFactor.set(0.2, 0.2);
     numberGroup = new FlxTypedSpriteGroup<Null<FunkinSprite>>(FlxG.width * 0.033, FlxG.camera.height * 0.01);
 
-    add(numberGroup);
     add(ratingGroup);
+    add(numberGroup);
   }
 
   /*

--- a/source/funkin/play/components/PopUpStuff.hx
+++ b/source/funkin/play/components/PopUpStuff.hx
@@ -64,6 +64,7 @@ class PopUpStuff extends FlxSpriteGroup
       rating.velocity.y = 0;
       rating.velocity.x = 0;
       rating.alpha = 1;
+      rating.setPosition(ratingGroup.x, ratingGroup.y);
       rating.revive();
     }
     else
@@ -95,18 +96,16 @@ class PopUpStuff extends FlxSpriteGroup
     rating.updateHitbox();
 
     trace(ratingGroup.length);
-    // rating.x = (FlxG.width * 0.474);
-    rating.x = ratingGroup.x;
     rating.x -= rating.width / 2;
-    // rating.y = (FlxG.camera.height * 0.45 - 60);
-    rating.y = ratingGroup.y;
     rating.y -= rating.height / 2;
+
     rating.x += offsets[0];
     rating.y += offsets[1];
-    var styleOffsets = noteStyle.getJudgementSpriteOffsets(daRating);
 
+    var styleOffsets = noteStyle.getJudgementSpriteOffsets(daRating);
     rating.x += styleOffsets[0];
     rating.y += styleOffsets[1];
+
     rating.acceleration.y = 550;
     rating.velocity.y -= FlxG.random.int(140, 175);
     rating.velocity.x -= FlxG.random.int(0, 10);
@@ -178,7 +177,6 @@ class PopUpStuff extends FlxSpriteGroup
       trace("Num Scores: " + numberGroup.length);
 
       numScore.x = numberGroup.x - (36 * (i + 1)) - 65;
-
       numScore.x += offsets[0];
       numScore.y += offsets[1];
       var styleOffsets = noteStyle.getComboNumSpriteOffsets(seperatedScore[i]);

--- a/source/funkin/play/components/PopUpStuff.hx
+++ b/source/funkin/play/components/PopUpStuff.hx
@@ -45,11 +45,11 @@ class PopUpStuff extends FlxSpriteGroup
   }
 
   /*
-    * Display the player's rating when hitting a note
+    * Display the player's rating when hitting a note.
     @param daRating Null<String>
     @return
    */
-  public function displayRating(daRating:Null<String>)
+  public function displayRating(daRating:Null<String>):Void
   {
     if (daRating == null) daRating = "good";
 
@@ -72,7 +72,7 @@ class PopUpStuff extends FlxSpriteGroup
       ratingGroup.add(rating);
     }
 
-    // if (rating == null) return;
+    if (rating == null) return;
     var ratingInfo = noteStyle.buildJudgementSprite(daRating) ??
       {
         assetPath: null,
@@ -124,6 +124,10 @@ class PopUpStuff extends FlxSpriteGroup
       });
   }
 
+  /*
+    * Display the player's combo when hitting a note.
+     @param combo Int
+   */
   public function displayCombo(combo:Int = 0):Void
   {
     var seperatedScore:Array<Int> = [];
@@ -137,35 +141,38 @@ class PopUpStuff extends FlxSpriteGroup
     while (seperatedScore.length < 3)
       seperatedScore.push(0);
 
-    // seperatedScore.reverse();
-
     var daLoop:Int = 1;
     for (digit in seperatedScore)
     {
-      var numScore:Null<FunkinSprite> = noteStyle.buildComboNumSprite(digit);
-      if (numScore == null) continue;
+      var numScore:Null<FunkinSprite> = null;
 
-      numScore.x = (FlxG.width * 0.507) - (36 * daLoop) - 65;
-      numScore.y = (FlxG.camera.height * 0.44);
+      numScore = new FunkinSprite();
+      var comboInfo = noteStyle.buildComboNumSprite(digit);
 
-      numScore.x += offsets[0];
-      numScore.y += offsets[1];
-      var styleOffsets = noteStyle.getComboNumSpriteOffsets(digit);
-      numScore.x += styleOffsets[0];
-      numScore.y += styleOffsets[1];
+      numScore.loadTexture(comboInfo.assetPath);
+      // if (numScore == null) continue;
 
-      numScore.acceleration.y = FlxG.random.int(250, 300);
-      numScore.velocity.y -= FlxG.random.int(130, 150);
-      numScore.velocity.x = FlxG.random.float(-5, 5);
+      // numScore.x = (FlxG.width * 0.507) - (36 * daLoop) - 65;
+      // numScore.y = (FlxG.camera.height * 0.44);
 
-      add(numScore);
+      // numScore.x += offsets[0];
+      // numScore.y += offsets[1];
+      // var styleOffsets = noteStyle.getComboNumSpriteOffsets(digit);
+      // numScore.x += styleOffsets[0];
+      // numScore.y += styleOffsets[1];
+
+      // numScore.acceleration.y = FlxG.random.int(250, 300);
+      // numScore.velocity.y -= FlxG.random.int(130, 150);
+      // numScore.velocity.x = FlxG.random.float(-5, 5);
+
+      numberGroup.add(numScore);
 
       var fadeEase = noteStyle.isComboNumSpritePixel(digit) ? EaseUtil.stepped(2) : null;
 
       FlxTween.tween(numScore, {alpha: 0}, 0.2,
         {
           onComplete: function(tween:FlxTween) {
-            remove(numScore, true);
+            numberGroup.remove(numScore, true);
             numScore.destroy();
           },
           startDelay: Conductor.instance.beatLengthMs * 0.002,

--- a/source/funkin/play/components/PopUpStuff.hx
+++ b/source/funkin/play/components/PopUpStuff.hx
@@ -26,9 +26,10 @@ class PopUpStuff extends FlxSpriteGroup
   var offsets:Array<Int> = [0, 0];
 
   var ratingGroup:FlxTypedSpriteGroup<Null<FunkinSprite>>;
-  var latestZIndex:Int = 0;
+  var latestRatingZIndex:Int = 0;
 
   var numberGroup:FlxTypedSpriteGroup<Null<FunkinSprite>>;
+  var latestComboZIndex:Int = 0;
 
   override public function new(noteStyle:NoteStyle)
   {
@@ -38,7 +39,7 @@ class PopUpStuff extends FlxSpriteGroup
 
     ratingGroup = new FlxTypedSpriteGroup<Null<FunkinSprite>>();
     // ratingGroup.zIndex = 1000;
-    numberGroup = new FlxTypedSpriteGroup<Null<FunkinSprite>>();
+    numberGroup = new FlxTypedSpriteGroup<Null<FunkinSprite>>(FlxG.width * 0.507, FlxG.camera.height * 0.44);
 
     add(numberGroup);
     add(ratingGroup);
@@ -81,8 +82,8 @@ class PopUpStuff extends FlxSpriteGroup
         isPixel: false,
       };
 
-    rating.zIndex = latestZIndex;
-    latestZIndex--;
+    rating.zIndex = latestRatingZIndex;
+    latestRatingZIndex--;
     ratingGroup.sort(SortUtil.byZIndex, FlxSort.DESCENDING);
     trace("rating Z index: " + rating.zIndex);
     rating.loadTexture(ratingInfo.assetPath);
@@ -141,8 +142,7 @@ class PopUpStuff extends FlxSpriteGroup
     while (seperatedScore.length < 3)
       seperatedScore.push(0);
 
-    var daLoop:Int = 1;
-    for (digit in seperatedScore)
+    for (i in 0...seperatedScore.length)
     {
       var numScore:Null<FunkinSprite> = null;
 
@@ -151,9 +151,9 @@ class PopUpStuff extends FlxSpriteGroup
       if (numScore != null)
       {
         numScore.acceleration.y = 0;
-        numScore.velocity.y = 0;
-        numScore.velocity.x = 0;
+        numScore.velocity.set(0, 0);
         numScore.alpha = 1;
+        numScore.setPosition(numberGroup.x, numberGroup.y);
         numScore.revive();
       }
       else
@@ -162,26 +162,36 @@ class PopUpStuff extends FlxSpriteGroup
         numberGroup.add(numScore);
       }
 
-      var comboInfo = noteStyle.buildComboNumSprite(digit);
+      var comboInfo = noteStyle.buildComboNumSprite(seperatedScore[i]);
+
+      numScore.zIndex = latestComboZIndex;
+      latestComboZIndex--;
+      numberGroup.sort(SortUtil.byZIndex, FlxSort.DESCENDING);
       numScore.loadTexture(comboInfo.assetPath);
+
+      numScore.scale = comboInfo.scale;
+
+      numScore.antialiasing = !comboInfo.isPixel;
+      numScore.pixelPerfectRender = comboInfo.isPixel;
+      numScore.pixelPerfectPosition = comboInfo.isPixel;
+      numScore.updateHitbox();
       // if (numScore == null) continue;
 
       trace("Num Scores: " + numberGroup.length);
 
-      // numScore.x = (FlxG.width * 0.507) - (36 * daLoop) - 65;
-      // numScore.y = (FlxG.camera.height * 0.44);
+      numScore.x = numberGroup.x - (36 * (i + 1)) - 65;
 
-      // numScore.x += offsets[0];
-      // numScore.y += offsets[1];
-      // var styleOffsets = noteStyle.getComboNumSpriteOffsets(digit);
-      // numScore.x += styleOffsets[0];
-      // numScore.y += styleOffsets[1];
+      numScore.x += offsets[0];
+      numScore.y += offsets[1];
+      var styleOffsets = noteStyle.getComboNumSpriteOffsets(seperatedScore[i]);
+      numScore.x += styleOffsets[0];
+      numScore.y += styleOffsets[1];
 
-      // numScore.acceleration.y = FlxG.random.int(250, 300);
-      // numScore.velocity.y -= FlxG.random.int(130, 150);
-      // numScore.velocity.x = FlxG.random.float(-5, 5);
+      numScore.acceleration.y = FlxG.random.int(250, 300);
+      numScore.velocity.y -= FlxG.random.int(130, 150);
+      numScore.velocity.x = FlxG.random.float(-5, 5);
 
-      var fadeEase = noteStyle.isComboNumSpritePixel(digit) ? EaseUtil.stepped(2) : null;
+      var fadeEase = noteStyle.isComboNumSpritePixel(seperatedScore[i]) ? EaseUtil.stepped(2) : null;
 
       FlxTween.tween(numScore, {alpha: 0}, 0.2,
         {
@@ -191,8 +201,6 @@ class PopUpStuff extends FlxSpriteGroup
           startDelay: Conductor.instance.beatLengthMs * 0.002,
           ease: fadeEase
         });
-
-      daLoop++;
     }
   }
 }

--- a/source/funkin/play/components/PopUpStuff.hx
+++ b/source/funkin/play/components/PopUpStuff.hx
@@ -1,13 +1,13 @@
 package funkin.play.components;
 
-import flixel.group.FlxGroup.FlxTypedGroup;
+import flixel.group.FlxSpriteGroup.FlxTypedSpriteGroup;
 import flixel.tweens.FlxTween;
 import funkin.graphics.FunkinSprite;
 import funkin.util.EaseUtil;
 import funkin.play.notes.notestyle.NoteStyle;
 
 @:nullSafety
-class PopUpStuff extends FlxTypedGroup<FunkinSprite>
+class PopUpStuff extends FlxTypedSpriteGroup<FunkinSprite>
 {
   /**
    * The current note style to use. This determines which graphics to display.

--- a/source/funkin/play/components/PopUpStuff.hx
+++ b/source/funkin/play/components/PopUpStuff.hx
@@ -146,11 +146,27 @@ class PopUpStuff extends FlxSpriteGroup
     {
       var numScore:Null<FunkinSprite> = null;
 
-      numScore = new FunkinSprite();
-      var comboInfo = noteStyle.buildComboNumSprite(digit);
+      numScore = numberGroup.getFirstDead();
 
+      if (numScore != null)
+      {
+        numScore.acceleration.y = 0;
+        numScore.velocity.y = 0;
+        numScore.velocity.x = 0;
+        numScore.alpha = 1;
+        numScore.revive();
+      }
+      else
+      {
+        numScore = new FunkinSprite();
+        numberGroup.add(numScore);
+      }
+
+      var comboInfo = noteStyle.buildComboNumSprite(digit);
       numScore.loadTexture(comboInfo.assetPath);
       // if (numScore == null) continue;
+
+      trace("Num Scores: " + numberGroup.length);
 
       // numScore.x = (FlxG.width * 0.507) - (36 * daLoop) - 65;
       // numScore.y = (FlxG.camera.height * 0.44);
@@ -165,15 +181,12 @@ class PopUpStuff extends FlxSpriteGroup
       // numScore.velocity.y -= FlxG.random.int(130, 150);
       // numScore.velocity.x = FlxG.random.float(-5, 5);
 
-      numberGroup.add(numScore);
-
       var fadeEase = noteStyle.isComboNumSpritePixel(digit) ? EaseUtil.stepped(2) : null;
 
       FlxTween.tween(numScore, {alpha: 0}, 0.2,
         {
           onComplete: function(tween:FlxTween) {
-            numberGroup.remove(numScore, true);
-            numScore.destroy();
+            numScore.kill();
           },
           startDelay: Conductor.instance.beatLengthMs * 0.002,
           ease: fadeEase

--- a/source/funkin/play/components/PopUpStuff.hx
+++ b/source/funkin/play/components/PopUpStuff.hx
@@ -32,7 +32,7 @@ class PopUpStuff extends FlxSpriteGroup
     this.noteStyle = noteStyle;
 
     ratingGroup = new FlxTypedSpriteGroup<Null<FunkinSprite>>();
-    ratingGroup.zIndex = 1000;
+
     add(ratingGroup);
   }
 
@@ -46,15 +46,9 @@ class PopUpStuff extends FlxSpriteGroup
 
     var rating:Null<FunkinSprite> = null;
 
-    rating = ratingGroup.getFirstDead();
-
     if (rating != null)
     {
       rating.revive();
-      rating.alpha = 1;
-      rating.acceleration.y = 0;
-      rating.velocity.y = 0;
-      rating.velocity.x = 0;
     }
     else
     {
@@ -78,6 +72,12 @@ class PopUpStuff extends FlxSpriteGroup
     rating.pixelPerfectRender = ratingInfo.isPixel;
     rating.pixelPerfectPosition = ratingInfo.isPixel;
     rating.updateHitbox();
+
+    rating.alpha = 1;
+    rating.zIndex = 1000;
+    rating.acceleration.y = 0;
+    rating.velocity.y = 0;
+    rating.velocity.x = 0;
 
     trace(ratingGroup.length);
     rating.x = (FlxG.width * 0.474);

--- a/source/funkin/play/components/PopUpStuff.hx
+++ b/source/funkin/play/components/PopUpStuff.hx
@@ -38,11 +38,10 @@ class PopUpStuff extends FlxSpriteGroup
     this.noteStyle = noteStyle;
 
     ratingGroup = new FlxTypedSpriteGroup<Null<FunkinSprite>>();
-    // ratingGroup.zIndex = 1000;
     numberGroup = new FlxTypedSpriteGroup<Null<FunkinSprite>>(FlxG.width * 0.507, FlxG.camera.height * 0.44);
 
-    add(numberGroup);
     add(ratingGroup);
+    // add(numberGroup);
   }
 
   /*
@@ -73,7 +72,6 @@ class PopUpStuff extends FlxSpriteGroup
       ratingGroup.add(rating);
     }
 
-    if (rating == null) return;
     var ratingInfo = noteStyle.buildJudgementSprite(daRating) ??
       {
         assetPath: null,
@@ -97,26 +95,27 @@ class PopUpStuff extends FlxSpriteGroup
     rating.updateHitbox();
 
     trace(ratingGroup.length);
-    rating.x = (FlxG.width * 0.474);
+    // rating.x = (FlxG.width * 0.474);
+    rating.x = ratingGroup.x;
     rating.x -= rating.width / 2;
-    rating.y = (FlxG.camera.height * 0.45 - 60);
+    // rating.y = (FlxG.camera.height * 0.45 - 60);
+    rating.y = ratingGroup.y;
     rating.y -= rating.height / 2;
     rating.x += offsets[0];
     rating.y += offsets[1];
     var styleOffsets = noteStyle.getJudgementSpriteOffsets(daRating);
 
-    rating.x += styleOffsets[0];
-    rating.y += styleOffsets[1];
-    rating.acceleration.y = 550;
-    rating.velocity.y -= FlxG.random.int(140, 175);
-    rating.velocity.x -= FlxG.random.int(0, 10);
+    // rating.x += styleOffsets[0];
+    // rating.y += styleOffsets[1];
+    // rating.acceleration.y = 550;
+    // rating.velocity.y -= FlxG.random.int(140, 175);
+    // rating.velocity.x -= FlxG.random.int(0, 10);
 
     var fadeEase = noteStyle.isJudgementSpritePixel(daRating) ? EaseUtil.stepped(2) : null;
 
     FlxTween.tween(rating, {alpha: 0}, 0.2,
       {
         onComplete: function(tween:FlxTween) {
-          // rating.zIndex = 1000;
           rating.kill();
           trace("Killed Rating!");
         },
@@ -175,7 +174,6 @@ class PopUpStuff extends FlxSpriteGroup
       numScore.pixelPerfectRender = comboInfo.isPixel;
       numScore.pixelPerfectPosition = comboInfo.isPixel;
       numScore.updateHitbox();
-      // if (numScore == null) continue;
 
       trace("Num Scores: " + numberGroup.length);
 

--- a/source/funkin/play/components/PopUpStuff.hx
+++ b/source/funkin/play/components/PopUpStuff.hx
@@ -38,10 +38,10 @@ class PopUpStuff extends FlxSpriteGroup
     this.noteStyle = noteStyle;
 
     ratingGroup = new FlxTypedSpriteGroup<Null<FunkinSprite>>();
-    numberGroup = new FlxTypedSpriteGroup<Null<FunkinSprite>>(FlxG.width * 0.507, FlxG.camera.height * 0.44);
+    numberGroup = new FlxTypedSpriteGroup<Null<FunkinSprite>>(FlxG.width * 0.033, (FlxG.camera.height * 0.01) + 50);
 
     add(ratingGroup);
-    // add(numberGroup);
+    add(numberGroup);
   }
 
   /*
@@ -105,11 +105,11 @@ class PopUpStuff extends FlxSpriteGroup
     rating.y += offsets[1];
     var styleOffsets = noteStyle.getJudgementSpriteOffsets(daRating);
 
-    // rating.x += styleOffsets[0];
-    // rating.y += styleOffsets[1];
-    // rating.acceleration.y = 550;
-    // rating.velocity.y -= FlxG.random.int(140, 175);
-    // rating.velocity.x -= FlxG.random.int(0, 10);
+    rating.x += styleOffsets[0];
+    rating.y += styleOffsets[1];
+    rating.acceleration.y = 550;
+    rating.velocity.y -= FlxG.random.int(140, 175);
+    rating.velocity.x -= FlxG.random.int(0, 10);
 
     var fadeEase = noteStyle.isJudgementSpritePixel(daRating) ? EaseUtil.stepped(2) : null;
 

--- a/source/funkin/play/components/PopUpStuff.hx
+++ b/source/funkin/play/components/PopUpStuff.hx
@@ -1,13 +1,13 @@
 package funkin.play.components;
 
-import flixel.group.FlxSpriteGroup.FlxTypedSpriteGroup;
+import flixel.group.FlxSpriteGroup;
 import flixel.tweens.FlxTween;
 import funkin.graphics.FunkinSprite;
 import funkin.util.EaseUtil;
 import funkin.play.notes.notestyle.NoteStyle;
 
 @:nullSafety
-class PopUpStuff extends FlxTypedSpriteGroup<FunkinSprite>
+class PopUpStuff extends FlxSpriteGroup
 {
   /**
    * The current note style to use. This determines which graphics to display.
@@ -21,11 +21,17 @@ class PopUpStuff extends FlxTypedSpriteGroup<FunkinSprite>
    */
   var offsets:Array<Int> = [0, 0];
 
+  var ratingGroup:FlxSpriteGroup;
+
   override public function new(noteStyle:NoteStyle)
   {
     super();
 
     this.noteStyle = noteStyle;
+
+    ratingGroup = new FlxSpriteGroup();
+    ratingGroup.zIndex = 1000;
+    add(ratingGroup);
   }
 
   public function displayRating(daRating:Null<String>)
@@ -34,8 +40,6 @@ class PopUpStuff extends FlxTypedSpriteGroup<FunkinSprite>
 
     var rating:Null<FunkinSprite> = noteStyle.buildJudgementSprite(daRating);
     if (rating == null) return;
-
-    rating.zIndex = 1000;
 
     rating.x = (FlxG.width * 0.474);
     rating.x -= rating.width / 2;
@@ -52,14 +56,14 @@ class PopUpStuff extends FlxTypedSpriteGroup<FunkinSprite>
     rating.velocity.y -= FlxG.random.int(140, 175);
     rating.velocity.x -= FlxG.random.int(0, 10);
 
-    add(rating);
+    ratingGroup.add(rating);
 
     var fadeEase = noteStyle.isJudgementSpritePixel(daRating) ? EaseUtil.stepped(2) : null;
 
     FlxTween.tween(rating, {alpha: 0}, 0.2,
       {
         onComplete: function(tween:FlxTween) {
-          remove(rating, true);
+          ratingGroup.remove(rating, true);
           rating.destroy();
         },
         startDelay: Conductor.instance.beatLengthMs * 0.001,

--- a/source/funkin/play/components/PopUpStuff.hx
+++ b/source/funkin/play/components/PopUpStuff.hx
@@ -46,18 +46,22 @@ class PopUpStuff extends FlxSpriteGroup
 
     var rating:Null<FunkinSprite> = null;
 
-    // rating = ratingGroup.getFirstAvailable();
+    rating = ratingGroup.getFirstDead();
 
-    // if (rating != null)
-    // {
-    //   rating.revive();
-    // }
-    // else
-    // {
-    rating = new FunkinSprite();
-    // }
+    if (rating != null)
+    {
+      rating.revive();
+      rating.alpha = 1;
+      rating.acceleration.y = 0;
+      rating.velocity.y = 0;
+      rating.velocity.x = 0;
+    }
+    else
+    {
+      rating = new FunkinSprite();
+    }
 
-    if (rating == null) return;
+    // if (rating == null) return;
     var ratingInfo = noteStyle.buildJudgementSprite(daRating) ??
       {
         assetPath: null,
@@ -75,6 +79,7 @@ class PopUpStuff extends FlxSpriteGroup
     rating.pixelPerfectPosition = ratingInfo.isPixel;
     rating.updateHitbox();
 
+    trace(ratingGroup.length);
     rating.x = (FlxG.width * 0.474);
     rating.x -= rating.width / 2;
     rating.y = (FlxG.camera.height * 0.45 - 60);

--- a/source/funkin/play/components/PopUpStuff.hx
+++ b/source/funkin/play/components/PopUpStuff.hx
@@ -10,7 +10,9 @@ import flixel.math.FlxPoint;
 import funkin.util.SortUtil;
 import flixel.util.FlxSort;
 
-// @:nullSafety
+/*
+ * The class which is responsible for managing in-game Pop-ups.
+ */
 class PopUpStuff extends FlxSpriteGroup
 {
   /**
@@ -25,10 +27,20 @@ class PopUpStuff extends FlxSpriteGroup
    */
   var offsets:Array<Int> = [0, 0];
 
+  /*
+   * A group that contains all of the rating Pop-ups.
+   * Used to easily recycle previous ratings.
+   */
   var ratingGroup:FlxTypedSpriteGroup<Null<FunkinSprite>>;
+
   var latestRatingZIndex:Int = 0;
 
+  /*
+   * A group that contains all of the combo number Pop-ups
+   * Used to easily recycle previous combo numbers.
+   */
   var numberGroup:FlxTypedSpriteGroup<Null<FunkinSprite>>;
+
   var latestComboZIndex:Int = 0;
 
   override public function new(noteStyle:NoteStyle)
@@ -39,14 +51,14 @@ class PopUpStuff extends FlxSpriteGroup
 
     ratingGroup = new FlxTypedSpriteGroup<Null<FunkinSprite>>(0, -60);
     ratingGroup.scrollFactor.set(0.2, 0.2);
-    numberGroup = new FlxTypedSpriteGroup<Null<FunkinSprite>>(FlxG.width * 0.033, 0);
+    numberGroup = new FlxTypedSpriteGroup<Null<FunkinSprite>>(FlxG.width * 0.033, FlxG.camera.height * 0.01);
 
-    add(ratingGroup);
     add(numberGroup);
+    add(ratingGroup);
   }
 
   /*
-    * Display the player's rating when hitting a note.
+    * Creates a Rating Pop-up and displays it when the player hits a note.
     @param daRating Null<String>
     @return Void
    */
@@ -73,7 +85,7 @@ class PopUpStuff extends FlxSpriteGroup
       ratingGroup.add(rating);
     }
 
-    var ratingInfo = noteStyle.buildJudgementSprite(daRating) ??
+    var ratingInfo:JudgementSpriteInfo = noteStyle.buildJudgementSprite(daRating) ??
       {
         assetPath: null,
         scale: new FlxPoint(1.0, 1.0),
@@ -82,8 +94,8 @@ class PopUpStuff extends FlxSpriteGroup
 
     // Can't think of a better way to do this.
     rating.zIndex = latestRatingZIndex;
-    latestRatingZIndex--;
-    ratingGroup.sort(SortUtil.byZIndex, FlxSort.DESCENDING);
+    latestRatingZIndex++;
+    ratingGroup.sort(SortUtil.byZIndex, FlxSort.ASCENDING);
     trace("rating Z index: " + rating.zIndex);
 
     rating.loadTexture(ratingInfo.assetPath);
@@ -124,7 +136,7 @@ class PopUpStuff extends FlxSpriteGroup
   }
 
   /*
-    * Display the player's combo when hitting a note.
+    * Creates a Combo Pop-up to display the player's combo when hitting a note.
      @param combo Int
    */
   public function displayCombo(combo:Int = 0):Void
@@ -160,11 +172,11 @@ class PopUpStuff extends FlxSpriteGroup
         numberGroup.add(numScore);
       }
 
-      var comboInfo = noteStyle.buildComboNumSprite(seperatedScore[i]);
+      var comboInfo:JudgementSpriteInfo = noteStyle.buildComboNumSprite(seperatedScore[i]);
 
       numScore.zIndex = latestComboZIndex;
-      latestComboZIndex--;
-      numberGroup.sort(SortUtil.byZIndex, FlxSort.DESCENDING);
+      latestComboZIndex++;
+      numberGroup.sort(SortUtil.byZIndex, FlxSort.ASCENDING);
       numScore.loadTexture(comboInfo.assetPath);
 
       numScore.scale = comboInfo.scale;

--- a/source/funkin/play/components/PopUpStuff.hx
+++ b/source/funkin/play/components/PopUpStuff.hx
@@ -38,6 +38,7 @@ class PopUpStuff extends FlxSpriteGroup
     this.noteStyle = noteStyle;
 
     ratingGroup = new FlxTypedSpriteGroup<Null<FunkinSprite>>(0, -60);
+    ratingGroup.scrollFactor.set(0.2, 0.2);
     numberGroup = new FlxTypedSpriteGroup<Null<FunkinSprite>>(FlxG.width * 0.033, 0);
 
     add(ratingGroup);
@@ -75,18 +76,18 @@ class PopUpStuff extends FlxSpriteGroup
       {
         assetPath: null,
         scale: new FlxPoint(1.0, 1.0),
-        scrollFactor: new FlxPoint(1.0, 1.0),
         isPixel: false,
       };
 
+    // Can't think of a better way to do this.
     rating.zIndex = latestRatingZIndex;
     latestRatingZIndex--;
     ratingGroup.sort(SortUtil.byZIndex, FlxSort.DESCENDING);
     trace("rating Z index: " + rating.zIndex);
+
     rating.loadTexture(ratingInfo.assetPath);
 
     rating.scale = ratingInfo.scale;
-    rating.scrollFactor = ratingInfo.scrollFactor;
 
     rating.antialiasing = !ratingInfo.isPixel;
     rating.pixelPerfectRender = ratingInfo.isPixel;
@@ -206,6 +207,5 @@ typedef JudgementSpriteInfo =
 {
   var assetPath:Null<String>;
   var scale:FlxPoint;
-  var scrollFactor:FlxPoint;
   var isPixel:Bool;
 }

--- a/source/funkin/play/components/PopUpStuff.hx
+++ b/source/funkin/play/components/PopUpStuff.hx
@@ -37,8 +37,8 @@ class PopUpStuff extends FlxSpriteGroup
 
     this.noteStyle = noteStyle;
 
-    ratingGroup = new FlxTypedSpriteGroup<Null<FunkinSprite>>();
-    numberGroup = new FlxTypedSpriteGroup<Null<FunkinSprite>>(FlxG.width * 0.033, (FlxG.camera.height * 0.01) + 50);
+    ratingGroup = new FlxTypedSpriteGroup<Null<FunkinSprite>>(0, -60);
+    numberGroup = new FlxTypedSpriteGroup<Null<FunkinSprite>>(FlxG.width * 0.033, 0);
 
     add(ratingGroup);
     add(numberGroup);
@@ -47,7 +47,7 @@ class PopUpStuff extends FlxSpriteGroup
   /*
     * Display the player's rating when hitting a note.
     @param daRating Null<String>
-    @return
+    @return Void
    */
   public function displayRating(daRating:Null<String>):Void
   {
@@ -62,7 +62,6 @@ class PopUpStuff extends FlxSpriteGroup
       rating.acceleration.y = 0;
       rating.velocity.y = 0;
       rating.velocity.x = 0;
-      // rating.zIndex = 0;
       rating.alpha = 1;
       rating.revive();
     }

--- a/source/funkin/play/notes/notestyle/NoteStyle.hx
+++ b/source/funkin/play/notes/notestyle/NoteStyle.hx
@@ -379,7 +379,6 @@ class NoteStyle implements IRegistryEntry<NoteStyleData>
         return null;
     }
 
-    result.scrollFactor.set(0, 0);
     result.antialiasing = !isCountdownSpritePixel(step);
     result.updateHitbox();
 
@@ -527,7 +526,6 @@ class NoteStyle implements IRegistryEntry<NoteStyleData>
       {
         assetPath: null,
         scale: new FlxPoint(1.0, 1.0),
-        scrollFactor: new FlxPoint(1.0, 1.0),
         isPixel: false,
       }; // = new JudgementSpriteInfo(null, new FlxPoint(1.0, 1.0), new FlxPoint(1.0, 1.0), true);
 
@@ -561,7 +559,6 @@ class NoteStyle implements IRegistryEntry<NoteStyleData>
         return null;
     }
 
-    result.scrollFactor.set(0.2, 0.2);
     result.isPixel = isJudgementSpritePixel(rating);
 
     return result;
@@ -653,7 +650,6 @@ class NoteStyle implements IRegistryEntry<NoteStyleData>
       {
         assetPath: null,
         scale: new FlxPoint(1.0, 1.0),
-        scrollFactor: new FlxPoint(0, 0),
         isPixel: false,
       };
 

--- a/source/funkin/play/notes/notestyle/NoteStyle.hx
+++ b/source/funkin/play/notes/notestyle/NoteStyle.hx
@@ -517,6 +517,7 @@ class NoteStyle implements IRegistryEntry<NoteStyleData>
   }
 
   /*
+    * Fetches the information for a judgement sprite.
     @param rating String
     @return JudgementSpriteInfo
    */
@@ -562,10 +563,6 @@ class NoteStyle implements IRegistryEntry<NoteStyleData>
 
     result.scrollFactor.set(0.2, 0.2);
     result.isPixel = isJudgementSpritePixel(rating);
-    // result.antialiasing = !isPixel;
-    // result.pixelPerfectRender = isPixel;
-    // result.pixelPerfectPosition = isPixel;
-    // result.updateHitbox();
 
     return result;
   }
@@ -645,91 +642,88 @@ class NoteStyle implements IRegistryEntry<NoteStyleData>
     }
   }
 
-  public function buildComboNumSprite(digit:Int):Null<FunkinSprite>
+  /*
+    * Fetches the information for a combo number sprite.
+    @param digit Int
+    @return JudgementSpriteInfo
+   */
+  public function buildComboNumSprite(digit:Int):Null<JudgementSpriteInfo>
   {
-    var result = new FunkinSprite();
+    var result:JudgementSpriteInfo =
+      {
+        assetPath: null,
+        scale: new FlxPoint(1.0, 1.0),
+        scrollFactor: new FlxPoint(0, 0),
+        isPixel: false,
+      };
 
     switch (digit)
     {
       case 0:
         if (_data.assets.comboNumber0 == null) return fallback?.buildComboNumSprite(digit);
-        var assetPath = buildComboNumSpritePath(digit);
-        if (assetPath == null) return null;
-        result.loadTexture(assetPath);
+        result.assetPath = buildComboNumSpritePath(digit);
+        if (result.assetPath == null) return null;
         result.scale.x = _data.assets.comboNumber0?.scale ?? 1.0;
         result.scale.y = _data.assets.comboNumber0?.scale ?? 1.0;
       case 1:
         if (_data.assets.comboNumber1 == null) return fallback?.buildComboNumSprite(digit);
-        var assetPath = buildComboNumSpritePath(digit);
-        if (assetPath == null) return null;
-        result.loadTexture(assetPath);
+        result.assetPath = buildComboNumSpritePath(digit);
+        if (result.assetPath == null) return null;
         result.scale.x = _data.assets.comboNumber1?.scale ?? 1.0;
         result.scale.y = _data.assets.comboNumber1?.scale ?? 1.0;
       case 2:
         if (_data.assets.comboNumber2 == null) return fallback?.buildComboNumSprite(digit);
-        var assetPath = buildComboNumSpritePath(digit);
-        if (assetPath == null) return null;
-        result.loadTexture(assetPath);
+        result.assetPath = buildComboNumSpritePath(digit);
+        if (result.assetPath == null) return null;
         result.scale.x = _data.assets.comboNumber2?.scale ?? 1.0;
         result.scale.y = _data.assets.comboNumber2?.scale ?? 1.0;
       case 3:
         if (_data.assets.comboNumber3 == null) return fallback?.buildComboNumSprite(digit);
-        var assetPath = buildComboNumSpritePath(digit);
-        if (assetPath == null) return null;
-        result.loadTexture(assetPath);
+        result.assetPath = buildComboNumSpritePath(digit);
+        if (result.assetPath == null) return null;
         result.scale.x = _data.assets.comboNumber3?.scale ?? 1.0;
         result.scale.y = _data.assets.comboNumber3?.scale ?? 1.0;
       case 4:
         if (_data.assets.comboNumber4 == null) return fallback?.buildComboNumSprite(digit);
-        var assetPath = buildComboNumSpritePath(digit);
-        if (assetPath == null) return null;
-        result.loadTexture(assetPath);
+        result.assetPath = buildComboNumSpritePath(digit);
+        if (result.assetPath == null) return null;
         result.scale.x = _data.assets.comboNumber4?.scale ?? 1.0;
         result.scale.y = _data.assets.comboNumber4?.scale ?? 1.0;
       case 5:
         if (_data.assets.comboNumber5 == null) return fallback?.buildComboNumSprite(digit);
-        var assetPath = buildComboNumSpritePath(digit);
-        if (assetPath == null) return null;
-        result.loadTexture(assetPath);
+        result.assetPath = buildComboNumSpritePath(digit);
+        if (result.assetPath == null) return null;
         result.scale.x = _data.assets.comboNumber5?.scale ?? 1.0;
         result.scale.y = _data.assets.comboNumber5?.scale ?? 1.0;
       case 6:
         if (_data.assets.comboNumber6 == null) return fallback?.buildComboNumSprite(digit);
-        var assetPath = buildComboNumSpritePath(digit);
-        if (assetPath == null) return null;
-        result.loadTexture(assetPath);
+        result.assetPath = buildComboNumSpritePath(digit);
+        if (result.assetPath == null) return null;
         result.scale.x = _data.assets.comboNumber6?.scale ?? 1.0;
         result.scale.y = _data.assets.comboNumber6?.scale ?? 1.0;
       case 7:
         if (_data.assets.comboNumber7 == null) return fallback?.buildComboNumSprite(digit);
-        var assetPath = buildComboNumSpritePath(digit);
-        if (assetPath == null) return null;
-        result.loadTexture(assetPath);
+        result.assetPath = buildComboNumSpritePath(digit);
+        if (result.assetPath == null) return null;
         result.scale.x = _data.assets.comboNumber7?.scale ?? 1.0;
         result.scale.y = _data.assets.comboNumber7?.scale ?? 1.0;
       case 8:
         if (_data.assets.comboNumber8 == null) return fallback?.buildComboNumSprite(digit);
-        var assetPath = buildComboNumSpritePath(digit);
-        if (assetPath == null) return null;
-        result.loadTexture(assetPath);
+        result.assetPath = buildComboNumSpritePath(digit);
+        if (result.assetPath == null) return null;
         result.scale.x = _data.assets.comboNumber8?.scale ?? 1.0;
         result.scale.y = _data.assets.comboNumber8?.scale ?? 1.0;
       case 9:
         if (_data.assets.comboNumber9 == null) return fallback?.buildComboNumSprite(digit);
-        var assetPath = buildComboNumSpritePath(digit);
-        if (assetPath == null) return null;
-        result.loadTexture(assetPath);
+        result.assetPath = buildComboNumSpritePath(digit);
+        if (result.assetPath == null) return null;
         result.scale.x = _data.assets.comboNumber9?.scale ?? 1.0;
         result.scale.y = _data.assets.comboNumber9?.scale ?? 1.0;
       default:
         return null;
     }
 
-    var isPixel = isComboNumSpritePixel(digit);
-    result.antialiasing = !isPixel;
-    result.pixelPerfectRender = isPixel;
-    result.pixelPerfectPosition = isPixel;
-    result.updateHitbox();
+    result.isPixel = isComboNumSpritePixel(digit);
 
     return result;
   }

--- a/source/funkin/play/notes/notestyle/NoteStyle.hx
+++ b/source/funkin/play/notes/notestyle/NoteStyle.hx
@@ -9,6 +9,8 @@ import funkin.graphics.FunkinSprite;
 import funkin.data.notestyle.NoteStyleData;
 import funkin.data.notestyle.NoteStyleRegistry;
 import funkin.util.assets.FlxAnimationUtil;
+import funkin.play.components.PopUpStuff.JudgementSpriteInfo;
+import flixel.math.FlxPoint;
 
 using funkin.data.animation.AnimationData.AnimationDataUtil;
 
@@ -514,38 +516,44 @@ class NoteStyle implements IRegistryEntry<NoteStyleData>
     return Paths.sound(parts[1], parts[0]);
   }
 
-  public function buildJudgementSprite(rating:String):Null<FunkinSprite>
+  /*
+    @param rating String
+    @return JudgementSpriteInfo
+   */
+  public function buildJudgementSprite(rating:String):Null<JudgementSpriteInfo>
   {
-    var result = new FunkinSprite();
+    var result:JudgementSpriteInfo =
+      {
+        assetPath: null,
+        scale: new FlxPoint(1.0, 1.0),
+        scrollFactor: new FlxPoint(1.0, 1.0),
+        isPixel: false,
+      }; // = new JudgementSpriteInfo(null, new FlxPoint(1.0, 1.0), new FlxPoint(1.0, 1.0), true);
 
     switch (rating)
     {
       case "sick":
         if (_data.assets.judgementSick == null) return fallback?.buildJudgementSprite(rating);
-        var assetPath = buildJudgementSpritePath(rating);
-        if (assetPath == null) return null;
-        result.loadTexture(assetPath);
+        result.assetPath = buildJudgementSpritePath(rating);
+        if (result.assetPath == null) return null;
         result.scale.x = _data.assets.judgementSick?.scale ?? 1.0;
         result.scale.y = _data.assets.judgementSick?.scale ?? 1.0;
       case "good":
         if (_data.assets.judgementGood == null) return fallback?.buildJudgementSprite(rating);
-        var assetPath = buildJudgementSpritePath(rating);
-        if (assetPath == null) return null;
-        result.loadTexture(assetPath);
+        result.assetPath = buildJudgementSpritePath(rating);
+        if (result.assetPath == null) return null;
         result.scale.x = _data.assets.judgementGood?.scale ?? 1.0;
         result.scale.y = _data.assets.judgementGood?.scale ?? 1.0;
       case "bad":
         if (_data.assets.judgementBad == null) return fallback?.buildJudgementSprite(rating);
-        var assetPath = buildJudgementSpritePath(rating);
-        if (assetPath == null) return null;
-        result.loadTexture(assetPath);
+        result.assetPath = buildJudgementSpritePath(rating);
+        if (result.assetPath == null) return null;
         result.scale.x = _data.assets.judgementBad?.scale ?? 1.0;
         result.scale.y = _data.assets.judgementBad?.scale ?? 1.0;
       case "shit":
         if (_data.assets.judgementShit == null) return fallback?.buildJudgementSprite(rating);
-        var assetPath = buildJudgementSpritePath(rating);
-        if (assetPath == null) return null;
-        result.loadTexture(assetPath);
+        result.assetPath = buildJudgementSpritePath(rating);
+        if (result.assetPath == null) return null;
         result.scale.x = _data.assets.judgementShit?.scale ?? 1.0;
         result.scale.y = _data.assets.judgementShit?.scale ?? 1.0;
       default:
@@ -553,11 +561,11 @@ class NoteStyle implements IRegistryEntry<NoteStyleData>
     }
 
     result.scrollFactor.set(0.2, 0.2);
-    var isPixel = isJudgementSpritePixel(rating);
-    result.antialiasing = !isPixel;
-    result.pixelPerfectRender = isPixel;
-    result.pixelPerfectPosition = isPixel;
-    result.updateHitbox();
+    result.isPixel = isJudgementSpritePixel(rating);
+    // result.antialiasing = !isPixel;
+    // result.pixelPerfectRender = isPixel;
+    // result.pixelPerfectPosition = isPixel;
+    // result.updateHitbox();
 
     return result;
   }


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
N/A

<!-- Briefly describe the issue(s) fixed. -->
## Description
This PR contains a lot of tweaks surrounding the combo and ratings pop-ups that appear mid-song, these tweaks allow for better performance and makes it easier for modders to mess around with them.

1. Combo and Rating Pop-ups are now recycled to save memory.
2. Both now have their own groups to allow for easier recycling and to allow modders to posititon each element more easily.
3. Changed ```PopUpStuff.hx``` to extend FlxSpriteGroup to allow modders to mess around with it more. 
4. Added more documentation for ```PopUpStuff.hx```.
5. Added a new typedef to ```NoteStyle.hx``` that contains data for pop-ups (JudgementSpriteInfo)
6. ```buildJudgementSprite``` and ```buildComboNumSprite``` now return ```JudgementSpriteInfo``` instead of a FunkinSprite


<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos
N/A (positions should be the exact same)
