### PR TITLE
[BUGFIX] Fix Subtitle `HTML` tags

### DIFF
--- a/source/funkin/play/components/Subtitles.hx
+++ b/source/funkin/play/components/Subtitles.hx
@@ -33,7 +33,7 @@ class Subtitles extends FlxSpriteGroup
     background.alpha = 0.5;
     add(background);
 
-    subtitleText = new SubtitlesText(0, 0, 30, Paths.font('vcr.ttf'));
+    subtitleText = new SubtitlesText(0, 0, 30, 'VCR OSD Mono');
     add(subtitleText);
 
     setText([], true);
@@ -164,6 +164,11 @@ class SubtitlesText extends FlxText
       _regen = (textField.htmlText != ot) || _regen;
     }
     return Text;
+  }
+
+  override function applyFormats(_:openfl.text.TextFormat, __:Bool = false):Void
+  {
+    // This function shouldn't get called because it messes up `htmlText`.
   }
 }
 


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
<!--## Linked Issues -->

<!-- Briefly describe the issue(s) fixed. -->
## Description
Originally, `FlxText` would override the `HTML` format tags added through `htmlText` by adding its own formatting every text edit. This PR makes sure that those `HTML` tags don't get overriden by disabling `FlxText`'s `applyFormat` behavior.

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos

Before:
<img width="1450" height="322" alt="image" src="https://github.com/user-attachments/assets/72d2110d-b0af-4ec6-a8ee-9214edf1b470" />

After:
<img width="533" height="187" alt="image" src="https://github.com/user-attachments/assets/387d253c-57cd-490a-96aa-f1f80159deaa" />

- NOTE: This PR goes well with FunkinCrew/funkin.assets#292! It is not required.