### PR TITLE
[ENHANCEMENT] Make Hot Reload key bindable

### DIFF
--- a/source/funkin/input/Controls.hx
+++ b/source/funkin/input/Controls.hx
@@ -72,6 +72,7 @@ class Controls extends FlxActionSet
   #if FEATURE_STAGE_EDITOR
   var _debug_stage = new FunkinAction(Action.DEBUG_STAGE);
   #end
+  var _hot_reload = new FunkinAction(Action.HOT_RELOAD);
   var _debug_display = new FunkinAction(Action.DEBUG_DISPLAY);
   var _volume_up = new FunkinAction(Action.VOLUME_UP);
   var _volume_down = new FunkinAction(Action.VOLUME_DOWN);
@@ -310,6 +311,11 @@ class Controls extends FlxActionSet
     return _debug_stage.check();
   #end
 
+  public var HOT_RELOAD(get, never):Bool;
+
+  inline function get_HOT_RELOAD()
+    return _hot_reload.check();
+
   public var DEBUG_DISPLAY(get, never):Bool;
 
   inline function get_DEBUG_DISPLAY()
@@ -358,6 +364,7 @@ class Controls extends FlxActionSet
     #if FEATURE_DEBUG_MENU add(_debug_menu); #end
     #if FEATURE_CHART_EDITOR add(_debug_chart); #end
     #if FEATURE_STAGE_EDITOR add(_debug_stage); #end
+    add(_hot_reload);
     add(_debug_display);
     add(_volume_up);
     add(_volume_down);
@@ -487,6 +494,7 @@ class Controls extends FlxActionSet
       #if FEATURE_DEBUG_MENU case DEBUG_MENU: _debug_menu; #end
       #if FEATURE_CHART_EDITOR case DEBUG_CHART: _debug_chart; #end
       #if FEATURE_STAGE_EDITOR case DEBUG_STAGE: _debug_stage; #end
+      case HOT_RELOAD: _hot_reload;
       case DEBUG_DISPLAY: _debug_display;
       case VOLUME_UP: _volume_up;
       case VOLUME_DOWN: _volume_down;
@@ -581,6 +589,8 @@ class Controls extends FlxActionSet
       case DEBUG_STAGE:
         func(_debug_stage, JUST_PRESSED);
       #end
+      case HOT_RELOAD:
+        func(_hot_reload, JUST_PRESSED);
       case DEBUG_DISPLAY:
         func(_debug_display, JUST_PRESSED);
       case VOLUME_UP:
@@ -806,6 +816,7 @@ class Controls extends FlxActionSet
     #if FEATURE_STAGE_EDITOR
     bindKeys(Control.DEBUG_STAGE, getDefaultKeybinds(scheme, Control.DEBUG_STAGE));
     #end
+    bindKeys(Control.HOT_RELOAD, getDefaultKeybinds(scheme, Control.HOT_RELOAD));
     bindKeys(Control.DEBUG_DISPLAY, getDefaultKeybinds(scheme, Control.DEBUG_DISPLAY));
     bindKeys(Control.VOLUME_UP, getDefaultKeybinds(scheme, Control.VOLUME_UP));
     bindKeys(Control.VOLUME_DOWN, getDefaultKeybinds(scheme, Control.VOLUME_DOWN));
@@ -843,6 +854,7 @@ class Controls extends FlxActionSet
           #if FEATURE_DEBUG_MENU case Control.DEBUG_MENU: return [GRAVEACCENT]; #end
           #if FEATURE_CHART_EDITOR case Control.DEBUG_CHART: return []; #end
           #if FEATURE_STAGE_EDITOR case Control.DEBUG_STAGE: return []; #end
