### PR TITLE
[BUGFIX] Fix stickers persisting after exiting menus

### DIFF
--- a/source/funkin/ui/freeplay/FreeplayState.hx
+++ b/source/funkin/ui/freeplay/FreeplayState.hx
@@ -1717,7 +1717,8 @@ class FreeplayState extends MusicBeatSubState
 
   function handleInputs(elapsed:Float):Void
   {
-    if (!controls.active) return;
+    @:privateAccess
+    if (!controls.active || (stickerSubState?.switchingState ?? false)) return;
 
     #if FEATURE_TOUCH_CONTROLS
     handleTouchCapsuleClick();
@@ -2119,7 +2120,8 @@ class FreeplayState extends MusicBeatSubState
 
   function goBack():Void
   {
-    if (!controls.active) return;
+    @:privateAccess
+    if (!controls.active || (stickerSubState?.switchingState ?? false)) return;
     backTransitioning = true;
     #if FEATURE_TOUCH_CONTROLS
     if (backButton != null)

--- a/source/funkin/ui/story/StoryMenuState.hx
+++ b/source/funkin/ui/story/StoryMenuState.hx
@@ -340,6 +340,9 @@ class StoryMenuState extends MusicBeatState
 
   function handleKeyPresses():Void
   {
+    @:privateAccess
+    if ((stickerSubState?.switchingState ?? false)) return;
+
     if (!exitingMenu)
     {
       if (!selectedLevel)
@@ -723,7 +726,8 @@ class StoryMenuState extends MusicBeatState
 
   function goBack():Void
   {
-    if (exitingMenu || selectedLevel) return;
+    @:privateAccess
+    if (exitingMenu || selectedLevel || (stickerSubState?.switchingState ?? false)) return;
 
     exitingMenu = true;
     FlxG.keys.enabled = false;

--- a/source/funkin/ui/transition/stickers/StickerSubState.hx
+++ b/source/funkin/ui/transition/stickers/StickerSubState.hx
@@ -247,15 +247,15 @@ class StickerSubState extends MusicBeatSubState
   override public function close():Void
   {
     if (switchingState) return;
-    super.close();
     transitionSprite?.clear();
+    super.close();
   }
 
   override public function destroy():Void
   {
+    transitionSprite?.clear();
     if (switchingState) return;
     super.destroy();
-    transitionSprite?.clear();
   }
 }
 
@@ -284,8 +284,8 @@ class StickerTransitionSprite extends openfl.display.Sprite
     grpStickers?.update(elapsed);
     stickersCamera.update(elapsed);
 
-    stickersCamera.clearDrawStack();
-    stickersCamera.canvas.graphics.clear();
+    stickersCamera?.clearDrawStack();
+    stickersCamera?.canvas?.graphics.clear();
 
     grpStickers?.draw();
 
@@ -294,7 +294,7 @@ class StickerTransitionSprite extends openfl.display.Sprite
 
   public function insert():Void
   {
-    FlxG.addChildBelowMouse(this);
+    FlxG.addChildBelowMouse(this, 9999);
     visible = true;
     onResize();
   }
@@ -304,6 +304,8 @@ class StickerTransitionSprite extends openfl.display.Sprite
     FlxG.removeChild(this);
     visible = false;
     grpStickers = null;
+    stickersCamera?.clearDrawStack();
+    stickersCamera?.canvas?.graphics.clear();
   }
 
   public function onResize():Void


### PR DESCRIPTION
## Linked Issues
https://discord.com/channels/1419268615605325907/1419276431032189038/1423371876968828942

## Description
If you were to spam escape while the stickers are de-transitioning, the stickers will persist across the game. This PR fixes it by preventing the player from ever leaving any menu with stickers (i.e. the story menu and the freeplay menu) until the stickers are done transitioning.

## Screenshots/Videos
I don't know how to record a video of me spamming escape you just have to trust me on this one