### PR TITLE
[ENHANCEMENT] Add a preference option for score separation

### DIFF
--- a/source/funkin/Preferences.hx
+++ b/source/funkin/Preferences.hx
@@ -483,6 +483,44 @@ class Preferences
   }
 
   /**
+   * Determines the thousands separators type for the score:
+   * - `"Comma"` -> uses commas, e.g. `1,000`
+   * - `"Period"` -> uses periods, e.g. `1.000`
+   * - `"Off"` -> no separator, e.g. `1000`
+   *
+   * @default `"Comma"`
+   */
+  public static var separatedScore(get, set):String;
+
+  static function get_separatedScore():String
+  {
+    var value = Save?.instance?.options?.separatedScore ?? "Comma";
+    return value;
+  }
+
+  static function set_separatedScore(value:String):String
+  {
+    var normalized:String = value.toLowerCase();
+
+    var result:String = switch (normalized)
+    {
+      case "off":
+        "Off";
+      case "comma":
+        "Comma";
+      case "period":
+        "Period";
+      default:
+        "Comma";
+    };
+
+    var save:Save = Save.instance;
+    save.options.separatedScore = result;
+    save.flush();
+    return result;
+  }
+
+  /**
    * If enabled, the game will hide the mouse when taking a screenshot.
    * @default `true`
    */

--- a/source/funkin/play/PlayState.hx
+++ b/source/funkin/play/PlayState.hx
@@ -2750,9 +2750,10 @@ class PlayState extends MusicBeatSubState
     }
     else
     {
+      final COMMA_SEPARATED:Bool = Preferences.separatedScore == "Comma";
       final SHOW_DECIMALS:Bool = false;
-      final COMMA_SEPARATED:Bool = true;
-      scoreText.text = 'Score: ${FlxStringUtil.formatMoney(songScore, SHOW_DECIMALS, COMMA_SEPARATED)}';
+      final SCORE:String = Preferences.separatedScore != "Off" ? FlxStringUtil.formatMoney(songScore, SHOW_DECIMALS, COMMA_SEPARATED) : '${Std.int(songScore)}';
+      scoreText.text = 'Score: ${SCORE}';
     }
   }
 

--- a/source/funkin/save/Save.hx
+++ b/source/funkin/save/Save.hx
@@ -110,6 +110,7 @@ class Save implements ConsoleClass
         autoPause: true,
         vsyncMode: 'Off',
         strumlineBackgroundOpacity: 0,
+        separatedScore: "Comma",
         autoFullscreen: false,
         globalOffset: 0,
         audioVisualOffset: 0,
@@ -1181,6 +1182,16 @@ typedef SaveDataOptions =
    * @default `0`
    */
   var strumlineBackgroundOpacity:Int;
+
+  /**
+   * Determines the thousands separators type for the score:
+   * - `"Comma"` -> uses commas, e.g. `1,000`
+   * - `"Period"` -> uses periods, e.g. `1.000`
+   * - `"Off"` -> no separator, e.g. `1000`
+   *
+   * @default `"Comma"`
+   */
+  var separatedScore:String;
 
   /**
    * If enabled, the game will automatically launch in fullscreen on startup.

--- a/source/funkin/ui/options/PreferencesMenu.hx
+++ b/source/funkin/ui/options/PreferencesMenu.hx
@@ -124,6 +124,13 @@ class PreferencesMenu extends Page<OptionsState.OptionsMenuPageName>
     {
       Preferences.strumlineBackgroundOpacity = value;
     }, Preferences.strumlineBackgroundOpacity);
+    createPrefItemEnum('Separated Score', 'If enabled, the score will be formatted using thousands separators based on the given mode.', [
+      "Period" => "Period",
+      "Comma" => "Comma",
+      "Off" => "Off"
+    ], (key:String, value:String) -> {
+      Preferences.separatedScore = value;
+    }, Preferences.separatedScore);
     #if FEATURE_HAPTICS
     createPrefItemEnum('Haptics', 'When enabled, the game plays haptic feedback effects.', [
       "All" => HapticsMode.ALL,

--- a/source/funkin/ui/story/StoryMenuState.hx
+++ b/source/funkin/ui/story/StoryMenuState.hx
@@ -315,8 +315,10 @@ class StoryMenuState extends MusicBeatState
 
     highScoreLerp = Std.int(MathUtil.snap(MathUtil.smoothLerpPrecision(highScoreLerp, highScore, elapsed, 0.307), highScore, 1));
 
-    var commaSeparated:Bool = true;
-    scoreText.text = 'LEVEL SCORE: ${FlxStringUtil.formatMoney(highScoreLerp, false, commaSeparated)}';
+    final COMMA_SEPARATED:Bool = Preferences.separatedScore == "Comma";
+    final SHOW_DECIMALS:Bool = false;
+    final SCORE:String = Preferences.separatedScore != "Off" ? FlxStringUtil.formatMoney(highScoreLerp, SHOW_DECIMALS, COMMA_SEPARATED) : '${Std.int(highScoreLerp)}';
+    scoreText.text = 'LEVEL SCORE: ${SCORE}';
 
     levelTitleText.text = currentLevel.getTitle();
 


### PR DESCRIPTION
## Description
This PR adds a preference option to allow players to choose how the score displays thousands separators.

It adds 3 types of separation:
| Separation |  |
| --- | --- |
| "Comma" | uses commas, e.g. 1,000 |
| "Period" | uses periods, e.g. 1.000 |
| "Off" | no separator, e.g. 1000 |

## Screenshots/Videos

**Example Vid**

https://github.com/user-attachments/assets/82fd1a6c-7597-4002-b51c-45ba9d399f23

Update: I also added this in StoryMode since the PR #4965 was merged

<sub>Low quality because of the compression for github to allow the video</sub>