### PR TITLE
[OPTIMIZATION] Unify player/opponent voice list builders into one function using `CharacterType`

### DIFF
--- a/source/funkin/play/song/Song.hx
+++ b/source/funkin/play/song/Song.hx
@@ -3,6 +3,7 @@ package funkin.play.song;
 import funkin.audio.VoicesGroup;
 import funkin.audio.FunkinSound;
 import funkin.data.IRegistryEntry;
+import funkin.data.freeplay.player.PlayerRegistry;
 import funkin.data.song.SongData.SongCharacterData;
 import funkin.data.song.SongData.SongChartData;
 import funkin.data.song.SongData.SongEventData;
@@ -14,8 +15,8 @@ import funkin.data.song.SongData.SongTimeFormat;
 import funkin.data.song.SongRegistry;
 import funkin.modding.IScriptedClass.IPlayStateScriptedClass;
 import funkin.modding.events.ScriptEvent;
+import funkin.play.character.BaseCharacter.CharacterType;
 import funkin.ui.freeplay.charselect.PlayableCharacter;
-import funkin.data.freeplay.player.PlayerRegistry;
 import funkin.util.SortUtil;
 
 /**
@@ -880,8 +881,8 @@ class SongDifficulty
   public function buildVoiceList():Array<String>
   {
     var result:Array<String> = [];
-    result = result.concat(buildPlayerVoiceList());
-    result = result.concat(buildOpponentVoiceList());
+    result = result.concat(buildVoiceListForCharacter(CharacterType.BF));
+    result = result.concat(buildVoiceListForCharacter(CharacterType.DAD));
     if (result.length == 0)
     {
       var suffix:String = (variation != null && variation != '' && variation != 'default') ? '-$variation' : '';
@@ -891,105 +892,66 @@ class SongDifficulty
     return result;
   }
 
-  public function buildPlayerVoiceList():Array<String>
+  public function buildVoiceListForCharacter(charType:CharacterType):Array<String>
   {
     var suffix:String = (variation != null && variation != '' && variation != 'default') ? '-$variation' : '';
 
-    if (characters.playerVocals != null)
+    var vocals:Array<String> = null;
+    var charId:String = null;
+
+    switch (charType)
     {
-      // The metadata explicitly defines the list of voices.
-      var playerIds:Array<String> = characters?.playerVocals ?? [characters.player];
-      var playerVoices:Array<String> = playerIds.map((id) -> Paths.voices(this.song.id, '-$id$suffix'));
+      case BF:
+        vocals = characters?.playerVocals;
+        charId = characters.player;
+      case DAD:
+        vocals = characters?.opponentVocals;
+        charId = characters.opponent;
+      default:
+        return [];
+    }
+
+    if (vocals != null) {
+      var charIds:Array<String> = vocals ?? [charId];
+      var charVoices:Array<String> = charIds.map((id) -> Paths.voices(this.song.id, '-$id$suffix'));
       var validVoices:Bool = true;
 
-      // Check if all voice paths exist before returning
-      // If not, fallback to the default method for resolving voices
-      for (voice in playerVoices)
+      for (voice in charVoices)
       {
         if (voice == null || !Assets.exists(voice)) validVoices = false;
       }
-      if (validVoices) return playerVoices;
+
+      if (validVoices) return charVoices;
     }
 
     // Automatically resolve voices by removing suffixes.
     // For example, if `Voices-bf-car-erect.ogg` does not exist, check for `Voices-bf-erect.ogg`.
     // Then, check for  `Voices-bf-car.ogg`, then `Voices-bf.ogg`.
-    var playerId:String = characters.player;
-    var playerVoice:String = Paths.voices(this.song.id, '-${playerId}$suffix');
+    var originalId = charId;
+    var charVoice:String = Paths.voices(this.song.id, '-$charId$suffix');
 
-    while (playerVoice != null && !Assets.exists(playerVoice))
+    // Remove the last suffix. For example, bf-car becomes bf.
+    while (charVoice != null && !Assets.exists(charVoice))
     {
-      // Remove the last suffix.
-      // For example, bf-car becomes bf.
-      playerId = playerId.split('-').slice(0, -1).join('-');
-      // Try again.
-      playerVoice = playerId == '' ? null : Paths.voices(this.song.id, '-${playerId}$suffix');
+      charId = charId.split('-').slice(0, -1).join('-');
+      charVoice = charId == '' ? null : Paths.voices(this.song.id, '-$charId$suffix');
     }
-    if (playerVoice == null)
+
+    // Try again without $suffix.
+    if (charVoice == null)
     {
-      // Try again without $suffix.
-      playerId = characters.player;
-      playerVoice = Paths.voices(this.song.id, '-${playerId}');
-      while (playerVoice != null && !Assets.exists(playerVoice))
+      charId = originalId;
+      charVoice = Paths.voices(this.song.id, '-$charId');
+
+      // Remove the last suffix. For example, bf-car becomes bf.
+      while (charVoice != null && !Assets.exists(charVoice))
       {
-        // Remove the last suffix.
-        playerId = playerId.split('-').slice(0, -1).join('-');
-        // Try again.
-        playerVoice = playerId == '' ? null : Paths.voices(this.song.id, '-${playerId}$suffix');
+        charId = charId.split('-').slice(0, -1).join('-');
+        charVoice = charId == '' ? null : Paths.voices(this.song.id, '-$charId');
       }
     }
 
-    return playerVoice != null ? [playerVoice] : [];
-  }
-
-  public function buildOpponentVoiceList():Array<String>
-  {
-    var suffix:String = (variation != null && variation != '' && variation != 'default') ? '-$variation' : '';
-
-    if (characters.opponentVocals != null)
-    {
-      // The metadata explicitly defines the list of voices.
-      var opponentIds:Array<String> = characters?.opponentVocals ?? [characters.opponent];
-      var opponentVoices:Array<String> = opponentIds.map((id) -> Paths.voices(this.song.id, '-$id$suffix'));
-      var validVoices:Bool = true;
-
-      // Check if all voice paths exist before returning
-      // If not, fallback to the default method for resolving voices
-      for (voice in opponentVoices)
-      {
-        if (voice == null || !Assets.exists(voice)) validVoices = false;
-      }
-      if (validVoices) return opponentVoices;
-    }
-
-    // Automatically resolve voices by removing suffixes.
-    // For example, if `Voices-bf-car-erect.ogg` does not exist, check for `Voices-bf-erect.ogg`.
-    // Then, check for  `Voices-bf-car.ogg`, then `Voices-bf.ogg`.
-
-    var opponentId:String = characters.opponent;
-    var opponentVoice:String = Paths.voices(this.song.id, '-${opponentId}$suffix');
-    while (opponentVoice != null && !Assets.exists(opponentVoice))
-    {
-      // Remove the last suffix.
-      opponentId = opponentId.split('-').slice(0, -1).join('-');
-      // Try again.
-      opponentVoice = opponentId == '' ? null : Paths.voices(this.song.id, '-${opponentId}$suffix');
-    }
-    if (opponentVoice == null)
-    {
-      // Try again without $suffix.
-      opponentId = characters.opponent;
-      opponentVoice = Paths.voices(this.song.id, '-${opponentId}');
-      while (opponentVoice != null && !Assets.exists(opponentVoice))
-      {
-        // Remove the last suffix.
-        opponentId = opponentId.split('-').slice(0, -1).join('-');
-        // Try again.
-        opponentVoice = opponentId == '' ? null : Paths.voices(this.song.id, '-${opponentId}$suffix');
-      }
-    }
-
-    return opponentVoice != null ? [opponentVoice] : [];
+    return charVoice != null ? [charVoice] : [];
   }
 
   /**
@@ -1001,8 +963,8 @@ class SongDifficulty
   {
     var result:VoicesGroup = new VoicesGroup();
 
-    var playerVoiceList:Array<String> = this.buildPlayerVoiceList();
-    var opponentVoiceList:Array<String> = this.buildOpponentVoiceList();
+    var playerVoiceList:Array<String> = this.buildVoiceListForCharacter(CharacterType.BF);
+    var opponentVoiceList:Array<String> = this.buildVoiceListForCharacter(CharacterType.DAD);
 
     // Add player vocals.
     for (playerVoice in playerVoiceList)

--- a/source/funkin/ui/debug/charting/handlers/ChartEditorImportExportHandler.hx
+++ b/source/funkin/ui/debug/charting/handlers/ChartEditorImportExportHandler.hx
@@ -9,6 +9,7 @@ import funkin.util.SortUtil;
 import funkin.util.FileUtil;
 import funkin.util.FileUtil.FileWriteMode;
 import haxe.io.Bytes;
+import funkin.play.character.BaseCharacter.CharacterType;
 import funkin.play.song.Song;
 import funkin.data.song.SongData.SongChartData;
 import funkin.data.song.SongData.SongMetadata;
@@ -80,13 +81,13 @@ class ChartEditorImportExportHandler
 
         var instId:String = diff.variation == Constants.DEFAULT_VARIATION ? '' : diff.variation;
 
-        var playerVoiceList:Array<String> = diff.buildPlayerVoiceList(); // SongDifficulty accounts for variation already.
+        var playerVoiceList:Array<String> = diff.buildVoiceListForCharacter(CharacterType.BF); // SongDifficulty accounts for variation already.
         for (voice in playerVoiceList)
         {
           state.loadVocalsFromAsset(voice, diff.characters.player, instId);
         }
 
-        var opponentVoiceList:Array<String> = diff.buildOpponentVoiceList();
+        var opponentVoiceList:Array<String> = diff.buildVoiceListForCharacter(CharacterType.DAD);
         for (voice in opponentVoiceList)
         {
           state.loadVocalsFromAsset(voice, diff.characters.opponent, instId);


### PR DESCRIPTION
## Description
This PR unifies the functions `buildOpponentVoiceList` and `buildPlayerVoiceList` into a single `buildVoiceListForCharacter` function, which uses `CharacterType` to determine which vocal list to build.

Also removes the `$suffix` from the second checking, which prevented normal vocals from characters to be searched for, such as `Vocals-bf` if there is no `Vocals-bf-car-variation` or `Vocals-bf-variation`