### PR TITLE
[BUGFIX] Render NGlogo behind intro text

### DIFF
--- a/source/funkin/ui/title/TitleState.hx
+++ b/source/funkin/ui/title/TitleState.hx
@@ -143,11 +143,6 @@ class TitleState extends MusicBeatState
     textGroup = new FlxGroup();
 
     blackScreen = bg.clone();
-    if (credGroup != null)
-    {
-      credGroup.add(blackScreen);
-      credGroup.add(textGroup);
-    }
 
     ngSpr = new FlxSprite(0, FlxG.height * 0.52);
 
@@ -169,8 +164,13 @@ class TitleState extends MusicBeatState
       ngSpr.setGraphicSize(Std.int(ngSpr.width * 0.8));
     }
 
-    add(ngSpr);
     ngSpr.visible = false;
+    if (credGroup != null)
+    {
+      credGroup.add(blackScreen);
+      credGroup.add(ngSpr);
+      credGroup.add(textGroup);
+    }
 
     ngSpr.updateHitbox();
     ngSpr.screenCenter(X);


### PR DESCRIPTION


<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
https://github.com/FunkinCrew/Funkin/issues/5918
<!-- Briefly describe the issue(s) fixed. -->
## Description
That pesky ng logo isn't in front of the title text anymore
<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos
<img width="833" height="573" alt="image" src="https://github.com/user-attachments/assets/988c11b5-8e16-4127-8d6c-58360a140dd9" />
