### PR TITLE
[BUGFIX] Hide the Mobile Back Button When Selecting a Week

### DIFF
--- a/source/funkin/ui/story/StoryMenuState.hx
+++ b/source/funkin/ui/story/StoryMenuState.hx
@@ -619,6 +619,10 @@ class StoryMenuState extends MusicBeatState
     Highscore.talliesLevel = new funkin.Highscore.Tallies();
 
     new FlxTimer().start(1, function(tmr:FlxTimer) {
+      #if mobile
+      FlxTween.tween(backButton, {alpha: 0}, 0.2, {ease: FlxEase.quadOut});
+      #end
+
       FlxTransitionableState.skipNextTransIn = false;
       FlxTransitionableState.skipNextTransOut = false;
 


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
Fixes #5935

<!-- Briefly describe the issue(s) fixed. -->
## Description
Although selecting a song in the freeplay menu hides the back button on mobile, the back button does not hide when selecting a week in the story menu. This PR fixes that issue by actually hiding the mobile back button after selecting a week.

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos

Before:

https://github.com/user-attachments/assets/99403aff-1ec8-40e2-80b8-18f9fb789bbf

After:

https://github.com/user-attachments/assets/d9c6949a-7e08-4344-8625-c5a29fab8ff9
