### PR TITLE
[BUGFIX] Fix pause state not being properly set during cutscenes

### DIFF
--- a/source/funkin/play/PlayState.hx
+++ b/source/funkin/play/PlayState.hx
@@ -1378,7 +1378,6 @@ class PlayState extends MusicBeatSubState
 
         if (!event.eventCanceled)
         {
-          shouldSubstatePause = true;
           persistentUpdate = false;
           persistentDraw = true;
 
@@ -1431,6 +1430,7 @@ class PlayState extends MusicBeatSubState
     FlxTransitionableState.skipNextTransOut = true;
     pauseSubState.camera = cam;
     persistentUpdate = false;
+    shouldSubstatePause = true;
     openSubState(pauseSubState);
   }
 


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
Not reported yet.
<!-- Briefly describe the issue(s) fixed. -->
## Description
After some changes to how the pause substate handling works to apparently not make it so reliant on the Pause and GameOver substates, some odd issues started to arise, one of them being that the cutscene music would not resume after unpausing the game. There were also other issues like the pause button on mobile never reappearing after resuming the game.

This is because when you're in a cutscene the code that would set `shouldSubStatePause` would not run, this fixes it by simply moving the code to the function that creates the pause menu.
<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos
