### PR TITLE
[ENHANCEMENT] Custom per-character CharSelect and Random Capsule themes

### DIFF
--- a/source/funkin/FunkinMemory.hx
+++ b/source/funkin/FunkinMemory.hx
@@ -86,7 +86,7 @@ class FunkinMemory
     permanentCacheSound(Paths.sound("soundtray/Voldown"));
     permanentCacheSound(Paths.sound("soundtray/VolMAX"));
     permanentCacheSound(Paths.sound("soundtray/Volup"));
-    permanentCacheSound(Paths.music("freakyMenu/freakyMenu"));
+    permanentCacheSound(Paths.music(Constants.DEFAULT_GAME_THEME + "/" + Constants.DEFAULT_GAME_THEME));
     permanentCacheSound(Paths.music("offsetsLoop/offsetsLoop"));
     permanentCacheSound(Paths.music("offsetsLoop/drumsLoop"));
     permanentCacheSound(Paths.sound("missnote1", "shared"));
@@ -405,7 +405,7 @@ class FunkinMemory
     Assets.cache.clear("songs");
     Assets.cache.clear("music");
     // Felt lazy.
-    var key = Paths.music("freakyMenu/freakyMenu");
+    var key = Paths.music(Constants.DEFAULT_GAME_THEME + "/" + Constants.DEFAULT_GAME_THEME);
     var sound:Null<Sound> = Assets.getSound(key, true);
     if (sound != null)
     {

--- a/source/funkin/data/freeplay/player/PlayerData.hx
+++ b/source/funkin/data/freeplay/player/PlayerData.hx
@@ -103,6 +103,13 @@ class PlayerFreeplayDJData
   var assetPath:String;
   var animations:Array<AnimationData>;
 
+  /**
+   * Music, that will play, when you select Random! capsule in freeplay.
+   */
+  @:optional
+  @:default(funkin.util.Constants.DEFAULT_FREEPLAY_RANDOM_THEME)
+  public var freeplayRandomTheme:String = Constants.DEFAULT_FREEPLAY_RANDOM_THEME;
+
   @:optional
   @:default(false)
   var applyStageMatrix:Bool;
@@ -283,6 +290,10 @@ class PlayerFreeplayDJData
 
 class PlayerCharSelectData
 {
+  @:optional
+  @:default(funkin.util.Constants.DEFAULT_CHAR_SELECT_THEME)
+  public var charSelectTheme:String = Constants.DEFAULT_CHAR_SELECT_THEME;
+
   /**
    * A zero-indexed number for the character's preferred position in the grid.
    * 0 = top left, 4 = center, 8 = bottom right

--- a/source/funkin/ui/charSelect/CharSelectSubState.hx
+++ b/source/funkin/ui/charSelect/CharSelectSubState.hx
@@ -340,15 +340,6 @@ class CharSelectSubState extends MusicBeatSubState
     FlxG.sound.defaultSoundGroup.add(staticSound);
     FlxG.sound.list.add(staticSound);
 
-    // playing it here to preload it. not doing this makes a super awkward pause at the end of the intro
-    // TODO: probably make an intro thing for funkinSound itself that preloads the next audio?
-    FunkinSound.playMusic('stayFunky',
-      {
-        startingVolume: 0,
-        overrideExisting: true,
-        restartTrack: true,
-      });
-
     initLocks();
 
     for (index => member in grpIcons.members)
@@ -420,6 +411,14 @@ class CharSelectSubState extends MusicBeatSubState
     FlxG.sound.defaultSoundGroup.add(introSound);
     FlxG.sound.list.add(introSound);
 
+    // playing it here to preload it. not doing this makes a super awkward pause at the end of the intro
+    // TODO: probably make an intro thing for funkinSound itself that preloads the next audio?
+    FunkinSound.playMusic(getCurrentCharacter()?.getCharSelectTheme() ?? Constants.DEFAULT_CHAR_SELECT_THEME, {
+      startingVolume: 0,
+      overrideExisting: true,
+      restartTrack: true,
+    });
+
     openSubState(new IntroSubState());
 
     subStateClosed.addOnce((_) -> {
@@ -455,24 +454,7 @@ class CharSelectSubState extends MusicBeatSubState
       if (availableChars.size() > 1) Medals.award(CharSelect);
       #end
 
-      FunkinSound.playMusic('stayFunky',
-        {
-          startingVolume: 1,
-          overrideExisting: true,
-          restartTrack: true,
-          onLoad: function() {
-            allowInput = true;
-
-            @:privateAccess
-            gfChill.analyzer = new SpectralAnalyzer(FlxG.sound.music._channel.__audioSource, 7, 0.1);
-            #if sys
-            // On native it uses FFT stuff that isn't as optimized as the direct browser stuff we use on HTML5
-            // So we want to manually change it!
-            @:privateAccess
-            gfChill.analyzer.fftN = 512;
-            #end
-          }
-        });
+      loadCharacterSelectTheme();
     }
   }
 
@@ -505,7 +487,12 @@ class CharSelectSubState extends MusicBeatSubState
         var playableCharacterId:Null<String> = availableChars.get(i) ?? Constants.DEFAULT_CHARACTER;
         var player:Null<PlayableCharacter> = PlayerRegistry.instance.fetchEntry(playableCharacterId);
         var isPlayerUnlocked:Bool = player?.isUnlocked() ?? false;
-        if (availableChars.exists(i) && isPlayerUnlocked) nonLocks.push(i);
+        if (availableChars.exists(i) && isPlayerUnlocked)
+        {
+          nonLocks.push(i);
+          final playerTheme:String = player?.getCharSelectTheme() ?? Constants.DEFAULT_CHAR_SELECT_THEME;
+          FunkinMemory.cacheSound(Paths.music(playerTheme + "/" + playerTheme));
+        }
 
         var temp:Lock = new Lock(0, 0, i,
           {
@@ -610,24 +597,7 @@ class CharSelectSubState extends MusicBeatSubState
 
           staticSound.stop();
 
-          FunkinSound.playMusic('stayFunky',
-            {
-              startingVolume: 1,
-              overrideExisting: true,
-              restartTrack: true,
-              onLoad: function() {
-                allowInput = true;
-
-                @:privateAccess
-                gfChill.analyzer = new SpectralAnalyzer(FlxG.sound.music._channel.__audioSource, 7, 0.1);
-                #if sys
-                // On native it uses FFT stuff that isn't as optimized as the direct browser stuff we use on HTML5
-                // So we want to manually change it!
-                @:privateAccess
-                gfChill.analyzer.fftN = 512;
-                #end
-              }
-            });
+          loadCharacterSelectTheme();
         }
         else
           playerChill.anim.onFinish.addOnce((_) -> unLock());
@@ -1119,6 +1089,13 @@ class CharSelectSubState extends MusicBeatSubState
     return gridPosition;
   }
 
+  function getCurrentCharacter():Null<PlayableCharacter>
+  {
+    final index:Int = getCurrentSelected();
+    @:nullSafety(Off) // I really hate you
+    return availableChars.exists(index) ? PlayerRegistry.instance.fetchEntry(availableChars.get(index)) : null;
+  }
+
   function setCursorPosition(index:Int, instant:Bool = false):Void
   {
     var copy = 3;
@@ -1158,6 +1135,7 @@ class CharSelectSubState extends MusicBeatSubState
     else
       staticSound.stop();
 
+    loadCharacterSelectTheme();
     dispatchEvent(new CharacterSelectScriptEvent(CHARACTER_SELECTED, value));
 
     nametag.switchChar(value);
@@ -1184,6 +1162,41 @@ class CharSelectSubState extends MusicBeatSubState
     });
 
     return value;
+  }
+
+  var currentSelectTheme:Null<String> = null;
+
+  function loadCharacterSelectTheme():Void
+  {
+    final requiredTheme:String = getCurrentCharacter()?.getCharSelectTheme() ?? Constants.DEFAULT_CHAR_SELECT_THEME;
+
+    if (currentSelectTheme == requiredTheme) return;
+
+    trace('Switching to character theme: "$requiredTheme"');
+    final previousTime:Float = FlxG.sound?.music?.time ?? 0.0;
+
+    FunkinSound.playMusic(requiredTheme,
+      {
+        startingVolume: 1,
+        overrideExisting: true,
+        restartTrack: true,
+        onLoad: () -> {
+          allowInput = true;
+
+          FlxG.sound.music.time = (previousTime >= FlxG.sound.music.length) ? 0 : previousTime;
+          Conductor.instance.update();
+          @:privateAccess
+          gfChill.analyzer = new SpectralAnalyzer(FlxG.sound.music._channel.__audioSource, 7, 0.1);
+          #if sys
+          // On native it uses FFT stuff that isn't as optimized as the direct browser stuff we use on HTML5
+          // So we want to manually change it!
+          @:privateAccess
+          gfChill.analyzer.fftN = 512;
+          #end
+        }
+      });
+
+    currentSelectTheme = requiredTheme;
   }
 
   function set_grpXSpread(value:Float):Float

--- a/source/funkin/ui/freeplay/FreeplayState.hx
+++ b/source/funkin/ui/freeplay/FreeplayState.hx
@@ -2255,7 +2255,7 @@ class FreeplayState extends MusicBeatSubState
       FlxTransitionableState.skipNextTransOut = true;
       if (Type.getClass(_parentState) == MainMenuState)
       {
-        FunkinSound.playMusic('freakyMenu',
+        FunkinSound.playMusic(Constants.DEFAULT_GAME_THEME,
           {
             overrideExisting: true,
             restartTrack: false,
@@ -2944,12 +2944,11 @@ class FreeplayState extends MusicBeatSubState
 
     if (curSelected == 0)
     {
-      FunkinSound.playMusic('freeplayRandom',
-        {
-          startingVolume: 0.0,
-          overrideExisting: true,
-          restartTrack: false
-        });
+      FunkinSound.playMusic(currentCharacter?.getFreeplayRandomTheme() ?? Constants.DEFAULT_FREEPLAY_RANDOM_THEME, {
+        startingVolume: 0.0,
+        overrideExisting: true,
+        restartTrack: false
+      });
       FlxG.sound.music.fadeIn(2, 0, previewVolume);
     }
     else

--- a/source/funkin/ui/freeplay/charselect/PlayableCharacter.hx
+++ b/source/funkin/ui/freeplay/charselect/PlayableCharacter.hx
@@ -79,6 +79,11 @@ class PlayableCharacter implements IRegistryEntry<PlayerData>
     return _data?.freeplayStyle ?? Constants.DEFAULT_FREEPLAY_STYLE;
   }
 
+  public function getFreeplayRandomTheme():String
+  {
+    return _data?.freeplayDJ?.freeplayRandomTheme ?? Constants.DEFAULT_FREEPLAY_RANDOM_THEME;
+  }
+
   public function getFreeplayDJData():Null<PlayerFreeplayDJData>
   {
     return _data?.freeplayDJ;
@@ -88,6 +93,11 @@ class PlayableCharacter implements IRegistryEntry<PlayerData>
   {
     // Silly little placeholder
     return _data?.freeplayDJ?.getFreeplayDJText(index) ?? 'GET FREAKY ON A FRIDAY';
+  }
+
+  public function getCharSelectTheme():String
+  {
+    return _data?.charSelect?.charSelectTheme ?? Constants.DEFAULT_CHAR_SELECT_THEME;
   }
 
   public function getCharSelectData():Null<PlayerCharSelectData>

--- a/source/funkin/ui/mainmenu/MainMenuState.hx
+++ b/source/funkin/ui/mainmenu/MainMenuState.hx
@@ -322,7 +322,7 @@ class MainMenuState extends MusicBeatState
 
   function playMenuMusic():Void
   {
-    FunkinSound.playMusic('freakyMenu',
+    FunkinSound.playMusic(Constants.DEFAULT_GAME_THEME,
       {
         overrideExisting: true,
         restartTrack: false,

--- a/source/funkin/ui/options/OptionsState.hx
+++ b/source/funkin/ui/options/OptionsState.hx
@@ -115,8 +115,8 @@ class OptionsState extends MusicBeatState
     {
       drumsBG.fadeOut(0.5, 0);
     }
-    FlxG.sound.music.fadeOut(0.5, 0, function(tw) {
-      FunkinSound.playMusic('freakyMenu',
+    FlxG.sound.music.fadeOut(0.5, 0, tw -> {
+      FunkinSound.playMusic(Constants.DEFAULT_GAME_THEME,
         {
           startingVolume: 0,
           overrideExisting: true,

--- a/source/funkin/ui/story/StoryMenuState.hx
+++ b/source/funkin/ui/story/StoryMenuState.hx
@@ -249,7 +249,7 @@ class StoryMenuState extends MusicBeatState
 
   function playMenuMusic():Void
   {
-    FunkinSound.playMusic('freakyMenu',
+    FunkinSound.playMusic(Constants.DEFAULT_GAME_THEME,
       {
         overrideExisting: true,
         restartTrack: false,

--- a/source/funkin/ui/title/TitleState.hx
+++ b/source/funkin/ui/title/TitleState.hx
@@ -175,7 +175,7 @@ class TitleState extends MusicBeatState
   {
     var shouldFadeIn:Bool = (FlxG.sound.music == null);
     // Load music. Includes logic to handle BPM changes.
-    FunkinSound.playMusic('freakyMenu',
+    FunkinSound.playMusic(Constants.DEFAULT_GAME_THEME,
       {
         startingVolume: 0.0,
         overrideExisting: true,

--- a/source/funkin/util/Constants.hx
+++ b/source/funkin/util/Constants.hx
@@ -197,6 +197,11 @@ class Constants
   public static final DEFAULT_CHARACTER:String = 'bf';
 
   /**
+   * The default theme, that plays in Character Select.
+   */
+  public static final DEFAULT_CHAR_SELECT_THEME:String = 'stayFunky';
+
+  /**
    * Default player character for health icons.
    */
   public static final DEFAULT_HEALTH_ICON:String = 'face';
@@ -243,6 +248,11 @@ class Constants
   public static final DEFAULT_ZOOM_OFFSET:Int = 0;
 
   /**
+   * The default game music theme.
+   */
+  public static final DEFAULT_GAME_THEME:String = "freakyMenu";
+
+  /**
    * The default BPM for charts, so things don't break if none is specified.
    */
   public static final DEFAULT_BPM:Float = 100.0;
@@ -271,6 +281,11 @@ class Constants
    * The default freeplay style for characters.
    */
   public static final DEFAULT_FREEPLAY_STYLE:String = 'bf';
+
+  /**
+   * The default random capsule theme in freeplay.
+   */
+  public static final DEFAULT_FREEPLAY_RANDOM_THEME:String = 'freeplayRandom';
 
   /**
    * The default pixel note style for songs.


### PR DESCRIPTION
## Linked Issues
nah

## Description
* The path of the main theme for the game is now stored in Constants (DEFAULT_GAME_THEME).
* Same happened with stayFunky and freeplayRandom (DEFAULT_CHAR_SELECT_THEME and DEFAULT_FREEPLAY_RANDOM_THEME).
* Now modders can add their own freeplayRandom theme via ```freeplayDJ.freeplayRandomTheme``` in ```data/players/yourPlayer.json```, and it will play, when you select Random! capsule.
* When you select your custom character in CharacterSelectSubState, you can add your own theme via ```charSelect.charSelectTheme``` in ```data/players/yourPlayer.json```
And some other litle nitpicks
