### PR TITLE
[MODDING] Make some local variables global for convenience

### DIFF
--- a/source/funkin/play/GameOverSubState.hx
+++ b/source/funkin/play/GameOverSubState.hx
@@ -63,6 +63,8 @@ class GameOverSubState extends MusicBeatSubState
 
   static var blueballed:Bool = false;
 
+  var bg:FunkinSprite;
+
   /**
    * The boyfriend character.
    */
@@ -146,7 +148,7 @@ class GameOverSubState extends MusicBeatSubState
     //
 
     // Add a black background to the screen.
-    var bg:FunkinSprite = new FunkinSprite().makeSolidColor(FlxG.width * 2, FlxG.height * 2, FlxColor.BLACK);
+    bg = new FunkinSprite().makeSolidColor(FlxG.width * 2, FlxG.height * 2, FlxColor.BLACK);
     // We make this transparent so that we can see the stage underneath during debugging,
     // but it's normally opaque.
     bg.alpha = transparent ? 0.25 : 1.0;

--- a/source/funkin/ui/options/ControlsMenu.hx
+++ b/source/funkin/ui/options/ControlsMenu.hx
@@ -63,6 +63,7 @@ class ControlsMenu extends Page<OptionsState.OptionsMenuPageName>
   var popup:Prompt;
   var camFollow:FlxObject;
   var labels:FlxTypedGroup<AtlasText>;
+  var headers:FlxTypedGroup<AtlasText>;
   var currentDevice:Device = Keys;
   var deviceListSelected:Bool = false;
   var actionPrevented:Bool = false;
@@ -81,7 +82,7 @@ class ControlsMenu extends Page<OptionsState.OptionsMenuPageName>
     camera = menuCamera;
 
     labels = new FlxTypedGroup<AtlasText>();
-    var headers:FlxTypedGroup<AtlasText> = new FlxTypedGroup<AtlasText>();
+    headers = new FlxTypedGroup<AtlasText>();
     controlGrid = new MenuTypedList(Columns(COLUMNS), Vertical);
 
     add(labels);

--- a/source/funkin/ui/options/OptionsState.hx
+++ b/source/funkin/ui/options/OptionsState.hx
@@ -43,6 +43,8 @@ class OptionsState extends MusicBeatState
    */
   public static var instance:OptionsState;
 
+  var menuBG:FlxSprite;
+
   var optionsCodex:Codex<OptionsMenuPageName>;
 
   public var drumsBG:FunkinSound;
@@ -57,7 +59,7 @@ class OptionsState extends MusicBeatState
 
     drumsBG = FunkinSound.load(Paths.music('offsetsLoop/drumsLoop'), 0, true, false, false, false);
 
-    var menuBG = new FlxSprite().loadGraphic(Paths.image('menuBG'));
+    menuBG = new FlxSprite().loadGraphic(Paths.image('menuBG'));
     var hsv = new HSVShader(-0.6, 0.9, 3.6);
     menuBG.shader = hsv;
     menuBG.setGraphicSize(Std.int(FlxG.width * 1.1));

--- a/source/funkin/ui/title/TitleState.hx
+++ b/source/funkin/ui/title/TitleState.hx
@@ -57,6 +57,7 @@ class TitleState extends MusicBeatState
       startIntro();
   }
 
+  var bg:FunkinSprite;
   var logoBl:FunkinSprite;
   var gfDance:FunkinSprite;
   var danceLeft:Bool = false;
@@ -71,7 +72,7 @@ class TitleState extends MusicBeatState
 
     persistentUpdate = true;
 
-    var bg:FunkinSprite = new FunkinSprite(-1).makeSolidColor(FlxG.width + 2, FlxG.height, FlxColor.BLACK);
+    bg = new FunkinSprite(-1).makeSolidColor(FlxG.width + 2, FlxG.height, FlxColor.BLACK);
     bg.screenCenter();
     add(bg);
 


### PR DESCRIPTION
## Description
This PR softcodes some local variables inside functions for convenience, so mods no longer need to use the `FlxState` members to get them.

The following variables were softcoded:
| Class | Variable |
| ------- | ------------ |
| `ResultState` | `bg` |
| `ControlsMenu` | `headers` |
| `TitleState` | `bg` |
| `OptionsState` | `menuBG` |
| `Strumline` | `HOLD_COVERS_CAP` |
| `GameOverSubState` | `bg` |