### PR TITLE
[BUGFIX] Fix the normal gameover music not playing after the starting one

### DIFF
--- a/source/funkin/play/GameOverSubState.hx
+++ b/source/funkin/play/GameOverSubState.hx
@@ -499,9 +499,9 @@ class GameOverSubState extends MusicBeatSubState
       else
       {
         onComplete = function() {
-          isStarting = true;
+          isStarting = false;
           // We need to force to ensure that the non-starting music plays.
-          startDeathMusic(0.0, true);
+          startDeathMusic(1.0, true);
         };
       }
     }


### PR DESCRIPTION
## Linked Issues
Probably available

## Description
When a starting game over music finishes, the player will be met with silence. This is noticable in the game when dying in 2hot due to Darnell throwing a can at you. The bug happens because the `isStarting` variable is never turned off, even when it should be.

## Screenshots/Videos

https://github.com/user-attachments/assets/9c99be31-e244-43c3-88b5-ed7a5a5c1848

(you can kind of tell it works since it takes a little bit to load pico's normal gameover music)