### PR TITLE
[CHORE] Fix Typo In PlayState

### DIFF
--- a/source/funkin/play/PlayState.hx
+++ b/source/funkin/play/PlayState.hx
@@ -1114,7 +1114,7 @@ class PlayState extends MusicBeatSubState
 
     var pauseButtonCheck:Bool = false;
     var androidPause:Bool = false;
-    // So the player wouldn't miss when pressing the pause utton
+    // So the player wouldn't miss when pressing the pause button
     #if mobile
     pauseButtonCheck = TouchUtil.pressAction(pauseButton);
     #end


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Briefly describe the issue(s) fixed. -->
## Description
What is an "utton"?

Fixes a typo in `PlayState.hx`: "utton" -> "button"
<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos
<img width="412" height="44" alt="Screenshot 2025-09-13 152043" src="https://github.com/user-attachments/assets/b7b080d4-800b-4703-8a3c-272c81864425" />
