### PR TITLE
[BUGFIX] Fix Script Create Event Not Running After Hot Reload

### DIFF
--- a/source/funkin/modding/PolymodHandler.hx
+++ b/source/funkin/modding/PolymodHandler.hx
@@ -589,5 +589,6 @@ class PolymodHandler
     CharacterDataParser.loadCharacterCache(); // TODO: Migrate characters to BaseRegistry.
     NoteKindManager.loadScripts();
     ModuleHandler.loadModuleCache();
+    ModuleHandler.callOnCreate();
   }
 }


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues

Fixes #6010

<!-- Briefly describe the issue(s) fixed. -->
## Description

When hot reloading, the `onCreate` event for scripts doesn't run, making it so that the event would only run when the game was in the process of initializing everything. This PR solves that issue by committing to another **one liner** in this game's history at the end of the PolymodHandler `forceReloadAssets()` function.

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos

The screenshot below shows text that I decided to trace in the console. This line does indeed run after hot reloading 👍.

<img width="432" height="20" alt="image" src="https://github.com/user-attachments/assets/261264b1-9d02-4802-8287-34e61259be36" />