### PR TITLE
[BUGFIX] Fix icons snapping away for one frame on song restart

### DIFF
--- a/source/funkin/play/components/HealthIcon.hx
+++ b/source/funkin/play/components/HealthIcon.hx
@@ -193,6 +193,7 @@ class HealthIcon extends FunkinSprite
       this.size.set(1.0, 1.0);
       this.iconOffset.set();
       this.flipX = false;
+      this.updatePosition();
     }
     else
     {
@@ -212,6 +213,7 @@ class HealthIcon extends FunkinSprite
       }
 
       this.flipX = data.flipX ?? false; // Face the OTHER way by default, since that is more common.
+      this.updatePosition();
     }
   }
 


### PR DESCRIPTION
<!-- Briefly describe the issue(s) fixed. -->
## Description
Fixed health icons position not setting when restarting song.

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos
Bug I Fixed:

https://github.com/user-attachments/assets/0d47b35c-213c-4376-a901-6e424154e4a8

