### PR TITLE
[ENHANCEMENT] Chart Editor - Modify chart & metadata difficulties separately

### DIFF
--- a/source/funkin/ui/debug/charting/ChartEditorState.hx
+++ b/source/funkin/ui/debug/charting/ChartEditorState.hx
@@ -84,6 +84,7 @@ import funkin.ui.debug.charting.components.ChartEditorNotePreview;
 import funkin.ui.debug.charting.components.ChartEditorNoteSprite;
 import funkin.ui.debug.charting.components.ChartEditorPlaybarHead;
 import funkin.ui.debug.charting.components.ChartEditorSelectionSquareSprite;
+import funkin.ui.debug.charting.toolboxes.ChartEditorMetadataToolbox;
 import funkin.ui.debug.charting.toolboxes.ChartEditorDifficultyToolbox;
 import funkin.ui.debug.charting.toolboxes.ChartEditorFreeplayToolbox;
 import funkin.ui.debug.charting.toolboxes.ChartEditorOffsetsToolbox;
@@ -5649,12 +5650,12 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
 
   function handleToolboxes():Void
   {
-    handleDifficultyToolbox();
+    handleToolboxDifficultyTrees();
     handlePlayerPreviewToolbox();
     handleOpponentPreviewToolbox();
   }
 
-  function handleDifficultyToolbox():Void
+  function handleToolboxDifficultyTrees():Void
   {
     if (difficultySelectDirty)
     {
@@ -5664,10 +5665,9 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
       if (variationMetadata != null)
         variationMetadata.playData.difficulties.sort(SortUtil.defaultsThenAlphabetically.bind(Constants.DEFAULT_DIFFICULTY_LIST_FULL));
 
-      var difficultyToolbox:ChartEditorDifficultyToolbox = cast this.getToolbox(CHART_EDITOR_TOOLBOX_DIFFICULTY_LAYOUT);
-      if (difficultyToolbox == null) return;
+      cast(this.getToolbox(CHART_EDITOR_TOOLBOX_DIFFICULTY_LAYOUT), ChartEditorDifficultyToolbox)?.updateTree();
 
-      difficultyToolbox.updateTree();
+      cast(this.getToolbox(CHART_EDITOR_TOOLBOX_METADATA_LAYOUT), ChartEditorMetadataToolbox)?.updateTree();
     }
   }
 
@@ -6790,23 +6790,32 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
     return event != null && currentEventSelection.indexOf(event) != -1;
   }
 
-  function createDifficulty(variation:String, difficulty:String, scrollSpeed:Float = 1.0):Void
+  function createDifficulty(variation:String, difficulty:String, scrollSpeed:Float = 1.0, difficultyRating:Int = 0, addtoMetadata:Bool = true,
+      addtoChartdata:Bool = true):Void
   {
     var variationMetadata:Null<SongMetadata> = songMetadata.get(variation);
     if (variationMetadata == null) return;
 
-    variationMetadata.playData.difficulties.push(difficulty);
+    if (addtoMetadata)
+    {
+      variationMetadata.playData.difficulties.push(difficulty);
+      variationMetadata.playData.ratings.set(difficulty, difficultyRating);
+    }
 
     var resultChartData = songChartData.get(variation);
-    if (resultChartData == null)
+    if (addtoChartdata)
     {
-      resultChartData = new SongChartData([difficulty => scrollSpeed], [], [difficulty => []]);
-      songChartData.set(variation, resultChartData);
-    }
-    else
-    {
-      resultChartData.scrollSpeed.set(difficulty, scrollSpeed);
-      resultChartData.notes.set(difficulty, []);
+      if (resultChartData == null)
+      {
+        resultChartData = new SongChartData([difficulty => scrollSpeed], [], [difficulty => []]);
+        songChartData.set(variation, resultChartData);
+      }
+      else
+      {
+        // Maybe there should be a warning for overriding a difficulty?
+        resultChartData.scrollSpeed.set(difficulty, scrollSpeed);
+        resultChartData.notes.set(difficulty, []);
+      }
     }
 
     difficultySelectDirty = true; // Force the Difficulty toolbox to update.
@@ -6852,15 +6861,15 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
     difficultySelectDirty = true; // Force the Difficulty toolbox to update.
   }
 
-  function removeDifficulty(variation:String, difficulty:String):Void
+  function removeDifficulty(variation:String, difficulty:String, removeFromMetadata:Bool = true, removeFromChartdata:Bool = true):Void
   {
     var variationMetadata:Null<SongMetadata> = songMetadata.get(variation);
     if (variationMetadata == null) return;
 
-    variationMetadata.playData.difficulties.remove(difficulty);
+    if (removeFromMetadata) variationMetadata.playData.difficulties.remove(difficulty);
 
     var resultChartData = songChartData.get(variation);
-    if (resultChartData != null)
+    if (resultChartData != null && removeFromChartdata)
     {
       resultChartData.scrollSpeed.remove(difficulty);
       resultChartData.notes.remove(difficulty);
@@ -6889,7 +6898,35 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
       || !variationMetadata.playData.difficulties.contains(selectedDifficulty)) selectedDifficulty = variationMetadata.playData.difficulties[0];
 
     refreshPlayDataVariations();
-    difficultySelectDirty = true; // Force the Difficulty toolbox to update.
+    difficultySelectDirty = true; // Force the difficulty trees to update.
+  }
+
+  // Same as the above function, but removes the variation and all it's difficulties instead of when it's the last one.
+  function removeVariation(variation:String):Void
+  {
+    var variationMetadata:Null<SongMetadata> = songMetadata.get(variation);
+    if (variationMetadata == null) return;
+
+    if (songMetadata.size() > 1)
+    {
+      if (variation != Constants.DEFAULT_VARIATION)
+      {
+        songMetadata.remove(variation);
+        songChartData.remove(variation);
+      }
+
+      if (variation == selectedVariation)
+      {
+        var firstVariation = songMetadata.keyValues()[0];
+        if (firstVariation != null) selectedVariation = firstVariation;
+        variationMetadata = songMetadata.get(selectedVariation);
+      }
+    }
+
+    if (availableDifficulties.indexOf(selectedDifficulty) < 0) selectedDifficulty = availableDifficulties[0];
+
+    refreshPlayDataVariations();
+    difficultySelectDirty = true; // Force the difficulty trees to update.
   }
 
   function incrementDifficulty(change:Int):Void
@@ -7101,7 +7138,8 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
   {
     var oldTimeSignatureNum:Int = Conductor.instance.timeSignatureNumerator;
     var oldTimeSignatureDen:Int = Conductor.instance.timeSignatureDenominator;
-    Conductor.instance.update(audioInstTrack.time, false);
+    if (audioInstTrack != null) Conductor.instance.update(audioInstTrack.time, false);
+    else if (audioVocalTrackGroup != null) Conductor.instance.update(audioVocalTrackGroup.time, false);
     if (Conductor.instance.timeSignatureNumerator != oldTimeSignatureNum
       || Conductor.instance.timeSignatureDenominator != oldTimeSignatureDen)
     {

--- a/source/funkin/ui/debug/charting/ChartEditorState.hx
+++ b/source/funkin/ui/debug/charting/ChartEditorState.hx
@@ -94,6 +94,7 @@ import funkin.ui.debug.charting.components.ChartEditorNoteSprite;
 import funkin.ui.debug.charting.components.ChartEditorPlaybarHead;
 import funkin.ui.debug.charting.components.ChartEditorCommentPanel;
 import funkin.ui.debug.charting.components.ChartEditorSelectionSquareSprite;
+import funkin.ui.debug.charting.toolboxes.ChartEditorMetadataToolbox;
 import funkin.ui.debug.charting.toolboxes.ChartEditorDifficultyToolbox;
 import funkin.ui.debug.charting.toolboxes.ChartEditorFreeplayToolbox;
 import funkin.ui.debug.charting.toolboxes.ChartEditorOffsetsToolbox;
@@ -5998,12 +5999,12 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
 
   function handleToolboxes():Void
   {
-    handleDifficultyToolbox();
+    handleToolboxDifficultyTrees();
     handlePlayerPreviewToolbox();
     handleOpponentPreviewToolbox();
   }
 
-  function handleDifficultyToolbox():Void
+  function handleToolboxDifficultyTrees():Void
   {
     if (difficultySelectDirty)
     {
@@ -6014,10 +6015,9 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
         SortUtil.defaultsThenAlphabetically.bind(Constants.DEFAULT_DIFFICULTY_LIST_FULL)
       );
 
-      var difficultyToolbox:ChartEditorDifficultyToolbox = cast this.getToolbox(CHART_EDITOR_TOOLBOX_DIFFICULTY_LAYOUT);
-      if (difficultyToolbox == null) return;
+      cast(this.getToolbox(CHART_EDITOR_TOOLBOX_DIFFICULTY_LAYOUT), ChartEditorDifficultyToolbox)?.updateTree();
 
-      difficultyToolbox.updateTree();
+      cast(this.getToolbox(CHART_EDITOR_TOOLBOX_METADATA_LAYOUT), ChartEditorMetadataToolbox)?.updateTree();
     }
   }
 
@@ -7365,23 +7365,32 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
     return event != null && currentEventSelection.indexOf(event) != -1;
   }
 
-  function createDifficulty(variation:String, difficulty:String, scrollSpeed:Float = 1.0):Void
+  function createDifficulty(variation:String, difficulty:String, scrollSpeed:Float = 1.0, difficultyRating:Int = 0, addtoMetadata:Bool = true,
+      addtoChartdata:Bool = true):Void
   {
     var variationMetadata:Null<SongMetadata> = songMetadata.get(variation);
     if (variationMetadata == null) return;
 
-    variationMetadata.playData.difficulties.pushUnique(difficulty);
+    if (addtoMetadata)
+    {
+      variationMetadata.playData.difficulties.push(difficulty);
+      variationMetadata.playData.ratings.set(difficulty, difficultyRating);
+    }
 
     var resultChartData = songChartData.get(variation);
-    if (resultChartData == null)
+    if (addtoChartdata)
     {
-      resultChartData = new SongChartData([difficulty => scrollSpeed], [], [difficulty => []]);
-      songChartData.set(variation, resultChartData);
-    }
-    else
-    {
-      resultChartData.scrollSpeed.set(difficulty, scrollSpeed);
-      resultChartData.notes.set(difficulty, []);
+      if (resultChartData == null)
+      {
+        resultChartData = new SongChartData([difficulty => scrollSpeed], [], [difficulty => []]);
+        songChartData.set(variation, resultChartData);
+      }
+      else
+      {
+        // Maybe there should be a warning for overriding a difficulty?
+        resultChartData.scrollSpeed.set(difficulty, scrollSpeed);
+        resultChartData.notes.set(difficulty, []);
+      }
     }
 
     difficultySelectDirty = true; // Force the Difficulty toolbox to update.
@@ -7427,15 +7436,15 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
     difficultySelectDirty = true; // Force the Difficulty toolbox to update.
   }
 
