### PR TITLE
[BUGFIX] Stop the Haxe Compilation Server from clearing assets

### DIFF
--- a/project.hxp
+++ b/project.hxp
@@ -1466,6 +1466,9 @@ class Project extends HXProject
 
   function clearAssets():Void
   {
+	// We don't want the haxe compilation server deleting our assets, do we?
+	if (!isDisplay()) return;
+
     var exportPath:Null<String> = app.path ?? "";
 
     // mac target uses `macos` for the export folder instead of `mac`


### PR DESCRIPTION
<!-- Briefly describe the issue(s) fixed. -->
## Description
This PR fixes a little oversight made in `clearAssets`, which caused the Haxe Compilation Server to delete the `assets` folder.
