### PR TITLE
[FIX] `FileUtil#sanitizePath` not working correctly on Linux

### DIFF
--- a/source/funkin/util/FileUtil.hx
+++ b/source/funkin/util/FileUtil.hx
@@ -60,7 +60,7 @@ class FileUtil
    */
   public static var PROTECTED_PATHS(get, never):Array<String>;
 
-  public static function get_PROTECTED_PATHS():Array<String>
+  static function get_PROTECTED_PATHS():Array<String>
   {
     final protected:Array<String> = [
       '',
@@ -85,7 +85,8 @@ class FileUtil
     #if sys
     for (i in 0...protected.length)
     {
-      protected[i] = sys.FileSystem.fullPath(Path.join([gameDirectory, protected[i]]));
+      // On Linux 'fullPath' just makes most of these null which actually just makes the paths unprotected
+      protected[i] = #if !linux sys.FileSystem.fullPath #end (Path.join([gameDirectory, protected[i]]));
     }
     #end
 
@@ -1336,8 +1337,26 @@ class FileUtilSandboxed
 
     #if sys
     // TODO: figure out how to get "real" path of symlinked paths
-    final realPath:String = sys.FileSystem.fullPath(Path.join([FileUtil.gameDirectory, sanitized.join('/')]));
-    if (!realPath.startsWith(FileUtil.gameDirectory))
+    #if linux
+    // The implementation on Linux fails if the path doesn't exist
+    var realPath:Null<String> = null;
+    var unresolvedSegments:Array<String> = [];
+    while (realPath == null && sanitized.length > 0)
+    {
+      realPath = sys.FileSystem.fullPath(Path.join([FileUtil.gameDirectory].concat(sanitized)));
+      if (realPath == null) unresolvedSegments.unshift(sanitized.pop() ?? continue);
+    }
+
+    if (unresolvedSegments.length > 0)
+    {
+      if (realPath != null) unresolvedSegments.unshift(realPath);
+      realPath = Path.join(unresolvedSegments);
+    }
+    #else
+    final realPath:Null<String> = sys.FileSystem.fullPath(Path.join([FileUtil.gameDirectory].concat(sanitized)));
+    #end
+
+    if (realPath == null || !realPath.startsWith(FileUtil.gameDirectory))
     {
       return FileUtil.gameDirectory;
     }


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
None, though it came from [this report of a mod failing to create a file on Linux on the Discord server](https://discord.com/channels/1419268615605325907/1430187336846671963/1434513191173623829)
<!-- Briefly describe the issue(s) fixed. -->
## Description
There's some inconsistency with how `fullPath` which is used by `sanitizePath` works on Linux and Windows, on the former it will return null if the path doesn't exist and on the latter it'll work regardless, ironic considering that the [documentation for the function in HXCPP implies it should work like Linux in that case](https://github.com/HaxeFoundation/hxcpp/blob/1618253d7bb2dd8eea1bc7ffcd612452df76a7b7/src/hx/libs/std/Sys.cpp#L744-L747). 
The fact it returns null means that on Linux using functions like `FileUtil.writeStringToPath` would fail on most cases.
<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos
[Kooha-2025-11-02-23-06-44.webm](https://github.com/user-attachments/assets/eef87a20-c832-47c3-ab07-94cd67e3240b)