-  function removeDifficulty(variation:String, difficulty:String):Void
+  function removeDifficulty(variation:String, difficulty:String, removeFromMetadata:Bool = true, removeFromChartdata:Bool = true):Void
   {
     var variationMetadata:Null<SongMetadata> = songMetadata.get(variation);
     if (variationMetadata == null) return;
 
-    variationMetadata.playData.difficulties.remove(difficulty);
+    if (removeFromMetadata) variationMetadata.playData.difficulties.remove(difficulty);
 
     var resultChartData = songChartData.get(variation);
-    if (resultChartData != null)
+    if (resultChartData != null && removeFromChartdata)
     {
       resultChartData.scrollSpeed.remove(difficulty);
       resultChartData.notes.remove(difficulty);
@@ -7466,7 +7475,35 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
     ) selectedDifficulty = variationMetadata.playData.difficulties[0];
 
     refreshPlayDataVariations();
-    difficultySelectDirty = true; // Force the Difficulty toolbox to update.
+    difficultySelectDirty = true; // Force the difficulty trees to update.
+  }
+
+  // Same as the above function, but removes the variation and all it's difficulties instead of when it's the last one.
+  function removeVariation(variation:String):Void
+  {
+    var variationMetadata:Null<SongMetadata> = songMetadata.get(variation);
+    if (variationMetadata == null) return;
+
+    if (songMetadata.size() > 1)
+    {
+      if (variation != Constants.DEFAULT_VARIATION)
+      {
+        songMetadata.remove(variation);
+        songChartData.remove(variation);
+      }
+
+      if (variation == selectedVariation)
+      {
+        var firstVariation = songMetadata.keyValues()[0];
+        if (firstVariation != null) selectedVariation = firstVariation;
+        variationMetadata = songMetadata.get(selectedVariation);
+      }
+    }
+
+    if (availableDifficulties.indexOf(selectedDifficulty) < 0) selectedDifficulty = availableDifficulties[0];
+
+    refreshPlayDataVariations();
+    difficultySelectDirty = true; // Force the difficulty trees to update.
   }
 
   function incrementDifficulty(change:Int):Void
