### PR TITLE
[ENHANCEMENT] Make hot-reloading during chart editor playtest only affect PlayState

### DIFF
--- a/source/funkin/ui/debug/charting/ChartEditorState.hx
+++ b/source/funkin/ui/debug/charting/ChartEditorState.hx
@@ -49,6 +49,7 @@ import funkin.play.components.Subtitles;
 import funkin.play.notes.NoteSprite;
 import funkin.play.PlayStatePlaylist;
 import funkin.play.song.Song;
+import funkin.play.PlayState;
 import funkin.save.Save;
 import funkin.ui.debug.charting.commands.AddEventsCommand;
 import funkin.ui.debug.charting.commands.AddNotesCommand;
@@ -2329,6 +2330,24 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
         default: // Continue
       }
     }
+  }
+
+  public override function reloadAssets()
+  {
+    // If PlayState isn't open, do a regular reload.
+    if (!Std.isOfType(this.subState, PlayState))
+    {
+      super.reloadAssets();
+      return;
+    }
+
+    funkin.modding.PolymodHandler.forceReloadAssets();
+
+    // Create a new instance of the current substate, so old data is cleared.
+    this.resetSubState();
+
+    @:privateAccess
+    testSongInPlayState(PlayState.lastParams.minimalMode);
   }
 
   override function create():Void


### PR DESCRIPTION
## Linked Issues
who up available they not

## Description
When hot-reloading in general, the state gets reset. This also closes any substates it may have. The PlayState playtest in the chart editor is a SubState, so naturally it gets closed when hot-reloading. This makes it a pain in the ass when changing script variables, since you'd have to re-open the song and do all the metadata configuration again.

Heartwarming: Modder finally discovers the pain of source coding ❤️

## Screenshots/Videos

https://github.com/user-attachments/assets/897d5989-eb03-4add-85a6-d6e9607ffa6d
