### PR TITLE
[BUGFIX] Crash in `NoteStyle.getCountdownSoundPath` library separator code

### DIFF
--- a/source/funkin/play/notes/notestyle/NoteStyle.hx
+++ b/source/funkin/play/notes/notestyle/NoteStyle.hx
@@ -510,7 +510,7 @@ class NoteStyle implements IRegistryEntry<NoteStyleData>
     // library:path
     var parts = getCountdownSoundPath(step, true)?.split(Constants.LIBRARY_SEPARATOR) ?? [];
     if (parts.length == 0) return null;
-    if (parts.length == 1) return Paths.image(parts[0]);
+    if (parts.length == 1) return Paths.sound(parts[0]);
     return Paths.sound(parts[1], parts[0]);
   }
 


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Briefly describe the issue(s) fixed. -->
## Description
If `assets.countdownX.data.audioPath` doesn't specify any library, the game will try to handle the path as an image path, leading into a crash or whatever behavior if the wrong path actually exists

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos
<img width="412" height="341" alt="image" src="https://github.com/user-attachments/assets/1368e22a-ddf8-4dd3-9bfb-b95a5ec85b79" />

```json
...
"assets": {
	"countdownThree": {
		"data": {
			"audioPath": "gameplay/countdown/4eva/introTHREE"
		},
		"assetPath": null
	}
}
...
```