### PR TITLE
[ENHANCEMENT] Allow level props to have a flipX field in JSON

### DIFF
--- a/source/funkin/data/story/level/LevelData.hx
+++ b/source/funkin/data/story/level/LevelData.hx
@@ -114,4 +114,11 @@ typedef LevelPropData =
   @:default([])
   @:optional
   var animations:Array<AnimationData>;
+
+  /**
+   * Flips the sprite on X axis.
+   */
+  @:default(false)
+  @:optional
+  var flipX:Null<Bool>;
 }

--- a/source/funkin/ui/story/LevelProp.hx
+++ b/source/funkin/ui/story/LevelProp.hx
@@ -78,6 +78,7 @@ class LevelProp extends Bopper
     this.alpha = propData.alpha;
     this.x = propData.offsets[0];
     this.y = propData.offsets[1];
+    this.flipX = propData.flipX;
 
     FlxAnimationUtil.addAtlasAnimations(this, propData.animations);
     for (propAnim in propData.animations)


### PR DESCRIPTION
## Linked Issues
*-*

## Description
This PR adds support for the `flipX` field in `LevelProp`s, which could be useful in the future or for mods. Since previously, using `flipX` in a prop’s JSON would cause a crash.