### PR TITLE
[BUGFIX] Fix Menu Music Not Playing After Freeplay Exit

### DIFF
--- a/source/funkin/ui/freeplay/FreeplayState.hx
+++ b/source/funkin/ui/freeplay/FreeplayState.hx
@@ -2980,6 +2980,8 @@ class FreeplayState extends MusicBeatSubState
 
     clearPreviews();
 
+    if (FlxG.sound.music != null) FlxG.sound.music.stop();
+
     if (curSelected == 0)
     {
       FunkinSound.playMusic('freeplayRandom',
@@ -3054,8 +3056,6 @@ class FreeplayState extends MusicBeatSubState
     }
 
     previewTimers = [];
-
-    if (FlxG.sound.music != null) FlxG.sound.music.stop();
   }
 
   public function switchBackingImage(?freeplaySongData:FreeplaySongData):Void


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Briefly describe the issue(s) fixed. -->
## Description

This PR fixes a problem with the latest version of the develop branch where the main menu music refuses to play. This PR solves that issue by moving the line that stops the music to where the previews are cleared when changing a song.

https://github.com/user-attachments/assets/de989ef2-5a4b-47d7-b6a5-3519a9550c8b