### PR TITLE
[BUGFIX] Prevent double-pressing when switching the difficulty in freeplay

### DIFF
--- a/source/funkin/ui/freeplay/FreeplayState.hx
+++ b/source/funkin/ui/freeplay/FreeplayState.hx
@@ -1827,9 +1827,7 @@ class FreeplayState extends MusicBeatSubState
       dj?.onPlayerAction(); // dj?.resetAFKTimer();
       changeDiff(-1);
       generateSongList(currentFilter, true, false);
-    }
-
-    if (rightPressed)
+    } else if (rightPressed)
     {
       dj?.onPlayerAction(); // dj?.resetAFKTimer();
       changeDiff(1);


### PR DESCRIPTION
## Linked Issues
Closes #6207

## Description
This PR prevents double-pressing when switching the difficulty in freeplay, which caused the difficulty display to fail due to conflicting tweens.

This approach feels more intended than allowing the same difficulty to be selected.