### PR TITLE
[FIX] Fix memory leak with the new Debug Display on Linux

### DIFF
--- a/source/funkin/util/MemoryUtil.hx
+++ b/source/funkin/util/MemoryUtil.hx
@@ -64,21 +64,31 @@ class MemoryUtil
     try
     {
       #if cpp
-      final content:String = sys.io.File.read('/proc/${cpp.NativeSys.sys_get_pid()}/status', false).readAll().toString();
+      final input:sys.io.FileInput = sys.io.File.read('/proc/${cpp.NativeSys.sys_get_pid()}/status', false);
       #else
-      final content:String = sys.io.File.read('/proc/self/status', false).readAll().toString();
+      final input:sys.io.FileInput = sys.io.File.read('/proc/self/status', false);
       #end
 
       final regex:EReg = ~/^VmRSS:\s+(\d+)\s+kB/m;
-
-      if (regex.match(content))
+      var line:String;
+      do
       {
-        final kb:Float = Std.parseFloat(regex.matched(1));
-
-        if (kb != Math.NaN)
+        if (input.eof())
         {
-          return kb * 1024.0;
+          input.close();
+          return 0.0;
         }
+        line = input.readLine();
+      }
+      while (!regex.match(line));
+
+      input.close();
+
+      final kb:Float = Std.parseFloat(regex.matched(1));
+
+      if (kb != Math.NaN)
+      {
+        return kb * 1024.0;
       }
     }
     catch (e:Dynamic) {}


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
None
<!-- Briefly describe the issue(s) fixed. -->
## Description
This memory leak was due to how Haxe always allocates new bytes when running `FileInput#readAll()`. For some reason the other methods don't seem to do this so I fixed it by simply using `readLine` instead.
<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos
(Note: The task memory here is big because I was using Tracy)

[Gravar a tela_20250914_014146.webm](https://github.com/user-attachments/assets/21c657b0-7499-4b38-b15e-38f80a047762)
