### PR TITLE
[BUGFIX] Mouse input not working on HaxeFlixel debugger

### DIFF
--- a/source/funkin/util/plugins/ScreenshotPlugin.hx
+++ b/source/funkin/util/plugins/ScreenshotPlugin.hx
@@ -112,6 +112,7 @@ class ScreenshotPlugin extends FlxBasic
     lastHeight = FlxG.height;
 
     flashSprite = new Sprite();
+    flashSprite.mouseEnabled = false;
     flashSprite.alpha = 0;
     flashBitmap = new Bitmap(new BitmapData(lastWidth, lastHeight, true, Preferences.flashingLights ? FlxColor.WHITE : FlxColor.TRANSPARENT));
     flashSprite.addChild(flashBitmap);


### PR DESCRIPTION

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
.
<!-- Briefly describe the issue(s) fixed. -->
## Description
The HaxeFlixel debugger had stopped working properly for a while now, and the cause was the Screenshot plugin, which creates a sprite that covers the whole screen. It was covering the sprites of the debugger and preventing mouse events to be dispatched for them. The sprite in question is only ever used for the "camera flash" effect so this PR fixes the issue by disabling its `mouseEnabled` property which makes it be ignored by mouse events.

There's still a newly introduced issue where Tab doesn't open the console anymore, I'll probably include a fix for that in this PR some time soon, that is if I even find a fix for that.
<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos
[Gravar a tela_20251019_224441.webm](https://github.com/user-attachments/assets/fea4791f-0e2e-4033-8f81-f5b93e07787c)
