### PR TITLE
[BUGFIX] Fix Mobile Cutout Size In Character Select

### DIFF
--- a/source/funkin/ui/charSelect/CharSelectSubState.hx
+++ b/source/funkin/ui/charSelect/CharSelectSubState.hx
@@ -102,6 +102,8 @@ class CharSelectSubState extends MusicBeatSubState
     super();
     rememberedChar = params?.character ?? "";
 
+    cutoutSize = FullScreenScaleMode.gameCutoutSize.x / 2;
+
     grpCursors = new FlxTypedGroup<FunkinSprite>();
     grpHitboxes = new FlxTypedGroup<FlxObject>();
 
@@ -168,8 +170,6 @@ class CharSelectSubState extends MusicBeatSubState
     super.create();
 
     loadAvailableCharacters();
-
-    cutoutSize = FullScreenScaleMode.gameCutoutSize.x / 2;
 
     bopInfo = FramesJSFLParser.parse(Paths.file("images/charSelect/iconBopInfo/iconBopInfo.txt"));
     if (bopInfo == null)


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Briefly describe the issue(s) fixed. -->
## Description
The new changes to the develop branch has a problem on mobile where the character select sprites aren't positioned properly. This has to do with the `cutoutSize` being initialized after things get positioned. This PR fixes that issue by moving a line up.

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos

Before:
<img width="1591" height="713" alt="Screenshot 2025-11-22 081218" src="https://github.com/user-attachments/assets/e4b1b69a-183c-4418-b0ad-3bdfc5e22845" />

After:
<img width="1582" height="702" alt="Screenshot 2025-11-22 082302" src="https://github.com/user-attachments/assets/17390b09-f337-44ac-a854-ec718026c279" />
