### PR TITLE
[BUGFIX] Always save preferences when exiting the Chart Editor

### DIFF
--- a/source/funkin/ui/debug/charting/ChartEditorState.hx
+++ b/source/funkin/ui/debug/charting/ChartEditorState.hx
@@ -5725,6 +5725,8 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
       return;
     }
 
+    writePreferences(false);
+
     this.hideAllToolboxes();
 
     stopWelcomeMusic();


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
Fixes #6125
<!-- Briefly describe the issue(s) fixed. -->
## Description
Preferences for the chart editor are currently only saved if leaving through the confirmation dialogue or completely closing the window. This happens because the `autosave` function (which calls the `writePreferences` function) is no longer always called when leaving the chart editor.

This PR fixes the issue by adding a call to `writePreferences` to the `quitChartEditor` function.
<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos

https://github.com/user-attachments/assets/0e9274e0-8f51-4fc2-ab31-f0396e296ccf