### PR TITLE
[BUGFIX] Check if `iconP1` and `iconP2` is null in Minimal Mode

### DIFF
--- a/source/funkin/play/character/AnimateAtlasCharacter.hx
+++ b/source/funkin/play/character/AnimateAtlasCharacter.hx
@@ -47,13 +47,13 @@ class AnimateAtlasCharacter extends BaseCharacter
     originalSizes.set(this.width, this.height);
   }
 
-  function loadAtlas()
+  function loadAtlas():Void
   {
     trace('[ATLASCHAR] Loading sprite atlas for ${characterId}.');
     var assetLibrary:String = Paths.getLibrary(_data.assetPath);
     var assetPath:String = Paths.stripLibrary(_data.assetPath);
 
-    loadTextureAtlas(assetPath, assetLibrary, cast _data.atlasSettings);
+    loadTextureAtlas(assetPath, assetLibrary, getAtlasSettings());
 
     if (_data.isPixel)
     {
@@ -69,7 +69,7 @@ class AnimateAtlasCharacter extends BaseCharacter
     this.setScale(_data.scale);
   }
 
-  function loadAnimations()
+  function loadAnimations():Void
   {
     trace('[ATLASCHAR] Loading ${_data.animations.length} animations for ${characterId}');
 
@@ -99,5 +99,14 @@ class AnimateAtlasCharacter extends BaseCharacter
   override function get_height():Float
   {
     return originalSizes.y;
+  }
+
+  /**
+   * Get the configuration for the texture atlas.
+   * @return The configuration for the texture atlas.
+   */
+  public function getAtlasSettings():AtlasSpriteSettings
+  {
+    return cast _data.atlasSettings;
   }
 }

--- a/source/funkin/play/character/MultiAnimateAtlasCharacter.hx
+++ b/source/funkin/play/character/MultiAnimateAtlasCharacter.hx
@@ -49,7 +49,7 @@ class MultiAnimateAtlasCharacter extends BaseCharacter
     originalSizes.set(this.width, this.height);
   }
 
-  function loadAtlases()
+  function loadAtlases():Void
   {
     trace('[MULTIATLASCHAR] Loading sprite atlases for ${characterId}.');
 
@@ -65,7 +65,7 @@ class MultiAnimateAtlasCharacter extends BaseCharacter
     var baseAssetLibrary:String = Paths.getLibrary(_data.assetPath);
     var baseAssetPath:String = Paths.stripLibrary(_data.assetPath);
 
-    loadTextureAtlas(baseAssetPath, baseAssetLibrary, cast _data.atlasSettings);
+    loadTextureAtlas(baseAssetPath, baseAssetLibrary, getAtlasSettings());
 
     for (asset in assetList)
     {
@@ -95,7 +95,7 @@ class MultiAnimateAtlasCharacter extends BaseCharacter
     this.setScale(_data.scale);
   }
 
-  function loadAnimations()
+  function loadAnimations():Void
   {
     trace('[MULTIATLASCHAR] Loading ${_data.animations.length} animations for ${characterId}');
 
@@ -125,5 +125,14 @@ class MultiAnimateAtlasCharacter extends BaseCharacter
   override function get_height():Float
   {
     return originalSizes.y;
+  }
+
+  /**
+   * Get the configuration for the texture atlas.
+   * @return The configuration for the texture atlas.
+   */
+  public function getAtlasSettings():AtlasSpriteSettings
+  {
+    return cast _data.atlasSettings;
   }
 }


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
#6479

<!-- Briefly describe the issue(s) fixed. -->
## Description
this fixes the Set Health Icon event crashing on minimal mode, does what it says on the tin
