### PR TITLE
[BUGFIX] Fix Missing Album Title Asset Showing Flixel Logo

### DIFF
--- a/source/funkin/ui/freeplay/AlbumRoll.hx
+++ b/source/funkin/ui/freeplay/AlbumRoll.hx
@@ -183,7 +183,7 @@ class AlbumRoll extends FlxSpriteGroup
 
   public function showTitle():Void
   {
-    if (albumTitle != null) albumTitle.visible = true;
+    if (albumTitle != null && albumTitle.frames != null) albumTitle.visible = true;
   }
 
   public function buildAlbumTitle(assetKey:String, ?titleOffsets:Null<Array<Float>>):Void


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Briefly describe the issue(s) fixed. -->
## Description

When having an album that doesn't have a title asset, the Flixel logo appears and this PR is good enough to solve that problem. Just know that the logo disappears when reselecting the song after selecting a different song with a different album, but that shouldn't matter because like I said, this PR prevents the logo from appearing.

Also, this is not a problem with the actual album art as albums have a fallback for when its art is missing.

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos

Before:
<img width="1280" height="720" alt="screenshot-2025-11-11-20-10-12" src="https://github.com/user-attachments/assets/455f723b-471a-48d0-913d-8772ae8107fb" />

After:
<img width="1280" height="720" alt="screenshot-2025-11-11-20-17-05" src="https://github.com/user-attachments/assets/43e99e41-db68-4965-8c25-8118a8621fde" />