### PR TITLE
[BUGFIX] Fix the hold note covers persisting when holding notes and lagging

### DIFF
--- a/source/funkin/play/notes/SustainTrail.hx
+++ b/source/funkin/play/notes/SustainTrail.hx
@@ -414,6 +414,7 @@ class SustainTrail extends FlxSprite
     sustainLength = 0;
     fullSustainLength = 0;
     noteData = null;
+    if (!((cover?.animation?.name ?? "").startsWith("holdCoverEnd"))) cover?.playEnd();
 
     hitNote = false;
     missedNote = false;


### PR DESCRIPTION
## Linked Issues
I'm pretty sure there was an issue for this but I can't for the life of me find it

## Description
If you were to lag heavily while holding a note, the hold note cover would still play the usual animation throughout the song as if you were still holding the note. This PR fixes it by playing the end animation if it isn't being played by the time the hold note is killed. This does not impact dropping the hold note.

## Screenshots/Videos

https://github.com/user-attachments/assets/3e547d6d-cca6-4019-bb8f-f191e872c8c2

Disclaimer: The lag-inator (i.e. just calling `Sys.sleep`) is not included in this PR, althought it would be nice to have in-game as a debug plugin.