### PR TITLE
[BUGFIX] Fix Save Data Options Back Fully Exiting Options

### DIFF
--- a/source/funkin/ui/options/OptionsState.hx
+++ b/source/funkin/ui/options/OptionsState.hx
@@ -69,13 +69,16 @@ class OptionsState extends MusicBeatState
     optionsCodex = new Codex<OptionsMenuPageName>(Options);
     add(optionsCodex);
 
-    var saveData:SaveDataMenu = optionsCodex.addPage(SaveData, new SaveDataMenu());
-    var options:OptionsMenu = optionsCodex.addPage(Options, new OptionsMenu(saveData));
+    var options:OptionsMenu = optionsCodex.addPage(Options, new OptionsMenu());
     var preferences:PreferencesMenu = optionsCodex.addPage(Preferences, new PreferencesMenu());
     var controls:ControlsMenu = optionsCodex.addPage(Controls, new ControlsMenu());
     #if FEATURE_LAG_ADJUSTMENT
     var offsets:OffsetMenu = optionsCodex.addPage(Offsets, new OffsetMenu());
     #end
+    var saveData:SaveDataMenu = optionsCodex.addPage(SaveData, new SaveDataMenu());
+
+    options.addSaveDataOptionsItem(saveData);
+    options.addExitItem();
 
     if (options.hasMultipleOptions())
     {
@@ -162,7 +165,7 @@ class OptionsMenu extends Page<OptionsMenuPageName>
 
   final CAMERA_MARGIN:Int = 150;
 
-  public function new(saveDataMenu:SaveDataMenu)
+  public function new()
   {
     super();
     add(items = new TextMenuList());
@@ -231,30 +234,6 @@ class OptionsMenu extends Page<OptionsMenuPageName>
     }
     #end
 
-    // no need to show an entire new menu for just one option
-    if (saveDataMenu.hasMultipleOptions())
-    {
-      createItem("SAVE DATA OPTIONS", function() {
-        codex.switchPage(SaveData);
-      });
-    }
-    else
-    {
-      createItem("CLEAR SAVE DATA", saveDataMenu.openSaveDataPrompt);
-    }
-
-    #if NO_FEATURE_TOUCH_CONTROLS
-    createItem("EXIT", exit);
-    #else
-    backButton = new FunkinBackButton(FlxG.width - 230, FlxG.height - 200, exit, 1.0);
-    backButton.onConfirmStart.add(function() {
-      items.busy = true;
-      goingBack = true;
-      backButton.active = true;
-    });
-    add(backButton);
-    #end
-
     // Create an object for the camera to track.
     camFocusPoint = new FlxObject(0, 0, 140, 70);
     add(camFocusPoint);
@@ -272,6 +251,36 @@ class OptionsMenu extends Page<OptionsMenuPageName>
     items.selectItem(OptionsState.rememberedSelectedIndex);
     #if FEATURE_TOUCH_CONTROLS
     FlxG.touches.swipeThreshold.y = 100;
+    #end
+  }
+
+  public function addSaveDataOptionsItem(saveDataMenu:SaveDataMenu):Void
+  {
+    // no need to show an entire new menu for just one option
+    if (saveDataMenu.hasMultipleOptions())
+    {
+      createItem("SAVE DATA OPTIONS", function() {
+        codex.switchPage(SaveData);
+      });
+    }
+    else
+    {
+      createItem("CLEAR SAVE DATA", saveDataMenu.openSaveDataPrompt);
+    }
+  }
+
+  public function addExitItem():Void
+  {
+    #if NO_FEATURE_TOUCH_CONTROLS
+    createItem("EXIT", exit);
+    #else
+    backButton = new FunkinBackButton(FlxG.width - 230, FlxG.height - 200, exit, 1.0);
+    backButton.onConfirmStart.add(function() {
+      items.busy = true;
+      goingBack = true;
+      backButton.active = true;
+    });
+    add(backButton);
     #end
   }
 


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
Fixes #5943

<!-- Briefly describe the issue(s) fixed. -->
## Description
When entering the save data options menu, pressing the back button will cause it to completely exit the options menu. As it turns out, the problem had to do with the order of pages being created.

<img width="552" height="81" alt="image" src="https://github.com/user-attachments/assets/30725e8a-ccce-439b-96e9-6e04f8259eea" />

As you can see in the screenshot above, the save data menu is being created BEFORE the options menu. Because of this, the options menu checks if the back button was pressed immediately after the save data menu closes.

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos

A video of the intended behavior.

https://github.com/user-attachments/assets/9f95de74-2b48-414f-90eb-958680a6de72
