### PR TITLE
[ENHANCEMENT] Group Stage Editor backups with Chart Editor backups

### DIFF
--- a/source/funkin/ui/debug/charting/handlers/ChartEditorImportExportHandler.hx
+++ b/source/funkin/ui/debug/charting/handlers/ChartEditorImportExportHandler.hx
@@ -23,7 +23,7 @@ import thx.semver.Version as SemverVersion;
 @:access(funkin.ui.debug.charting.ChartEditorState)
 class ChartEditorImportExportHandler
 {
-  public static final BACKUPS_PATH:String = './backups/';
+  public static final BACKUPS_PATH:String = './backups/charts/';
 
   /**
    * Fetch's a song's existing chart and audio and loads it, replacing the current song.

--- a/source/funkin/ui/debug/stageeditor/StageEditorState.hx
+++ b/source/funkin/ui/debug/stageeditor/StageEditorState.hx
@@ -60,7 +60,7 @@ class StageEditorState extends UIState
 {
   // i aint documenting allat
   // the uh finals
-  public static final BACKUPS_PATH:String = "./stagebackups/";
+  public static final BACKUPS_PATH:String = "./backups/stages/";
   public static final LIGHT_MODE_COLORS:Array<FlxColor> = [0xFFE7E6E6, 0xFFF8F8F8];
   public static final DARK_MODE_COLORS:Array<FlxColor> = [0xFF181919, 0xFF202020];
 


### PR DESCRIPTION
## Description
This PR changes where the backups get saved

### Before:
```
- | assets/
- | backups/
- - | chart-editor-songid-yyyy-mm-dd-hh-mm-ss.fnfc
- | manifest/
- | mods/
- | plugins/
- | stagebackups/
- - | stage-editor-stageid-yyyy-mm-dd-hh-mm-ss.fnfc
- | CHANGELOG.md
- | do NOT readme.txt
- | Funkin.exe
- | libvlc.dll
- | libvlccore.dll
- | LICENSE.md
- | lime.ndll
```

### After:
```
- | assets/
- | backups/
- - | charts/
- - - | chart-editor-songid-yyyy-mm-dd-hh-mm-ss.fnfc
- - | stages/
- - - | stage-editor-stageid-yyyy-mm-dd-hh-mm-ss.fnfc
- | manifest/
- | mods/
- | plugins/
- | CHANGELOG.md
- | do NOT readme.txt
- | Funkin.exe
- | libvlc.dll
- | libvlccore.dll
- | LICENSE.md
- | lime.ndll
```