### PR TITLE
Provide a nicer error message when software rendering is used

### DIFF
--- a/source/Main.hx
+++ b/source/Main.hx
@@ -84,7 +84,7 @@ class Main extends Sprite
 
     // Manually crash the game when using a software renderer in order to give a nicer error message.
     var context = stage.window.context.type;
-    if (context != WEBGL && context != OPENGL && context != WEBGL)
+    if (context != WEBGL && context != OPENGL && context != OPENGLES)
     {
       var tech:String = #if web "WebGL" #elseif desktop "OpenGL" #else "OpenGL ES" #end;
       var requiredVersion:String = #if web '$tech 1.0 or newer' #elseif desktop '$tech 3.0 or newer' #else '$tech 2.0 or newer' #end;


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
N/A

<!-- Briefly describe the issue(s) fixed. -->
## Description

Software rendering (blitting) is not supported in Funkin. When someone starts the game with a software rendering context (usually due to improper drivers) they get a strange error that makes it seem like a game bug (See: https://github.com/FunkinCrew/Funkin/issues/6157, https://github.com/FunkinCrew/Funkin/issues/5983).

With this, when a software rendering context is detected, the game will crash itself but provide a much nicer message for the user.

To test this just disable your graphics card in device manager and try to launch the game.

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos

<img width="520" height="262" alt="image" src="https://github.com/user-attachments/assets/21d1ddda-c057-4e98-8a30-c112c86c3163" />


