### PR TITLE
[BUGFIX] Fix Animation Editor Onion Skin Scaling

### DIFF
--- a/source/funkin/ui/debug/anim/DebugBoundingState.hx
+++ b/source/funkin/ui/debug/anim/DebugBoundingState.hx
@@ -180,8 +180,10 @@ class DebugBoundingState extends FlxState
     onionSkinChar.frame = swagChar.frame;
     onionSkinChar.alpha = 0.6;
     onionSkinChar.flipX = swagChar.flipX;
-    onionSkinChar.offset.x = swagChar.animOffsets[0];
-    onionSkinChar.offset.y = swagChar.animOffsets[1];
+    onionSkinChar.scale.set(swagChar.scale.x, swagChar.scale.y);
+    onionSkinChar.updateHitbox();
+    onionSkinChar.offset.x = swagChar.offset.x + swagChar.animOffsets[0] * swagChar.scale.x;
+    onionSkinChar.offset.y = swagChar.offset.y + swagChar.animOffsets[1] * swagChar.scale.y;
 
     swagChar.playAnimation(currentAnimationName, true); // reset animation to the one it should be
   }


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
Fixes #6121

<!-- Briefly describe the issue(s) fixed. -->
## Description
In the animation editor, for whatever reason the onion skin doesn't scale to the size of the character. Everything works as it should now. Offsetting the idle properly offsets the onion skin, as it should. It looks good on scaled up characters. It looks good on characters that have a normal scale. This also took way too long to figure out.

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos

Hey would you look at that, it works.

<img width="461" height="430" alt="image" src="https://github.com/user-attachments/assets/2eb83ad6-9e65-4962-948b-e446c1aaf24f" />
