### PR TITLE
[BUGFIX] Fix health bar resetting incorrectly after restarting a song and make lerping FPS-independent.

### DIFF
--- a/source/funkin/play/PlayState.hx
+++ b/source/funkin/play/PlayState.hx
@@ -56,6 +56,7 @@ import funkin.play.scoring.Scoring;
 import funkin.play.song.Song;
 import funkin.play.stage.Stage;
 import funkin.save.Save;
+import funkin.util.MathUtil;
 #if FEATURE_CHART_EDITOR
 import funkin.ui.debug.charting.ChartEditorState;
 #end
@@ -1041,7 +1042,7 @@ class PlayState extends MusicBeatSubState
 
     super.update(elapsed);
 
-    updateHealthBar();
+    updateHealthBar(elapsed);
     updateScoreText();
 
     // Handle restarting the song when needed (player death or pressing Retry)
@@ -1117,7 +1118,7 @@ class PlayState extends MusicBeatSubState
       hudCameraZoomIntensity = (cameraBopIntensity - 1.0) * 2.0;
       cameraZoomRate = Constants.DEFAULT_ZOOM_RATE;
 
-      health = Constants.HEALTH_STARTING;
+      resetHealth(false);
       songScore = 0.0;
       Highscore.tallies.combo = 0;
 
@@ -1447,10 +1448,7 @@ class PlayState extends MusicBeatSubState
     songScore = 0.0;
     updateScoreText();
 
-    health = Constants.HEALTH_STARTING;
-    healthLerp = health;
-
-    healthBar.value = healthLerp;
+    resetHealth();
 
     if (!isMinimalMode)
     {
@@ -2711,7 +2709,7 @@ class PlayState extends MusicBeatSubState
   /**
      * Updates the values of the health bar.
      */
-  function updateHealthBar():Void
+  function updateHealthBar(elapsed:Float):Void
   {
     if (isBotPlayMode)
     {
@@ -2719,8 +2717,19 @@ class PlayState extends MusicBeatSubState
     }
     else
     {
-      healthLerp = FlxMath.lerp(healthLerp, health, 0.15);
+      healthLerp = MathUtil.smoothLerpDecay(healthLerp, health, elapsed, Constants.HEALTH_BAR_HALF_LIFE);
+      if (Math.abs(healthLerp - health) < 0.01) healthLerp = health;
     }
+  }
+
+  /**
+   * Reset the player's health and health bar to their starting values.
+   */
+  function resetHealth(ignoreLerp:Bool = true):Void
+  {
+    health = Constants.HEALTH_STARTING;
+    if (ignoreLerp) healthLerp = health;
+    healthBar.value = 0;
   }
 
   /**

--- a/source/funkin/util/Constants.hx
+++ b/source/funkin/util/Constants.hx
@@ -418,13 +418,18 @@ class Constants
   /**
    * The player's starting health.
    */
-  public static final HEALTH_STARTING = HEALTH_MAX / 2.0;
+  public static final HEALTH_STARTING:Float = HEALTH_MAX / 2.0;
 
   /**
    * The player's minimum health.
    * If the player is at or below this value, they lose.
    */
   public static final HEALTH_MIN:Float = 0.0;
+
+  /**
+   * The smoothness of the health bar value during lerping.
+   */
+  public static final HEALTH_BAR_HALF_LIFE:Float = 0.03;
 
   /**
    * The amount of health the player gains when hitting a note with the KILLER rating.


### PR DESCRIPTION
## Linked Issues
Fixes #6009 

## Description
This PR fixes the health bar value being incorrect after resetting a song and fixes the health bar lerping to be FPS-independent.
Additionally, the health reset logic is now into it's own function `resetHealth()` for convenience and a new constant was added for the lerping `Constant.HEALTH_BAR_HALF_LIFE` which is 0.04 by default.

## Screenshots/Videos

0.8.3:

https://github.com/user-attachments/assets/1db69985-1556-4833-9139-a61f8c305494

This PR:

https://github.com/user-attachments/assets/3cb8d9ec-3a7b-420a-b883-559bd76959cf


Here is how the differences look like visually (holds up in 0.8.3 aswell):
(Start showing how it looks like when starting the song)

<img width="560" height="60" alt="to" src="https://github.com/user-attachments/assets/9708de05-ea61-42b9-9f93-865f1ab26794" />
