### PR TITLE
[ENHANCEMENT] Make the chart editor open the current song at the current timestamp

### DIFF
--- a/source/funkin/play/PlayState.hx
+++ b/source/funkin/play/PlayState.hx
@@ -3059,6 +3059,7 @@ class PlayState extends MusicBeatSubState
             targetSongId: currentSong.id,
             targetSongDifficulty: currentDifficulty,
             targetSongVariation: currentVariation,
+            targetSongPosition: Conductor.instance.songPosition
           }));
       }
     }

--- a/source/funkin/ui/debug/charting/ChartEditorState.hx
+++ b/source/funkin/ui/debug/charting/ChartEditorState.hx
@@ -2377,6 +2377,11 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
       var targetSongDifficulty = params.targetSongDifficulty ?? null;
       var targetSongVariation = params.targetSongVariation ?? null;
       this.loadSongAsTemplate(params.targetSongId, targetSongDifficulty, targetSongVariation);
+
+      // Set the scroll position to the current song time.
+      scrollPositionInMs = Math.min(params.targetSongPosition ?? 0, songLengthInMs);
+      currentScrollEase = scrollPositionInPixels;
+      moveSongToScrollPosition();
     }
     else
     {
@@ -6126,7 +6131,7 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
     }
 
     PlayStatePlaylist.reset();
-    
+
     // TODO: Rework asset system so we can remove this jank.
     switch (currentSongStage)
     {
@@ -7060,6 +7065,11 @@ typedef ChartEditorParams =
    * If non-null, load this variation immediately instead of the default variation.
    */
   var ?targetSongVariation:String;
+
+  /**
+   * If non-null, set this as the song position immidiately instead of the default song position.
+   */
+  var ?targetSongPosition:Float;
 };
 
 /**


### PR DESCRIPTION
## Linked Issues
Closes https://github.com/FunkinCrew/Funkin/issues/6204

## Description
Loading into a song in the chart editor used to move you to the beginning of said song. This PR fixes it by introducing `targetSongPosition` to chart editor params (Conductor just kinda gets reset when going into the editor thru a song so this was the next best thing) and then moving the current scroll to that time.

## Screenshots/Videos

https://github.com/user-attachments/assets/2bfec96b-a23f-45c5-9081-744260e60082
