### PR TITLE
[ENHANCEMENT/FIX] Better Strumline Note Confirm Animation

### DIFF
--- a/source/funkin/play/notes/StrumlineNote.hx
+++ b/source/funkin/play/notes/StrumlineNote.hx
@@ -40,7 +40,7 @@ class StrumlineNote extends FunkinSprite
   /**
    * How long to continue the hold note animation after a note is pressed.
    */
-  static final CONFIRM_HOLD_TIME:Float = 0.1;
+  static final CONFIRM_HOLD_TIME:Float = 0.15;
 
   /**
    * How long the hold note animation has been playing after a note is pressed.
@@ -72,9 +72,8 @@ class StrumlineNote extends FunkinSprite
   function onAnimationFinished(name:String):Void
   {
     // Run a timer before we stop playing the confirm animation.
-    // On opponent, this prevent issues with hold notes.
     // On player, this allows holding the confirm key to fall back to press.
-    if (name == 'confirm')
+    if (isPlayer && name == 'confirm')
     {
       confirmHoldTimer = 0;
     }
@@ -143,6 +142,10 @@ class StrumlineNote extends FunkinSprite
   {
     this.active = (forceActive || isAnimationDynamic('confirm'));
     this.playAnimation('confirm', true);
+
+    // On opponent, run a timer to stop playing the confirm animation.
+    // On player, stop the timer to avoid stopping the confirm animation earlier.
+    confirmHoldTimer = isPlayer ? -1 : 0;
   }
 
   public function isConfirm():Bool


### PR DESCRIPTION
Basically restores the pre-weekend1 behavior of the strumline notes confirm animation, which, a lot of people including me, looked way nicer and responsive, while keeping the fallback to press animation on players.

Old PR: #2864

<details>

<summary>Old PR Description (kinda relevant)</summary>

The opponent strumline notes confirm animation were too long and didn't looked great. I increased CONFIRM_HOLD_TIME up to 0.15 and start the timer right when the animation is started and not when finished, just for opponents/botplay, the player confirm animation is almost the same, i just fixed a premature static animation playing when hitting a double note.

resumed list:

- Opponent/Botplay strumline notes confirm animation is stopped earlier so it looks nicer (by starting the stop timer when playing the confirm animation and not when finishing it)
- Player/controlled strumline notes confirm animation is a little bit longer so it doesnt start the "press" animation too early and look weird.

Sorry for not being able to provide a video comparation but i couldnt record it properly

</details>