### PR TITLE
[BUGFIX] Fix Animation Editor Onion Skin Offset

### DIFF
--- a/source/funkin/ui/debug/anim/DebugBoundingState.hx
+++ b/source/funkin/ui/debug/anim/DebugBoundingState.hx
@@ -175,27 +175,26 @@ class DebugBoundingState extends FlxState
   function updateOnionSkin():Void
   {
     if (swagChar == null) return;
-    if (swagChar.hasAnimation("idle")) swagChar.playAnimation("idle", true);
 
     onionSkinChar.alpha = 0.6;
+    onionSkinChar.flipX = swagChar.flipX;
 
     if (onionSkinChar.hasAnimation("idle"))
     {
       onionSkinChar.playAnimation("idle", true);
     }
+    else if (onionSkinChar.hasAnimation("danceLeft"))
+    {
+      onionSkinChar.playAnimation("danceLeft", true);
+    }
+    else if (onionSkinChar.hasAnimation("danceRight"))
+    {
+      onionSkinChar.playAnimation("danceRight", true);
+    }
     else
     {
       onionSkinChar.playAnimation(currentAnimationName, true);
     }
-
-    onionSkinChar.animation.pause();
-    onionSkinChar.flipX = swagChar.flipX;
-    onionSkinChar.scale.set(swagChar.scale.x, swagChar.scale.y);
-    onionSkinChar.updateHitbox();
-    onionSkinChar.offset.x = swagChar.offset.x + (swagChar.animOffsets[0] - swagChar.globalOffsets[0]) * swagChar.scale.x;
-    onionSkinChar.offset.y = swagChar.offset.y + (swagChar.animOffsets[1] - swagChar.globalOffsets[1]) * swagChar.scale.y;
-
-    swagChar.playAnimation(currentAnimationName, true);
   }
 
   function initOffsetView():Void


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Briefly describe the issue(s) fixed. -->
## Description

With the recent Flixel Animate changes, the animation editor had been changed to where my previous onion skin offset fixes are unnecessary and causing problems.

<img width="510" height="407" alt="Screenshot 2025-11-23 201134" src="https://github.com/user-attachments/assets/cfe51b41-808f-4f66-9d48-9a0c5298a6f1" />

This PR fixes the onion skin offset problems that can be seen in the current develop branch, along with removing lines of code that were no longer needed and making it so that the onion skin for characters that use danceLeft or danceRight work (it was working, but it was hard to tell as the onion skin was using the same animation as the character).

<img width="406" height="406" alt="image" src="https://github.com/user-attachments/assets/c4a422a9-620d-4d17-9954-ae85e3dde6b2" />

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos

Below are two screenshots of this problem.

<img width="789" height="593" alt="Screenshot 2025-11-23 195023" src="https://github.com/user-attachments/assets/e22dbc37-29c7-4819-8585-a2123ce3fa59" />

<img width="439" height="496" alt="Screenshot 2025-11-23 195335" src="https://github.com/user-attachments/assets/5d8ba859-dce8-4022-89a3-fb4061557e96" />