### PR TITLE
[BUGFIX] Fix event dropdown field values passing to the next selected event 

### DIFF
--- a/source/funkin/ui/debug/charting/toolboxes/ChartEditorEventDataToolbox.hx
+++ b/source/funkin/ui/debug/charting/toolboxes/ChartEditorEventDataToolbox.hx
@@ -133,6 +133,7 @@ class ChartEditorEventDataToolbox extends ChartEditorBaseToolbox
       var value:Null<Dynamic> = pair.value;
 
       var field:Component = toolboxEventsDataGrid.findComponent(fieldId);
+      field.pauseEvent(UIEvent.CHANGE, true);
 
       if (field == null)
       {
@@ -158,6 +159,7 @@ class ChartEditorEventDataToolbox extends ChartEditorBaseToolbox
             throw 'ChartEditorEventDataToolbox - Field "${fieldId}" is of unknown type "${Type.getClassName(Type.getClass(field))}".';
         }
       }
+      field.resumeEvent(UIEvent.CHANGE, true, true);
     }
 
     toolboxEventsEventKind.resumeEvent(UIEvent.CHANGE, true, true);


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
No one dared making a report on this yet...
<!-- Briefly describe the issue(s) fixed. -->
## Description
Each time you select an event, the event toolbox is refreshed, and in turn it updates the values for each field with the values in `eventDataToPlace`, which is used in this case to store the newly selected event's data. However in doing so it triggers each field's `onChange` event, which will also take `eventDataToPlace` and apply it to the currently selected event.

The issue is that `onChange` will take the current value of the dropdown – which sometimes corresponds to the prior event's data – and apply that to `eventDataToPlace`, which causes the "persistence" you see.

So... this fixes the issue by simply preventing the fields' `onChange` to be dispatched when the toolbox is refreshed.
<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos
[and i'm not gonna stop till i forget what we had.webm](https://github.com/user-attachments/assets/42147c22-a5a4-4b1e-98a3-7ce366c1d0cf)
