### PR TITLE
[OPTIMIZATION?] Don't process killed notes

### DIFF
--- a/source/funkin/play/PlayState.hx
+++ b/source/funkin/play/PlayState.hx
@@ -2700,7 +2700,7 @@ class PlayState extends MusicBeatSubState
     // Process notes on the opponent's side.
     for (note in opponentStrumline.notes.members)
     {
-      if (note == null) continue;
+      if (note == null || !note.alive) continue;
       var r = GRhythmUtil.processWindow(note, false);
       if (r.botplayHit)
       {
@@ -2750,7 +2750,7 @@ class PlayState extends MusicBeatSubState
     // Process notes on the player's side.
     for (note in playerStrumline.notes.members)
     {
-      if (note == null) continue;
+      if (note == null || !note.alive) continue;
       var r = GRhythmUtil.processWindow(note, !isBotPlayMode);
       if (r.botplayHit)
       {


### PR DESCRIPTION
## Description
A tiny optimization I guess? Skips calculating all the hit window stuff for notes that were killed.
<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos
Not applicable since the gameplay doesn't change... and probably not performance either.