### PR TITLE
[BUGFIX?] Nest song capsule text squash and stretch timers

### DIFF
--- a/source/funkin/ui/freeplay/SongMenuItem.hx
+++ b/source/funkin/ui/freeplay/SongMenuItem.hx
@@ -526,11 +526,10 @@ class SongMenuItem extends FlxSpriteGroup
     {
       songText.scale.x = 0.4;
       songText.scale.y = 1.4;
-    });
-
-    new FlxTimer().start(2 / 24, function(_)
-    {
-      songText.scale.x = songText.scale.y = 1;
+      new FlxTimer().start(2 / 24, function(_)
+      {
+        songText.scale.x = songText.scale.y = 1;
+      });
     });
   }
 
@@ -540,6 +539,8 @@ class SongMenuItem extends FlxSpriteGroup
     {
       spr.visible = value;
     }
+
+    textAppear();
 
     updateSelected();
   }


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
Fixes https://github.com/FunkinCrew/Funkin/issues/5981 (?)
<!-- Briefly describe the issue(s) fixed. -->
## Description
My intial tests of this seem to suggest that this change works, as I was unable to encounter the squashed text at all, though I'd appreciate if other contributors test this change to prove or disprove this.

I've also restored the function call that makes it do the squash and stretch when the capsules refresh, just fyi.


<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos
