### PR TITLE
[OPTIMIZATION] Remove unused Chart Editor Context Menu code

### DIFF
--- a/source/funkin/ui/debug/charting/ChartEditorState.hx
+++ b/source/funkin/ui/debug/charting/ChartEditorState.hx
@@ -2408,7 +2408,6 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
 
     // Setup the onClick listeners for the UI after it's been created.
     setupUIListeners();
-    setupContextMenu();
     setupTurboKeyHandlers();
 
     setupAutoSave();
@@ -3374,21 +3373,6 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
 
     // TODO: Pass specific HaxeUI components to add context menus to them.
     // registerContextMenu(null, Paths.ui('chart-editor/context/test'));
-  }
-
-  function setupContextMenu():Void
-  {
-    Screen.instance.registerEvent(MouseEvent.RIGHT_MOUSE_UP, function(e:MouseEvent) {
-      var xPos = e.screenX;
-      var yPos = e.screenY;
-      onContextMenu(xPos, yPos);
-    });
-  }
-
-  function onContextMenu(xPos:Float, yPos:Float)
-  {
-    trace('User right clicked to open menu at (${xPos}, ${yPos})');
-    // this.openDefaultContextMenu(xPos, yPos);
   }
 
   function copySelection():Void


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
None
<!-- Briefly describe the issue(s) fixed. -->
## Description
* The game previously was registering an event listening for whenever the user would click their mouse button, which was most likely used to display the default context menu meant for testing that is not left unused.

https://github.com/FunkinCrew/Funkin/blob/e62c5a223c406db56ff13aba12bdc837fab59124/source/funkin/ui/debug/charting/ChartEditorState.hx#L3284

Yet, the game does not unregisted the mouse event, and to be fair, there is no point for it to be registered in the first place.