### PR TITLE
[ENHANCEMENT] Add Mobile Back Button to Character Select

### DIFF
--- a/source/funkin/ui/charSelect/CharSelectSubState.hx
+++ b/source/funkin/ui/charSelect/CharSelectSubState.hx
@@ -729,6 +729,13 @@ class CharSelectSubState extends MusicBeatSubState
     allowInput = false;
     autoFollow = false;
 
+    #if mobile
+    if (backButton != null)
+    {
+      FlxTween.tween(backButton, {alpha: 0}, 0.4, {ease: FlxEase.quadOut});
+    }
+    #end
+
     FlxTween.tween(cursor, {alpha: 0}, 0.8, {ease: FlxEase.expoOut});
     FlxTween.tween(cursorBlue, {alpha: 0}, 0.8, {ease: FlxEase.expoOut});
     FlxTween.tween(cursorDarkBlue, {alpha: 0}, 0.8, {ease: FlxEase.expoOut});
@@ -1099,7 +1106,6 @@ class CharSelectSubState extends MusicBeatSubState
     #if mobile
     if (backButton != null)
     {
-      FlxTween.tween(backButton, {alpha: 0}, 0.4, {ease: FlxEase.quadOut});
       backButton.animation.play("confirm");
     }
     #end


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
Implements #6244

<!-- Briefly describe the issue(s) fixed. -->
## Description
This PR adds the back button to the character select for mobile. Pressing the back button on mobile does the exact same thing on desktop builds when you press back, the back button ~~hides~~ and becomes disabled when selecting a character and it will not reenable until you deselect that character.

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos

Sorry for the bad video quality, I had just figured out how to record my phone screen from my computer.

https://github.com/user-attachments/assets/29f0cc91-79f5-4b83-ab11-edf33c2373e6

Edit: I decided that the back button should stay visible after selecting a character. I changed this so that the back button would be consistent with the behavior of any other menu. If a developer wants this reverted or changed at all, I will do so. I also fixed a problem with this pr where the button wouldn't hide when going back to freeplay after selecting a character.
