### PR TITLE
[BUGFIX/Chart Editor] Center waveforms on health icons and adjust icon X-offsets

### DIFF
--- a/source/funkin/audio/waveform/WaveformSprite.hx
+++ b/source/funkin/audio/waveform/WaveformSprite.hx
@@ -2,6 +2,7 @@ package funkin.audio.waveform;
 
 import funkin.graphics.rendering.MeshRender;
 import flixel.util.FlxColor;
+import funkin.play.character.BaseCharacter.CharacterType;
 
 /**
  * A sprite which displays the waveform of audio data.
@@ -16,6 +17,8 @@ class WaveformSprite extends MeshRender
   static final DEFAULT_Y:Float = 0.0;
   static final DEFAULT_WIDTH:Float = 100.0;
   static final DEFAULT_HEIGHT:Float = 100.0;
+
+  public var iconId:CharacterType;
 
   /**
    * Set this to true to tell the waveform to rebuild itself.

--- a/source/funkin/ui/debug/charting/ChartEditorState.hx
+++ b/source/funkin/ui/debug/charting/ChartEditorState.hx
@@ -988,9 +988,14 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
   var noteTooltipsDirty:Bool = true;
 
   /**
-   * Whether the selected charactesr have been modified and the health icons need to be updated.
+   * Whether the selected characters have been modified and the health icons need to be updated.
    */
   var healthIconsDirty:Bool = true;
+
+  /**
+   * Whether the waveforms were modified and need to be updated.
+   */
+  var waveformsDirty:Bool = false;
 
   /**
    * Whether the note preview graphic needs to be FULLY rebuilt.
@@ -3623,6 +3628,7 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
     handlePlaybar();
     handleNotePreview();
     handleHealthIcons();
+    handleWaveforms();
 
     handleFileKeybinds();
     handleViewKeybinds();
@@ -5855,6 +5861,7 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
       {
         buttonSelectOpponent.text = _charIconData?.name ?? 'Opponent';
       }
+      waveformsDirty = true;
       healthIconsDirty = false;
       _charIconData = null;
     }
@@ -5863,8 +5870,7 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
     if (healthIconBF != null)
     {
       // Base X position to the right of the grid.
-      var xOffset = 45 - (healthIconBF.width / 2);
-      healthIconBF.x = (gridTiledSprite == null) ? (0) : (GRID_X_POS + gridTiledSprite.width + xOffset);
+      healthIconBF.x = (gridTiledSprite == null) ? (0) : (gridTiledSprite.x + gridTiledSprite.width);
       var yOffset = 30 - (healthIconBF.height / 2);
       healthIconBF.y = (gridTiledSprite == null) ? (0) : (GRID_INITIAL_Y_POS - NOTE_SELECT_BUTTON_HEIGHT + 8) + yOffset;
     }
@@ -5872,11 +5878,30 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
     // Visibly center the Dad health icon.
     if (healthIconDad != null)
     {
-      var xOffset = 75 + (healthIconDad.width / 2);
-      healthIconDad.x = (gridTiledSprite == null) ? (0) : (GRID_X_POS - xOffset);
+      healthIconDad.x = (gridTiledSprite == null) ? (0) : (measureTicks.x - healthIconDad.width);
       var yOffset = 30 - (healthIconDad.height / 2);
       healthIconDad.y = (gridTiledSprite == null) ? (0) : (GRID_INITIAL_Y_POS - NOTE_SELECT_BUTTON_HEIGHT + 8) + yOffset;
     }
+  }
+
+  /**
+   * Handle waveforms aligning based on the health icons position.
+   */
+  function handleWaveforms()
+  {
+    if (!waveformsDirty) return;
+
+    for (waveform in audioWaveforms.members)
+    {
+      waveform.x = switch (waveform.iconId)
+      {
+        case BF: healthIconBF != null ? healthIconBF.x : 840 + FullScreenScaleMode.gameCutoutSize.x * 0.5;
+        case DAD: healthIconDad != null ? healthIconDad.x : 360 + FullScreenScaleMode.gameCutoutSize.x * 0.5;
+        default: 0;
+      }
+    }
+
+    waveformsDirty = false;
   }
 
   /**

--- a/source/funkin/ui/debug/charting/handlers/ChartEditorAudioHandler.hx
+++ b/source/funkin/ui/debug/charting/handlers/ChartEditorAudioHandler.hx
@@ -200,8 +200,7 @@ class ChartEditorAudioHandler
 
         if (waveformData != null)
         {
-          var waveformSprite:WaveformSprite = initWaveformSprite(waveformData, state);
-          waveformSprite.x = 840;
+          var waveformSprite:WaveformSprite = initWaveformSprite(waveformData, state, charType);
           state.audioWaveforms.add(waveformSprite);
         }
         else
@@ -218,8 +217,7 @@ class ChartEditorAudioHandler
 
         if (waveformData != null)
         {
-          var waveformSprite:WaveformSprite = initWaveformSprite(waveformData, state);
-          waveformSprite.x = 360;
+          var waveformSprite:WaveformSprite = initWaveformSprite(waveformData, state, charType);
           state.audioWaveforms.add(waveformSprite);
         }
         else
@@ -242,7 +240,7 @@ class ChartEditorAudioHandler
   }
 
   // initializes a waveform sprite with buncho non-charType specific things
-  static function initWaveformSprite(waveformData:WaveformData, state:ChartEditorState):WaveformSprite
+  static function initWaveformSprite(waveformData:WaveformData, state:ChartEditorState, charType:CharacterType):WaveformSprite
   {
     var waveformSprite:WaveformSprite = new WaveformSprite(waveformData, VERTICAL, FlxColor.WHITE);
     waveformSprite.y = Math.max(state.gridTiledSprite?.y ?? 0.0, ChartEditorState.GRID_INITIAL_Y_POS - ChartEditorState.GRID_TOP_PAD);
@@ -250,6 +248,7 @@ class ChartEditorAudioHandler
     waveformSprite.width = (ChartEditorState.GRID_SIZE) * 2;
     waveformSprite.time = 0;
     waveformSprite.duration = Conductor.instance.getStepTimeInMs(16) * 0.001;
+    waveformSprite.iconId = charType;
     return waveformSprite;
   }
 


### PR DESCRIPTION
## Linked Issues
- Fixes #5468 

## Description
The voice waveforms were misaligned with the health icons because they used preset positions, causing them to appear off-center. 
This PR fixes that by centering them on the health icons, correcting the alignment for any resolution.

It also aligns the icons x position to now be based on the width of the icon instead of preset, which might bring visual issues for larger icons.

Extra: Because Hundrec wanted I also fixed the health icons X position when resizing the window before exiting playtesting.

## Screenshots/Videos
Before (0.7.5):

<img width="648" height="121" alt="image" src="https://github.com/user-attachments/assets/49de4d63-a79d-4606-b718-dcfc4d154f8b" />

Wide Screen (0.7.5):

<img width="1022" height="147" alt="image" src="https://github.com/user-attachments/assets/b1f90296-38e7-4cfd-a152-7cf4ad47d761" />

---

This PR (After):

<img width="621" height="85" alt="image" src="https://github.com/user-attachments/assets/186de0a0-9c5e-4492-8e2f-50e8fb0ba51f" />


Wide Screen (After)

<img width="967" height="141" alt="image" src="https://github.com/user-attachments/assets/50725c7d-bcb0-44ee-a476-16f716436a47" />
