### PR TITLE
[CHORE] Fix typo in `CreditsState`, `peformance` -> `performance`

### DIFF
--- a/source/funkin/ui/credits/CreditsState.hx
+++ b/source/funkin/ui/credits/CreditsState.hx
@@ -132,7 +132,7 @@ class CreditsState extends MusicBeatState
     // add(bg);
 
     // TODO: Once we need to display Kickstarter backers,
-    // make this use a recycled pool so we don't kill peformance.
+    // make this use a recycled pool so we don't kill performance.
     creditsGroup = new FlxSpriteGroup();
     creditsGroup.x = Math.max(funkin.ui.FullScreenScaleMode.gameNotchSize.x, SCREEN_PAD);
     creditsGroup.y = STARTING_HEIGHT;


### PR DESCRIPTION
<!-- Briefly describe the issue(s) fixed. -->
## Description
i was in the middle of doing another pr and then i saw... yet another typo yay.

## Screenshots
<img width="285" height="139" alt="image" src="https://github.com/user-attachments/assets/be4b3ae9-64c1-4f5a-b4ed-da687a33f182" />