### PR TITLE
[ENHANCEMENT] Add milliseconds to remaining time in the Chart Editor timebar

### DIFF
--- a/source/funkin/ui/debug/charting/ChartEditorState.hx
+++ b/source/funkin/ui/debug/charting/ChartEditorState.hx
@@ -5406,9 +5406,10 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
     if (playbarSongPos.value != songPosString) playbarSongPos.value = songPosString;
 
     var songRemaining:Float = Math.max(songLengthInMs - songPos, 0.0);
+    var songRemainingMilliseconds:String = Std.string(Math.floor(Math.abs(songRemaining) % 1000)).lpad('0', 3).substr(0, 2);
     var songRemainingSeconds:String = Std.string(Math.floor((songRemaining / 1000) % 60)).lpad('0', 2);
     var songRemainingMinutes:String = Std.string(Math.floor((songRemaining / 1000) / 60)).lpad('0', 2);
-    var songRemainingString:String = '-${songRemainingMinutes}:${songRemainingSeconds}';
+    var songRemainingString:String = '-${songRemainingMinutes}:${songRemainingSeconds}.${songRemainingMilliseconds}';
 
     if (playbarSongRemaining.value != songRemainingString) playbarSongRemaining.value = songRemainingString;
 


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues

No linked issues.

<!-- Briefly describe the issue(s) fixed. -->
## Description
This Pull Request adds millisecond formatting to the remaining time in the Chart Editor.

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos
<img width="1280" height="720" alt="screenshot-2025-09-21-10-27-43" src="https://github.com/user-attachments/assets/169f525d-fd25-4ba8-b7ee-1e35c8fafa04" />
<img width="1280" height="720" alt="screenshot-2025-09-21-10-32-16" src="https://github.com/user-attachments/assets/70997d60-a5e8-41f1-a576-d5d60ac0ab26" />
<img width="1280" height="720" alt="screenshot-2025-09-21-10-32-42" src="https://github.com/user-attachments/assets/c2c00e14-8ad2-4d68-a181-af36accd633e" />


