### PR TITLE
[BUGFIX] Disable Haxe UI auto-localization

### DIFF
--- a/source/Main.hx
+++ b/source/Main.hx
@@ -184,6 +184,8 @@ class Main extends Sprite
 
   function initHaxeUI():Void
   {
+    // This has to come before Toolkit.init since locales get initialized there
+    haxe.ui.locale.LocaleManager.instance.autoSetLocale = false;
     // Calling this before any HaxeUI components get used is important:
     // - It initializes the theme styles.
     // - It scans the class path and registers any HaxeUI components.


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
Closes #6116 
<!-- Briefly describe the issue(s) fixed. -->
## Description
Disables the auto-localization feature so that certain UI elements don't use your system's language.
<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos
"Yes" and "No" buttons stay in English instead of Portuguese (in my case)

<img width="301" height="168" alt="image" src="https://github.com/user-attachments/assets/72f672fb-e8e5-4572-8a36-a9bb383419d3" />

<img width="301" height="168" alt="image" src="https://github.com/user-attachments/assets/5af4ce3d-cc29-4e75-b301-556e09ae6e9e" />
