### PR TITLE
[TWEAK] Remove redundant/useless sharpness setting from infoDisplay

### DIFF
--- a/source/funkin/ui/debug/FunkinDebugDisplay.hx
+++ b/source/funkin/ui/debug/FunkinDebugDisplay.hx
@@ -143,7 +143,6 @@ class FunkinDebugDisplay extends Sprite
     infoDisplay.mouseEnabled = false;
     infoDisplay.defaultTextFormat = new TextFormat('Monsterrat', 12, color, JUSTIFY);
     infoDisplay.antiAliasType = NORMAL;
-    infoDisplay.sharpness = 100;
     infoDisplay.multiline = true;
     addChild(infoDisplay);
   }


### PR DESCRIPTION
This value only sets if you have antiAliasType as ADVANCED, which V-Slice does not.