### PR TITLE
[ENHANCEMENT] Add back the FlxTransitions

### DIFF
--- a/source/funkin/play/PauseSubState.hx
+++ b/source/funkin/play/PauseSubState.hx
@@ -262,7 +262,7 @@ class PauseSubState extends MusicBeatSubState
 
     regenerateMenu();
 
-    transitionIn();
+    transitionSpritesIn();
 
     startCharterTimer();
   }
@@ -531,7 +531,7 @@ class PauseSubState extends MusicBeatSubState
   /**
    * Perform additional animations to transition the pause menu in when it is first displayed.
    */
-  function transitionIn():Void
+  function transitionSpritesIn():Void
   {
     FlxTween.tween(background, {alpha: 0.6}, 0.8, {ease: FlxEase.quartOut});
 

--- a/source/funkin/ui/MusicBeatState.hx
+++ b/source/funkin/ui/MusicBeatState.hx
@@ -250,6 +250,15 @@ class MusicBeatState extends FlxTransitionableState implements IEventHandler
     sort(SortUtil.byZIndex, FlxSort.ASCENDING);
   }
 
+  override public function transitionIn()
+  {
+    // If there is a SubState either open or pending, don't do the transition, as the transition itself is a SubState.
+    if (this._requestedSubState == null && this.subState == null)
+    {
+      super.transitionIn();
+    }
+  }
+
   @:nullSafety(Off)
   override function startOutro(onComplete:() -> Void):Void
   {
@@ -265,7 +274,15 @@ class MusicBeatState extends FlxTransitionableState implements IEventHandler
     {
       FunkinSound.stopAllAudio();
 
-      onComplete();
+      // If the SubState can fadeout, make it use the transition instead.
+      if (Std.isOfType(this.subState, MusicBeatSubState))
+      {
+        cast(this.subState, MusicBeatSubState).startOutro(onComplete);
+      }
+      else
+      {
+        super.startOutro(onComplete);
+      }
     }
   }
 

--- a/source/funkin/ui/MusicBeatSubState.hx
+++ b/source/funkin/ui/MusicBeatSubState.hx
@@ -1,5 +1,6 @@
 package funkin.ui;
 
+import flixel.addons.transition.FlxTransitionableSubState;
 import flixel.FlxSubState;
 import flixel.text.FlxText;
 import funkin.ui.mainmenu.MainMenuState;
@@ -25,7 +26,7 @@ import funkin.play.notes.NoteDirection;
  * MusicBeatSubState reincorporates the functionality of MusicBeatState into an FlxSubState.
  */
 @:nullSafety
-class MusicBeatSubState extends FlxSubState implements IEventHandler
+class MusicBeatSubState extends FlxTransitionableSubState implements IEventHandler
 {
   public var leftWatermarkText:Null<FlxText> = null;
   public var rightWatermarkText:Null<FlxText> = null;
@@ -252,6 +253,15 @@ class MusicBeatSubState extends FlxSubState implements IEventHandler
     this._parentState.openSubState(substate);
   }
 
+  override public function transitionIn()
+  {
+    // If there is a SubState either open or pending, don't do the transition, as the transition itself is a SubState.
+    if (this._requestedSubState == null && this.subState == null)
+    {
+      super.transitionIn();
+    }
+  }
+
   @:nullSafety(Off)
   override function startOutro(onComplete:() -> Void):Void
   {
@@ -267,7 +277,15 @@ class MusicBeatSubState extends FlxSubState implements IEventHandler
     {
       FunkinSound.stopAllAudio();
 
-      onComplete();
+      // If the SubState can fade out, make it use the transition instead.
+      if (Std.isOfType(this.subState, MusicBeatSubState))
+      {
+        cast(this.subState, MusicBeatSubState).startOutro(onComplete);
+      }
+      else
+      {
+        super.startOutro(onComplete);
+      }
     }
   }
 


### PR DESCRIPTION
## Linked Issues
trayfellow's endless comments about it being omitted

## Description
Previously, every transition aside from the state enter was omitted. This PR brings them back, while also accounting for custom transitions like the Sticker Substate being open.
One thing I noticed is that if you're in a substate and switching to another menu, `onStateChangeBegin` actually gets triggered twice. I decided not to touch it, since it's out of scope for this PR but still worth mentioning because I am unsure if it's an oversight or intended behavior.

## Screenshots/Videos

https://github.com/user-attachments/assets/32148f70-4741-4e08-a383-cd013965a2e7
