### PR TITLE
[BUGFIX] Replace wrong PRESSED checks with JUST_PRESSED checks

### DIFF
--- a/source/funkin/play/GameOverSubState.hx
+++ b/source/funkin/play/GameOverSubState.hx
@@ -273,7 +273,7 @@ class GameOverSubState extends MusicBeatSubState
     //
 
     // Restart the level when pressing the assigned key.
-    if ((controls.ACCEPT #if mobile || (TouchUtil.pressAction() && !TouchUtil.overlaps(backButton) && canInput) #end)
+    if ((controls.ACCEPT_P #if mobile || (TouchUtil.pressAction() && !TouchUtil.overlaps(backButton) && canInput) #end)
       && blueballed
       && !mustNotExit)
     {
@@ -281,7 +281,7 @@ class GameOverSubState extends MusicBeatSubState
       confirmDeath();
     }
 
-    if (controls.BACK && !mustNotExit && !isEnding) goBack();
+    if (controls.BACK_P && !mustNotExit && !isEnding) goBack();
 
     if (gameOverMusic != null && gameOverMusic.playing)
     {

--- a/source/funkin/play/GitarooPause.hx
+++ b/source/funkin/play/GitarooPause.hx
@@ -76,7 +76,7 @@ class GitarooPause extends MusicBeatState
   {
     if (controls.UI_LEFT_P || controls.UI_RIGHT_P #if mobile || SwipeUtil.justSwipedLeft || SwipeUtil.justSwipedRight #end) changeThing();
 
-    if (controls.ACCEPT #if mobile || checkSelectionPress() #end)
+    if (controls.ACCEPT_P #if mobile || checkSelectionPress() #end)
     {
       if (replaySelect)
       {

--- a/source/funkin/play/PlayState.hx
+++ b/source/funkin/play/PlayState.hx
@@ -3309,7 +3309,7 @@ class PlayState extends MusicBeatSubState
       {
         currentConversation.advanceConversation();
       }
-      else if ((controls.PAUSE || androidPause || pauseButtonCheck) && !justUnpaused)
+      else if ((controls.PAUSE_P || androidPause || pauseButtonCheck) && !justUnpaused)
       {
         pause(Conversation);
       }
@@ -3317,7 +3317,7 @@ class PlayState extends MusicBeatSubState
     else if (VideoCutscene.isPlaying())
     {
       // This is a video cutscene.
-      if ((controls.PAUSE || androidPause || pauseButtonCheck) && !justUnpaused)
+      if ((controls.PAUSE_P || androidPause || pauseButtonCheck) && !justUnpaused)
       {
         pause(Cutscene);
       }

--- a/source/funkin/play/ResultState.hx
+++ b/source/funkin/play/ResultState.hx
@@ -774,7 +774,7 @@ class ResultState extends MusicBeatSubState
       }
     }
 
-    if (controls.PAUSE || controls.ACCEPT #if mobile || TouchUtil.pressAction() #end)
+    if (controls.PAUSE_P || controls.ACCEPT_P #if mobile || TouchUtil.pressAction() #end)
     {
       if (busy) return;
       if (_parentState is funkin.ui.debug.results.ResultsDebugSubState)

--- a/source/funkin/ui/Page.hx
+++ b/source/funkin/ui/Page.hx
@@ -48,7 +48,7 @@ class Page<T:PageName> extends FlxGroup
 
   function updateEnabled(elapsed:Float)
   {
-    if (canExit && controls.BACK)
+    if (canExit && controls.BACK_P)
     {
       exit();
       FunkinSound.playOnce(Paths.sound('cancelMenu'));

--- a/source/funkin/ui/charSelect/CharSelectSubState.hx
+++ b/source/funkin/ui/charSelect/CharSelectSubState.hx
@@ -898,7 +898,7 @@ class CharSelectSubState extends MusicBeatSubState
         selectSound.play(true);
       }
 
-      if (controls.BACK) goBack();
+      if (controls.BACK_P) goBack();
     }
 
     if (cursorX < -1)
@@ -924,7 +924,7 @@ class CharSelectSubState extends MusicBeatSubState
       var charId:String = availableChars.get(getCurrentSelected()) ?? Constants.DEFAULT_CHARACTER;
       if (charId != null) curChar = charId;
 
-      if (allowInput && pressedSelect && (controls.BACK #if FEATURE_TOUCH_CONTROLS || (mobileDeny && TouchUtil.justReleased) #end))
+      if (allowInput && pressedSelect && (controls.BACK_P #if FEATURE_TOUCH_CONTROLS || (mobileDeny && TouchUtil.justReleased) #end))
       {
         mobileDeny = false;
         cursorConfirmed.visible = false;
@@ -960,7 +960,7 @@ class CharSelectSubState extends MusicBeatSubState
         selectTimer.cancel();
       }
 
-      if (allowInput && !pressedSelect && (controls.ACCEPT || mobileAccept))
+      if (allowInput && !pressedSelect && (controls.ACCEPT_P || mobileAccept))
       {
         mobileDeny = false;
         spamUp = false;
@@ -1006,7 +1006,7 @@ class CharSelectSubState extends MusicBeatSubState
 
       gfChill.visible = false;
 
-      if (allowInput && (controls.ACCEPT || mobileAccept))
+      if (allowInput && (controls.ACCEPT_P || mobileAccept))
       {
         cursorDenied.visible = true;
 
@@ -1166,7 +1166,7 @@ class CharSelectSubState extends MusicBeatSubState
               case "idle":
                 lock.anim.play("selected");
               case "selected" | "clicked":
-                if (controls.ACCEPT) lock.anim.play("clicked", true);
+                if (controls.ACCEPT_P) lock.anim.play("clicked", true);
             }
           }
           else

--- a/source/funkin/ui/charSelect/CharacterUnlockState.hx
+++ b/source/funkin/ui/charSelect/CharacterUnlockState.hx
@@ -115,7 +115,7 @@ class CharacterUnlockState extends MusicBeatState
   {
     super.update(elapsed);
 
-    if (controls.ACCEPT || controls.BACK #if mobile || TouchUtil.pressAction() #end && !busy)
+    if (controls.ACCEPT_P || controls.BACK_P #if mobile || TouchUtil.pressAction() #end && !busy)
     {
       busy = true;
       startClose();

--- a/source/funkin/ui/credits/CreditsState.hx
+++ b/source/funkin/ui/credits/CreditsState.hx
@@ -285,7 +285,7 @@ class CreditsState extends MusicBeatState
         creditsGroup.y -= CREDITS_SCROLL_BASE_SPEED * elapsed;
       }
     }
-    if (controls.BACK || hasEnded())
+    if (controls.BACK_P || hasEnded())
     {
       exit();
     }

--- a/source/funkin/ui/debug/DebugMenuSubState.hx
+++ b/source/funkin/ui/debug/DebugMenuSubState.hx
@@ -87,7 +87,7 @@ class DebugMenuSubState extends MusicBeatSubState
   {
     super.update(elapsed);
 
-    if (controls.BACK)
+    if (controls.BACK_P)
     {
       FunkinSound.playOnce(Paths.sound('cancelMenu'));
       exitDebugMenu();

--- a/source/funkin/ui/freeplay/CapsuleOptionsMenu.hx
+++ b/source/funkin/ui/freeplay/CapsuleOptionsMenu.hx
@@ -78,7 +78,7 @@ class CapsuleOptionsMenu extends FlxSpriteGroup
     if (!busy)
     {
       @:privateAccess
-      if (parent.controls.BACK #if mobile || TouchUtil.pressAction(parent.backButton) #end)
+      if (parent.controls.BACK_P #if mobile || TouchUtil.pressAction(parent.backButton) #end)
       {
         close();
         return;
@@ -95,7 +95,7 @@ class CapsuleOptionsMenu extends FlxSpriteGroup
         changedInst = true;
       }
       if (parent.getControls()
-        .ACCEPT #if mobile
+        .ACCEPT_P #if mobile
         || ((TouchUtil.pressAction(currentInstrumental))
           && !(TouchUtil.overlapsComplex(leftArrow) || TouchUtil.overlapsComplex(rightArrow))) #end)
       {

--- a/source/funkin/ui/freeplay/FreeplayState.hx
+++ b/source/funkin/ui/freeplay/FreeplayState.hx
@@ -1764,12 +1764,12 @@ class FreeplayState extends MusicBeatSubState
     }
     #end
 
-    if (controls.BACK)
+    if (controls.BACK_P)
     {
       goBack();
     }
 
-    if (controls.ACCEPT && controls.active)
+    if (controls.ACCEPT_P && controls.active)
     {
       currentCapsule.onConfirm();
     }

--- a/source/funkin/ui/options/OffsetMenu.hx
+++ b/source/funkin/ui/options/OffsetMenu.hx
@@ -606,7 +606,7 @@ class OffsetMenu extends Page<OptionsState.OptionsMenuPageName>
     _lastTime = FlxG.sound.music.time;
 
     // Back logic
-    if (controls.BACK && shouldOffset == 1)
+    if (controls.BACK_P && shouldOffset == 1)
     {
       exitCalibration(true);
       return;
@@ -853,7 +853,7 @@ class OffsetMenu extends Page<OptionsState.OptionsMenuPageName>
 
     /*debugBeatText.x = receptor.x + receptor.width * 2;
         debugBeatText.y = receptor.y - 20;
-  
+
             debugBeatText.text = 'Beat: ' + b; */
 
     // receptor.angle += angleVel * elapsed;

--- a/source/funkin/ui/story/StoryMenuState.hx
+++ b/source/funkin/ui/story/StoryMenuState.hx
@@ -431,7 +431,7 @@ class StoryMenuState extends MusicBeatState
         }
       }
 
-      if (controls.ACCEPT)
+      if (controls.ACCEPT_P)
       {
         selectLevel();
       }
@@ -452,7 +452,7 @@ class StoryMenuState extends MusicBeatState
       #end
     }
 
-    if (controls.BACK) goBack();
+    if (controls.BACK_P) goBack();
   }
 
   /**

--- a/source/funkin/ui/transition/LoadingState.hx
+++ b/source/funkin/ui/transition/LoadingState.hx
@@ -157,7 +157,7 @@ class LoadingState extends MusicBeatSubState
     funkay.updateHitbox();
     // funkay.updateHitbox();
 
-    if (controls.ACCEPT)
+    if (controls.ACCEPT_P)
     {
       funkay.setGraphicSize(Std.int(funkay.width + 60));
       funkay.updateHitbox();


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues

#6462

<!-- Briefly describe the issue(s) fixed. -->
## Description

Funkin' has had many wrong input checks where it checks if the key is pressed (which is `true` for the entire duration the key is held down) instead of if the key was JUST pressed (which is `true` for only the first frame when the key was held down).

No idea how this wasn't an issue before, but the very simple fix is to just use the controls' actions with the `_P` suffix, to check if the key was JUST pressed.

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos

N/A
