### PR TITLE
[ENHANCEMENT/FIX] Sort notes by length

### DIFF
--- a/source/funkin/data/song/SongDataUtils.hx
+++ b/source/funkin/data/song/SongDataUtils.hx
@@ -5,6 +5,7 @@ import funkin.data.song.SongData.SongEventData;
 import funkin.data.song.SongData.SongNoteData;
 import funkin.data.song.SongData.SongTimeChange;
 import funkin.util.ClipboardUtil;
+import funkin.util.SortUtil;
 
 using Lambda;
 
@@ -241,7 +242,7 @@ class SongDataUtils
     // TODO: Modifies the array in place. Is this okay?
     notes.sort(function(a:SongNoteData, b:SongNoteData):Int
     {
-      return FlxSort.byValues(desc ? FlxSort.DESCENDING : FlxSort.ASCENDING, a.time, b.time);
+      return SortUtil.noteDataByTime(desc ? FlxSort.DESCENDING : FlxSort.ASCENDING, a, b);
     });
     return notes;
   }
@@ -254,20 +255,20 @@ class SongDataUtils
     // TODO: Modifies the array in place. Is this okay?
     events.sort(function(a:SongEventData, b:SongEventData):Int
     {
-      return FlxSort.byValues(desc ? FlxSort.DESCENDING : FlxSort.ASCENDING, a.time, b.time);
+      return SortUtil.eventDataByTime(desc ? FlxSort.DESCENDING : FlxSort.ASCENDING, a, b);
     });
     return events;
   }
 
   /**
-   * Sort an array of notes by strum time.
+   * Sort an array of time changes by strum time.
    */
   public static function sortTimeChanges(timeChanges:Array<SongTimeChange>, desc:Bool = false):Array<SongTimeChange>
   {
     // TODO: Modifies the array in place. Is this okay?
     timeChanges.sort(function(a:SongTimeChange, b:SongTimeChange):Int
     {
-      return FlxSort.byValues(desc ? FlxSort.DESCENDING : FlxSort.ASCENDING, a.timeStamp, b.timeStamp);
+      return SortUtil.timeChangeByTime(desc ? FlxSort.DESCENDING : FlxSort.ASCENDING, a, b);
     });
     return timeChanges;
   }

--- a/source/funkin/play/PlayState.hx
+++ b/source/funkin/play/PlayState.hx
@@ -1873,7 +1873,7 @@ class PlayState extends MusicBeatSubState
     if (generatedMusic)
     {
       // TODO: Sort more efficiently, or less often, to improve performance.
-      // activeNotes.sort(SortUtil.byStrumtime, FlxSort.DESCENDING);
+      // activeNotes.sort(SortUtil.noteSpriteByStrumtime, FlxSort.DESCENDING);
     }
 
     if (FlxG.sound.music != null)

--- a/source/funkin/play/notes/Strumline.hx
+++ b/source/funkin/play/notes/Strumline.hx
@@ -830,9 +830,9 @@ class Strumline extends FlxSpriteGroup
   public function onBeatHit():Void
   {
     // why are we doing this every beat? >:(
-    if (notes.members.length > 1) notes.members.insertionSort(compareNoteSprites.bind(FlxSort.ASCENDING));
+    if (notes.members.length > 1) notes.members.insertionSort(SortUtil.noteSpriteByStrumtime.bind(FlxSort.ASCENDING));
 
-    if (holdNotes.members.length > 1) holdNotes.members.insertionSort(compareHoldNoteSprites.bind(FlxSort.ASCENDING));
+    if (holdNotes.members.length > 1) holdNotes.members.insertionSort(SortUtil.sustainTrailByStrumtime.bind(FlxSort.ASCENDING));
   }
 
   /**
@@ -930,7 +930,7 @@ class Strumline extends FlxSpriteGroup
     this.nextNoteIndex = 0;
 
     // Sort the notes by strumtime.
-    this.noteData.insertionSort(compareNoteData.bind(FlxSort.ASCENDING));
+    this.noteData.insertionSort(SortUtil.noteDataByTime.bind(FlxSort.ASCENDING));
   }
 
   /**
@@ -944,7 +944,7 @@ class Strumline extends FlxSpriteGroup
     if (note == null) return;
 
     this.noteData.push(note);
-    if (sort) this.noteData.sort(compareNoteData.bind(FlxSort.ASCENDING));
+    if (sort) this.noteData.sort(SortUtil.noteDataByTime.bind(FlxSort.ASCENDING));
   }
 
   /**
@@ -1408,40 +1408,22 @@ class Strumline extends FlxSpriteGroup
     }
   }
 
-  /**
-   * Compare two note data objects by their strumtime.
-   * @param order The order to sort the notes in.
-   * @param a The first note data object.
-   * @param b The second note data object.
-   * @return The comparison result, based on the time of the notes.
-   */
+  @:deprecated("Use SortUtil.noteDataByTime() instead")
   function compareNoteData(order:Int, a:SongNoteData, b:SongNoteData):Int
   {
-    return FlxSort.byValues(order, a.time, b.time);
+    return SortUtil.noteDataByTime(order, a, b);
   }
 
-  /**
-   * Compare two note sprites by their strumtime.
-   * @param order The order to sort the notes in.
-   * @param a The first note sprite.
-   * @param b The second note sprite.
-   * @return The comparison result, based on the time of the notes.
-   */
+  @:deprecated("Use SortUtil.noteSpriteByStrumtime() instead")
   function compareNoteSprites(order:Int, a:NoteSprite, b:NoteSprite):Int
   {
-    return FlxSort.byValues(order, a?.strumTime, b?.strumTime);
+    return SortUtil.noteSpriteByStrumtime(order, a, b);
   }
 
