### PR TITLE
Fix `RegistryMacro` error on language server

### DIFF
--- a/source/funkin/data/BaseRegistry.hx
+++ b/source/funkin/data/BaseRegistry.hx
@@ -18,7 +18,7 @@ typedef EntryConstructorFunction = (String, ?Dynamic) -> Void;
  */
 @:nullSafety
 @:generic
-@:autoBuild(funkin.util.macro.DataRegistryMacro.buildRegistry())
+@:autoBuild(funkin.util.macro.RegistryMacro.buildRegistry())
 abstract class BaseRegistry<T:(IRegistryEntry<J> & Constructible<EntryConstructorFunction>), J, P>
 {
   /**

--- a/source/funkin/util/macro/RegistryMacro.hx
+++ b/source/funkin/util/macro/RegistryMacro.hx
@@ -101,26 +101,34 @@ class RegistryMacro
    */
   static function getTypeParams(cls:ClassType):RegistryTypeParams
   {
+    var params:Array<Type> = [];
+    var typeParams:Array<Any> = [];
     switch (cls.superClass.t.get().kind)
     {
-      case KGenericInstance(_, params):
-        var typeParams:Array<Any> = [];
-        for (param in params)
-        {
-          switch (param)
-          {
-            case TInst(t, _):
-              typeParams.push(t.get());
-            case TType(t, _):
-              typeParams.push(t.get());
-            default:
-              throw 'Not a class';
-          }
-        }
-        return {entryType: typeParams[0], dataType: typeParams[1]};
+      case KGenericInstance(_, _params):
+        params = _params;
+      case KGeneric:
+        // For some reason the only case where it's KGeneric
+        // is on the language server so we have to handle it too.
+        // This seems to be somehow related to the broken code completion.
+        params = cls.superClass.params;
       default:
         throw '${cls.name}: Could not interpret type parameters of Registry class.';
     }
+
+    for (param in params)
+    {
+      switch (param)
+      {
+        case TInst(t, _):
+          typeParams.push(t.get());
+        case TType(t, _):
+          typeParams.push(t.get());
+        default:
+          throw 'Not a class';
+      }
+    }
+    return {entryType: typeParams[0], dataType: typeParams[1]};
   }
 
   /**


### PR DESCRIPTION
## Linked Issues
None.
<!-- Briefly describe the issue(s) fixed. -->
## Description
> [!NOTE]
> This does NOT fix the broken code completion, only the macro breaking it.

Fixes an issue where, after changing code, the registry macro starts throwing an error.
 
<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos
The error in question.
<img width="833" height="67" alt="image" src="https://github.com/user-attachments/assets/0de84484-b564-4442-a75b-5b563d4d23e0" />
