### PR TITLE
[OPTIMIZATION?] Copy cache maps instead of assigning

### DIFF
--- a/source/funkin/FunkinMemory.hx
+++ b/source/funkin/FunkinMemory.hx
@@ -170,7 +170,7 @@ class FunkinMemory
     graphic.persist = true;
     permanentCachedTextures.set(key, graphic);
     forceRender(graphic);
-    currentCachedTextures = permanentCachedTextures;
+    currentCachedTextures = permanentCachedTextures.copy();
   }
 
   /**
@@ -211,7 +211,7 @@ class FunkinMemory
    */
   public inline static function preparePurgeTextureCache():Void
   {
-    previousCachedTextures = currentCachedTextures;
+    previousCachedTextures = currentCachedTextures.copy();
 
     for (graphicKey in previousCachedTextures.keys())
     {
@@ -221,7 +221,7 @@ class FunkinMemory
       }
     }
 
-    currentCachedTextures = permanentCachedTextures;
+    currentCachedTextures = permanentCachedTextures.copy();
   }
 
   /**
@@ -358,7 +358,7 @@ class FunkinMemory
 
   public static function preparePurgeSoundCache():Void
   {
-    previousCachedSounds = currentCachedSounds;
+    previousCachedSounds = currentCachedSounds.copy();
 
     for (key in previousCachedSounds.keys())
     {
@@ -368,7 +368,7 @@ class FunkinMemory
       }
     }
 
-    currentCachedSounds = permanentCachedSounds;
+    currentCachedSounds = permanentCachedSounds.copy();
   }
 
   /**


### PR DESCRIPTION
## Linked Issues
N/A

## Description
Unlike other basic types, arrays and maps aren't automatically copied when you asign them to a variable.

<img width="309" height="225" alt="image" src="https://github.com/user-attachments/assets/98b67a24-25cd-4d45-bf85-5ec0a104effe" />
<img width="232" height="59" alt="image" src="https://github.com/user-attachments/assets/ddf56b7d-2eb0-4ccc-bfbb-334c5e5e2848" />

This means that in `FunkinMemory`, there are cases where permament cache maps get fully cleared, which hurts performance since the sounds/bitmaps would have to get cached again.
I can't say how much this affects performance, as this doesn't affect my computer that heavily, though what I can say is that with this the memory usage won't build up over time the more songs are played in a session, since the cache is cleared after exiting results. From my testing I've had memory usage roll back from 1gb to 0.75gb after exiting a song.

## Screenshots/Videos
N/A
