### PR TITLE
[GITHUB] Exclude IntelliJ IDEA project files from version control

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,8 +15,7 @@ NewgroundsCredentials.hx
 
 # Exclude IntelliJ IDEA stuff
 .idea/
-Funkin.iml
-tests/unit/unit.iml
+*.iml
 
 # Mobile signing stuff
 .apple/


### PR DESCRIPTION
## Description
This PR updates the `.gitignore` to exclude IntelliJ IDEA project files (`.idea/`, `*.iml`) from being tracked by the repo when committing changes. 

This is useful for those who use IntelliJ for writing Haxe instead of VSCode.