### PR TITLE
[POLISH] Fix double hold note confirm animations / small StrumlineNote rewrite

### DIFF
--- a/source/funkin/play/notes/Strumline.hx
+++ b/source/funkin/play/notes/Strumline.hx
@@ -724,7 +724,7 @@ class Strumline extends FlxSpriteGroup
       else if (conductorInUse.songPosition > holdNote.strumTime && holdNote.hitNote)
       {
         // Hold note is currently being hit, clip it off.
-        holdConfirm(holdNote.noteDirection);
+        holdConfirm(holdNote.noteDirection, holdNote.fullSustainLength);
         holdNote.visible = true;
 
         holdNote.sustainLength = (holdNote.strumTime + holdNote.fullSustainLength) - conductorInUse.songPosition;
@@ -1054,9 +1054,9 @@ class Strumline extends FlxSpriteGroup
    * Play a confirm animation for a hold note.
    * @param direction The direction of the note to play the confirm animation for.
    */
-  public function holdConfirm(direction:NoteDirection):Void
+  public function holdConfirm(direction:NoteDirection, ?length:Float = 0):Void
   {
-    getByDirection(direction).holdConfirm();
+    getByDirection(direction).holdConfirm(length / 1000);
 
     if (isPlayer) noteVibrations.noteStatuses[direction] = NoteStatus.holdConfirm;
   }

--- a/source/funkin/play/notes/StrumlineNote.hx
+++ b/source/funkin/play/notes/StrumlineNote.hx
@@ -42,6 +42,8 @@ class StrumlineNote extends FunkinSprite
    */
   static final CONFIRM_HOLD_TIME:Float = 0.15;
 
+  static final DEFAULT_OFFSET:Int = 13;
+
   /**
    * How long the hold note animation has been playing after a note is pressed.
    */
@@ -73,9 +75,9 @@ class StrumlineNote extends FunkinSprite
   {
     // Run a timer before we stop playing the confirm animation.
     // On player, this allows holding the confirm key to fall back to press.
-    if (isPlayer && name == 'confirm')
+    if (isPlayer && name == 'confirm' && !holding)
     {
-      confirmHoldTimer = 0;
+      confirmHoldTimer = CONFIRM_HOLD_TIME;
     }
   }
 
@@ -85,15 +87,16 @@ class StrumlineNote extends FunkinSprite
 
     centerOrigin();
 
-    if (confirmHoldTimer >= 0)
+    if (confirmHoldTimer > 0)
     {
-      confirmHoldTimer += elapsed;
+      confirmHoldTimer -= elapsed;
 
       // Ensure the opponent stops holding the key after a certain amount of time.
-      if (confirmHoldTimer >= CONFIRM_HOLD_TIME)
+      if (confirmHoldTimer <= 0)
       {
         confirmHoldTimer = -1;
         playStatic();
+        holding = false;
       }
     }
   }
@@ -145,7 +148,8 @@ class StrumlineNote extends FunkinSprite
 
     // On opponent, run a timer to stop playing the confirm animation.
     // On player, stop the timer to avoid stopping the confirm animation earlier.
-    confirmHoldTimer = isPlayer ? -1 : 0;
+    confirmHoldTimer = isPlayer ? -1 : CONFIRM_HOLD_TIME;
+    holding = false;
   }
 
   public function isConfirm():Bool
@@ -153,29 +157,34 @@ class StrumlineNote extends FunkinSprite
     return getCurrentAnimation().startsWith('confirm');
   }
 
-  public function holdConfirm():Void
+  public var holding:Bool = false;
+
+  public function holdConfirm(?length:Float = 0):Void
   {
     this.active = true;
 
-    if (getCurrentAnimation() == "confirm-hold")
+    if (holding) return;
+
+    this.confirmHoldTimer = isPlayer ? -1 : Math.max(length, CONFIRM_HOLD_TIME);
+
+    if ((getCurrentAnimation() == 'confirm' && isAnimationFinished()) || !gotCorrectConfirmHoldAnimation()) holding = true;
+
+    if (holding)
     {
-      return;
-    }
-    else if (getCurrentAnimation() == "confirm")
-    {
-      if (isAnimationFinished())
+      if (gotCorrectConfirmHoldAnimation())
       {
-        this.confirmHoldTimer = -1;
         this.playAnimation('confirm-hold', false, false);
       }
-    }
-    else
-    {
-      this.playAnimation('confirm', false, false);
+      else
+      {
+        // Commented out, since it will spam this trace in console on every hold note with default notestlyes lol.
+        // trace('[WARN] Incorrect data for `confirm-hold` animation!');
+      }
     }
   }
 
-  static final DEFAULT_OFFSET:Int = 13;
+  private inline function gotCorrectConfirmHoldAnimation():Bool
+    return animation?.getByName("confirm-hold")?.looped ?? false;
 
   /**
    * Adjusts the position of the sprite's graphic relative to the hitbox.


### PR DESCRIPTION
## Linked Issues
#6379 

## Description
I slightly rewrote StrumlineNote to run confirm-hold animation, only if there's correct data is present for that animation. (if it not looped)
Otherwise we just hold last frame of confirm animation 😁 

Also added `holding` variable to prevent unnecessary actions.

## Screenshots/Videos
Before:
![before](https://github.com/user-attachments/assets/f221db2c-5d0d-4fe4-93bc-9a0e116c8993)

After:
![Funkin_FhA7lWSvWT](https://github.com/user-attachments/assets/1394b6ec-d7c8-4354-81dd-4106eabf0b0f)

