### PR TITLE
[BUGFIX] Fix Lag Adjustment Menu Fade-in after re-enter

### DIFF
--- a/source/funkin/ui/options/OffsetMenu.hx
+++ b/source/funkin/ui/options/OffsetMenu.hx
@@ -978,6 +978,15 @@ class OffsetMenu extends Page<OptionsState.OptionsMenuPageName>
     return item;
   }
 
+  override function exit():Void
+  {
+    lerped = 0;
+    shouldOffset = 0;
+    offsetLerp = 0;
+    scaleModifier = 1;
+    super.exit();
+  }
+
   override public function destroy()
   {
     MenuTypedList.pauseInput = false;


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
Fixes #6044
<!-- Briefly describe the issue(s) fixed. -->
## Description
The Lag Adjustment menu has a fade-in transition when entering it. This transition is done using variables for lerping, but they aren't reset upon exiting the menu. This causes the menu to no longer do its fade-in transition after exiting and re-entering.

This PR fixes the issue by resetting the transition variables whenever the Offset Menu is exited.
<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos

https://github.com/user-attachments/assets/d7a000ba-0658-4b00-a3ef-ebd3f4ad5172