### PR TITLE
Add `onReload` event to HScripted classes

### DIFF
--- a/source/funkin/modding/IScriptedClass.hx
+++ b/source/funkin/modding/IScriptedClass.hx
@@ -12,6 +12,7 @@ interface IScriptedClass
   public function onScriptEvent(event:ScriptEvent):Void;
 
   public function onCreate(event:ScriptEvent):Void;
+  public function onReload(event:ScriptEvent):Void;
   public function onDestroy(event:ScriptEvent):Void;
   public function onUpdate(event:UpdateScriptEvent):Void;
 }

--- a/source/funkin/modding/PolymodHandler.hx
+++ b/source/funkin/modding/PolymodHandler.hx
@@ -589,6 +589,6 @@ class PolymodHandler
     CharacterDataParser.loadCharacterCache(); // TODO: Migrate characters to BaseRegistry.
     NoteKindManager.initialize();
     ModuleHandler.loadModuleCache();
-    ModuleHandler.callOnCreate();
+    ModuleHandler.callOnReload();
   }
 }

--- a/source/funkin/modding/events/ScriptEventDispatcher.hx
+++ b/source/funkin/modding/events/ScriptEventDispatcher.hx
@@ -33,6 +33,9 @@ class ScriptEventDispatcher
       case CREATE:
         target.onCreate(event);
         return;
+      case RELOAD:
+        target.onReload(event);
+        return;
       case STATE_CREATE:
         if (Std.isOfType(target, Module))
         {

--- a/source/funkin/modding/events/ScriptEventType.hx
+++ b/source/funkin/modding/events/ScriptEventType.hx
@@ -12,6 +12,8 @@ enum abstract ScriptEventType(String) from String to String
    */
   var CREATE = 'CREATE';
 
+  var RELOAD = 'RELOAD';
+
   /**
    * Called when the relevant object is fully created and ready to be used.
    * This assumes all data is loaded and ready to go.

--- a/source/funkin/modding/module/Module.hx
+++ b/source/funkin/modding/module/Module.hx
@@ -93,6 +93,12 @@ class Module implements IPlayStateScriptedClass implements IStateChangingScripte
   public function onCreate(event:ScriptEvent) {}
 
   /**
+   * Called after a hot reload.
+   * This happens after all modules cache loaded!
+   */
+  public function onReload(event:ScriptEvent) {}
+
+  /**
    * Called when a module is destroyed.
    * This currently only happens when reloading modules with F5.
    */

--- a/source/funkin/modding/module/ModuleHandler.hx
+++ b/source/funkin/modding/module/ModuleHandler.hx
@@ -163,4 +163,9 @@ class ModuleHandler
   {
     callEvent(new ScriptEvent(CREATE, false));
   }
+
+  public static inline function callOnReload():Void
+  {
+      callEvent(new ScriptEvent(RELOAD, false));
+  }
 }

--- a/source/funkin/play/cutscene/dialogue/Conversation.hx
+++ b/source/funkin/play/cutscene/dialogue/Conversation.hx
@@ -648,6 +648,8 @@ class Conversation extends FlxSpriteGroup implements IDialogueScriptedClass impl
       outroTween = null;
     }
   }
+
+  public function onReload(event:ScriptEvent):Void {}
 }
 
 // Managing things with a single enum is a lot easier than a multitude of flags.

--- a/source/funkin/play/cutscene/dialogue/DialogueBox.hx
+++ b/source/funkin/play/cutscene/dialogue/DialogueBox.hx
@@ -403,6 +403,8 @@ class DialogueBox extends FlxSpriteGroup implements IDialogueScriptedClass imple
 
   public function onDialogueEnd(event:DialogueScriptEvent):Void {}
 
+  public function onReload(event:ScriptEvent):Void {}
+
   public function onUpdate(event:UpdateScriptEvent):Void {}
 
   public function onDestroy(event:ScriptEvent):Void

--- a/source/funkin/play/cutscene/dialogue/Speaker.hx
+++ b/source/funkin/play/cutscene/dialogue/Speaker.hx
@@ -272,6 +272,8 @@ class Speaker extends FlxSprite implements IDialogueScriptedClass implements IRe
     }
   }
 
+  public function onReload(event:ScriptEvent):Void {}
+
   public function onDialogueStart(event:DialogueScriptEvent):Void {}
 
   public function onDialogueCompleteLine(event:DialogueScriptEvent):Void {}

