### PR TITLE
[BUGFIX] Fix Offset Calibration/Test Logic starting after exiting the Lag Adjustment menu

### DIFF
--- a/source/funkin/ui/options/OffsetMenu.hx
+++ b/source/funkin/ui/options/OffsetMenu.hx
@@ -294,6 +294,9 @@ class OffsetMenu extends Page<OptionsState.OptionsMenuPageName>
     createButtonItem('Offset Calibration', function() {
       // Reset calibration state and start another one.
 
+      @:privateAccess
+      if (OptionsState.instance.optionsCodex.currentPage != this) return;
+
       jumpInText.text = 'Press any key to the beat!\nThe arrow will start to sync to the receptor.';
       #if mobile
       jumpInText.text = 'Tap to the beat!\nThe arrow will start to sync to the receptor.';
@@ -326,6 +329,9 @@ class OffsetMenu extends Page<OptionsState.OptionsMenuPageName>
     createButtonItem('Test', function() {
       // Reset testing state and start another one.
       // We do not reset the offset here, so the player can test their current offset.
+
+      @:privateAccess
+      if (OptionsState.instance.optionsCodex.currentPage != this) return;
 
       shouldOffset = 1;
       testStrumline.clean();


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
Fixes #6079
<!-- Briefly describe the issue(s) fixed. -->
## Description
If you pressed the back keybind while the text was flickering after selecting Offset Calibration or Test, but before the transition to the new state, the game would exit to the options menu, but carry over the drums for the calibration/test. It would also block all key inputs except for volume control and the back keybind.

This PR fixes the issue by checking if the offset menu is still the current page before starting the calibration or test. If it isn't the current page anymore for whatever reason, the calibration/test logic won't start.

(`@:privateAccess` is used because `optionsCodex` is private)
<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos

https://github.com/user-attachments/assets/9a38ffa6-dd95-41b2-a19d-4d6e7b061d41