### PR TITLE
[BUGFIX] Fix stage/chart editor UI file checks

### DIFF
--- a/project.hxp
+++ b/project.hxp
@@ -1410,9 +1410,9 @@ class Project extends HXProject
 
     if (!FEATURE_ANIMATION_EDITOR.isEnabled(this)) removeAssetPath('assets/preload/data/ui/animation-editor', "default");
 
-    if (!FEATURE_ANIMATION_EDITOR.isEnabled(this)) removeAssetPath('assets/preload/data/ui/chart-editor', "default");
+    if (!FEATURE_CHART_EDITOR.isEnabled(this)) removeAssetPath('assets/preload/data/ui/chart-editor', "default");
 
-    if (!FEATURE_ANIMATION_EDITOR.isEnabled(this)) removeAssetPath('assets/preload/data/ui/stage-editor', "default");
+    if (!FEATURE_STAGE_EDITOR.isEnabled(this)) removeAssetPath('assets/preload/data/ui/stage-editor', "default");
 
     // Font assets
     var shouldEmbedFonts = true;


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
https://github.com/FunkinCrew/Funkin/commit/5c07c41e6248fc2971accf3c199e30c9c24654bd#r168282354
<!-- Briefly describe the issue(s) fixed. -->
## Description
title.

Alternative title: disabling the animation editor in a build causes the stage and chart editor ui files to be left out of it.
<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos
