### PR TITLE
[ENHANCEMENT/Modding] Allow custom exit callbacks in some states

### DIFF
--- a/source/funkin/ui/credits/CreditsState.hx
+++ b/source/funkin/ui/credits/CreditsState.hx
@@ -9,6 +9,7 @@ import flixel.group.FlxSpriteGroup;
 import funkin.util.TouchUtil;
 import funkin.ui.credits.CreditsData.CreditsDataRole;
 import funkin.ui.credits.CreditsData.CreditsDataMember;
+import flixel.FlxState;
 
 /**
  * The state used to display the credits scroll.
@@ -76,6 +77,8 @@ class CreditsState extends MusicBeatState
    * The speed the credits scroll at while the pause keybind is held, in pixels per second.
    */
   static final CREDITS_SCROLL_PAUSE_SPEED = 0.0;
+
+  public var exitState:()->FlxState = exitCallback;
 
   /**
    * The actual sprites and text used to display the credits.
@@ -293,8 +296,13 @@ class CreditsState extends MusicBeatState
 
   function exit():Void
   {
+    FlxG.switchState(exitState);
+  }
+
+  static function exitCallback():FlxState
+  {
     FlxG.keys.enabled = false;
-    FlxG.switchState(() -> new MainMenuState());
+    return new MainMenuState();
   }
 
   override public function destroy():Void

--- a/source/funkin/ui/options/OptionsState.hx
+++ b/source/funkin/ui/options/OptionsState.hx
@@ -1,17 +1,11 @@
 package funkin.ui.options;
 
 import funkin.ui.Page.PageName;
-import funkin.ui.transition.LoadingState;
-import funkin.ui.TextMenuList;
-import funkin.ui.TextMenuList.TextMenuItem;
-import flixel.math.FlxPoint;
 import funkin.ui.TextMenuList;
 import funkin.ui.TextMenuList.TextMenuItem;
 import flixel.FlxSprite;
+import flixel.FlxState;
 import flixel.FlxObject;
-import flixel.FlxSubState;
-import flixel.group.FlxGroup;
-import flixel.util.FlxSignal;
 import funkin.audio.FunkinSound;
 import funkin.ui.mainmenu.MainMenuState;
 import funkin.ui.MusicBeatState;
@@ -21,7 +15,6 @@ import funkin.input.Controls;
 import funkin.api.newgrounds.NewgroundsClient;
 #end
 #if mobile
-import funkin.util.TouchUtil;
 import funkin.mobile.ui.FunkinBackButton;
 import funkin.mobile.input.ControlsHandler;
 import funkin.mobile.ui.options.ControlsSchemeMenu;
@@ -29,7 +22,6 @@ import funkin.mobile.ui.options.ControlsSchemeMenu;
 #if FEATURE_MOBILE_IAP
 import funkin.mobile.util.InAppPurchasesUtil;
 #end
-import flixel.util.FlxColor;
 
 /**
  * The main options menu
@@ -42,6 +34,8 @@ class OptionsState extends MusicBeatState
    * Instance of the OptionsState
    */
   public static var instance:OptionsState;
+
+  public var exitState:()->FlxState = exitCallback;
 
   var optionsCodex:Codex<OptionsMenuPageName>;
 
@@ -82,7 +76,7 @@ class OptionsState extends MusicBeatState
 
     if (options.hasMultipleOptions())
     {
-      options.onExit.add(exitToMainMenu);
+      options.onExit.add(exitOptions);
       controls.onExit.add(exitControls);
       preferences.onExit.add(optionsCodex.switchPage.bind(Options));
       #if FEATURE_LAG_ADJUSTMENT
@@ -94,10 +88,10 @@ class OptionsState extends MusicBeatState
     {
       // No need to show Options page
       #if mobile
-      preferences.onExit.add(exitToMainMenu);
+      preferences.onExit.add(exitOptions);
       optionsCodex.setPage(Preferences);
       #else
-      controls.onExit.add(exitToMainMenu);
+      controls.onExit.add(exitOptions);
       optionsCodex.setPage(Controls);
       #end
     }
@@ -137,12 +131,17 @@ class OptionsState extends MusicBeatState
     optionsCodex.switchPage(Options);
   }
 
-  function exitToMainMenu():Void
+  function exitOptions():Void
   {
     optionsCodex.currentPage.enabled = false;
     // TODO: Animate this transition?
+    FlxG.switchState(exitState);
+  }
+
+  static function exitCallback():FlxState
+  {
     FlxG.keys.enabled = false;
-    FlxG.switchState(() -> new MainMenuState());
+    return new MainMenuState();
   }
 }
 

--- a/source/funkin/ui/story/StoryMenuState.hx
+++ b/source/funkin/ui/story/StoryMenuState.hx
@@ -28,6 +28,7 @@ import funkin.util.MathUtil;
 import funkin.util.SwipeUtil;
 import funkin.util.TouchUtil;
 import funkin.ui.FullScreenScaleMode;
+import flixel.FlxState;
 #if FEATURE_DISCORD_RPC
 import funkin.api.discord.DiscordClient;
 #end
@@ -44,6 +45,9 @@ class StoryMenuState extends MusicBeatState
   var currentLevelTitle:LevelTitle;
   var highScore:Int = 42069420;
   var highScoreLerp:Int = 12345678;
+
+  public var exitState:()->FlxState = exitCallback;
+
   var exitingMenu:Bool = false;
   var selectedLevel:Bool = false;
   //
@@ -721,9 +725,14 @@ class StoryMenuState extends MusicBeatState
     if (exitingMenu || selectedLevel || (stickerSubState?.switchingState ?? false)) return;
 
     exitingMenu = true;
-    FlxG.keys.enabled = false;
-    FlxG.switchState(() -> new MainMenuState());
+    FlxG.switchState(exitState);
     FunkinSound.playOnce(Paths.sound('cancelMenu'));
+  }
+
+  static function exitCallback():FlxState
+  {
+    FlxG.keys.enabled = false;
+    return new MainMenuState();
   }
 
   /**


### PR DESCRIPTION
## Description
This PR allows modification of the exiting state in some states such as: `OptionsState`, `StoryMenuState` and `CreditsState`. 
Allowing mods to modify the behavior when exiting them instead of being hardcoded to MainMenuState and having to use workarounds that might not always work properly and feel choppy because it goes into the MainMenu for a bit before switching the state again.

**Example Script**
```haxe
import funkin.modding.module.ScriptedModule;
import funkin.modding.events.ScriptEvent;
import funkin.ui.options.OptionsState;
import flixel.FlxG;
import funkin.ui.title.TitleState;
import funkin.ui.story.StoryMenuState;

class Testing extends ScriptedModule {
  override public function onStateCreate(event:ScriptEvent) {
    // Set the StoryMenuState exit state to TitleState
    if (!(FlxG.state is StoryMenuState)) return;
    var storymenu:StoryMenuState = FlxG.state;
    storymenu.exitState = () -> new TitleState();

    // Set the OptionsState exit state to TitleState
    if (!(FlxG.state is OptionsState)) return;
    OptionsState.instance.exitState = () -> new TitleState();

    // Set the CreditsState exit state to TitleState
    if (!(FlxG.state is CreditsState)) return;
    var creditsState:CreditsState = FlxG.state;
    creditsState.exitState = () -> new TitleState();
  }
}
```