### PR TITLE
[BUGFIX] Fix Results Screen Song Text Being Framerate Dependent

### DIFF
--- a/source/funkin/play/PlayState.hx
+++ b/source/funkin/play/PlayState.hx
@@ -811,6 +811,10 @@ class PlayState extends MusicBeatSubState
     // This state receives draw calls even when a substate is active.
     this.persistentDraw = true;
 
+    // Make the player unable to pause if they're moving from the chart editor while the focus is still on since the input persists.
+    @:privateAccess
+    justUnpaused = isChartingMode && !FlxG.game._lostFocus;
+
     // Stop any pre-existing music.
     if (!overrideMusic)
     {


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Briefly describe the issue(s) fixed. -->
## Description

This PR fixes an issue with the results screen where the song text scrolls at a speed that isn't framerate independent. This means that the text will scroll faster at a higher framerate and slower and a lower framerate, when really it should be the same scroll speed.

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos

Below are videos of what this problem looks like at 60 FPS and 200 FPS. Luckily, this PR fixes this problem!

https://github.com/user-attachments/assets/09018fff-7992-4b24-bc28-0053986d2062

https://github.com/user-attachments/assets/033ba37b-96b0-4e3c-9ee2-045c5aca3533
