### PR TITLE
[ENHANCEMENT] Provide Import Aliases for Typedefs

### DIFF
--- a/source/funkin/modding/PolymodHandler.hx
+++ b/source/funkin/modding/PolymodHandler.hx
@@ -21,6 +21,7 @@ import funkin.util.FileUtil;
 import funkin.util.macro.ClassMacro;
 import polymod.backends.PolymodAssets.PolymodAssetType;
 import polymod.format.ParseRules.TextFileFormat;
+import polymod.hscript._internal.PolymodScriptClass;
 import polymod.Polymod;
 
 /**
@@ -387,7 +388,7 @@ class PolymodHandler
     {
       if (cls == null) continue;
       var className:String = Type.getClassName(cls);
-      if (polymod.hscript._internal.PolymodScriptClass.importOverrides.exists(className)) continue;
+      if (PolymodScriptClass.importOverrides.exists(className)) continue;
       Polymod.blacklistImport(className);
     }
 
@@ -450,6 +451,16 @@ class PolymodHandler
     Polymod.blacklistImport('funkin.external.android.CallbackUtil');
     Polymod.blacklistImport('funkin.external.android.DataFolderUtil');
     Polymod.blacklistImport('funkin.external.android.JNIUtil');
+
+    // Add import aliases for Typedefs that extend classes and abstracts like FlxSpriteGroup or FlxSignal.
+    // Doing this last so that we don't set an alias for an already blacklisted import.
+    for (name => cls in ClassMacro.listTypedefWrappers())
+    {
+      if (PolymodScriptClass.importOverrides.exists(name)) continue;
+
+      var resolvedCls:Class<Dynamic> = Type.resolveClass(cls);
+      Polymod.addImportAlias(name, resolvedCls);
+    }
   }
 
   /**

--- a/source/funkin/util/macro/CompiledClassList.hx
+++ b/source/funkin/util/macro/CompiledClassList.hx
@@ -11,6 +11,7 @@ using funkin.util.AnsiUtil;
 class CompiledClassList
 {
   static var classLists:Map<String, List<Class<Dynamic>>> = [];
+  static var typedefWrappers:Map<String, String> = [];
   static var initialized:Bool = false;
 
   /**
@@ -24,7 +25,7 @@ class CompiledClassList
     // Meta.getType returns Dynamic<Array<Dynamic>>.
     var metaData = Meta.getType(CompiledClassList);
 
-    if (metaData.classLists != null)
+    if (metaData.classLists != null && metaData.typedefList != null)
     {
       for (list in metaData.classLists)
       {
@@ -44,6 +45,14 @@ class CompiledClassList
         }
 
         classLists.set(id, classes);
+      }
+
+      for (list in metaData.typedefList)
+      {
+        var data:Array<String> = cast list;
+
+        // The first element is the wrapper name, whereas the second is the wrapper class behind it.
+        typedefWrappers.set(data[0], data[1]);
       }
     }
     else
@@ -65,6 +74,12 @@ class CompiledClassList
     // A faulty request sets the value to an empty list above so this will never be null
     @:nullSafety(Off)
     return classLists.get(request);
+  }
+
+  public static function getTypedefWrappers():Map<String, String>
+  {
+    if (!initialized) init();
+    return typedefWrappers;
   }
 
   public static inline function getTyped<T>(request:String, type:Class<T>):List<Class<T>>


### PR DESCRIPTION
## Linked Issues
No, sire, none at all.

## Description
This PR adds more functionality to ClassMacro - using it to list all typedefs and store them and their underlying class into a map to then be added as an import alias for HScript.
This works for both typedefs that point to a class (such as FlxSpriteGroup) and typedefs that point to an abstract of a class (such as FlxSignal).

If you're wondering why I'm comparing string versions of parameters instead of their regular enum selves, refer to this screenshot: 
<img width="1342" height="469" alt="image" src="https://github.com/user-attachments/assets/08c19b64-c772-4e24-a603-c8999eb36079" />
As you can see, Type.enumEq returns false despite the two parameters being literally the exact same. Macros are infuriating.

## Screenshots/Videos
<img width="1039" height="251" alt="image" src="https://github.com/user-attachments/assets/48c1f850-e789-4799-990f-5219ffa6e80e" />