### PR TITLE
Fix OTG/USB keyboard detection on Android

### DIFF
--- a/source/funkin/external/android/KeyboardUtil.hx
+++ b/source/funkin/external/android/KeyboardUtil.hx
@@ -1,0 +1,26 @@
+package funkin.external.android;
+
+#if android
+import lime.system.JNI;
+
+/**
+ * Utility class for keyboard detection.
+ */
+class KeyboardUtil
+{
+  /**
+   * Returns `true` if a keyboard is currently connected to the device.
+   */
+  public static var keyboardConnected(get, never):Bool;
+
+  @:noCompletion
+  static function get_keyboardConnected():Bool
+  {
+    final method:Null<Dynamic> = JNIUtil.createStaticMethod('funkin/util/KeyboardUtil', 'isKeyboardConnected', '()Z');
+
+    if (method == null) return false;
+
+    return inline JNI.callStatic(method, []);
+  }
+}
+#end

--- a/source/funkin/external/android/java/funkin/util/KeyboardUtil.java
+++ b/source/funkin/external/android/java/funkin/util/KeyboardUtil.java
@@ -1,0 +1,14 @@
+package funkin.util;
+
+import org.haxe.extension.Extension;
+
+public class KeyboardUtil
+{
+  public static boolean isKeyboardConnected()
+  {
+    if (Extension.mainContext == null) return false;
+
+    // KEYBOARD_UNDEFINED = 0, KEYBOARD_NOKEYS = 1
+    return Extension.mainContext.getResources().getConfiguration().keyboard > 1;
+  }
+}

--- a/source/funkin/mobile/input/ControlsHandler.hx
+++ b/source/funkin/mobile/input/ControlsHandler.hx
@@ -10,6 +10,9 @@ import funkin.mobile.ui.FunkinHitbox;
 import funkin.play.notes.NoteDirection;
 import openfl.events.KeyboardEvent;
 import openfl.events.TouchEvent;
+#if android
+import funkin.external.android.KeyboardUtil;
+#end
 
 /**
  * Handles setting up and managing input controls for the game.
@@ -125,7 +128,7 @@ class ControlsHandler
   @:noCompletion
   private static function get_hasExternalInputDevice():Bool
   {
-    return FlxG.gamepads.numActiveGamepads > 0 #if android || extension.androidtools.Tools.isChromebook() #end;
+    return FlxG.gamepads.numActiveGamepads > 0 #if android || KeyboardUtil.keyboardConnected || extension.androidtools.Tools.isChromebook() #end;
   }
 
   @:noCompletion


### PR DESCRIPTION
## Linked Issues
Maybe fixes #6059 if HID detection isn't also part of the issue.
## Description
Adds hardware keyboard detection for Android, since the way it detected a keyboard before was by checking how many controllers were connected, keyboards were also considered controllers for some reason and that was fixed for Android only apparently which broke stuff.

This is my first time working with Android API and JNI stuff so please do tell me if this is the proper way to implement it.

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos

https://github.com/user-attachments/assets/5498487d-bd75-44c5-bc4c-79f0c939db26

