### PR TITLE
[ENHANCEMENT] Move the Chart Editor Notifications Up a Bit

### DIFF
--- a/source/funkin/ui/debug/charting/handlers/ChartEditorNotificationHandler.hx
+++ b/source/funkin/ui/debug/charting/handlers/ChartEditorNotificationHandler.hx
@@ -1,8 +1,10 @@
 package funkin.ui.debug.charting.handlers;
 
 #if FEATURE_CHART_EDITOR
+import haxe.ui.animation.AnimationBuilder;
 import haxe.ui.components.Button;
 import haxe.ui.containers.HBox;
+import haxe.ui.core.Screen;
 import haxe.ui.notifications.Notification;
 import haxe.ui.notifications.NotificationManager;
 import haxe.ui.notifications.NotificationType;
@@ -15,6 +17,35 @@ class ChartEditorNotificationHandler
     // Setup notifications.
     @:privateAccess
     NotificationManager.GUTTER_SIZE = 45;
+
+    NotificationManager.instance.animationFn = AnimateFromBottom;
+  }
+
+  // since GUTTER_SIZE affects both x and y, we'll replace the positioning with this!
+  // for some reason the first notif always has a downwards offset of like 10 and idk how to fix that
+  // that was also a problem before this
+  public static function AnimateFromBottom(notifications:Array<Notification>):Array<AnimationBuilder>
+  {
+    var builders = [];
+
+    var scy = Screen.instance.height;
+    var baselineY = scy - 65;
+
+    for (notification in notifications)
+    {
+      var builder = new AnimationBuilder(notification);
+      builder.setPosition(0, "top", Std.int(notification.top), true);
+      builder.setPosition(100, "top", Std.int(baselineY - notification.height), true);
+      if (notification.opacity == 0)
+      {
+        builder.setPosition(0, "opacity", 0, true);
+        builder.setPosition(100, "opacity", 1, true);
+      }
+      builders.push(builder);
+      baselineY -= (notification.height + @:privateAccess NotificationManager.SPACING);
+    }
+
+    return builders;
   }
 
   /**


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
#6436 

<!-- Briefly describe the issue(s) fixed. -->
## Description
Now the notifications have been moved up! It does this by setting `NotificationManager`'s `AnimateFromBottom` field to a cutsom version that doesn't use the `GUTTER_SIZE` variable.

There's probably a better place to put the redefintion of `AnimateFromBottom` and might be a bit overboard with an entire redefine, but oh well, it works!

> [!NOTE]
> For some reason, the first notification to ever pop up is always off by about 10, but that was a thing before this PR.

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos

https://github.com/user-attachments/assets/9b873172-0a7d-43d1-8cd2-359d65de201e

