### PR TITLE
[ENHANCEMENT] Hide Cursor When Playtesting Chart

### DIFF
--- a/source/funkin/ui/debug/charting/ChartEditorState.hx
+++ b/source/funkin/ui/debug/charting/ChartEditorState.hx
@@ -3516,7 +3516,7 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
 
     // Show the mouse cursor.
     // Just throwing this somewhere convenient and infrequently called because sometimes Flixel's debug thing hides the cursor.
-    Cursor.show();
+    if (this.subState == null) Cursor.show();
 
     return true;
   }
@@ -6136,6 +6136,8 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
     this.persistentDraw = false;
     stopWelcomeMusic();
 
+    Cursor.hide();
+
     LoadingState.loadPlayState(targetStateParams, false, true, function(targetState) {
       targetState.vocals = audioVocalTrackGroup;
     });
@@ -6541,6 +6543,8 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
     moveSongToScrollPosition();
 
     fadeInWelcomeMusic(WELCOME_MUSIC_FADE_IN_DELAY, WELCOME_MUSIC_FADE_IN_DURATION);
+
+    Cursor.show();
 
     // Reapply the volume and playback rate.
     var instTargetVolume:Float = (menubarItemVolumeInstrumental.value / 100.0) ?? 1.0;


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
Implements #6129

<!-- Briefly describe the issue(s) fixed. -->
## Description
When using the chart editor, playtesting your chart will keep the cursor visible. This PR changes it so that the cursor hides when playtesting the chart and has it appear again when reopening the chart editor.

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos

https://github.com/user-attachments/assets/1a5e4c95-2933-49e1-b1d0-e2be6f13ea15
