### PR TITLE
[ENHANCEMENT] FPS Independent health icon bopping

### DIFF
--- a/source/funkin/play/PlayState.hx
+++ b/source/funkin/play/PlayState.hx
@@ -1503,6 +1503,10 @@ class PlayState extends MusicBeatSubState
         cameraTweensPausedBySubState.add(cameraZoomTween);
       }
 
+      // Icons should not bop while the game is paused.
+      if (iconP1 != null && iconP1.bopTween != null) iconP1.bopTween.active = false;
+      if (iconP2 != null && iconP2.bopTween != null) iconP2.bopTween.active = false;
+
       // Pause camera follow
       FlxG.camera.followLerp = 0;
 
@@ -1553,6 +1557,9 @@ class PlayState extends MusicBeatSubState
         camTween.active = true;
       }
       cameraTweensPausedBySubState.clear();
+
+      if (iconP1 != null && iconP1.bopTween != null) iconP1.bopTween.active = true;
+      if (iconP2 != null && iconP2.bopTween != null) iconP2.bopTween.active = true;
 
       // Resume camera follow
       FlxG.camera.followLerp = Constants.DEFAULT_CAMERA_FOLLOW_RATE;

--- a/source/funkin/play/components/HealthIcon.hx
+++ b/source/funkin/play/components/HealthIcon.hx
@@ -290,6 +290,7 @@ class HealthIcon extends FunkinSprite
     if (bopEvery != 0 && curStep % bopEvery == 0 && isLegacyStyle)
     {
       bopTween?.cancel();
+      setGraphicSize(Std.int(this.width + (HEALTH_ICON_SIZE * this.size.x * BOP_SCALE)), 0);
       bopTween = FlxTween.num(this.width + (HEALTH_ICON_SIZE * this.size.x * BOP_SCALE), HEALTH_ICON_SIZE * this.size.x,
         Math.min(Conductor.instance.stepLengthMs * 0.002, .175), {onComplete: _ -> bopTween = null}, value -> {
           setGraphicSize(Std.int(value), 0);

--- a/source/funkin/play/components/HealthIcon.hx
+++ b/source/funkin/play/components/HealthIcon.hx
@@ -4,6 +4,8 @@ import funkin.data.character.CharacterData;
 import flixel.FlxSprite;
 import flixel.math.FlxMath;
 import flixel.math.FlxPoint;
+import flixel.tweens.FlxTween;
+import flixel.tweens.FlxEase;
 import funkin.data.character.CharacterData.CharacterDataParser;
 import funkin.graphics.FunkinSprite;
 import funkin.util.MathUtil;
@@ -91,7 +93,7 @@ class HealthIcon extends FunkinSprite
   /**
    * The maximum health of the player.
    */
-  static final MAXIMUM_HEALTH:Float = 2;
+  static final MAXIMUM_HEALTH:Float = Constants.HEALTH_MAX;
 
   /**
    * The size of a non-pixel icon when using the legacy format.
@@ -116,6 +118,11 @@ class HealthIcon extends FunkinSprite
   static final POSITION_OFFSET:Int = 26;
 
   public var iconOffset:FlxPoint = FlxPoint.get();
+
+  /**
+   * Tween, that makes icon *bop*.
+   */
+  public var bopTween:Null<FlxTween> = null;
 
   public function new(char:Null<String>, playerId:Int = 0)
   {
@@ -167,7 +174,7 @@ class HealthIcon extends FunkinSprite
       loadCharacter(characterId);
     }
 
-    lerpIconSize(true);
+    snapToTargetSize();
   }
 
   /**
@@ -215,45 +222,9 @@ class HealthIcon extends FunkinSprite
   {
     super.update(elapsed);
 
-    if (bopEvery != 0)
-    {
-      lerpIconSize();
-
-      // Lerp the health icon back to its normal angle.
-      this.angle = MathUtil.smoothLerpPrecision(this.angle, 0, elapsed, 0.512);
-    }
+    if (bopEvery != 0) this.angle = MathUtil.smoothLerpPrecision(this.angle, 0, elapsed, 0.512);
 
     this.updatePosition();
-  }
-
-  /**
-   * Does the calculation to lerp the icon size. Usually called every frame, but can be forced to the target size.
-   * Mainly forced when changing to old icon to not have a weird lerp related to changing from pixel icon to non-pixel old icon
-   * @param force Force the icon immedialtely to be the target size. Defaults to false.
-   */
-  function lerpIconSize(force:Bool = false):Void
-  {
-    // Lerp the health icon back to its normal size,
-    // while maintaining aspect ratio.
-    if (this.width > this.height)
-    {
-      // Apply linear interpolation while accounting for frame rate.
-      var targetSize:Int = Std.int(MathUtil.smoothLerpPrecision(this.width, HEALTH_ICON_SIZE * this.size.x, FlxG.elapsed, 0.512));
-
-      if (force) targetSize = Std.int(HEALTH_ICON_SIZE * this.size.x);
-
-      setGraphicSize(targetSize, 0);
-    }
-    else
-    {
-      var targetSize:Int = Std.int(MathUtil.smoothLerpPrecision(this.height, HEALTH_ICON_SIZE * this.size.y, FlxG.elapsed, 0.512));
-
-      if (force) targetSize = Std.int(HEALTH_ICON_SIZE * this.size.y);
-
-      setGraphicSize(0, targetSize);
-    }
-
-    this.updateHitbox();
   }
 
   /*
@@ -261,6 +232,7 @@ class HealthIcon extends FunkinSprite
    */
   public function snapToTargetSize():Void
   {
+    bopTween?.cancel();
     if (this.width > this.height)
     {
       setGraphicSize(Std.int(HEALTH_ICON_SIZE * this.size.x), 0);
@@ -270,6 +242,13 @@ class HealthIcon extends FunkinSprite
       setGraphicSize(0, Std.int(HEALTH_ICON_SIZE * this.size.y));
     }
     updateHitbox();
+  }
+
+  // Apply custom icons offset after hitbox update.
+  override public function updateHitbox():Void
+  {
+    super.updateHitbox();
+    offset += iconOffset;
   }
 
   /**
@@ -296,11 +275,8 @@ class HealthIcon extends FunkinSprite
             + (PlayState.instance.healthBar.width * (FlxMath.remapToRange(PlayState.instance.healthBar.value, 0, 2, 100, 0) * 0.01))
             - (this.width - POSITION_OFFSET);
       }
-
       // Keep the icon centered vertically on the health bar.
       this.y = PlayState.instance.healthBar.y - (this.height / 2); // - (PlayState.instance.healthBar.height / 2)
-
-      offset += iconOffset;
     }
   }
 
@@ -313,22 +289,19 @@ class HealthIcon extends FunkinSprite
     // Make the icons bop.
     if (bopEvery != 0 && curStep % bopEvery == 0 && isLegacyStyle)
     {
-      // Make the icon increase in size (the update function causes them to lerp back down).
-      if (this.width > this.height)
-      {
-        setGraphicSize(Std.int(this.width + (HEALTH_ICON_SIZE * this.size.x * BOP_SCALE)), 0);
-      }
-      else
-      {
-        setGraphicSize(0, Std.int(this.height + (HEALTH_ICON_SIZE * this.size.y * BOP_SCALE)));
-      }
-      // Make the icon twist (the update function causes them to lerp back to normal).
-      this.angle += bopAngle * (playerId == 0 ? 1 : -1);
-
-      this.updateHitbox();
-
+      bopTween?.cancel();
+      bopTween = FlxTween.num(this.width + (HEALTH_ICON_SIZE * this.size.x * BOP_SCALE), HEALTH_ICON_SIZE * this.size.x,
+        Math.min(Conductor.instance.stepLengthMs * 0.002, .175), {onComplete: _ -> bopTween = null}, value -> {
+          setGraphicSize(Std.int(value), 0);
+          // Ensure the icon is positioned correctly after updating the hitbox, while its changing size.
+          this.updateHitbox();
+          this.updatePosition();
+        });
       // Ensure the icon is positioned correctly after updating the hitbox.
+      this.updateHitbox();
       this.updatePosition();
+
+      this.angle += bopAngle * (playerId == 0 ? 1 : -1);
     }
   }
 


### PR DESCRIPTION
## Linked Issues
Any issues about FPS Dependent HealthIcons

## Description
Now icons use their own tween (bopTween) to **bop**.
And also the speed of bopping accelerates at high BMP (noticeable at BMP > 190)