### PR TITLE
[ENHANCEMENT/TWEAK] Add offset var to note in NoteStyle.hx

### DIFF
--- a/source/funkin/play/notes/notestyle/NoteStyle.hx
+++ b/source/funkin/play/notes/notestyle/NoteStyle.hx
@@ -86,6 +86,9 @@ class NoteStyle implements IRegistryEntry<NoteStyleData>
 
     target.antialiasing = !(_data.assets?.note?.isPixel ?? false);
 
+    var noteOffsets:Array<Float> = getNoteOffsets();
+    target.offset.set(noteOffsets[0], noteOffsets[1]);
+
     // Apply the animations.
     buildNoteAnimations(target);
 
@@ -178,6 +181,11 @@ class NoteStyle implements IRegistryEntry<NoteStyleData>
   public function getNoteScale():Float
   {
     return _data.assets?.note?.scale ?? fallback?.getNoteScale() ?? 1.0;
+  }
+
+  public function getNoteOffsets():Array<Float>
+  {
+    return _data?.assets?.note?.offsets ?? fallback?.getNoteOffsets() ?? [0.0, 0.0];
   }
 
   function fetchNoteAnimationData(dir:NoteDirection):Null<AnimationData>


### PR DESCRIPTION
## Description
Adds the ability to offset the actual notes, not entirely sure why this wasn't already a thing (unless it is)

I also made a script version of it but it would be better if it existed already