### PR TITLE
[ENHANCEMENT/BUGFIX] Fix Chart/Stage Editor backup window retrieving incorrect file

### DIFF
--- a/source/funkin/ui/debug/charting/ChartEditorState.hx
+++ b/source/funkin/ui/debug/charting/ChartEditorState.hx
@@ -697,7 +697,7 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
   var wasCursorOverHaxeUI:Bool = false;
 
   /**
-   * Set by ChartEditorDialogHandler, used to prevent background interaction while the dialog is open.
+   * Set by ChartEditorDialogHandler, used to prevent background interaction while a dialog is open.
    */
   var isHaxeUIDialogOpen:Bool = false;
 
@@ -3051,7 +3051,7 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
       }
     };
     menubarItemSaveChartAs.onClick = _ -> this.exportAllSongData(false, null);
-    menubarItemExit.onClick = _ -> quitChartEditor();
+    menubarItemExit.onClick = _ -> quitChartEditor(true);
 
     // Edit
     menubarItemUndo.onClick = _ -> undoLastCommand();
@@ -5750,20 +5750,20 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
     // CTRL + Q = Quit to Menu
     if (pressingControl() && FlxG.keys.justPressed.Q)
     {
-      quitChartEditor();
+      quitChartEditor(true);
     }
   }
 
   @:nullSafety(Off)
-  function quitChartEditor():Void
+  function quitChartEditor(exitPrompt:Bool = false):Void
   {
-    if (saveDataDirty)
+    if (saveDataDirty && exitPrompt)
     {
       this.openLeaveConfirmationDialog();
       return;
     }
 
-    writePreferences(false);
+    autoSave();
 
     this.hideAllToolboxes();
 

--- a/source/funkin/ui/debug/charting/handlers/ChartEditorDialogHandler.hx
+++ b/source/funkin/ui/debug/charting/handlers/ChartEditorDialogHandler.hx
@@ -1325,13 +1325,12 @@ class ChartEditorDialogHandler
   {
     var dialog:Null<Dialog> = Dialogs.messageBox("You are about to leave the editor without saving.\n\nAre you sure?", "Leave Editor", MessageBoxType.TYPE_YESNO, true,
       function(button:DialogButton)
-      {
-        state.isHaxeUIDialogOpen = false;
+    {
         if (button == DialogButton.YES)
         {
-          state.autoSave();
           state.quitChartEditor();
         }
+        state.isHaxeUIDialogOpen = false;
       }
     );
 

--- a/source/funkin/ui/debug/charting/handlers/ChartEditorImportExportHandler.hx
+++ b/source/funkin/ui/debug/charting/handlers/ChartEditorImportExportHandler.hx
@@ -351,10 +351,32 @@ class ChartEditorImportExportHandler
     #if sys
     FileUtil.createDirIfNotExists(BACKUPS_PATH);
 
-    var entries:Array<String> = sys.FileSystem.readDirectory(BACKUPS_PATH);
-    entries.sort(SortUtil.alphabetically);
+    var files:Array<String> = sys.FileSystem.readDirectory(BACKUPS_PATH);
+    var filestats:Array<sys.FileStat> = [];
+    if (files.length > 0)
+    {
+      while (!files[files.length - 1].endsWith(Constants.EXT_CHART) || !files[files.length - 1].startsWith("chart-editor-"))
+      {
+        if (files.length == 0) break;
+        files.pop();
+      }
+    }
 
-    var latestBackupPath:Null<String> = entries[(entries.length - 1)];
+    var latestBackupPath:Null<String> = files[0];
+    for (file in files)
+    {
+      filestats.push(sys.FileSystem.stat(haxe.io.Path.join([BACKUPS_PATH + file])));
+    }
+
+    var latestFileIndex:Int = 0;
+    for (index in 0...filestats.length)
+    {
+      if (filestats[latestFileIndex].mtime.getTime() < filestats[index].mtime.getTime())
+      {
+        latestFileIndex = index;
+        latestBackupPath = files[index];
+      }
+    }
 
     if (latestBackupPath == null) return null;
     return haxe.io.Path.join([BACKUPS_PATH, latestBackupPath]);

--- a/source/funkin/ui/debug/stageeditor/StageEditorState.hx
+++ b/source/funkin/ui/debug/stageeditor/StageEditorState.hx
@@ -498,18 +498,35 @@ class StageEditorState extends UIState
         FileUtil.createDirIfNotExists(BACKUPS_PATH);
 
         var files = sys.FileSystem.readDirectory(BACKUPS_PATH);
-
+        var filestats:Array<sys.FileStat> = [];
         if (files.length > 0)
         {
-          // ensures that the top most file is a backup
-          files.sort(funkin.util.SortUtil.alphabetically);
-
           while (!files[files.length - 1].endsWith(FileUtil.FILE_EXTENSION_INFO_FNFS.extension)
             || !files[files.length - 1].startsWith("stage-editor-"))
+          {
+            if (files.length == 0) break;
             files.pop();
+          }
         }
 
-        if (files.length != 0) new BackupAvailableDialog(this, haxe.io.Path.join([BACKUPS_PATH, files[files.length - 1]])).showDialog(true);
+        var latestBackupPath:Null<String> = files[0];
+
+        for (file in files)
+        {
+          filestats.push(sys.FileSystem.stat(haxe.io.Path.join([BACKUPS_PATH, file])));
+        }
+
+        var latestFileIndex:Int = 0;
+        for (index in 0...filestats.length)
+        {
+          if (filestats[latestFileIndex].mtime.getTime() < filestats[index].mtime.getTime())
+          {
+            latestFileIndex = index;
+            latestBackupPath = files[index];
+          }
+        }
+
+        if (latestBackupPath != null) new BackupAvailableDialog(this, haxe.io.Path.join([BACKUPS_PATH, latestBackupPath])).showDialog(true);
       }
       #end
     }


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
No / Answer

<!-- Briefly describe the issue(s) fixed. -->
## Description
Get the last modified (and valid) editor backup rather than the one that came alphabetically first.

Also fixes a regression caused by removing the `autosave()` call in `quitChartEditor()` in https://github.com/FunkinCrew/Funkin/pull/5091

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos

<img width="673" height="462" alt="Screenshot 2025-09-25 212603" src="https://github.com/user-attachments/assets/562c361a-8411-4705-9ff0-2416e4381998" />
<img width="651" height="481" alt="Screenshot 2025-09-25 212957" src="https://github.com/user-attachments/assets/44ae32d7-b7a5-4f13-8ef0-bb75822a847e" />

