### PR TITLE
[BUGFIX] Fix the missing object icon spawing when switching from Spritesheet to Animations

### DIFF
--- a/source/funkin/ui/debug/anim/DebugBoundingState.hx
+++ b/source/funkin/ui/debug/anim/DebugBoundingState.hx
@@ -320,12 +320,12 @@ class DebugBoundingState extends FlxState
         spriteSheetView.visible = true;
         offsetView.visible = false;
         offsetView.active = false;
-        offsetAnimationDropdown.visible = false;
+        offsetAnimationDropdown.hide();
       case ANIMATIONS:
         spriteSheetView.visible = false;
         offsetView.visible = true;
         offsetView.active = true;
-        offsetAnimationDropdown.visible = true;
+        offsetAnimationDropdown.show();
         offsetControls();
         mouseOffsetMovement();
     }


### PR DESCRIPTION
## Linked Issues
Closes https://github.com/FunkinCrew/Funkin/issues/4810

## Description
When changing to the animations mode in the animation editor, a lone haxeflixel icon will spawn on top of the animation dropdown. This is because the haxe ui dropdown doesnt get initialized properly when its visibility is set to false. This PR fixes this by making the animation dropdown use `hide()` and `show()` as opposed to toggling the visibility variable.

## Screenshots/Videos

https://github.com/user-attachments/assets/b6d9e191-aaa5-4dcb-8513-d9e7ba301c89