--- a/source/funkin/play/notes/notekind/NoteKind.hx
+++ b/source/funkin/play/notes/notekind/NoteKind.hx
@@ -72,6 +72,8 @@ class NoteKind implements INoteScriptedClass
     });
   }
 
+  public function onReload(event:ScriptEvent):Void {}
+
   public function onScriptEvent(event:ScriptEvent):Void {}
 
   public function onCreate(event:ScriptEvent):Void {}

--- a/source/funkin/play/song/Song.hx
+++ b/source/funkin/play/song/Song.hx
@@ -622,6 +622,8 @@ class Song implements IPlayStateScriptedClass implements IRegistryEntry<SongMeta
     }
   }
 
+  public function onReload(event:ScriptEvent):Void {}
+
   public function onPause(event:PauseScriptEvent):Void {};
 
   public function onResume(event:ScriptEvent):Void {};

--- a/source/funkin/play/stage/Stage.hx
+++ b/source/funkin/play/stage/Stage.hx
@@ -865,6 +865,8 @@ class Stage extends FlxSpriteGroup implements IPlayStateScriptedClass implements
     }
   }
 
+  public function onReload(event:ScriptEvent):Void {}
+
   public function onPause(event:PauseScriptEvent) {}
 
   public function onResume(event:ScriptEvent) {}

--- a/source/funkin/play/stage/StageProp.hx
+++ b/source/funkin/play/stage/StageProp.hx
@@ -22,6 +22,8 @@ class StageProp extends FunkinSprite implements IStateStageProp
    */
   public function onAdd(event:ScriptEvent):Void {}
 
+  public function onReload(event:ScriptEvent):Void {}
+
   public function onScriptEvent(event:ScriptEvent) {}
 
   public function onCreate(event:ScriptEvent) {}

--- a/source/funkin/ui/charSelect/CharSelectGF.hx
+++ b/source/funkin/ui/charSelect/CharSelectGF.hx
@@ -200,6 +200,8 @@ class CharSelectGF extends FlxAtlasSprite implements IBPMSyncedScriptedClass
 
   public function onCreate(event:ScriptEvent):Void {};
 
+  public function onReload(event:ScriptEvent):Void {}
+
   public function onDestroy(event:ScriptEvent):Void {};
 
   public function onUpdate(event:UpdateScriptEvent):Void {};

--- a/source/funkin/ui/charSelect/CharSelectPlayer.hx
+++ b/source/funkin/ui/charSelect/CharSelectPlayer.hx
@@ -80,6 +80,8 @@ class CharSelectPlayer extends FlxAtlasSprite implements IBPMSyncedScriptedClass
     updatePosition(str);
   }
 
+  public function onReload(event:ScriptEvent):Void {}
+
   public function onScriptEvent(event:ScriptEvent):Void {};
 
   public function onCreate(event:ScriptEvent):Void {};

--- a/source/funkin/ui/freeplay/backcards/BackingCard.hx
+++ b/source/funkin/ui/freeplay/backcards/BackingCard.hx
@@ -251,6 +251,8 @@ class BackingCard extends FlxSpriteGroup implements IBPMSyncedScriptedClass impl
     add(cardGlow);
   }
 
+  public function onReload(event:ScriptEvent):Void {}
+
   public function onDestroy(event:ScriptEvent):Void {}
 
   public function onUpdate(event:UpdateScriptEvent):Void {}


### PR DESCRIPTION
## Linked Issues
*-*

## Description
This PR reverts commit [2f865a5](https://github.com/FunkinCrew/Funkin/commit/2f865a5c7f4d8712f1b1e0bc70cb910f4fed08dc), from PR #6084 , because `Module.onCreate` should only be fired on game launch.

As an alternative, this PR adds a new event, `onReload`, which fires when hot reloading (F5) the game, similar to the behavior introduced in the reverted PR. 

This provides better convenience for mod developers, preventing unintended repetitive `onCreate` calls on hot reload.

Adds `onReload` for the following scripted classes:
`Module`
`NoteKind`
`Song`
`Stage` & `StageProp`
`DialogueBox`, `Conversation` & `Speaker`, `BackingCard`
`CharSelectGf` & `CharSelectPlayer`

## Screenshots/Videos

https://github.com/user-attachments/assets/a3623e03-d129-49f0-b052-a953d99d9b59