+          case Control.HOT_RELOAD: return [#if html5 FIVE, SHIFT #else F5 #end];
           case Control.DEBUG_DISPLAY: return [F6];
           case Control.VOLUME_UP: return [PLUS, NUMPADPLUS];
           case Control.VOLUME_DOWN: return [MINUS, NUMPADMINUS];
@@ -875,6 +887,7 @@ class Controls extends FlxActionSet
           #if FEATURE_DEBUG_MENU case Control.DEBUG_MENU: return [GRAVEACCENT]; #end
           #if FEATURE_CHART_EDITOR case Control.DEBUG_CHART: return []; #end
           #if FEATURE_STAGE_EDITOR case Control.DEBUG_STAGE: return []; #end
+          case Control.HOT_RELOAD: return [#if html5 FIVE, SHIFT #else F5 #end];
           case Control.DEBUG_DISPLAY: return [F6];
           case Control.VOLUME_UP: return [PLUS];
           case Control.VOLUME_DOWN: return [MINUS];
@@ -907,6 +920,7 @@ class Controls extends FlxActionSet
           #if FEATURE_DEBUG_MENU case Control.DEBUG_MENU: return []; #end
           #if FEATURE_CHART_EDITOR case Control.DEBUG_CHART: return []; #end
           #if FEATURE_STAGE_EDITOR case Control.DEBUG_STAGE: return []; #end
+          case Control.HOT_RELOAD: return [#if html5 FIVE, SHIFT #else F5 #end];
           case Control.DEBUG_DISPLAY: return [];
           case Control.VOLUME_UP: return [NUMPADPLUS];
           case Control.VOLUME_DOWN: return [NUMPADMINUS];
@@ -1010,6 +1024,7 @@ class Controls extends FlxActionSet
       #if FEATURE_STAGE_EDITOR
       Control.DEBUG_STAGE => getDefaultGamepadBinds(Control.DEBUG_STAGE),
       #end
+      Control.HOT_RELOAD => getDefaultGamepadBinds(Control.HOT_RELOAD),
       Control.DEBUG_DISPLAY => getDefaultGamepadBinds(Control.DEBUG_DISPLAY),
     ]);
   }
@@ -1080,6 +1095,8 @@ class Controls extends FlxActionSet
       case Control.DEBUG_STAGE:
         [];
       #end
+      case Control.HOT_RELOAD:
+        [];
       case Control.DEBUG_DISPLAY:
         [];
       default:
@@ -1499,6 +1516,7 @@ enum Control
   #if FEATURE_DEBUG_MENU DEBUG_MENU; #end
   #if FEATURE_CHART_EDITOR DEBUG_CHART; #end
   #if FEATURE_STAGE_EDITOR DEBUG_STAGE; #end
+  HOT_RELOAD;
   DEBUG_DISPLAY;
 }
 
@@ -1562,6 +1580,7 @@ enum abstract Action(String) to String from String
   #if FEATURE_STAGE_EDITOR
   var DEBUG_STAGE = "debug_stage";
   #end
+  var HOT_RELOAD = "hot_reload";
   var DEBUG_DISPLAY = "debug_display";
 }
 

--- a/source/funkin/ui/haxeui/HaxeUISubState.hx
+++ b/source/funkin/ui/haxeui/HaxeUISubState.hx
@@ -47,10 +47,7 @@ class HaxeUISubState extends MusicBeatSubState
     if (FlxG.keys.justPressed.F4) FlxG.switchState(() -> new MainMenuState());
 
     // Refresh the component.
-    if (FlxG.keys.justPressed.F5)
-    {
-      refreshComponent();
-    }
+    if (controls.HOT_RELOAD) refreshComponent();
   }
 
   function refreshComponent()

--- a/source/funkin/util/plugins/ReloadAssetsDebugPlugin.hx
+++ b/source/funkin/util/plugins/ReloadAssetsDebugPlugin.hx
@@ -10,7 +10,7 @@ import funkin.external.android.CallbackUtil;
 #end
 
 /**
- * A plugin which adds functionality to press `F5` to reload all game assets, then reload the current state.
+ * A plugin which adds functionality to press `F5` (configurable in Controls) to reload all game assets, then reload the current state.
  * This is useful for hot reloading assets during development.
  */
 @:nullSafety

--- a/source/funkin/util/plugins/ReloadAssetsDebugPlugin.hx
+++ b/source/funkin/util/plugins/ReloadAssetsDebugPlugin.hx
@@ -34,14 +34,7 @@ class ReloadAssetsDebugPlugin extends FlxBasic
   {
     super.update(elapsed);
 
-    #if html5
-    if (FlxG.keys.justPressed.FIVE && FlxG.keys.pressed.SHIFT)
-    #else
-    if (FlxG.keys.justPressed.F5)
-    #end
-    {
-      reload();
-    }
+    if (PlayerSettings.player1.controls.HOT_RELOAD) reload();
   }
 
   public override function destroy():Void


### PR DESCRIPTION
## Linked Issues
*-*

## Description
This PR makes the Hot Reload key configurable through the Controls menu, allowing players to rebind it to their preferred key instead of it being hardcoded to `F5`.

## Screenshots/Videos

<img width="1204" height="140" alt="image" src="https://github.com/user-attachments/assets/4342744c-3f78-4492-a6b4-c75972d0444b" />
