### PR TITLE
[ENHANCEMENT] Extend fullscreen aspect ratio

### DIFF
--- a/source/funkin/ui/FullScreenScaleMode.hx
+++ b/source/funkin/ui/FullScreenScaleMode.hx
@@ -35,7 +35,7 @@ class FullScreenScaleMode extends flixel.system.scaleModes.BaseScaleMode
   /**
    * The maximum aspect ratio a screen can have.
    */
-  public static var maxAspectRatio:FlxPoint = FlxPoint.get(20, 9);
+  public static var maxAspectRatio:FlxPoint = FlxPoint.get(22, 9);
 
   /**
    * The maximum ratio axis indicating on which axis the black bar will be added.


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->
<!-- Briefly describe the issue(s) fixed. -->
## Description
I noticed some pillarboxing running the normal build on my phone, and I figured out this is because of `FullScreenScaleMode`'s aspect ratio maximum of 20:9. This is a bit below quite a few Android phones, like the Pixel 9/10 (20.5:9), all Galaxy Z Flip phones (21-21.5:9) and the outer screen of the 2 newest Z Fold phones (22:9). This PR extends the maximum aspect ratio to the widest available Android phone, which I believe to be the Z Fold 7's outer screen at 22:9.

While this does mostly just work, there are a few edge cases I saw where some things aren't far enough to extend to this ratio, being in weeks 2 and 7, and I'm sure there's also some I missed. I'm leaving this PR as a draft for now because I'm not sure how to handle these, and I would imagine there are preferred ways to do this, so I wouldn't want to do it with no other input. If anyone has any ideas for how to handle this I would very much appreciate it!

Screenshots below are of the game at 22:9.
<!-- Include any relevant screenshots or videos. -->
## Screenshots
<img width="1287" height="527" alt="image" src="https://github.com/user-attachments/assets/6e8d3d2b-76c4-4d13-aa5c-3223a51b2cd6" />

<img width="1287" height="527" alt="image" src="https://github.com/user-attachments/assets/126f0ed2-6079-47c3-9fa8-cd7b9379a16c" />

<img width="1287" height="527" alt="image" src="https://github.com/user-attachments/assets/0b9dfbea-cd68-4285-a643-b7be639a0854" />

<img width="1287" height="527" alt="image" src="https://github.com/user-attachments/assets/2ef8bb4c-df3e-4f4e-81c3-a4a7c56dbaa5" />

<img width="1287" height="527" alt="image" src="https://github.com/user-attachments/assets/e49079f0-19a7-4047-a471-b42297a5b045" />

<img width="1287" height="527" alt="image" src="https://github.com/user-attachments/assets/626ea125-12d6-40e2-8534-4341d4e0c357" />