### PR TITLE
[BUGFIX] Fix animation editor frame outlines being improperly generated for multisparrow characters

### DIFF
--- a/source/funkin/play/character/MultiSparrowCharacter.hx
+++ b/source/funkin/play/character/MultiSparrowCharacter.hx
@@ -2,6 +2,7 @@ package funkin.play.character;
 
 import flixel.graphics.frames.FlxAtlasFrames;
 import flixel.graphics.frames.FlxFramesCollection;
+import flixel.graphics.FlxGraphic;
 import funkin.modding.events.ScriptEvent;
 import funkin.util.assets.FlxAnimationUtil;
 import funkin.data.character.CharacterData.CharacterRenderType;
@@ -19,6 +20,8 @@ import funkin.data.character.CharacterData.CharacterRenderType;
  */
 class MultiSparrowCharacter extends BaseCharacter
 {
+  var frameBase:Null<FlxGraphic> = null;
+
   public function new(id:String)
   {
     super(id, CharacterRenderType.MultiSparrow);
@@ -58,7 +61,7 @@ class MultiSparrowCharacter extends BaseCharacter
   {
     trace('Loading assets for Multi-Sparrow character "${characterId}"', flixel.util.FlxColor.fromString("#89CFF0"));
 
-    var assetList = [];
+    var assetList:Array<String> = [_data.assetPath];
     for (anim in _data.animations)
     {
       if (anim.assetPath != null && !assetList.contains(anim.assetPath))
@@ -67,7 +70,18 @@ class MultiSparrowCharacter extends BaseCharacter
       }
     }
 
-    var texture:FlxAtlasFrames = Paths.getSparrowAtlas(_data.assetPath);
+    // Forcefully create a new FlxAtlasFrames collection so that we don't add to the same FlxAtlasFrames instance.
+    var texture:Null<FlxAtlasFrames> = null;
+
+    if (frameBase == null)
+    {
+      frameBase = FlxGraphic.fromAssetKey(Paths.image(_data.assetPath), true, this.characterId, true);
+    }
+
+    if (frameBase != null)
+    {
+      texture = new FlxAtlasFrames(frameBase);
+    }
 
     if (texture == null)
     {

--- a/source/funkin/ui/debug/anim/DebugBoundingState.hx
+++ b/source/funkin/ui/debug/anim/DebugBoundingState.hx
@@ -531,7 +531,16 @@ class DebugBoundingState extends FlxState
       trace('ERROR: Failed to load character ${char}!');
     }
 
-    generateOutlines(swagChar.frames.frames);
+    // For multisparrow render types, only generate the outlines for the main spritesheet.
+    if (swagChar._data.renderType == "multisparrow")
+    {
+      generateOutlines(Paths.getSparrowAtlas(swagChar._data.assetPath).frames);
+    }
+    else
+    {
+      generateOutlines(swagChar.frames.frames);
+    }
+
     bf.pixels = swagChar.pixels;
 
     clearInfo();


### PR DESCRIPTION
## Linked Issues
None that I can think of.

## Description
The animation editor uses the character's frames to generate the outline data. This works great most of the time, however for multisparrow characters, it can lead to generating the frame outlines for frames that aren't on the main spritesheet, considering the frames get appended to the character's frame collection.
The PR fixes it by forcefully creating a new frame collection instance for multisparrow characters (since Flixel reuses the frame collection instances, even if it has appended frames from other frame collections).

The memory usage shouldn't in theory be horrible, however if you find a better solution, let me know.

## Screenshots/Videos
Pico (Playable) Before:
<img width="1382" height="749" alt="image" src="https://github.com/user-attachments/assets/aea4a72f-2bff-4a69-a0bd-52c7573a52c2" />

Pico (Playable) After:
<img width="1031" height="554" alt="image" src="https://github.com/user-attachments/assets/63f7cec3-35af-4825-b69a-eab7ded1c25f" />

