### PR TITLE
[ENHANCEMENT] Add back the "Video file does not exist" error

### DIFF
--- a/source/funkin/play/cutscene/VideoCutscene.hx
+++ b/source/funkin/play/cutscene/VideoCutscene.hx
@@ -73,13 +73,10 @@ class VideoCutscene
     if (!openfl.Assets.exists(filePath))
     {
       // Display a popup.
-      // funkin.util.WindowUtil.showError('Error playing video', 'Video file does not exist: ${filePath}');
-      // return;
-
-      // TODO: After moving videos to their own library,
-      // this function ALWAYS FAILS on web, but the video still plays.
-      // I think that's due to a weird quirk with how OpenFL libraries work.
+      funkin.util.WindowUtil.showError('Error playing video', 'Video file does not exist: ${filePath}');
       trace('Video file does not exist: ${filePath}');
+
+      return;
     }
 
     var rawFilePath = Paths.stripLibrary(filePath);

--- a/source/funkin/ui/transition/LoadingState.hx
+++ b/source/funkin/ui/transition/LoadingState.hx
@@ -95,6 +95,7 @@ class LoadingState extends MusicBeatSubState
       }
 
       checkLibrary('shared');
+      checkLibrary('videos');
       checkLibrary(stageDirectory);
       checkLibrary('tutorial');
 


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Briefly describe the issue(s) fixed. -->
## Description
Inside of `funkin.play.cutscene.VideoCutscene.play`, there was going to be an error for when a video is missing. This was scrapped because HTML5 would always report it as missing.

After debugging on HTML5 for way too long, I figured out that the OpenFL library was never loaded into the game, causing the `exists` lookup to completely skip the library.

This PR adds back the error message and loads the video library in `LoadingState`, so that the `Assets.exists` function can be accurate.