-  /**
-   * Compare two hold note sprites by their strumtime.
-   * @param order The order to sort the notes in.
-   * @param a The first hold note sprite.
-   * @param b The second hold note sprite.
-   * @return The comparison result, based on the time of the notes.
-   */
+  @:deprecated("Use SortUtil.sustainTrailByStrumtime() instead")
   function compareHoldNoteSprites(order:Int, a:SustainTrail, b:SustainTrail):Int
   {
-    return FlxSort.byValues(order, a?.strumTime, b?.strumTime);
+    return SortUtil.sustainTrailByStrumtime(order, a, b);
   }
 
   /**

--- a/source/funkin/ui/debug/charting/ChartEditorState.hx
+++ b/source/funkin/ui/debug/charting/ChartEditorState.hx
@@ -6654,13 +6654,13 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
     // TODO: .insertionSort()
     currentSongChartNoteData.sort(function(a:SongNoteData, b:SongNoteData):Int
     {
-      return FlxSort.byValues(FlxSort.ASCENDING, a.time, b.time);
+      return SortUtil.noteDataByTime(FlxSort.ASCENDING, a, b);
     });
 
     // TODO: .insertionSort()
     currentSongChartEventData.sort(function(a:SongEventData, b:SongEventData):Int
     {
-      return FlxSort.byValues(FlxSort.ASCENDING, a.time, b.time);
+      return SortUtil.eventDataByTime(FlxSort.ASCENDING, a, b);
     });
   }
 

--- a/source/funkin/util/SortUtil.hx
+++ b/source/funkin/util/SortUtil.hx
@@ -6,8 +6,10 @@ import flixel.FlxBasic;
 import flixel.util.FlxSort;
 #end
 import funkin.play.notes.NoteSprite;
+import funkin.play.notes.SustainTrail;
 import funkin.data.song.SongData.SongEventData;
 import funkin.data.song.SongData.SongNoteData;
+import funkin.data.song.SongData.SongTimeChange;
 
 /**
  * Utility functions related to sorting.
@@ -48,9 +50,29 @@ class SortUtil
    * @param b The second Note to compare.
    * @return 1 if `a` has an earlier strumtime, -1 if `b` has an earlier strumtime.
    */
-  public static inline function byStrumtime(order:Int, a:NoteSprite, b:NoteSprite):Int
+  public static inline function noteSpriteByStrumtime(order:Int, a:NoteSprite, b:NoteSprite):Int
   {
     return noteDataByTime(order, a.noteData, b.noteData);
+  }
+
+  @:deprecated("Use noteSpriteByStrumtime() instead")
+  public static function byStrumtime(order:Int, a:NoteSprite, b:NoteSprite):Void
+  {
+    noteSpriteByStrumtime(order, a, b);
+  }
+
+  /**
+   * Given two Sustain Trails, returns 1 or -1 based on whether `a` or `b` has an earlier strumtime.
+   *
+   * @param order Either `FlxSort.ASCENDING` or `FlxSort.DESCENDING`
+   * @param a The first hold note sprite to compare.
+   * @param b The second hold note sprite to compare.
+   * @return 1 if `a` has an earlier strumtime, -1 if `b` has an earlier strumtime.
+   */
+  public static inline function sustainTrailByStrumtime(order:Int, a:SustainTrail, b:SustainTrail):Int
+  {
+    if (a == null || b == null) return 0;
+    return FlxSort.byValues(order, a.strumTime, b.strumTime);
   }
 
   /**
@@ -63,7 +85,11 @@ class SortUtil
    */
   public static inline function noteDataByTime(order:Int, a:SongNoteData, b:SongNoteData):Int
   {
-    return FlxSort.byValues(order, a.time, b.time);
+    if (a == null || b == null) return 0;
+
+    var result = FlxSort.byValues(order, a.time, b.time);
+    if (result == 0) result = FlxSort.byValues(order, a.length, b.length);
+    return result;
   }
 
   /**
@@ -76,7 +102,22 @@ class SortUtil
    */
   public static inline function eventDataByTime(order:Int, a:SongEventData, b:SongEventData):Int
   {
+    if (a == null || b == null) return 0;
     return FlxSort.byValues(order, a.time, b.time);
+  }
+
+  /**
+   * Given two Time Change objects, returns 1 or -1 based on whether `a` or `b` has an earlier time.
+   *
+   * @param order Either `FlxSort.ASCENDING` or `FlxSort.DESCENDING`
+   * @param a The first Event to compare.
+   * @param b The second Event to compare.
+   * @return 1 if `a` has an earlier time, -1 if `b` has an earlier time.
+   */
+  public static inline function timeChangeByTime(order:Int, a:SongTimeChange, b:SongTimeChange):Int
+  {
+    if (a == null || b == null) return 0;
+    return FlxSort.byValues(order, a.timeStamp, b.timeStamp);
   }
 
   /**


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
Couldn't find any, but there could be.

<!-- Briefly describe the issue(s) fixed. -->
## Description
After the sustain notes rework, note hits just play the sing animation once, so if there is a double note, one with length 0 and another one being sustained, depending on the note list sorting for automatic characters or hit time for players, it can look weird to just sing the short note instead of the long one.

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos
_Before (the chart has to be done WITHOUT the fix, also you need to add the short note AFTER the long ones)_

https://github.com/user-attachments/assets/4116803b-0fc5-4dd2-8b6e-8ef899809f6b

---
_After, with the same chart_

https://github.com/user-attachments/assets/7f39849b-fc68-490b-b69c-0f1db4b19ba5