### PR TITLE
[CHORE] Fixed wrong Set Health Icon event description

### DIFF
--- a/source/funkin/play/event/SetHealthIconSongEvent.hx
+++ b/source/funkin/play/event/SetHealthIconSongEvent.hx
@@ -6,7 +6,7 @@ import funkin.data.song.SongData;
 import funkin.data.song.SongData.SongEventData;
 
 /**
- * This class represents a handler for scroll speed events.
+ * This class represents a handler for health icon events.
  *
  * Example: Set the health icon of Boyfriend to "bf-pixel":
  * ```


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Briefly describe the issue(s) fixed. -->
## Description

Fixes the quick explanation of the event to actually refer to the health icon event. Currently it mentions the scroll speed event instead.

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos
Before:
<img width="612" height="73" alt="image" src="https://github.com/user-attachments/assets/5c7e2488-65c1-4f53-bb8c-533be5a638a7" />

After:
<img width="590" height="87" alt="image" src="https://github.com/user-attachments/assets/48aa9cfc-735c-4d57-9393-316a2d24870f" />
