### PR TITLE
[BUGFIX] Dispatch `onOpening` signal to actually set video cutscene volume

### DIFF
--- a/source/funkin/play/cutscene/VideoCutscene.hx
+++ b/source/funkin/play/cutscene/VideoCutscene.hx
@@ -198,6 +198,7 @@ class VideoCutscene
       if (vid.load(filePath, fileOptions) && vid.play())
       {
         onVideoStarted.dispatch();
+        vid.bitmap.onOpening.dispatch();
       }
     }
     else


### PR DESCRIPTION
## Linked Issues
Not actually from issue tab, but from some dude from discord

https://github.com/user-attachments/assets/db1ea886-a312-4f15-ba6d-aecba1f88c1e


## Description
Dispatches `onOpening` signal to set video's volume in moment it started playing (not in the next frame)

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos
Video's just starts now with correct volume :D
