### PR TITLE
[BUG FIX / ENHANCEMENT] Freeplay State - Fixed custom difficulty sprites and extra difficulty dots not appearing, difficulty order changing, and stops inputs while in the alt instrumental menu

### DIFF
--- a/source/funkin/data/song/SongRegistry.hx
+++ b/source/funkin/data/song/SongRegistry.hx
@@ -540,6 +540,8 @@ using funkin.data.song.migrator.SongDataMigrator;
       }
     }
 
+    allDifficulties.sort(funkin.util.SortUtil.defaultsThenAlphabetically.bind(Constants.DEFAULT_DIFFICULTY_LIST_FULL));
+
     if (allDifficulties.length == 0)
     {
       trace('  [WARN] No difficulties found. Returning default difficulty list.');

--- a/source/funkin/ui/freeplay/FreeplayState.hx
+++ b/source/funkin/ui/freeplay/FreeplayState.hx
@@ -503,7 +503,8 @@ class FreeplayState extends MusicBeatSubState
         wait: 0.1
       });
 
-    for (diffId in Constants.DEFAULT_DIFFICULTY_LIST_FULL)
+    var allDifficulties = SongRegistry.instance.listAllDifficulties(currentCharacterId) ?? Constants.DEFAULT_DIFFICULTY_LIST_FULL;
+    for (diffId in allDifficulties)
     {
       var diffSprite:DifficultySprite = new DifficultySprite(diffId);
       diffSprite.visible = diffId == Constants.DEFAULT_DIFFICULTY;
@@ -511,9 +512,9 @@ class FreeplayState extends MusicBeatSubState
       grpDifficulties.add(diffSprite);
     }
 
-    for (i in 0...Constants.DEFAULT_DIFFICULTY_LIST_FULL.length)
+    for (i in 0...allDifficulties.length)
     {
-      var dot:DifficultyDot = new DifficultyDot(Constants.DEFAULT_DIFFICULTY_LIST_FULL[i], i);
+      var dot:DifficultyDot = new DifficultyDot(allDifficulties[i], i);
       difficultyDots.add(dot);
     }
 
@@ -796,8 +797,9 @@ class FreeplayState extends MusicBeatSubState
         albumRoll.skipIntro();
         albumRoll.showStars();
       }
+      var allDifficulties = SongRegistry.instance.listAllDifficulties(currentCharacterId) ?? Constants.DEFAULT_DIFFICULTY_LIST_FULL;
 
-      refreshDots(5, Constants.DEFAULT_DIFFICULTY_LIST_FULL.indexOf(currentDifficulty), Constants.DEFAULT_DIFFICULTY_LIST_FULL.indexOf(currentDifficulty));
+      refreshDots(5, allDifficulties.indexOf(currentDifficulty), allDifficulties.indexOf(currentDifficulty));
       fadeDots(true);
 
       #if FEATURE_TOUCH_CONTROLS
@@ -1583,7 +1585,7 @@ class FreeplayState extends MusicBeatSubState
               {
                 capsule.doLerp = true;
                 fromCharSelect = false;
-                controls.active = true;
+                if (capsuleOptionsMenu == null) controls.active = true;
               }
             }
           });


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
Fixes https://github.com/FunkinCrew/Funkin/issues/3912
Fixes https://github.com/FunkinCrew/Funkin/issues/4918

<!-- Briefly describe the issue(s) fixed. -->
## Description
This PR changes/fixes:

- How the difficulty sprites and difficulty dots are added to be based on SongRegistry's `listAllDifficulties` function instead of the `DEFAULT_DIFFICULTY_LIST_FULL` constants variable, allowing mods with extra difficulties to show properly in the freeplay menu 
- The order in which all song difficulties are grabbed from SongRegistry's `listAllDifficulties` function to have all base game difficulties start first in the array
- Stops the Freeplay menu from regaining control while the Alt Instrumental Menu is open

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos
BEFORE (Freeplay difficulty order + Custom difficulty sprite/difficulty dots:

https://github.com/user-attachments/assets/03a33dbe-ba98-48b4-98cf-0a0b0aedb54c

AFTER (Freeplay difficulty order + Custom difficulty sprite/difficulty dots:

https://github.com/user-attachments/assets/5cdcc130-fab6-409d-b88a-5bf5fe2672fe

Alt Instrumental Menu fix:

https://github.com/user-attachments/assets/ced5f481-b393-4434-9471-d9b654c3ebb3