### PR TITLE
[BUGFIX] Fix Old Icon Being Flipped Incorrectly For Flipped Icons

### DIFF
--- a/source/funkin/play/components/HealthIcon.hx
+++ b/source/funkin/play/components/HealthIcon.hx
@@ -171,6 +171,7 @@ class HealthIcon extends FunkinSprite
     {
       characterId = 'bf-old';
       isPixel = false;
+      flipX = true;
       loadCharacter(characterId);
     }
 


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
None

<!-- Briefly describe the issue(s) fixed. -->
## Description
In the game, having it so that the player health icon is flipped makes it so that the old icon is flipped incorrectly. This PR (of course) fixes this by setting `flipX` to true for the old icon (because player icons are normally flipped). Yes, the icon does properly go back to how it was before if you were to change the icon back.

I probably made this sound confusing, but to help explain what I mean, characters can have `healthIcon` data where you can have `flipX` set to true, but for the player, having it set to true really means false.

<img width="227" height="145" alt="Screenshot 2025-11-02 153534" src="https://github.com/user-attachments/assets/cdd293fd-844d-4993-8d0f-b180ac657eeb" />

<img width="225" height="136" alt="Screenshot 2025-11-02 154048" src="https://github.com/user-attachments/assets/20ba30b3-b686-456b-8fef-26db848fd1da" />

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos

FNF if it was good... or if you're playing the game with this PR:
<img width="250" height="165" alt="Screenshot 2025-11-02 153514" src="https://github.com/user-attachments/assets/4147810b-a71b-4b33-8955-95e518865e99" />

My organs failed trying to explain this. "Flipped" was used way too much in the making of this PR.