### PR TITLE
[BUGFIX] Fix Cursor staying visible after exiting the Animation Editor

### DIFF
--- a/source/funkin/ui/debug/anim/DebugBoundingState.hx
+++ b/source/funkin/ui/debug/anim/DebugBoundingState.hx
@@ -345,6 +345,14 @@ class DebugBoundingState extends FlxState
     super.update(elapsed);
   }
 
+  override function destroy()
+  {
+    super.destroy();
+
+    // Hide the mouse cursor on other states.
+    Cursor.hide();
+  }
+
   function offsetControls():Void
   {
     // CTRL + S = Save Character Data


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
None

<!-- Briefly describe the issue(s) fixed. -->
## Description
When exiting the animation editor, your mouse cursor stays visible unlike exiting something like the Chart Editor. Yeah, pretty self explanatory. 

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos

Before:

https://github.com/user-attachments/assets/3aed550a-a669-46e2-8e97-606080646355

After:

https://github.com/user-attachments/assets/9cd04593-069e-45fe-a3b7-9e53c82a23f9