### PR TITLE
[BUGFIX] Fix Animation Editor `Null Object Reference` Crash

### DIFF
--- a/source/funkin/ui/debug/anim/DebugBoundingState.hx
+++ b/source/funkin/ui/debug/anim/DebugBoundingState.hx
@@ -92,7 +92,7 @@ class DebugBoundingState extends FlxState
     var viewDropdown:DropDown = offsetEditorDialog.findComponent("swapper", DropDown);
     viewDropdown.onChange = function(e:UIEvent) {
       trace(e.type);
-      curView = cast e.data.curView;
+      curView = cast e?.data?.curView;
       trace(e.data);
       // trace(e.data);
     };


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
Fixes #6113

<!-- Briefly describe the issue(s) fixed. -->
## Description
When pressing the one or two keys in the animation editor while focusing on the mode dropdown, you'll get a null object reference crash because we all love Weekend 1, don't we? Apologizes if this seemed rushed. As of uh right now, I'm tired and I wanted to get this fixed so yeah.
