### PR TITLE
[ENHANCEMENT] Implement animation priority

### DIFF
--- a/source/funkin/data/character/CharacterData.hx
+++ b/source/funkin/data/character/CharacterData.hx
@@ -523,6 +523,12 @@ class CharacterDataParser
       input.startingAnimation = DEFAULT_STARTINGANIM;
     }
 
+    if (input.animPriorityQueue == null)
+    {
+      var canDance:Bool = [for (a in input.animations) a.name].contains("danceLeft");
+      input.animPriorityQueue = ["sing*", (canDance ? "dance*" : "idle")];
+    }
+
     if (input.scale == null)
     {
       input.scale = DEFAULT_SCALE;
@@ -559,7 +565,7 @@ class CharacterDataParser
       input.flipX = DEFAULT_FLIPX;
     }
 
-    if (input.animations.length == 0 && input.startingAnimation != null)
+    if (input.animations.length == 0 && (input.startingAnimation != null || input.animPriorityQueue != null))
     {
       return null;
     }
@@ -726,6 +732,12 @@ typedef CharacterData =
    * @default idle
    */
   var startingAnimation:Null<String>;
+
+  /**
+   * If animations are used, place them here to have some sort of priority queue.
+   * For example a queue ["sing*", "idle"] would have all animations starting with "sing" on a higher priority than idling.
+   */
+  var animPriorityQueue:Null<Array<String>>;
 
   /**
    * Whether or not the whole ass sprite is flipped by default.

--- a/source/funkin/play/character/AnimateAtlasCharacter.hx
+++ b/source/funkin/play/character/AnimateAtlasCharacter.hx
@@ -176,7 +176,8 @@ class AnimateAtlasCharacter extends BaseCharacter
 
     this.mainSprite = sprite;
 
-    mainSprite.ignoreExclusionPref = ["sing"];
+    var canDance:Bool = this.hasAnimation("danceLeft");
+    mainSprite.animPriorityQueue = _data.animPriorityQueue ?? ["sing*", (canDance ? "dance*" : "idle")];
 
     // This forces the atlas to recalcuate its width and height
     this.mainSprite.alpha = 0.0001;

--- a/source/funkin/play/character/BaseCharacter.hx
+++ b/source/funkin/play/character/BaseCharacter.hx
@@ -160,8 +160,6 @@ class BaseCharacter extends Bopper
 
     this.characterId = id;
 
-    ignoreExclusionPref = ["sing"];
-
     _data = CharacterDataParser.fetchCharacterData(this.characterId);
     if (_data == null)
     {
@@ -179,6 +177,9 @@ class BaseCharacter extends Bopper
       this.singTimeSteps = _data.singTime;
       this.globalOffsets = _data.offsets;
       this.flipX = _data.flipX;
+
+      var canDance:Bool = this.hasAnimation("danceLeft");
+      this.animPriorityQueue = _data.animPriorityQueue ?? ["sing*", (canDance ? "dance*" : "idle")];
     }
 
     shouldBop = false;


### PR DESCRIPTION
## Linked Issues
True... or False... call it.

## Description
Characters had a very weird implementation of animation priority. Singing was set to have the highest priority, despite not even being set to ignore other animations, overriding any other animation that may play instead. It was a mess.
This PR introduces a json-configurable animation priority system, which should hopefully make the animations a lot more consistent. The new system supports adding asterisks to animations, in case multiple animations should have the same priority. Any animation that isn't in the configurable array assumes the index of -1 and therefore has the highest priority. The default animation priority queue is `["sing*", "idle"]` or `["sing*", "dance*"]`, meaning that sing and miss animations should happen before the idling animation(s).

> [!CAUTION]
> This is a breaking change for mods using `ignoreExclusionPref`, as well as for the base game scripts using it! I've opened a PR in the assets repo (https://github.com/FunkinCrew/funkin.assets/pull/295) that should be merged as well so that there's no script errors being thrown on the screen for every character initialization.

## Screenshots/Videos

https://github.com/user-attachments/assets/fc007340-6d34-4630-a975-d9084fc9d64e
