### PR TITLE
[BUGFIX] Fix Crash When Using Static Pixel Icon In Character Select

### DIFF
--- a/source/funkin/ui/charSelect/CharSelectSubState.hx
+++ b/source/funkin/ui/charSelect/CharSelectSubState.hx
@@ -1177,8 +1177,8 @@ class CharSelectSubState extends MusicBeatSubState
               memb.filters = selectedBizz;
               memb.scale.set(2.6, 2.6);
             }
-            if (pressedSelect && memb.animation.curAnim.name == 'idle') memb.animation.play('confirm');
-            if (autoFollow && !pressedSelect && memb.animation.curAnim.name != 'idle')
+            if (pressedSelect && memb.animation.curAnim?.name == 'idle') memb.animation.play('confirm');
+            if (autoFollow && !pressedSelect && memb.animation.curAnim?.name != 'idle')
             {
               memb.animation.play("confirm", false, true);
               var onFinish:String->Void = null;


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues

Issues Smissues.

<!-- Briefly describe the issue(s) fixed. -->
## Description

Hm... well that's a lie.

<img width="405" height="88" alt="image" src="https://github.com/user-attachments/assets/2ec176a6-a574-4546-b161-b5bcef34b46d" />

This pr fixes a null object reference crash that occurs when using a static image as a pixel icon for the character select screen. This is not a problem for Freeplay.

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos

Below is a screenshot of the infamous null object reference crash that occurs in this particular screen for the particular reason stated above. How was this not reported (well at least I don't think it was)? This is an old issue I believe. Well... at least this pr fixes the crash.

<img width="563" height="367" alt="image" src="https://github.com/user-attachments/assets/aa60b4f7-575a-49d2-8e4a-538c02f90b82" />
