### PR TITLE
[BUGFIX] Fix returning difficulties from a level not properly removing extra difficulties

### DIFF
--- a/source/funkin/ui/story/Level.hx
+++ b/source/funkin/ui/story/Level.hx
@@ -176,7 +176,7 @@ class Level implements IRegistryEntry<LevelData>
 
       if (song == null) continue;
 
-      for (difficulty in difficulties)
+      for (difficulty in difficulties.copy())
       {
         if (!song.hasDifficulty(difficulty, [Constants.DEFAULT_VARIATION, 'erect']))
         {


### PR DESCRIPTION
## Linked Issues
A/N

## Description
Using Level's `getDifficulties` function on a level whose songs dont share the same difficulties will oftentimes not remove difficulties correctly. This is very noticeable if you were to run this function on week 4, as only Satin Panties and High have Erect remixes (publicly released at least 👀), meaning that not every difficulty from the Erect variation would be properly removed.
This PR fixes it by not removing from an iterating array goddamnit

Note that this function isn't used anywhere in the game at this moment but is just a random thing I noticed while doing some mod work lol

## Screenshots/Videos
Tracing for week 4 before:
<img width="601" height="32" alt="image" src="https://github.com/user-attachments/assets/d486c3a7-7501-4161-907d-511af9324552" />
Tracing for week 4 after:
<img width="522" height="25" alt="image" src="https://github.com/user-attachments/assets/d7a9ea58-3668-411f-b3b7-037cd3eea564" />
