### PR TITLE
[ENHANCEMENT] Restore strumline fade-out tween when transitioning to Results screen

### DIFF
--- a/source/funkin/play/PlayState.hx
+++ b/source/funkin/play/PlayState.hx
@@ -3631,6 +3631,9 @@ class PlayState extends MusicBeatSubState
             });
          */
     });
+
+    playerStrumline.fadeOutArrows();
+    opponentStrumline.fadeOutArrows();
   }
 
   /**

--- a/source/funkin/play/notes/Strumline.hx
+++ b/source/funkin/play/notes/Strumline.hx
@@ -146,7 +146,9 @@ class Strumline extends FlxSpriteGroup
    * The strumline notes (the receptors) themselves.
    */
   public var strumlineNotes:FlxTypedSpriteGroup<StrumlineNote>;
+
   var noteSplashes:FlxTypedSpriteGroup<NoteSplash>;
+
   /**
    * Hold note covers.
    */
@@ -1339,7 +1341,7 @@ class Strumline extends FlxSpriteGroup
    */
   public function fadeOutArrow(index:Int, arrow:StrumlineNote):Void
   {
-    FlxTween.tween(arrow, {y: arrow.y - 10, alpha: 0}, 0.5, {ease: FlxEase.circIn});
+    FlxTween.tween(arrow, {y: arrow.y - 10, alpha: 0}, 0.16, {ease: FlxEase.circIn, startDelay: 0.05 * (DIRECTIONS.length - index)});
   }
 
   /**


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Briefly describe the issue(s) fixed. -->
## Description
When digging around the source code, I found a fade out tween that was supposed to play when transitioning into the results screen. This PR adds the tween back with some tiny changes, because why not.

<!-- Include any relevant screenshots or videos. -->
## Video
https://github.com/user-attachments/assets/cdb8aa82-da15-4707-84fa-38cdf6dbeba8


