### PR TITLE
[BUGFIX] Allow Scoped Modules to be active while targeting a nested substate

### DIFF
--- a/source/funkin/modding/module/ModuleHandler.hx
+++ b/source/funkin/modding/module/ModuleHandler.hx
@@ -275,17 +275,25 @@ class ModuleHandler
       // The module needs to be active to receive events.
       if (module != null && module.active)
       {
-        if (module.state != null)
-        {
-          // Only call the event if the current state is what the module's state is.
-          if (!(Type.getClass(FlxG.state) == module.state) && !(Type.getClass(FlxG.state?.subState) == module.state))
-          {
-            continue;
-          }
-        }
+        // Only call the event if the module's state is active.
+        if (!isStateActive(module.state)) continue;
+
         ScriptEventDispatcher.callEvent(module, event);
       }
     }
+  }
+
+  static function isStateActive(stateToFind:Null<Class<Dynamic>>):Bool
+  {
+    if (stateToFind == null) return true;
+
+    var state:Null<flixel.FlxState> = FlxG.state;
+    while (state != null && !Std.isOfType(state, stateToFind))
+    {
+      state = state?.subState;
+    }
+
+    return state != null;
   }
 
   public static inline function callOnCreate():Void


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
<!-- ## Linked Issues -->

## Vocabulary
- Nested Substate
    - A substate initialized on top of an already existing substate.
    - Ex. Most Sticker Transitions, any substate on `PlayState` when using the chart editor.
- Recursive
    - A procedure or rule that is repeated. 
    - Ex. Friday Night' Funkin recursively searching the game for scripted classes.
- Scoped Module
    - A Module that can only run in a specific state.

These are your vocabulary words for today's PR, thank you for re-experiencing the horrors of Language Arts class. 

<!-- Briefly describe the issue(s) fixed. -->
## Description
Unfortunately, the `ModuleHandler` `callEvent` method only checks if the current state or substate on that state is active. This means that any nested substate won't activate scoped modules.

This PR makes sure this behavior doesn't happen by doing a recursive search through every substate, and checking if the substate is the state specified for the scoped module.
