### PR TITLE
[BUGFIX] Fix cursor not properly fading out when exiting CharSelect

### DIFF
--- a/source/funkin/ui/charSelect/CharSelectCursors.hx
+++ b/source/funkin/ui/charSelect/CharSelectCursors.hx
@@ -56,6 +56,7 @@ class CharSelectCursors extends FlxTypedSpriteContainer<FunkinSprite>
     add(cursorDenied);
 
     scrollFactor.set();
+    directAlpha = true;
   }
 
   public function confirm():Void


### PR DESCRIPTION
<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
Closes #6514 
<!-- Briefly describe the issue(s) fixed. -->
## Description
In recent `develop` commits there was a refactor to how the cursor is handled, this caused a bug where one of the cursor sprites wouldn't properly fade out when exiting via backspace since it's now in a FlxSpriteContainer, and so the ping-pong color tween that's applied to this one sprite impedes its alpha from being changed.

Fortunately sprite groups/containers have this `directAlpha` property which when enabled will force any changes to the alpha to be applied to a group's children no matter what.
<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos

https://github.com/user-attachments/assets/dc63abeb-b98a-4cfe-a34b-29f986eab7b2

