### PR TITLE
[ENHANCEMENT] resolveClass (Sandboxed) for ReflectUtil

### DIFF
--- a/source/funkin/util/ReflectUtil.hx
+++ b/source/funkin/util/ReflectUtil.hx
@@ -325,7 +325,8 @@ class ReflectUtil
   public static function resolveClass(name:String):Class<Any>
   {
     var className = name;
-    if (PolymodScriptClass.importOverrides.exists(className)) {
+    if (PolymodScriptClass.importOverrides.exists(className))
+    {
       if (PolymodScriptClass.importOverrides.get(className) == null) throw 'Class $className is blacklisted.';
       var cls = cast PolymodScriptClass.importOverrides.get(className);
       className = Type.getClassName(cls);


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
https://github.com/FunkinCrew/Funkin/issues/6369

<!-- Briefly describe the issue(s) fixed. -->
## Description
Adds a sandboxed version of Reflect's `resolveClass` function to ReflectUtil, allowing modders to use classes without importing them for the whole script.
The sandboxed `resolveClass` throws an error when trying to resolve a blacklisted class and uses the sandboxed/aliased versions for other classes if defined.