### PR TITLE
[BUGFIX] Fix deleting a newly-made chart backup displaying an incorrect date

### DIFF
--- a/source/funkin/ui/debug/charting/ChartEditorState.hx
+++ b/source/funkin/ui/debug/charting/ChartEditorState.hx
@@ -994,7 +994,7 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
 
   function get_shouldShowBackupAvailableDialog():Bool
   {
-    return Save.instance.chartEditorHasBackup;
+    return Save.instance.chartEditorHasBackup && ChartEditorImportExportHandler.getLatestBackupPath() != null;
   }
 
   function set_shouldShowBackupAvailableDialog(value:Bool):Bool


### PR DESCRIPTION
## Linked Issues
N/A (i think)

## Description
When deleting a newly made chart backup, opening the chart editor again will display the first possible date haxe registers (i.e. null), which is because the game doesn't check if the backup file exists before opening the backup available dialog. Silly Eric

## Screenshots/Videos

https://github.com/user-attachments/assets/c6ca4b4a-968a-48b4-83ca-d2169bbab1b5