@@ -7689,8 +7726,10 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
   {
     var oldTimeSignatureNum:Int = Conductor.instance.timeSignatureNumerator;
     var oldTimeSignatureDen:Int = Conductor.instance.timeSignatureDenominator;
-    Conductor.instance.update(audioInstTrack.time, false);
-    if (Conductor.instance.timeSignatureNumerator != oldTimeSignatureNum || Conductor.instance.timeSignatureDenominator != oldTimeSignatureDen)
+    if (audioInstTrack != null) Conductor.instance.update(audioInstTrack.time, false);
+    else if (audioVocalTrackGroup != null) Conductor.instance.update(audioVocalTrackGroup.time, false);
+    if (Conductor.instance.timeSignatureNumerator != oldTimeSignatureNum
+      || Conductor.instance.timeSignatureDenominator != oldTimeSignatureDen)
     {
       updateTimeSignature();
     }

--- a/source/funkin/ui/debug/charting/commands/SwitchDifficultyCommand.hx
+++ b/source/funkin/ui/debug/charting/commands/SwitchDifficultyCommand.hx
@@ -12,13 +12,15 @@ class SwitchDifficultyCommand implements ChartEditorCommand
   var newDifficulty:String;
   var prevVariation:String;
   var newVariation:String;
+  var resetMetadataToolbox:Bool;
 
-  public function new(prevDifficulty:String, newDifficulty:String, prevVariation:String, newVariation:String)
+  public function new(prevDifficulty:String, newDifficulty:String, prevVariation:String, newVariation:String, resetMetadataToolbox:Bool = true)
   {
     this.prevDifficulty = prevDifficulty;
     this.newDifficulty = newDifficulty;
     this.prevVariation = prevVariation;
     this.newVariation = newVariation;
+    this.resetMetadataToolbox = resetMetadataToolbox;
   }
 
   /**
@@ -33,7 +35,7 @@ class SwitchDifficultyCommand implements ChartEditorCommand
     trace('Done switching variation.');
     state.selectedDifficulty = newDifficulty != null ? newDifficulty : prevDifficulty;
 
-    markDirty(state);
+    if (resetMetadataToolbox) markDirty(state);
   }
 
   /**
@@ -46,14 +48,12 @@ class SwitchDifficultyCommand implements ChartEditorCommand
     state.selectedVariation = prevVariation != null ? prevVariation : newVariation;
     state.selectedDifficulty = prevDifficulty != null ? prevDifficulty : newDifficulty;
 
-    markDirty(state);
+    if (resetMetadataToolbox) markDirty(state);
   }
 
   function markDirty(state:ChartEditorState):Void
   {
     state.refreshToolbox(ChartEditorState.CHART_EDITOR_TOOLBOX_METADATA_LAYOUT);
-    state.noteDisplayDirty = true;
-    state.notePreviewDirty = true;
   }
 
   /**

--- a/source/funkin/ui/debug/charting/commands/SwitchDifficultyCommand.hx
+++ b/source/funkin/ui/debug/charting/commands/SwitchDifficultyCommand.hx
@@ -11,13 +11,15 @@ class SwitchDifficultyCommand implements ChartEditorCommand
   var newDifficulty:String;
   var prevVariation:String;
   var newVariation:String;
+  var resetMetadataToolbox:Bool;
 
-  public function new(prevDifficulty:String, newDifficulty:String, prevVariation:String, newVariation:String)
+  public function new(prevDifficulty:String, newDifficulty:String, prevVariation:String, newVariation:String, resetMetadataToolbox:Bool = true)
   {
     this.prevDifficulty = prevDifficulty;
     this.newDifficulty = newDifficulty;
     this.prevVariation = prevVariation;
     this.newVariation = newVariation;
+    this.resetMetadataToolbox = resetMetadataToolbox;
   }
 
   /**
@@ -29,7 +31,7 @@ class SwitchDifficultyCommand implements ChartEditorCommand
     state.selectedVariation = newVariation != null ? newVariation : prevVariation;
     state.selectedDifficulty = newDifficulty != null ? newDifficulty : prevDifficulty;
 
-    markDirty(state);
+    if (resetMetadataToolbox) markDirty(state);
   }
 
   /**
@@ -41,14 +43,12 @@ class SwitchDifficultyCommand implements ChartEditorCommand
     state.selectedVariation = prevVariation != null ? prevVariation : newVariation;
     state.selectedDifficulty = prevDifficulty != null ? prevDifficulty : newDifficulty;
 
-    markDirty(state);
+    if (resetMetadataToolbox) markDirty(state);
   }
 
   function markDirty(state:ChartEditorState):Void
   {
     state.refreshToolbox(ChartEditorState.CHART_EDITOR_TOOLBOX_METADATA_LAYOUT);
-    state.noteDisplayDirty = true;
-    state.notePreviewDirty = true;
   }
 
   /**

--- a/source/funkin/ui/debug/charting/handlers/ChartEditorDialogHandler.hx
+++ b/source/funkin/ui/debug/charting/handlers/ChartEditorDialogHandler.hx
@@ -33,6 +33,7 @@ import haxe.ui.components.NumberStepper;
 import haxe.ui.components.Slider;
 import haxe.ui.components.TextField;
 import haxe.ui.containers.Box;
+import haxe.ui.components.CheckBox;
 import haxe.ui.containers.dialogs.Dialog;
 import haxe.ui.containers.dialogs.Dialog.DialogButton;
 import haxe.ui.containers.dialogs.Dialogs;
@@ -1435,12 +1436,17 @@ class ChartEditorDialogHandler
    * Builds and opens a dialog where the user can add a new difficulty for a song.
    * @param state The current chart editor state.
    * @param closable Whether the dialog can be closed by the user.
+   * @param metadataDialog .
    * @return The dialog that was opened.
    */
-  public static function openAddDifficultyDialog(state:ChartEditorState, closable:Bool = true):Dialog
+  public static function openAddDifficultyDialog(state:ChartEditorState, closable:Bool = true, metadataDialog:Bool = false):Dialog
   {
     var dialog:Null<Dialog> = openDialog(state, CHART_EDITOR_DIALOG_ADD_DIFFICULTY_LAYOUT, true, false);
     if (dialog == null) throw 'Could not locate Add Difficulty dialog';
+
+    if (metadataDialog) dialog.title = 'Add (Metadata) Difficulty';
+    else
+      dialog.title = 'Add (Chartdata) Difficulty';
 
     var difficultyForm:Null<Form> = dialog.findComponent('difficultyForm', Form);
     if (difficultyForm == null) throw 'Could not locate difficultyForm Form in Add Difficulty dialog';
@@ -1476,6 +1482,21 @@ class ChartEditorDialogHandler
     inputScrollSpeed.value = state.currentSongChartScrollSpeed;
     labelScrollSpeed.text = 'Scroll Speed: ${inputScrollSpeed.value}x';
 
+    var inputDifficultyRating:Null<NumberStepper> = dialog.findComponent('inputDifficultyRating', NumberStepper);
+    if (inputDifficultyRating == null) throw 'Could not find inputDifficultyRating component.';
+    inputDifficultyRating.value = state.currentSongChartDifficultyRating;
+
+    var inputAddToMetadata:Null<CheckBox> = dialog.findComponent('inputAddToMetadata', CheckBox);
+    if (inputAddToMetadata == null) throw 'Could not find inputAddToMetadata component.';
+    inputAddToMetadata.disabled = metadataDialog;
+    inputAddToMetadata.hidden = metadataDialog;
+
+    var inputAddToChart:Null<CheckBox> = dialog.findComponent('inputAddToChart', CheckBox);
+    if (inputAddToChart == null) throw 'Could not find inputAddToChart component.';
+    inputAddToChart.selected = !metadataDialog;
+    inputAddToChart.disabled = !metadataDialog;
+    inputAddToChart.hidden = !metadataDialog;
+
     difficultyForm.onSubmit = function(_)
     {
       trace('Add Difficulty dialog submitted, validation succeeded!');
@@ -1483,7 +1504,8 @@ class ChartEditorDialogHandler
       var dialogDifficultyName:Null<TextField> = dialog.findComponent('dialogDifficultyName', TextField);
       if (dialogDifficultyName == null) throw 'Could not locate dialogDifficultyName TextField in Add Difficulty dialog';
 
-      state.createDifficulty(dialogVariation.value.id, dialogDifficultyName.text.toLowerCase(), inputScrollSpeed.value ?? 1.0);
+      state.createDifficulty(dialogVariation.value.id, dialogDifficultyName.text.toLowerCase(), inputScrollSpeed.value ?? 1.0,
+        inputDifficultyRating.value ?? 1, inputAddToMetadata.selected, inputAddToChart.selected);
 
       state.success('Add Difficulty', 'Added new difficulty "${dialogDifficultyName.text.toLowerCase()}"');
 

--- a/source/funkin/ui/debug/charting/handlers/ChartEditorDialogHandler.hx
+++ b/source/funkin/ui/debug/charting/handlers/ChartEditorDialogHandler.hx
@@ -34,6 +34,7 @@ import haxe.ui.components.NumberStepper;
 import haxe.ui.components.Slider;
 import haxe.ui.components.TextField;
 import haxe.ui.containers.Box;
+import haxe.ui.components.CheckBox;
 import haxe.ui.containers.dialogs.Dialog;
 import haxe.ui.containers.dialogs.Dialog.DialogButton;
 import haxe.ui.containers.dialogs.Dialogs;
@@ -1492,12 +1493,17 @@ class ChartEditorDialogHandler
    * Builds and opens a dialog where the user can add a new difficulty for a song.
    * @param state The current chart editor state.
    * @param closable Whether the dialog can be closed by the user.
+   * @param metadataDialog .
    * @return The dialog that was opened.
    */
-  public static function openAddDifficultyDialog(state:ChartEditorState, closable:Bool = true):Dialog
+  public static function openAddDifficultyDialog(state:ChartEditorState, closable:Bool = true, metadataDialog:Bool = false):Dialog
   {
     var dialog:Null<Dialog> = openDialog(state, CHART_EDITOR_DIALOG_ADD_DIFFICULTY_LAYOUT, true, false);
     if (dialog == null) throw 'Could not locate Add Difficulty dialog';
+
+    if (metadataDialog) dialog.title = 'Add (Metadata) Difficulty';
+    else
+      dialog.title = 'Add (Chartdata) Difficulty';
 
     var difficultyForm:Null<Form> = dialog.findComponent('difficultyForm', Form);
     if (difficultyForm == null) throw 'Could not locate difficultyForm Form in Add Difficulty dialog';
@@ -1533,6 +1539,21 @@ class ChartEditorDialogHandler
     inputScrollSpeed.value = state.currentSongChartScrollSpeed;
     labelScrollSpeed.text = 'Scroll Speed: ${inputScrollSpeed.value}x';
 
+    var inputDifficultyRating:Null<NumberStepper> = dialog.findComponent('inputDifficultyRating', NumberStepper);
+    if (inputDifficultyRating == null) throw 'Could not find inputDifficultyRating component.';
+    inputDifficultyRating.value = state.currentSongChartDifficultyRating;
+
+    var inputAddToMetadata:Null<CheckBox> = dialog.findComponent('inputAddToMetadata', CheckBox);
+    if (inputAddToMetadata == null) throw 'Could not find inputAddToMetadata component.';
+    inputAddToMetadata.disabled = metadataDialog;
+    inputAddToMetadata.hidden = metadataDialog;
+
+    var inputAddToChart:Null<CheckBox> = dialog.findComponent('inputAddToChart', CheckBox);
+    if (inputAddToChart == null) throw 'Could not find inputAddToChart component.';
+    inputAddToChart.selected = !metadataDialog;
+    inputAddToChart.disabled = !metadataDialog;
+    inputAddToChart.hidden = !metadataDialog;
+
     difficultyForm.onSubmit = function(_)
     {
       trace('Add Difficulty dialog submitted, validation succeeded!');
@@ -1540,7 +1561,8 @@ class ChartEditorDialogHandler
       var dialogDifficultyName:Null<TextField> = dialog.findComponent('dialogDifficultyName', TextField);
       if (dialogDifficultyName == null) throw 'Could not locate dialogDifficultyName TextField in Add Difficulty dialog';
 
-      state.createDifficulty(dialogVariation.value.id, dialogDifficultyName.text.toLowerCase(), inputScrollSpeed.value ?? 1.0);
+      state.createDifficulty(dialogVariation.value.id, dialogDifficultyName.text.toLowerCase(), inputScrollSpeed.value ?? 1.0,
+        inputDifficultyRating.value ?? 1, inputAddToMetadata.selected, inputAddToChart.selected);
 
       state.success('Add Difficulty', 'Added new difficulty "${dialogDifficultyName.text.toLowerCase()}"');
 

--- a/source/funkin/ui/debug/charting/toolboxes/ChartEditorDifficultyToolbox.hx
+++ b/source/funkin/ui/debug/charting/toolboxes/ChartEditorDifficultyToolbox.hx
@@ -1,7 +1,7 @@
 package funkin.ui.debug.charting.toolboxes;
 
-import funkin.ui.debug.charting.commands.SwitchDifficultyCommand;
 #if FEATURE_CHART_EDITOR
+import funkin.ui.debug.charting.commands.SwitchDifficultyCommand;
 import funkin.data.song.SongData.SongChartData;
 import funkin.data.song.SongData.SongMetadata;
 import funkin.data.song.SongRegistry;
@@ -9,20 +9,13 @@ import haxe.ui.components.Button;
 import haxe.ui.containers.dialogs.Dialogs;
 import haxe.ui.containers.dialogs.Dialog.DialogButton;
 import funkin.data.song.SongData.SongMetadata;
-import haxe.ui.components.DropDown;
-import haxe.ui.components.HorizontalSlider;
 import funkin.util.VersionUtil;
 import funkin.util.FileUtil;
 import openfl.net.FileReference;
 import haxe.ui.containers.dialogs.MessageBox.MessageBoxType;
-import haxe.ui.components.Label;
-import haxe.ui.components.NumberStepper;
-import haxe.ui.components.Slider;
-import haxe.ui.components.TextField;
-import funkin.play.stage.Stage;
-import haxe.ui.containers.Box;
 import haxe.ui.containers.TreeView;
 import haxe.ui.containers.TreeViewNode;
+import haxe.ui.core.ItemRenderer;
 import haxe.ui.events.UIEvent;
 
 /**
@@ -35,9 +28,10 @@ import haxe.ui.events.UIEvent;
 class ChartEditorDifficultyToolbox extends ChartEditorBaseToolbox
 {
   var difficultyToolboxTree:TreeView;
-  var difficultyToolboxAddVariation:Button;
   var difficultyToolboxAddDifficulty:Button;
   var difficultyToolboxRemoveDifficulty:Button;
+  var difficultyToolboxCloneDifficulty:Button;
+  var difficultyToolboxMoveDifficulty:Button;
   var difficultyToolboxSaveMetadata:Button;
   var difficultyToolboxSaveChart:Button;
   var difficultyToolboxLoadMetadata:Button;
@@ -96,15 +90,21 @@ class ChartEditorDifficultyToolbox extends ChartEditorBaseToolbox
         switch (button)
         {
           case DialogButton.YES:
-            // Remove the difficulty.
-            chartEditorState.removeDifficulty(currentVariation, currentDifficulty);
+            // Remove the difficulty from the chartdata and metadata.
+            chartEditorState.removeDifficulty(currentVariation, currentDifficulty, true, true);
             refresh();
-          case DialogButton.NO: // Do nothing.
+          case DialogButton.NO:
+            // Remove the difficulty from the chartdata.
+            chartEditorState.removeDifficulty(currentVariation, currentDifficulty, false, true);
+            refresh();
+          case DialogButton.CANCEL: // Do nothing.
+
           default: // Do nothing.
         }
       }
 
-      Dialogs.messageBox('Are you sure? This cannot be undone.', 'Remove Difficulty', MessageBoxType.TYPE_YESNO, callback);
+      Dialogs.messageBox('Are you sure? This is destructive and cannot be undone.\n\nYES will remove it from the chartdata and metadata.\n\nNO will remove it from the chartdata.',
+        'Remove Difficulty', MessageBoxType.TYPE_QUESTION, callback);
     };
 
     difficultyToolboxSaveMetadata.onClick = function(_:UIEvent)
@@ -250,7 +250,19 @@ class ChartEditorDifficultyToolbox extends ChartEditorBaseToolbox
       });
       treeVariation.expanded = true;
 
-      var difficultyList:Array<String> = variationMetadata.playData.difficulties;
+      var difficultyList:Array<String> = [];
+      var variationChartdata:Null<SongChartData> = chartEditorState.songChartData.get(curVariation);
+
+      if (variationChartdata != null)
+      {
+        var keys:Array<String> = [for (x in variationChartdata.notes.keys()) x];
+        keys.sort(funkin.util.SortUtil.defaultsThenAlphabetically.bind(Constants.DEFAULT_DIFFICULTY_LIST_FULL));
+
+        for (key in keys)
+        {
+          difficultyList.pushUnique(key);
+        }
+      }
 
       for (difficulty in difficultyList)
       {
@@ -268,23 +280,52 @@ class ChartEditorDifficultyToolbox extends ChartEditorBaseToolbox
   /**
    * Set the selected item in the tree to the current variation/difficulty.
    *
-   * @param targetNode The node to select. If null, the current variation/difficulty will be used.
+   * @param node The node to select. If null, the current variation/difficulty will be used.
    */
-  public function refreshTreeSelection():Void
+  public function refreshTreeSelection(node:TreeViewNode = null):Void
   {
-    var targetNode = getCurrentTreeNode();
-    if (targetNode != null) difficultyToolboxTree.selectedNode = targetNode;
+    var targetNode = getCurrentTreeNode(node);
+    if (this.visible && difficultyToolboxTree.selectedNode != targetNode)
+    {
+      if (difficultyToolboxTree.selectedNode != null)
+      {
+        var renderer = difficultyToolboxTree.selectedNode.findComponent(ItemRenderer, true);
+        if (renderer != null)
+        {
+          renderer.removeClass(":node-selected", true, true);
+        }
+      }
+      difficultyToolboxTree.selectedNode = targetNode;
+      if (targetNode != null) targetNode.selected = true;
+    }
   }
 
   /**
    * Get the node in the tree representing the current variation/difficulty.
    */
-  function getCurrentTreeNode():TreeViewNode
+  function getCurrentTreeNode(node:TreeViewNode):TreeViewNode
   {
-    return difficultyToolboxTree.findNodeByPath(
-      'stv_song/stv_variation_$chartEditorState.selectedVariation/stv_difficulty_${chartEditorState.selectedVariation}_$chartEditorState.selectedDifficulty',
-      'id'
-    );
+    if (node != null)
+    {
+      return switch (node.data.id.split('_')[1])
+      {
+        case 'song':
+          difficultyToolboxTree.findNodeByPath('${node.data.id}');
+
+        case 'variation':
+          difficultyToolboxTree.findNodeByPath('stv_song/${node.data.id}');
+
+        case 'difficulty':
+          difficultyToolboxTree.findNodeByPath('stv_song/stv_variation_${chartEditorState.selectedVariation}/${node.data.id}');
+        default:
+          difficultyToolboxTree.findNodeByPath('stv_song/stv_variation_${chartEditorState.selectedVariation}/stv_difficulty_${chartEditorState.selectedVariation}_${chartEditorState.selectedDifficulty}',
+            'id');
+      }
+    }
+    else
+      return
+        difficultyToolboxTree.findNodeByPath('stv_song/stv_variation_${chartEditorState.selectedVariation}/stv_difficulty_${chartEditorState.selectedVariation}_${chartEditorState.selectedDifficulty}',
+        'id');
   }
 
   /**
@@ -311,27 +352,71 @@ class ChartEditorDifficultyToolbox extends ChartEditorBaseToolbox
 
         if (variation != null && difficulty != null)
         {
+          if ((chartEditorState.songMetadata.size() == 1 || variation == Constants.DEFAULT_VARIATION)
+            && chartEditorState.availableDifficulties.length == 1
+            && difficulty == chartEditorState.availableDifficulties[0])
+          {
+            difficultyToolboxRemoveDifficulty.disabled = true;
+            difficultyToolboxMoveDifficulty.disabled = true;
+            difficultyToolboxCloneDifficulty.disabled = true;
+          }
+          else
+          {
+            difficultyToolboxRemoveDifficulty.disabled = false;
+            difficultyToolboxMoveDifficulty.disabled = false;
+            difficultyToolboxCloneDifficulty.disabled = false;
+          }
           trace('Changing difficulty to "$variation:$difficulty"');
-
-          chartEditorState.performCommand(
-            new SwitchDifficultyCommand(chartEditorState.selectedDifficulty, difficulty, chartEditorState.selectedVariation, variation)
-          );
-
-          refreshTreeSelection();
+          chartEditorState.performCommand(new SwitchDifficultyCommand(chartEditorState.selectedDifficulty, difficulty, chartEditorState.selectedVariation,
+            variation));
+          cast(chartEditorState.getToolbox(ChartEditorState.CHART_EDITOR_TOOLBOX_METADATA_LAYOUT),
+            ChartEditorMetadataToolbox)?.refreshTreeSelection(targetNode);
         }
       // case 'song':
-      // case 'variation':
+      case 'variation':
+        var variation:String = targetNode.data.id.split('_')[2];
+        var difficulty:String = chartEditorState.selectedDifficulty;
+        if (variation != null)
+        {
+          difficultyToolboxRemoveDifficulty.disabled = true;
+          difficultyToolboxMoveDifficulty.disabled = true;
+          difficultyToolboxCloneDifficulty.disabled = true;
+          // Use the first available difficulty as a fallback if the currently selected one cannot be found.
+          if (chartEditorState.availableDifficulties.indexOf(chartEditorState.selectedDifficulty) < 0) difficulty = chartEditorState.availableDifficulties[0];
+          trace('Changing difficulty to "$variation:${chartEditorState.selectedDifficulty}"');
+          chartEditorState.performCommand(new SwitchDifficultyCommand(chartEditorState.selectedDifficulty, difficulty, chartEditorState.selectedVariation,
+            variation));
+          cast(chartEditorState.getToolbox(ChartEditorState.CHART_EDITOR_TOOLBOX_METADATA_LAYOUT),
+            ChartEditorMetadataToolbox)?.refreshTreeSelection(targetNode);
+        }
       default:
+        difficultyToolboxRemoveDifficulty.disabled = true;
+        difficultyToolboxMoveDifficulty.disabled = true;
+        difficultyToolboxCloneDifficulty.disabled = true;
         // Reset the user's selection.
         trace('Selected wrong node type, resetting selection.');
-        refreshTreeSelection();
-        chartEditorState.refreshToolbox(ChartEditorState.CHART_EDITOR_TOOLBOX_METADATA_LAYOUT);
+        cast(chartEditorState.getToolbox(ChartEditorState.CHART_EDITOR_TOOLBOX_METADATA_LAYOUT), ChartEditorMetadataToolbox)?.refreshTreeSelection(targetNode);
     }
   }
 
   override public function refresh():Void
   {
     super.refresh();
+
+    if (chartEditorState.songMetadata.size() == 1
+      && chartEditorState.availableDifficulties.length == 1
+      && chartEditorState.selectedDifficulty == chartEditorState.availableDifficulties[0])
+    {
+      difficultyToolboxRemoveDifficulty.disabled = true;
+      difficultyToolboxMoveDifficulty.disabled = true;
+      difficultyToolboxCloneDifficulty.disabled = true;
+    }
+    else
+    {
+      difficultyToolboxRemoveDifficulty.disabled = false;
+      difficultyToolboxMoveDifficulty.disabled = false;
+      difficultyToolboxCloneDifficulty.disabled = false;
+    }
 
     refreshTreeSelection();
   }

--- a/source/funkin/ui/debug/charting/toolboxes/ChartEditorDifficultyToolbox.hx
+++ b/source/funkin/ui/debug/charting/toolboxes/ChartEditorDifficultyToolbox.hx
@@ -1,7 +1,7 @@
 package funkin.ui.debug.charting.toolboxes;
 
-import funkin.ui.debug.charting.commands.SwitchDifficultyCommand;
 #if FEATURE_CHART_EDITOR
+import funkin.ui.debug.charting.commands.SwitchDifficultyCommand;
 import funkin.data.song.SongData.SongChartData;
 import funkin.data.song.SongData.SongMetadata;
 import funkin.data.song.SongRegistry;
@@ -9,20 +9,13 @@ import haxe.ui.components.Button;
 import haxe.ui.containers.dialogs.Dialogs;
 import haxe.ui.containers.dialogs.Dialog.DialogButton;
 import funkin.data.song.SongData.SongMetadata;
-import haxe.ui.components.DropDown;
-import haxe.ui.components.HorizontalSlider;
 import funkin.util.VersionUtil;
 import funkin.util.FileUtil;
 import openfl.net.FileReference;
 import haxe.ui.containers.dialogs.MessageBox.MessageBoxType;
-import haxe.ui.components.Label;
-import haxe.ui.components.NumberStepper;
-import haxe.ui.components.Slider;
-import haxe.ui.components.TextField;
-import funkin.play.stage.Stage;
-import haxe.ui.containers.Box;
 import haxe.ui.containers.TreeView;
 import haxe.ui.containers.TreeViewNode;
+import haxe.ui.core.ItemRenderer;
 import haxe.ui.events.UIEvent;
 
 /**
@@ -34,9 +27,10 @@ import haxe.ui.events.UIEvent;
 class ChartEditorDifficultyToolbox extends ChartEditorBaseToolbox
 {
   var difficultyToolboxTree:TreeView;
-  var difficultyToolboxAddVariation:Button;
   var difficultyToolboxAddDifficulty:Button;
   var difficultyToolboxRemoveDifficulty:Button;
+  var difficultyToolboxCloneDifficulty:Button;
+  var difficultyToolboxMoveDifficulty:Button;
   var difficultyToolboxSaveMetadata:Button;
   var difficultyToolboxSaveChart:Button;
   var difficultyToolboxLoadMetadata:Button;
@@ -95,15 +89,21 @@ class ChartEditorDifficultyToolbox extends ChartEditorBaseToolbox
         switch (button)
         {
           case DialogButton.YES:
-            // Remove the difficulty.
-            chartEditorState.removeDifficulty(currentVariation, currentDifficulty);
+            // Remove the difficulty from the chartdata and metadata.
+            chartEditorState.removeDifficulty(currentVariation, currentDifficulty, true, true);
             refresh();
-          case DialogButton.NO: // Do nothing.
+          case DialogButton.NO:
+            // Remove the difficulty from the chartdata.
+            chartEditorState.removeDifficulty(currentVariation, currentDifficulty, false, true);
+            refresh();
+          case DialogButton.CANCEL: // Do nothing.
+
           default: // Do nothing.
         }
       }
 
-      Dialogs.messageBox('Are you sure? This cannot be undone.', 'Remove Difficulty', MessageBoxType.TYPE_YESNO, callback);
+      Dialogs.messageBox('Are you sure? This is destructive and cannot be undone.\n\nYES will remove it from the chartdata and metadata.\n\nNO will remove it from the chartdata.',
+        'Remove Difficulty', MessageBoxType.TYPE_QUESTION, callback);
     };
 
     difficultyToolboxSaveMetadata.onClick = function(_:UIEvent)
@@ -238,7 +238,19 @@ class ChartEditorDifficultyToolbox extends ChartEditorBaseToolbox
       });
       treeVariation.expanded = true;
 
-      var difficultyList:Array<String> = variationMetadata.playData.difficulties;
+      var difficultyList:Array<String> = [];
+      var variationChartdata:Null<SongChartData> = chartEditorState.songChartData.get(curVariation);
+
+      if (variationChartdata != null)
+      {
+        var keys:Array<String> = [for (x in variationChartdata.notes.keys()) x];
+        keys.sort(funkin.util.SortUtil.defaultsThenAlphabetically.bind(Constants.DEFAULT_DIFFICULTY_LIST_FULL));
+
+        for (key in keys)
+        {
+          difficultyList.pushUnique(key);
+        }
+      }
 
       for (difficulty in difficultyList)
       {
@@ -256,22 +268,52 @@ class ChartEditorDifficultyToolbox extends ChartEditorBaseToolbox
   /**
    * Set the selected item in the tree to the current variation/difficulty.
    *
-   * @param targetNode The node to select. If null, the current variation/difficulty will be used.
+   * @param node The node to select. If null, the current variation/difficulty will be used.
    */
-  public function refreshTreeSelection():Void
+  public function refreshTreeSelection(node:TreeViewNode = null):Void
   {
-    var targetNode = getCurrentTreeNode();
-    if (targetNode != null) difficultyToolboxTree.selectedNode = targetNode;
+    var targetNode = getCurrentTreeNode(node);
+    if (this.visible && difficultyToolboxTree.selectedNode != targetNode)
+    {
+      if (difficultyToolboxTree.selectedNode != null)
+      {
+        var renderer = difficultyToolboxTree.selectedNode.findComponent(ItemRenderer, true);
+        if (renderer != null)
+        {
+          renderer.removeClass(":node-selected", true, true);
+        }
+      }
+      difficultyToolboxTree.selectedNode = targetNode;
+      if (targetNode != null) targetNode.selected = true;
+    }
   }
 
   /**
    * Get the node in the tree representing the current variation/difficulty.
    */
-  function getCurrentTreeNode():TreeViewNode
+  function getCurrentTreeNode(node:TreeViewNode):TreeViewNode
   {
-    return
-      difficultyToolboxTree.findNodeByPath('stv_song/stv_variation_$chartEditorState.selectedVariation/stv_difficulty_${chartEditorState.selectedVariation}_$chartEditorState.selectedDifficulty',
-      'id');
+    if (node != null)
+    {
+      return switch (node.data.id.split('_')[1])
+      {
+        case 'song':
+          difficultyToolboxTree.findNodeByPath('${node.data.id}');
+
+        case 'variation':
+          difficultyToolboxTree.findNodeByPath('stv_song/${node.data.id}');
+
+        case 'difficulty':
+          difficultyToolboxTree.findNodeByPath('stv_song/stv_variation_${chartEditorState.selectedVariation}/${node.data.id}');
+        default:
+          difficultyToolboxTree.findNodeByPath('stv_song/stv_variation_${chartEditorState.selectedVariation}/stv_difficulty_${chartEditorState.selectedVariation}_${chartEditorState.selectedDifficulty}',
+            'id');
+      }
+    }
+    else
+      return
+        difficultyToolboxTree.findNodeByPath('stv_song/stv_variation_${chartEditorState.selectedVariation}/stv_difficulty_${chartEditorState.selectedVariation}_${chartEditorState.selectedDifficulty}',
+        'id');
   }
 
   /**
@@ -298,26 +340,71 @@ class ChartEditorDifficultyToolbox extends ChartEditorBaseToolbox
 
         if (variation != null && difficulty != null)
         {
+          if ((chartEditorState.songMetadata.size() == 1 || variation == Constants.DEFAULT_VARIATION)
+            && chartEditorState.availableDifficulties.length == 1
+            && difficulty == chartEditorState.availableDifficulties[0])
+          {
+            difficultyToolboxRemoveDifficulty.disabled = true;
+            difficultyToolboxMoveDifficulty.disabled = true;
+            difficultyToolboxCloneDifficulty.disabled = true;
+          }
+          else
+          {
+            difficultyToolboxRemoveDifficulty.disabled = false;
+            difficultyToolboxMoveDifficulty.disabled = false;
+            difficultyToolboxCloneDifficulty.disabled = false;
+          }
           trace('Changing difficulty to "$variation:$difficulty"');
-
           chartEditorState.performCommand(new SwitchDifficultyCommand(chartEditorState.selectedDifficulty, difficulty, chartEditorState.selectedVariation,
             variation));
-
-          refreshTreeSelection();
+          cast(chartEditorState.getToolbox(ChartEditorState.CHART_EDITOR_TOOLBOX_METADATA_LAYOUT),
+            ChartEditorMetadataToolbox)?.refreshTreeSelection(targetNode);
         }
       // case 'song':
-      // case 'variation':
+      case 'variation':
+        var variation:String = targetNode.data.id.split('_')[2];
+        var difficulty:String = chartEditorState.selectedDifficulty;
+        if (variation != null)
+        {
+          difficultyToolboxRemoveDifficulty.disabled = true;
+          difficultyToolboxMoveDifficulty.disabled = true;
+          difficultyToolboxCloneDifficulty.disabled = true;
+          // Use the first available difficulty as a fallback if the currently selected one cannot be found.
+          if (chartEditorState.availableDifficulties.indexOf(chartEditorState.selectedDifficulty) < 0) difficulty = chartEditorState.availableDifficulties[0];
+          trace('Changing difficulty to "$variation:${chartEditorState.selectedDifficulty}"');
+          chartEditorState.performCommand(new SwitchDifficultyCommand(chartEditorState.selectedDifficulty, difficulty, chartEditorState.selectedVariation,
+            variation));
+          cast(chartEditorState.getToolbox(ChartEditorState.CHART_EDITOR_TOOLBOX_METADATA_LAYOUT),
+            ChartEditorMetadataToolbox)?.refreshTreeSelection(targetNode);
+        }
       default:
+        difficultyToolboxRemoveDifficulty.disabled = true;
+        difficultyToolboxMoveDifficulty.disabled = true;
+        difficultyToolboxCloneDifficulty.disabled = true;
         // Reset the user's selection.
         trace('Selected wrong node type, resetting selection.');
-        refreshTreeSelection();
-        chartEditorState.refreshToolbox(ChartEditorState.CHART_EDITOR_TOOLBOX_METADATA_LAYOUT);
+        cast(chartEditorState.getToolbox(ChartEditorState.CHART_EDITOR_TOOLBOX_METADATA_LAYOUT), ChartEditorMetadataToolbox)?.refreshTreeSelection(targetNode);
     }
   }
 
   override public function refresh():Void
   {
     super.refresh();
+
+    if (chartEditorState.songMetadata.size() == 1
+      && chartEditorState.availableDifficulties.length == 1
+      && chartEditorState.selectedDifficulty == chartEditorState.availableDifficulties[0])
+    {
+      difficultyToolboxRemoveDifficulty.disabled = true;
+      difficultyToolboxMoveDifficulty.disabled = true;
+      difficultyToolboxCloneDifficulty.disabled = true;
+    }
+    else
+    {
+      difficultyToolboxRemoveDifficulty.disabled = false;
+      difficultyToolboxMoveDifficulty.disabled = false;
+      difficultyToolboxCloneDifficulty.disabled = false;
+    }
 
     refreshTreeSelection();
   }

--- a/source/funkin/ui/debug/charting/toolboxes/ChartEditorMetadataToolbox.hx
+++ b/source/funkin/ui/debug/charting/toolboxes/ChartEditorMetadataToolbox.hx
@@ -1,6 +1,8 @@
 package funkin.ui.debug.charting.toolboxes;
 
 #if FEATURE_CHART_EDITOR
+import funkin.data.song.SongData.SongChartData;
+import funkin.data.song.SongData.SongMetadata;
 import funkin.play.character.BaseCharacter.CharacterType;
 import funkin.data.character.CharacterData;
 import funkin.data.freeplay.album.AlbumRegistry;
@@ -11,7 +13,11 @@ import funkin.play.notes.notestyle.NoteStyle;
 import funkin.ui.debug.charting.commands.AddNewTimeChangeCommand;
 import funkin.ui.debug.charting.commands.ModifyTimeChangeCommand;
 import funkin.ui.debug.charting.commands.RemoveTimeChangeCommand;
+import funkin.ui.debug.charting.commands.SwitchDifficultyCommand;
 import funkin.ui.debug.charting.util.ChartEditorDropdowns;
+import haxe.ui.containers.dialogs.Dialogs;
+import haxe.ui.containers.dialogs.Dialog.DialogButton;
+import haxe.ui.containers.dialogs.MessageBox.MessageBoxType;
 import funkin.ui.freeplay.Album;
 import haxe.ui.components.Button;
 import haxe.ui.components.DropDown;
@@ -21,6 +27,9 @@ import haxe.ui.components.Slider;
 import haxe.ui.components.TextField;
 import funkin.play.stage.Stage;
 import haxe.ui.containers.Frame;
+import haxe.ui.containers.TreeView;
+import haxe.ui.containers.TreeViewNode;
+import haxe.ui.core.ItemRenderer;
 import haxe.ui.events.UIEvent;
 
 /**
@@ -41,6 +50,9 @@ class ChartEditorMetadataToolbox extends ChartEditorBaseToolbox
   var buttonCharacterPlayer:Button;
   var buttonCharacterGirlfriend:Button;
   var buttonCharacterOpponent:Button;
+  var buttonAddVariation:Button;
+  var buttonAddDifficulty:Button;
+  var buttonRemove:Button;
   var inputBPM:NumberStepper;
   var labelTimeStamp:Label;
   var inputTimeStamp:NumberStepper;
@@ -48,13 +60,14 @@ class ChartEditorMetadataToolbox extends ChartEditorBaseToolbox
   var inputScrollSpeed:Slider;
   var frameVariation:Frame;
   var frameDifficulty:Frame;
-  var tcDropdownItemRenderer:haxe.ui.core.ItemRenderer;
+  var tcDropdownItemRenderer:ItemRenderer;
+  var metadataToolboxTree:TreeView;
 
   public function new(chartEditorState2:ChartEditorState)
   {
     super(chartEditorState2);
 
-    tcDropdownItemRenderer = inputTimeChange.findComponent(haxe.ui.core.ItemRenderer);
+    tcDropdownItemRenderer = inputTimeChange.findComponent(ItemRenderer);
 
     initialize();
 
@@ -325,6 +338,62 @@ class ChartEditorMetadataToolbox extends ChartEditorBaseToolbox
       chartEditorState.openCharacterDropdown(CharacterType.BF, false);
     };
 
+    buttonAddVariation.onClick = function(_:UIEvent) {
+      chartEditorState.openAddVariationDialog(true);
+    };
+
+    buttonAddDifficulty.onClick = function(_:UIEvent) {
+      chartEditorState.openAddDifficultyDialog(true, true);
+    };
+
+    buttonRemove.onClick = function(_:UIEvent) {
+      var currentVariation:String = chartEditorState.selectedVariation;
+      var currentDifficulty:String = chartEditorState.selectedDifficulty;
+
+      var callback;
+      switch (metadataToolboxTree.selectedNode.data.id.split('_')[1])
+      {
+        case 'variation':
+          callback = (button) -> {
+            switch (button)
+            {
+              case DialogButton.YES:
+                // Remove the variation.
+                chartEditorState.removeVariation(currentVariation);
+                refresh();
+              case DialogButton.NO: // Do nothing.
+
+              default: // Huh?
+            }
+          }
+
+          Dialogs.messageBox('Are you sure? This is destructive and cannot be undone.', 'Remove Variation', MessageBoxType.TYPE_YESNO, callback);
+
+        case 'difficulty':
+          callback = (button) -> {
+            switch (button)
+            {
+              case DialogButton.YES:
+                // Remove the difficulty from the chartdata and metadata.
+                chartEditorState.removeDifficulty(currentVariation, currentDifficulty, true, true);
+                refresh();
+              case DialogButton.NO:
+                // Remove the difficulty from the metadata.
+                chartEditorState.removeDifficulty(currentVariation, currentDifficulty, true, false);
+                refresh();
+              case DialogButton.CANCEL: // Do nothing.
+
+              default: // Do nothing.
+            }
+          }
+
+          Dialogs.messageBox('Are you sure? This is destructive and cannot be undone.\n\nYES will remove it from both the chartdata and metadata.\n\nNO will remove it from the metadata.',
+            'Remove Difficulty', MessageBoxType.TYPE_QUESTION, callback);
+        default:
+          trace('WHAT');
+      }
+    };
+
     refresh();
   }
 
@@ -358,6 +427,314 @@ class ChartEditorMetadataToolbox extends ChartEditorBaseToolbox
       tcDropdownItemRenderer.data = inputTimeChange.value;
     }
     return currentTimeChange;
+  }
+
+  /**
+   * Clear the tree view and rebuild it with the current song metadata (variation and difficulty list).
+   */
+  public function updateTree():Void
+  {
+    // Clear the tree view so we can rebuild it.
+    metadataToolboxTree.clearNodes();
+
+    // , icon: 'haxeui-core/styles/default/haxeui_tiny.png'
+    var treeSong:TreeViewNode = metadataToolboxTree.addNode({id: 'stv_song', text: 'S: ${chartEditorState.currentSongName}'});
+    treeSong.expanded = true;
+
+    for (curVariation in chartEditorState.availableVariations)
+    {
+      var variationMetadata:Null<SongMetadata> = chartEditorState.songMetadata.get(curVariation);
+      if (variationMetadata == null) continue;
+
+      var treeVariation:TreeViewNode = treeSong.addNode(
+        {
+          id: 'stv_variation_$curVariation',
+          text: 'V: ${curVariation.toTitleCase()}'
+        });
+      treeVariation.expanded = true;
+
+      var difficultyList:Array<String> = variationMetadata.playData.difficulties;
+
+      for (difficulty in difficultyList)
+      {
+        var _treeDifficulty:TreeViewNode = treeVariation.addNode(
+          {
+            id: 'stv_difficulty_${curVariation}_$difficulty',
+            text: 'D: ${difficulty.toTitleCase()}'
+          });
+      }
+    }
+
+    metadataToolboxTree.onChange = onTreeChange;
+    refreshTreeSelection();
+  }
+
+  /**
+   * Set the selected item in the tree to the current variation/difficulty.
+   *
+   * @param node The node to select. If null, the current variation/difficulty will be used.
+   */
+  public function refreshTreeSelection(node:TreeViewNode = null):Void
+  {
+    var targetNode = getCurrentTreeNode(node);
+    if (this.visible && metadataToolboxTree.selectedNode != targetNode)
+    {
+      // Bit annoying I have to do this to remove the hightlight on the previous selection when updated by code.
+      if (metadataToolboxTree.selectedNode != null)
+      {
+        var renderer = metadataToolboxTree.selectedNode.findComponent(ItemRenderer, true);
+        if (renderer != null)
+        {
+          renderer.removeClass(':node-selected', true, true);
+        }
+      }
+      metadataToolboxTree.selectedNode = targetNode;
+      if (targetNode != null) targetNode.selected = true; // Add the hightlight to the new selected node.
+    }
+  }
+
+  /**
+   * Get the node in the tree representing the current variation/difficulty.
+   */
+  function getCurrentTreeNode(node:TreeViewNode):TreeViewNode
+  {
+    if (node != null)
+    {
+      return switch (node.data.id.split('_')[1])
+      {
+        case 'song':
+          metadataToolboxTree.findNodeByPath('${node.data.id}');
+
+        case 'variation':
+          metadataToolboxTree.findNodeByPath('stv_song/${node.data.id}');
+
+        case 'difficulty':
+          metadataToolboxTree.findNodeByPath('stv_song/stv_variation_${chartEditorState.selectedVariation}/${node.data.id}');
+        default:
+          metadataToolboxTree.findNodeByPath('stv_song/stv_variation_${chartEditorState.selectedVariation}/stv_difficulty_${chartEditorState.selectedVariation}_${chartEditorState.selectedDifficulty}',
+            'id');
+      }
+    }
+    else
+    return
+      metadataToolboxTree.findNodeByPath('stv_song/stv_variation_${chartEditorState.selectedVariation}/stv_difficulty_${chartEditorState.selectedVariation}_${chartEditorState.selectedDifficulty}',
+      'id');
+  }
+
+  /**
+   * Called when an item in the tree is selected. Updates the current variation/difficulty.
+   */
+  function onTreeChange(event:UIEvent):Void
+  {
+    // Get the newly selected node.
+    var treeView:TreeView = cast event.target;
+    var targetNode:TreeViewNode = metadataToolboxTree.selectedNode;
+
+    if (targetNode == null)
+    {
+      trace('No target node!');
+      buttonRemove.disabled = true;
+      // Reset the user's selection.
+      refreshTreeSelection();
+      return;
+    }
+
+    switch (targetNode.data.id.split('_')[1])
+    {
+      case 'difficulty':
+        var variation:String = targetNode.data.id.split('_')[2];
+        var difficulty:String = targetNode.data.id.split('_')[3];
+
+        if (variation != null && difficulty != null)
+        {
+          if ((chartEditorState.songMetadata.size() == 1 || variation == Constants.DEFAULT_VARIATION)
+            && chartEditorState.availableDifficulties.length == 1) buttonRemove.disabled = true;
+          else
+            buttonRemove.disabled = false;
+          trace('Changing difficulty to "$variation:$difficulty"');
+          chartEditorState.performCommand(new SwitchDifficultyCommand(chartEditorState.selectedDifficulty, difficulty, chartEditorState.selectedVariation,
+            variation, false));
+          cast(chartEditorState.getToolbox(ChartEditorState.CHART_EDITOR_TOOLBOX_DIFFICULTY_LAYOUT),
+            ChartEditorDifficultyToolbox)?.refreshTreeSelection(targetNode);
+        }
+      // case 'song':
+      case 'variation':
+        var variation:String = targetNode.data.id.split('_')[2];
+        var difficulty:String = chartEditorState.selectedDifficulty;
+        if (variation != null)
+        {
+          if (chartEditorState.songMetadata.size() == 1 || variation == Constants.DEFAULT_VARIATION) buttonRemove.disabled = true;
+          else
+            buttonRemove.disabled = false;
+          // Use the first available difficulty as a fallback if the currently selected one cannot be found.
+          if (chartEditorState.availableDifficulties.indexOf(chartEditorState.selectedDifficulty) < 0) difficulty = chartEditorState.availableDifficulties[0];
+          trace('Changing difficulty to "$variation:${difficulty}"');
+          chartEditorState.performCommand(new SwitchDifficultyCommand(chartEditorState.selectedDifficulty, difficulty, chartEditorState.selectedVariation,
+            variation, false));
+          cast(chartEditorState.getToolbox(ChartEditorState.CHART_EDITOR_TOOLBOX_DIFFICULTY_LAYOUT),
+          ChartEditorDifficultyToolbox)?.refreshTreeSelection(targetNode);
+        }
+      default:
+        buttonRemove.disabled = true;
+        // Reset the user's selection.
+        trace('Selected wrong node type, resetting selection.');
+        cast(chartEditorState.getToolbox(ChartEditorState.CHART_EDITOR_TOOLBOX_DIFFICULTY_LAYOUT),
+          ChartEditorDifficultyToolbox)?.refreshTreeSelection(targetNode);
+    }
+  }
+
+  /**
+   * Clear the tree view and rebuild it with the current song metadata (variation and difficulty list).
+   */
+  public function updateTree():Void
+  {
+    // Clear the tree view so we can rebuild it.
+    metadataToolboxTree.clearNodes();
+
+    // , icon: 'haxeui-core/styles/default/haxeui_tiny.png'
+    var treeSong:TreeViewNode = metadataToolboxTree.addNode({id: 'stv_song', text: 'S: ${chartEditorState.currentSongName}'});
+    treeSong.expanded = true;
+
+    for (curVariation in chartEditorState.availableVariations)
+    {
+      var variationMetadata:Null<SongMetadata> = chartEditorState.songMetadata.get(curVariation);
+      if (variationMetadata == null) continue;
+
+      var treeVariation:TreeViewNode = treeSong.addNode(
+        {
+          id: 'stv_variation_$curVariation',
+          text: 'V: ${curVariation.toTitleCase()}'
+        });
+      treeVariation.expanded = true;
+
+      var difficultyList:Array<String> = variationMetadata.playData.difficulties;
+
+      for (difficulty in difficultyList)
+      {
+        var _treeDifficulty:TreeViewNode = treeVariation.addNode(
+          {
+            id: 'stv_difficulty_${curVariation}_$difficulty',
+            text: 'D: ${difficulty.toTitleCase()}'
+          });
+      }
+    }
+
+    metadataToolboxTree.onChange = onTreeChange;
+    refreshTreeSelection();
+  }
+
+  /**
+   * Set the selected item in the tree to the current variation/difficulty.
+   *
+   * @param node The node to select. If null, the current variation/difficulty will be used.
+   */
+  public function refreshTreeSelection(node:TreeViewNode = null):Void
+  {
+    var targetNode = getCurrentTreeNode(node);
+    if (this.visible && metadataToolboxTree.selectedNode != targetNode)
+    {
+      // Bit annoying I have to do this to remove the hightlight on the previous selection when updated by code.
+      if (metadataToolboxTree.selectedNode != null)
+      {
+        var renderer = metadataToolboxTree.selectedNode.findComponent(ItemRenderer, true);
+        if (renderer != null)
+        {
+          renderer.removeClass(":node-selected", true, true);
+        }
+      }
+      metadataToolboxTree.selectedNode = targetNode;
+      if (targetNode != null) targetNode.selected = true; // Add the hightlight to the new selected node.
+    }
+  }
+
+  /**
+   * Get the node in the tree representing the current variation/difficulty.
+   */
+  function getCurrentTreeNode(node:TreeViewNode):TreeViewNode
+  {
+    if (node != null)
+    {
+      return switch (node.data.id.split('_')[1])
+      {
+        case 'song':
+          metadataToolboxTree.findNodeByPath('${node.data.id}');
+
+        case 'variation':
+          metadataToolboxTree.findNodeByPath('stv_song/${node.data.id}');
+
+        case 'difficulty':
+          metadataToolboxTree.findNodeByPath('stv_song/stv_variation_${chartEditorState.selectedVariation}/${node.data.id}');
+        default:
+          metadataToolboxTree.findNodeByPath('stv_song/stv_variation_${chartEditorState.selectedVariation}/stv_difficulty_${chartEditorState.selectedVariation}_${chartEditorState.selectedDifficulty}',
+            'id');
+      }
+    }
+    else
+    return
+      metadataToolboxTree.findNodeByPath('stv_song/stv_variation_${chartEditorState.selectedVariation}/stv_difficulty_${chartEditorState.selectedVariation}_${chartEditorState.selectedDifficulty}',
+      'id');
+  }
+
+  /**
+   * Called when an item in the tree is selected. Updates the current variation/difficulty.
+   */
+  function onTreeChange(event:UIEvent):Void
+  {
+    // Get the newly selected node.
+    var treeView:TreeView = cast event.target;
+    var targetNode:TreeViewNode = metadataToolboxTree.selectedNode;
+
+    if (targetNode == null)
+    {
+      trace('No target node!');
+      buttonRemove.disabled = true;
+      // Reset the user's selection.
+      refreshTreeSelection();
+      return;
+    }
+
+    switch (targetNode.data.id.split('_')[1])
+    {
+      case 'difficulty':
+        var variation:String = targetNode.data.id.split('_')[2];
+        var difficulty:String = targetNode.data.id.split('_')[3];
+
+        if (variation != null && difficulty != null)
+        {
+          if ((chartEditorState.songMetadata.size() == 1 || variation == Constants.DEFAULT_VARIATION)
+            && chartEditorState.availableDifficulties.length == 1) buttonRemove.disabled = true;
+          else
+            buttonRemove.disabled = false;
+          trace('Changing difficulty to "$variation:$difficulty"');
+          chartEditorState.performCommand(new SwitchDifficultyCommand(chartEditorState.selectedDifficulty, difficulty, chartEditorState.selectedVariation,
+            variation, false));
+          cast(chartEditorState.getToolbox(ChartEditorState.CHART_EDITOR_TOOLBOX_DIFFICULTY_LAYOUT),
+            ChartEditorDifficultyToolbox)?.refreshTreeSelection(targetNode);
+        }
+      // case 'song':
+      case 'variation':
+        var variation:String = targetNode.data.id.split('_')[2];
+        var difficulty:String = chartEditorState.selectedDifficulty;
+        if (variation != null)
+        {
+          if (chartEditorState.songMetadata.size() == 1 || variation == Constants.DEFAULT_VARIATION) buttonRemove.disabled = true;
+          else
+            buttonRemove.disabled = false;
+          // Use the first available difficulty as a fallback if the currently selected one cannot be found.
+          if (chartEditorState.availableDifficulties.indexOf(chartEditorState.selectedDifficulty) < 0) difficulty = chartEditorState.availableDifficulties[0];
+          trace('Changing difficulty to "$variation:${difficulty}"');
+          chartEditorState.performCommand(new SwitchDifficultyCommand(chartEditorState.selectedDifficulty, difficulty, chartEditorState.selectedVariation,
+            variation, false));
+          cast(chartEditorState.getToolbox(ChartEditorState.CHART_EDITOR_TOOLBOX_DIFFICULTY_LAYOUT),
+          ChartEditorDifficultyToolbox)?.refreshTreeSelection(targetNode);
+        }
+      default:
+        buttonRemove.disabled = true;
+        // Reset the user's selection.
+        trace('Selected wrong node type, resetting selection.');
+        cast(chartEditorState.getToolbox(ChartEditorState.CHART_EDITOR_TOOLBOX_DIFFICULTY_LAYOUT),
+          ChartEditorDifficultyToolbox)?.refreshTreeSelection(targetNode);
+    }
   }
 
   override public function refresh():Void
@@ -437,6 +814,11 @@ class ChartEditorMetadataToolbox extends ChartEditorBaseToolbox
       buttonCharacterPlayer.icon = null;
       buttonCharacterPlayer.text = 'None';
     }
+    if (chartEditorState.songMetadata.size() == 1 && chartEditorState.availableDifficulties.length == 1) buttonRemove.disabled = true;
+    else
+      buttonRemove.disabled = false;
+
+    refreshTreeSelection();
   }
 
   public static function build(chartEditorState:ChartEditorState):ChartEditorMetadataToolbox

--- a/source/funkin/ui/debug/charting/toolboxes/ChartEditorMetadataToolbox.hx
+++ b/source/funkin/ui/debug/charting/toolboxes/ChartEditorMetadataToolbox.hx
@@ -1,6 +1,8 @@
 package funkin.ui.debug.charting.toolboxes;
 
 #if FEATURE_CHART_EDITOR
+import funkin.data.song.SongData.SongChartData;
+import funkin.data.song.SongData.SongMetadata;
 import funkin.play.character.BaseCharacter.CharacterType;
 import funkin.data.character.CharacterData;
 import funkin.data.freeplay.album.AlbumRegistry;
@@ -11,7 +13,11 @@ import funkin.play.notes.notestyle.NoteStyle;
 import funkin.ui.debug.charting.commands.AddNewTimeChangeCommand;
 import funkin.ui.debug.charting.commands.ModifyTimeChangeCommand;
 import funkin.ui.debug.charting.commands.RemoveTimeChangeCommand;
+import funkin.ui.debug.charting.commands.SwitchDifficultyCommand;
 import funkin.ui.debug.charting.util.ChartEditorDropdowns;
+import haxe.ui.containers.dialogs.Dialogs;
+import haxe.ui.containers.dialogs.Dialog.DialogButton;
+import haxe.ui.containers.dialogs.MessageBox.MessageBoxType;
 import funkin.ui.freeplay.Album;
 import haxe.ui.components.Button;
 import haxe.ui.components.DropDown;
@@ -21,6 +27,9 @@ import haxe.ui.components.Slider;
 import haxe.ui.components.TextField;
 import funkin.play.stage.Stage;
 import haxe.ui.containers.Frame;
+import haxe.ui.containers.TreeView;
+import haxe.ui.containers.TreeViewNode;
+import haxe.ui.core.ItemRenderer;
 import haxe.ui.events.UIEvent;
 
 /**
@@ -42,6 +51,9 @@ class ChartEditorMetadataToolbox extends ChartEditorBaseToolbox
   var buttonCharacterPlayer:Button;
   var buttonCharacterGirlfriend:Button;
   var buttonCharacterOpponent:Button;
+  var buttonAddVariation:Button;
+  var buttonAddDifficulty:Button;
+  var buttonRemove:Button;
   var inputBPM:NumberStepper;
   var labelTimeStamp:Label;
   var inputTimeStamp:NumberStepper;
@@ -49,13 +61,14 @@ class ChartEditorMetadataToolbox extends ChartEditorBaseToolbox
   var inputScrollSpeed:Slider;
   var frameVariation:Frame;
   var frameDifficulty:Frame;
-  var tcDropdownItemRenderer:haxe.ui.core.ItemRenderer;
+  var tcDropdownItemRenderer:ItemRenderer;
+  var metadataToolboxTree:TreeView;
 
   public function new(chartEditorState2:ChartEditorState)
   {
     super(chartEditorState2);
 
-    tcDropdownItemRenderer = inputTimeChange.findComponent(haxe.ui.core.ItemRenderer);
+    tcDropdownItemRenderer = inputTimeChange.findComponent(ItemRenderer);
 
     initialize();
 
@@ -353,6 +366,62 @@ class ChartEditorMetadataToolbox extends ChartEditorBaseToolbox
       chartEditorState.openCharacterDropdown(CharacterType.BF, false);
     };
 
+    buttonAddVariation.onClick = function(_:UIEvent) {
+      chartEditorState.openAddVariationDialog(true);
+    };
+
+    buttonAddDifficulty.onClick = function(_:UIEvent) {
+      chartEditorState.openAddDifficultyDialog(true, true);
+    };
+
+    buttonRemove.onClick = function(_:UIEvent) {
+      var currentVariation:String = chartEditorState.selectedVariation;
+      var currentDifficulty:String = chartEditorState.selectedDifficulty;
+
+      var callback;
+      switch (metadataToolboxTree.selectedNode.data.id.split('_')[1])
+      {
+        case 'variation':
+          callback = (button) -> {
+            switch (button)
+            {
+              case DialogButton.YES:
+                // Remove the variation.
+                chartEditorState.removeVariation(currentVariation);
+                refresh();
+              case DialogButton.NO: // Do nothing.
+
+              default: // Huh?
+            }
+          }
+
+          Dialogs.messageBox('Are you sure? This is destructive and cannot be undone.', 'Remove Variation', MessageBoxType.TYPE_YESNO, callback);
+
+        case 'difficulty':
+          callback = (button) -> {
+            switch (button)
+            {
+              case DialogButton.YES:
+                // Remove the difficulty from the chartdata and metadata.
+                chartEditorState.removeDifficulty(currentVariation, currentDifficulty, true, true);
+                refresh();
+              case DialogButton.NO:
+                // Remove the difficulty from the metadata.
+                chartEditorState.removeDifficulty(currentVariation, currentDifficulty, true, false);
+                refresh();
+              case DialogButton.CANCEL: // Do nothing.
+
+              default: // Do nothing.
+            }
+          }
+
+          Dialogs.messageBox('Are you sure? This is destructive and cannot be undone.\n\nYES will remove it from both the chartdata and metadata.\n\nNO will remove it from the metadata.',
+            'Remove Difficulty', MessageBoxType.TYPE_QUESTION, callback);
+        default:
+          trace('WHAT');
+      }
+    };
+
     refresh();
   }
 
@@ -389,6 +458,314 @@ class ChartEditorMetadataToolbox extends ChartEditorBaseToolbox
       tcDropdownItemRenderer.data = inputTimeChange.value;
     }
     return currentTimeChange;
+  }
+
+  /**
+   * Clear the tree view and rebuild it with the current song metadata (variation and difficulty list).
+   */
+  public function updateTree():Void
+  {
+    // Clear the tree view so we can rebuild it.
+    metadataToolboxTree.clearNodes();
+
+    // , icon: 'haxeui-core/styles/default/haxeui_tiny.png'
+    var treeSong:TreeViewNode = metadataToolboxTree.addNode({id: 'stv_song', text: 'S: ${chartEditorState.currentSongName}'});
+    treeSong.expanded = true;
+
+    for (curVariation in chartEditorState.availableVariations)
+    {
+      var variationMetadata:Null<SongMetadata> = chartEditorState.songMetadata.get(curVariation);
+      if (variationMetadata == null) continue;
+
+      var treeVariation:TreeViewNode = treeSong.addNode(
+        {
+          id: 'stv_variation_$curVariation',
+          text: 'V: ${curVariation.toTitleCase()}'
+        });
+      treeVariation.expanded = true;
+
+      var difficultyList:Array<String> = variationMetadata.playData.difficulties;
+
+      for (difficulty in difficultyList)
+      {
+        var _treeDifficulty:TreeViewNode = treeVariation.addNode(
+          {
+            id: 'stv_difficulty_${curVariation}_$difficulty',
+            text: 'D: ${difficulty.toTitleCase()}'
+          });
+      }
+    }
+
+    metadataToolboxTree.onChange = onTreeChange;
+    refreshTreeSelection();
+  }
+
+  /**
+   * Set the selected item in the tree to the current variation/difficulty.
+   *
+   * @param node The node to select. If null, the current variation/difficulty will be used.
+   */
+  public function refreshTreeSelection(node:TreeViewNode = null):Void
+  {
+    var targetNode = getCurrentTreeNode(node);
+    if (this.visible && metadataToolboxTree.selectedNode != targetNode)
+    {
+      // Bit annoying I have to do this to remove the hightlight on the previous selection when updated by code.
+      if (metadataToolboxTree.selectedNode != null)
+      {
+        var renderer = metadataToolboxTree.selectedNode.findComponent(ItemRenderer, true);
+        if (renderer != null)
+        {
+          renderer.removeClass(':node-selected', true, true);
+        }
+      }
+      metadataToolboxTree.selectedNode = targetNode;
+      if (targetNode != null) targetNode.selected = true; // Add the hightlight to the new selected node.
+    }
+  }
+
+  /**
+   * Get the node in the tree representing the current variation/difficulty.
+   */
+  function getCurrentTreeNode(node:TreeViewNode):TreeViewNode
+  {
+    if (node != null)
+    {
+      return switch (node.data.id.split('_')[1])
+      {
+        case 'song':
+          metadataToolboxTree.findNodeByPath('${node.data.id}');
+
+        case 'variation':
+          metadataToolboxTree.findNodeByPath('stv_song/${node.data.id}');
+
+        case 'difficulty':
+          metadataToolboxTree.findNodeByPath('stv_song/stv_variation_${chartEditorState.selectedVariation}/${node.data.id}');
+        default:
+          metadataToolboxTree.findNodeByPath('stv_song/stv_variation_${chartEditorState.selectedVariation}/stv_difficulty_${chartEditorState.selectedVariation}_${chartEditorState.selectedDifficulty}',
+            'id');
+      }
+    }
+    else
+    return
+      metadataToolboxTree.findNodeByPath('stv_song/stv_variation_${chartEditorState.selectedVariation}/stv_difficulty_${chartEditorState.selectedVariation}_${chartEditorState.selectedDifficulty}',
+      'id');
+  }
+
+  /**
+   * Called when an item in the tree is selected. Updates the current variation/difficulty.
+   */
+  function onTreeChange(event:UIEvent):Void
+  {
+    // Get the newly selected node.
+    var treeView:TreeView = cast event.target;
+    var targetNode:TreeViewNode = metadataToolboxTree.selectedNode;
+
+    if (targetNode == null)
+    {
+      trace('No target node!');
+      buttonRemove.disabled = true;
+      // Reset the user's selection.
+      refreshTreeSelection();
+      return;
+    }
+
+    switch (targetNode.data.id.split('_')[1])
+    {
+      case 'difficulty':
+        var variation:String = targetNode.data.id.split('_')[2];
+        var difficulty:String = targetNode.data.id.split('_')[3];
+
+        if (variation != null && difficulty != null)
+        {
+          if ((chartEditorState.songMetadata.size() == 1 || variation == Constants.DEFAULT_VARIATION)
+            && chartEditorState.availableDifficulties.length == 1) buttonRemove.disabled = true;
+          else
+            buttonRemove.disabled = false;
+          trace('Changing difficulty to "$variation:$difficulty"');
+          chartEditorState.performCommand(new SwitchDifficultyCommand(chartEditorState.selectedDifficulty, difficulty, chartEditorState.selectedVariation,
+            variation, false));
+          cast(chartEditorState.getToolbox(ChartEditorState.CHART_EDITOR_TOOLBOX_DIFFICULTY_LAYOUT),
+            ChartEditorDifficultyToolbox)?.refreshTreeSelection(targetNode);
+        }
+      // case 'song':
+      case 'variation':
+        var variation:String = targetNode.data.id.split('_')[2];
+        var difficulty:String = chartEditorState.selectedDifficulty;
+        if (variation != null)
+        {
+          if (chartEditorState.songMetadata.size() == 1 || variation == Constants.DEFAULT_VARIATION) buttonRemove.disabled = true;
+          else
+            buttonRemove.disabled = false;
+          // Use the first available difficulty as a fallback if the currently selected one cannot be found.
+          if (chartEditorState.availableDifficulties.indexOf(chartEditorState.selectedDifficulty) < 0) difficulty = chartEditorState.availableDifficulties[0];
+          trace('Changing difficulty to "$variation:${difficulty}"');
+          chartEditorState.performCommand(new SwitchDifficultyCommand(chartEditorState.selectedDifficulty, difficulty, chartEditorState.selectedVariation,
+            variation, false));
+          cast(chartEditorState.getToolbox(ChartEditorState.CHART_EDITOR_TOOLBOX_DIFFICULTY_LAYOUT),
+          ChartEditorDifficultyToolbox)?.refreshTreeSelection(targetNode);
+        }
+      default:
+        buttonRemove.disabled = true;
+        // Reset the user's selection.
+        trace('Selected wrong node type, resetting selection.');
+        cast(chartEditorState.getToolbox(ChartEditorState.CHART_EDITOR_TOOLBOX_DIFFICULTY_LAYOUT),
+          ChartEditorDifficultyToolbox)?.refreshTreeSelection(targetNode);
+    }
+  }
+
+  /**
+   * Clear the tree view and rebuild it with the current song metadata (variation and difficulty list).
+   */
+  public function updateTree():Void
+  {
+    // Clear the tree view so we can rebuild it.
+    metadataToolboxTree.clearNodes();
+
+    // , icon: 'haxeui-core/styles/default/haxeui_tiny.png'
+    var treeSong:TreeViewNode = metadataToolboxTree.addNode({id: 'stv_song', text: 'S: ${chartEditorState.currentSongName}'});
+    treeSong.expanded = true;
+
+    for (curVariation in chartEditorState.availableVariations)
+    {
+      var variationMetadata:Null<SongMetadata> = chartEditorState.songMetadata.get(curVariation);
+      if (variationMetadata == null) continue;
+
+      var treeVariation:TreeViewNode = treeSong.addNode(
+        {
+          id: 'stv_variation_$curVariation',
+          text: 'V: ${curVariation.toTitleCase()}'
+        });
+      treeVariation.expanded = true;
+
+      var difficultyList:Array<String> = variationMetadata.playData.difficulties;
+
+      for (difficulty in difficultyList)
+      {
+        var _treeDifficulty:TreeViewNode = treeVariation.addNode(
+          {
+            id: 'stv_difficulty_${curVariation}_$difficulty',
+            text: 'D: ${difficulty.toTitleCase()}'
+          });
+      }
+    }
+
+    metadataToolboxTree.onChange = onTreeChange;
+    refreshTreeSelection();
+  }
+
+  /**
+   * Set the selected item in the tree to the current variation/difficulty.
+   *
+   * @param node The node to select. If null, the current variation/difficulty will be used.
+   */
+  public function refreshTreeSelection(node:TreeViewNode = null):Void
+  {
+    var targetNode = getCurrentTreeNode(node);
+    if (this.visible && metadataToolboxTree.selectedNode != targetNode)
+    {
+      // Bit annoying I have to do this to remove the hightlight on the previous selection when updated by code.
+      if (metadataToolboxTree.selectedNode != null)
+      {
+        var renderer = metadataToolboxTree.selectedNode.findComponent(ItemRenderer, true);
+        if (renderer != null)
+        {
+          renderer.removeClass(":node-selected", true, true);
+        }
+      }
+      metadataToolboxTree.selectedNode = targetNode;
+      if (targetNode != null) targetNode.selected = true; // Add the hightlight to the new selected node.
+    }
+  }
+
+  /**
+   * Get the node in the tree representing the current variation/difficulty.
+   */
+  function getCurrentTreeNode(node:TreeViewNode):TreeViewNode
+  {
+    if (node != null)
+    {
+      return switch (node.data.id.split('_')[1])
+      {
+        case 'song':
+          metadataToolboxTree.findNodeByPath('${node.data.id}');
+
+        case 'variation':
+          metadataToolboxTree.findNodeByPath('stv_song/${node.data.id}');
+
+        case 'difficulty':
+          metadataToolboxTree.findNodeByPath('stv_song/stv_variation_${chartEditorState.selectedVariation}/${node.data.id}');
+        default:
+          metadataToolboxTree.findNodeByPath('stv_song/stv_variation_${chartEditorState.selectedVariation}/stv_difficulty_${chartEditorState.selectedVariation}_${chartEditorState.selectedDifficulty}',
+            'id');
+      }
+    }
+    else
+    return
+      metadataToolboxTree.findNodeByPath('stv_song/stv_variation_${chartEditorState.selectedVariation}/stv_difficulty_${chartEditorState.selectedVariation}_${chartEditorState.selectedDifficulty}',
+      'id');
+  }
+
+  /**
+   * Called when an item in the tree is selected. Updates the current variation/difficulty.
+   */
+  function onTreeChange(event:UIEvent):Void
+  {
+    // Get the newly selected node.
+    var treeView:TreeView = cast event.target;
+    var targetNode:TreeViewNode = metadataToolboxTree.selectedNode;
+
+    if (targetNode == null)
+    {
+      trace('No target node!');
+      buttonRemove.disabled = true;
+      // Reset the user's selection.
+      refreshTreeSelection();
+      return;
+    }
+
+    switch (targetNode.data.id.split('_')[1])
+    {
+      case 'difficulty':
+        var variation:String = targetNode.data.id.split('_')[2];
+        var difficulty:String = targetNode.data.id.split('_')[3];
+
+        if (variation != null && difficulty != null)
+        {
+          if ((chartEditorState.songMetadata.size() == 1 || variation == Constants.DEFAULT_VARIATION)
+            && chartEditorState.availableDifficulties.length == 1) buttonRemove.disabled = true;
+          else
+            buttonRemove.disabled = false;
+          trace('Changing difficulty to "$variation:$difficulty"');
+          chartEditorState.performCommand(new SwitchDifficultyCommand(chartEditorState.selectedDifficulty, difficulty, chartEditorState.selectedVariation,
+            variation, false));
+          cast(chartEditorState.getToolbox(ChartEditorState.CHART_EDITOR_TOOLBOX_DIFFICULTY_LAYOUT),
+            ChartEditorDifficultyToolbox)?.refreshTreeSelection(targetNode);
+        }
+      // case 'song':
+      case 'variation':
+        var variation:String = targetNode.data.id.split('_')[2];
+        var difficulty:String = chartEditorState.selectedDifficulty;
+        if (variation != null)
+        {
+          if (chartEditorState.songMetadata.size() == 1 || variation == Constants.DEFAULT_VARIATION) buttonRemove.disabled = true;
+          else
+            buttonRemove.disabled = false;
+          // Use the first available difficulty as a fallback if the currently selected one cannot be found.
+          if (chartEditorState.availableDifficulties.indexOf(chartEditorState.selectedDifficulty) < 0) difficulty = chartEditorState.availableDifficulties[0];
+          trace('Changing difficulty to "$variation:${difficulty}"');
+          chartEditorState.performCommand(new SwitchDifficultyCommand(chartEditorState.selectedDifficulty, difficulty, chartEditorState.selectedVariation,
+            variation, false));
+          cast(chartEditorState.getToolbox(ChartEditorState.CHART_EDITOR_TOOLBOX_DIFFICULTY_LAYOUT),
+          ChartEditorDifficultyToolbox)?.refreshTreeSelection(targetNode);
+        }
+      default:
+        buttonRemove.disabled = true;
+        // Reset the user's selection.
+        trace('Selected wrong node type, resetting selection.');
+        cast(chartEditorState.getToolbox(ChartEditorState.CHART_EDITOR_TOOLBOX_DIFFICULTY_LAYOUT),
+          ChartEditorDifficultyToolbox)?.refreshTreeSelection(targetNode);
+    }
   }
 
   override public function refresh():Void
@@ -492,6 +869,11 @@ class ChartEditorMetadataToolbox extends ChartEditorBaseToolbox
       buttonCharacterPlayer.icon = null;
       buttonCharacterPlayer.text = 'None';
     }
+    if (chartEditorState.songMetadata.size() == 1 && chartEditorState.availableDifficulties.length == 1) buttonRemove.disabled = true;
+    else
+      buttonRemove.disabled = false;
+
+    refreshTreeSelection();
   }
 
   public static function build(chartEditorState:ChartEditorState):ChartEditorMetadataToolbox


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
Fixes #5206
<!-- Briefly describe the issue(s) fixed. -->
## Description
Modifies the metadata toolbox and difficulty toolbox to show difficulties that only appear in that data, and allows you to add and remove difficulties from each separately.

Also makes a few other minor changes, such as disabling the remove buttons under some circumstances, and moving the add variation button to the metadata toolbox.

Known Issues:
The vertical sliders don't work unless you force them to hide and reappear??? Haxe UI issue?

> [!IMPORTANT]  
> Requires https://github.com/FunkinCrew/funkin.assets/pull/329

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos

<img width="1172" height="525" alt="Screenshot 2025-09-28 233215" src="https://github.com/user-attachments/assets/d8a050d9-5db6-45c1-a10b-f4dcc9886f25" />

<img width="1034" height="543" alt="Screenshot 2025-09-28 233323" src="https://github.com/user-attachments/assets/aa69ca08-8304-4ecc-90c2-035331167eef" />

<img width="1019" height="536" alt="Screenshot 2025-09-28 233334" src="https://github.com/user-attachments/assets/3f104838-031f-4a37-9c4f-148ae5858934" />
