### PR TITLE
[ENHANCEMENT] Implement character's variations selection in Chart Editor

### DIFF
--- a/source/funkin/data/character/CharacterData.hx
+++ b/source/funkin/data/character/CharacterData.hx
@@ -43,6 +43,36 @@ class CharacterDataParser
   static final DEFAULT_CHAR_ID:String = 'UNKNOWN';
 
   /**
+   * Helper function to format variation names from file names.
+   * Converts hyphen-separated names to Title Case with spaces.
+   * Example: "dark-christmas" becomes "Dark Christmas"
+   * NOT AN ACTUAL VARIATION
+   */
+  static function formatVariationName(variationName:String):String
+  {
+    if (variationName == null || variationName == '') return '';
+
+    // Replace hyphens with spaces
+    var withSpaces:String = variationName.replace('-', ' ');
+
+    // Split into words and capitalize each word
+    var words:Array<String> = withSpaces.split(' ');
+    var formattedWords:Array<String> = [];
+
+    for (word in words)
+    {
+      if (word.length > 0)
+      {
+        // Capitalize first letter, lowercase the rest
+        var formattedWord:String = word.charAt(0).toUpperCase() + word.substr(1).toLowerCase();
+        formattedWords.push(formattedWord);
+      }
+    }
+
+    return formattedWords.join(' ');
+  }
+
+  /**
    * Parses and preloads the game's stage data and scripts when the game starts.
    *
    * If you want to force stages to be reloaded, you can just call this function again.
@@ -52,6 +82,10 @@ class CharacterDataParser
     // Clear any stages that are cached if there were any.
     clearCharacterCache();
     log(' INFO '.info() + 'Parsing all entries...');
+
+    // HANDLE CHARACTERS VARIATIONS
+    // VariationCharacterName -> {VariationName, TargetCharacter}
+    var variationsOnHold:Map<String, {variationName:String, targetCharacter:String}> = [];
 
     //
     // UNSCRIPTED CHARACTERS
@@ -71,12 +105,88 @@ class CharacterDataParser
         {
           log('Loaded character "${charId}"');
           characterCache.set(charId, charData);
+
+          @:nullSafety(Off)
+          // Check if character has variationFor explicitly set to null - if so, skip auto-detection
+          var shouldSkipAutoDetection:Bool = false;
+          if (charData.variations != null && charData.variations.variationFor == null)
+          {
+            // Check if variationFor was explicitly set in JSON (not from filename auto-detection)
+            // We can check if variationName is also null, or if the character ID has hyphen
+            if (charData.variations.variationName == null)
+            {
+              // Both variationFor and variationName are null, likely explicitly set
+              // Check if filename has hyphen but JSON explicitly sets variationFor to null
+              if (charId.indexOf('-') != -1)
+              {
+                // Filename has hyphen but JSON explicitly says no variation
+                shouldSkipAutoDetection = true;
+                trace('Skipping auto-detection for ${charId}: variationFor explicitly set to null');
+              }
+            }
+          }
+
+          // Only auto-detect if not explicitly skipped and filename has hyphen
+          if (!shouldSkipAutoDetection && charId.indexOf('-') != -1)
+          {
+            var parts:Array<String> = charId.split('-');
+            if (parts.length >= 2)
+            {
+              var baseId:String = parts[0];
+              var variationName:String = parts.slice(1).join('-');
+              var formattedVariationName:String = formatVariationName(variationName);
+
+              var baseData:Null<CharacterData> = characterCache.get(baseId);
+              @:nullSafety(Off)
+              if (baseData != null && !baseData.isVariation)
+              {
+                charData.isVariation = true;
+                charData.variations.variationFor = baseId;
+                charData.variations.variationName = formattedVariationName;
+
+                if (baseData.variations.variations == null)
+                {
+                  baseData.variations.variations = new Map<String, String>();
+                }
+                baseData.variations.variations.set(formattedVariationName, charId);
+
+                trace('Auto-detected variation: ${charId} is variation "${formattedVariationName}" of ${baseId}');
+              }
+              else if (charData?.variations?.variationName != null && charData?.variations?.variationFor != null)
+              {
+                @:nullSafety(Off)
+                variationsOnHold.set(charId, {variationName: charData.variations.variationName, targetCharacter: charData.variations.variationFor});
+              }
+            }
+          }
+          else if (charData?.variations?.variationName != null && charData?.variations?.variationFor != null)
+          {
+            @:nullSafety(Off)
+            variationsOnHold.set(charId, {variationName: charData.variations.variationName, targetCharacter: charData.variations.variationFor});
+          }
         }
       }
       catch (e)
       {
         // Assume error was already logged.
         continue;
+      }
+    }
+
+    // CONCAT VARIATIONS
+    @:nullSafety(Off) // i hate you
+    for (variationCharacter => variationMicroData in variationsOnHold)
+    {
+      if (!characterCache.exists(variationMicroData.targetCharacter))
+      {
+        trace('WARN: Attempted to add "${variationMicroData.variationName}" variation for non-existent "${variationMicroData.targetCharacter}" character!');
+        continue;
+      }
+      final targetCharData = characterCache.get(variationMicroData.targetCharacter);
+      if (targetCharData != null)
+      {
+        targetCharData.variations.variations.set(variationMicroData.variationName, variationCharacter);
+        characterCache.get(variationCharacter).isVariation = true;
       }
     }
 
@@ -310,6 +420,78 @@ class CharacterDataParser
   }
 
   /**
+   * Gets the base character ID for a variation.
+   * @param charId Character ID (can be a variation)
+   * @return Base character ID or null
+   */
+  public static function getBaseCharacterId(charId:String):Null<String>
+  {
+    if (charId == null || charId == '') return null;
+
+    var charData:Null<CharacterData> = fetchCharacterData(charId);
+    if (charData == null) return null;
+
+    if (charData.isVariation && charData.variations != null && charData.variations.variationFor != null)
+    {
+      return charData.variations.variationFor;
+    }
+
+    if (charId.indexOf('-') != -1)
+    {
+      var parts:Array<String> = charId.split('-');
+      var potentialBaseId:String = parts[0];
+
+      var baseData:Null<CharacterData> = fetchCharacterData(potentialBaseId);
+      @:nullSafety(Off)
+      if (baseData != null && !baseData.isVariation)
+      {
+        return potentialBaseId;
+      }
+    }
+
+    return charId;
+  }
+
+  /**
+   * Gets the variation name for a character.
+   * @param charId Character ID
+   * @return Variation name or null if not a variation
+   */
+  public static function getVariationName(charId:String):Null<String>
+  {
+    if (charId == null || charId == '') return null;
+
+    var charData:Null<CharacterData> = fetchCharacterData(charId);
+    if (charData == null) return null;
+
+    if (charData.isVariation && charData.variations != null && charData.variations.variationName != null)
+    {
+      return charData.variations.variationName;
+    }
+
+    if (charId.indexOf('-') != -1)
+    {
+      var parts:Array<String> = charId.split('-');
+      if (parts.length >= 2)
+      {
+        return formatVariationName(parts.slice(1).join('-'));
+      }
+    }
+
+    return null;
+  }
+
+  public static function getCharVariations(charId:String):Map<String, String>
+  {
+    var charData:Null<CharacterData> = fetchCharacterData(charId);
+    if (charData != null && charData.variations != null && charData.variations.variations != null)
+    {
+      return charData.variations.variations;
+    }
+    return new Map<String, String>();
+  }
+
+  /**
    * Lists all the valid character IDs.
    * @return An array of character IDs.
    */
@@ -505,6 +687,37 @@ class CharacterDataParser
     {
       trace('WARN: Character data for "$id" missing name');
       input.name = DEFAULT_NAME;
+    }
+    if (input.isVariation == null)
+    {
+      input.isVariation = false;
+    }
+
+    if (input.variations == null)
+    {
+      input.variations =
+        {
+          variations: new Map<String, String>(),
+          variationFor: null,
+          variationName: null
+        };
+    }
+    else if (input.variations.variations == null)
+    {
+      input.variations.variations = new Map<String, String>();
+    }
+
+    // If filename contains hyphen, try to determine base character and variation name
+    // But only if variationFor is not explicitly set to null in JSON
+    if (input.variations.variationFor == null && input.variations.variationName == null && id.indexOf('-') != -1)
+    {
+      var parts:Array<String> = id.split('-');
+      if (parts.length >= 2)
+      {
+        // Set temporary values, may be overridden in loadCharacterCache
+        input.variations.variationFor = parts[0];
+        input.variations.variationName = formatVariationName(parts.slice(1).join('-'));
+      }
     }
 
     if (input.renderType == null)
@@ -716,6 +929,15 @@ typedef CharacterData =
   var name:String;
 
   /**
+   * Optional data about the health icon for the character.
+   */
+  var variations:Null<VariationsData>;
+
+  @:optional
+  @:default(false)
+  var isVariation:Null<Bool>;
+
+  /**
    * The type of rendering system to use for the character.
    * @default sparrow
    */
@@ -821,6 +1043,28 @@ typedef CharacterData =
   @:optional
   var atlasSettings:funkin.data.stage.StageData.TextureAtlasData;
 };
+
+typedef VariationsData =
+{
+  /**
+   * Available variations list for character. ([dark => bf-dark, car => bf-car] etc.)
+   */
+  @:optional
+  @:default([])
+  var variations:Null<Map<String, String>>;
+
+  /**
+   * If current character IS A specific variation of a character, this is the variation name. (Dark, Car, Christmas, Pixel)
+   */
+  @:optional
+  var variationName:Null<String>;
+
+  /**
+   * Character's file name which this character is a variation of.
+   */
+  @:optional
+  var variationFor:Null<String>;
+}
 
 /**
  * The JSON data schema used to define the health icon for a character.

--- a/source/funkin/ui/debug/charting/dialogs/ChartEditorCharacterIconSelectorMenu.hx
+++ b/source/funkin/ui/debug/charting/dialogs/ChartEditorCharacterIconSelectorMenu.hx
@@ -14,6 +14,8 @@ import haxe.ui.core.Screen;
 import flixel.tweens.FlxTween;
 import flixel.tweens.FlxEase;
 import haxe.ui.components.Button;
+import haxe.ui.components.DropDown;
+import haxe.ui.data.DataSource;
 
 // @:nullSafety // TODO: Fix null safety when used with HaxeUI build macros.
 @:access(funkin.ui.debug.charting.ChartEditorState)
@@ -22,14 +24,132 @@ class ChartEditorCharacterIconSelectorMenu extends ChartEditorBaseMenu
 {
   public var charSelectScroll:ScrollView;
   public var charIconName:Label;
+  public var charVariationDropdown:DropDown;
 
   var currentCharButton:Null<Button> = null;
   var currentCharId:String = '';
+  var currentBaseCharId:String = '';
+  var charType:CharacterType;
+
+  var lastSelectedVariations:Map<String, String> = new Map();
+
+  function findBaseCharacterId(charId:String):String
+  {
+    if (charId == "") return "";
+
+    var charIds:Array<String> = CharacterDataParser.listCharacterIds();
+
+    for (baseId in charIds)
+    {
+      var charData:CharacterData = CharacterDataParser.fetchCharacterData(baseId);
+
+      if (charData?.isVariation) continue;
+
+      if (baseId == charId) return charId;
+
+      if (charData != null && charData.variations != null && charData.variations.variations != null)
+      {
+        var variations = charData.variations.variations;
+        var keys = variations.keys();
+
+        for (vName in keys)
+        {
+          if (variations.get(vName) == charId)
+          {
+            return baseId;
+          }
+        }
+      }
+    }
+
+    return charId;
+  }
+
+  function getCurrentVariationForBase(baseId:String):String
+  {
+    if (baseId == "") return "";
+
+    if (lastSelectedVariations.exists(baseId)) return lastSelectedVariations.get(baseId);
+
+    return baseId;
+  }
+
+  function saveVariationForBase(baseId:String, variationId:String):Void
+  {
+    if (baseId != "" && variationId != "") lastSelectedVariations.set(baseId, variationId);
+  }
+
+  function buildVariationItems(baseId:String, baseData:CharacterData):Array<Dynamic>
+  {
+    var items:Array<Dynamic> = [];
+
+    if (baseId == "" || baseData == null)
+    {
+      items.push({id: "", text: "None"});
+      return items;
+    }
+
+    items.push({id: baseId, text: "Default"});
+
+    if (baseData.variations != null && baseData.variations.variations != null)
+    {
+      var variations = baseData.variations.variations;
+      var keys = variations.keys();
+
+      for (vName in keys)
+      {
+        var vId = variations.get(vName);
+        items.push({id: vId, text: vName});
+      }
+    }
+
+    return items;
+  }
+
+  function populateVariationDropdown(baseId:String, baseData:CharacterData, selectedId:String):Void
+  {
+    charVariationDropdown.dataSource.clear();
+
+    if (baseId == "" || baseData == null)
+    {
+      charVariationDropdown.dataSource.add({id: "", text: "None"});
+      charVariationDropdown.selectedItem = {id: "", text: "None"};
+      charVariationDropdown.disabled = true;
+      return;
+    }
+
+    charVariationDropdown.disabled = false;
+    var items = buildVariationItems(baseId, baseData);
+
+    for (item in items)
+    {
+      charVariationDropdown.dataSource.add(item);
+    }
+
+    var foundItem = null;
+    for (item in items)
+    {
+      if (item.id == selectedId)
+      {
+        foundItem = item;
+        break;
+      }
+    }
+
+    if (foundItem != null)
+    {
+      charVariationDropdown.selectedItem = foundItem;
+    }
+    else if (items.length > 0)
+    {
+      charVariationDropdown.selectedItem = items[0];
+    }
+  }
 
   public function new(chartEditorState2:ChartEditorState, charType:CharacterType, lockPosition:Bool = false)
   {
     super(chartEditorState2);
-
+    this.charType = charType;
     initialize(charType, lockPosition);
     this.alpha = 0;
     this.y -= 10;
@@ -55,7 +175,10 @@ class ChartEditorCharacterIconSelectorMenu extends ChartEditorBaseMenu
       default: throw 'Invalid charType: ' + charType;
     };
 
-    // Position this menu.
+    currentBaseCharId = findBaseCharacterId(currentCharId);
+
+    if (currentBaseCharId != "") lastSelectedVariations.set(currentBaseCharId, currentCharId);
+
     var targetHealthIcon:Null<HealthIcon> = switch (charType)
     {
       case BF: chartEditorState.healthIconBF;
@@ -92,59 +215,130 @@ class ChartEditorCharacterIconSelectorMenu extends ChartEditorBaseMenu
     {
       var charData:CharacterData = CharacterDataParser.fetchCharacterData(charId);
 
+      if (charData?.isVariation) continue;
+
       var charButton = new Button();
       charButton.width = 70;
       charButton.height = 70;
       charButton.padding = 8;
       charButton.iconPosition = "top";
 
-      if (charId == currentCharId)
+      var isCurrentChar = (charId == currentBaseCharId);
+
+      if (isCurrentChar)
       {
         // Scroll to the character if it is already selected.
         charSelectScroll.vscrollPos = Math.floor(charIndex / 5) * 80;
         charButton.focus = true;
 
-        defaultText = (currentCharId != "") ? '${charData.name} [${charId}]' : 'None';
+        // Get the actual character data for display (could be variation)
+        var displayCharData:CharacterData = CharacterDataParser.fetchCharacterData(currentCharId);
+        defaultText = (currentCharId != "") ? '${displayCharData.name} [${currentCharId}]' : 'None';
 
         currentCharButton = charButton;
+
+        populateVariationDropdown(charId, charData, currentCharId);
       }
 
       var LIMIT = 6;
       charButton.icon = haxe.ui.util.Variant.fromImageData(CharacterDataParser.getCharPixelIconAsset(charId));
       charButton.text = (charId != "") ? (charData.name.length > LIMIT ? '${charData.name.substr(0, LIMIT)}.' : '${charData.name}') : 'None';
 
-      charButton.onClick = _ ->
-      {
-        switch (charType)
-        {
-          case BF:
-            chartEditorState.currentSongMetadata.playData.characters.player = charId;
-            chartEditorState.playerPreviewDirty = true;
-          case GF: chartEditorState.currentSongMetadata.playData.characters.girlfriend = charId;
-          case DAD:
-            chartEditorState.currentSongMetadata.playData.characters.opponent = charId;
-            chartEditorState.opponentPreviewDirty = true;
-          default: throw 'Invalid charType: ' + charType;
-        };
+      charButton.onClick = _ -> {
+        var savedVariationId = getCurrentVariationForBase(charId);
+        currentBaseCharId = charId;
+        currentCharId = savedVariationId;
 
-        defaultText = (charId != "") ? '${charData.name} [${charId}]' : 'None';
-        chartEditorState.healthIconsDirty = true;
+        var baseCharData = CharacterDataParser.fetchCharacterData(charId);
 
-        chartEditorState.refreshToolbox(ChartEditorState.CHART_EDITOR_TOOLBOX_METADATA_LAYOUT);
-      };
+        populateVariationDropdown(charId, baseCharData, currentCharId);
 
-      charButton.onMouseOver = _ ->
-      {
-        charIconName.text = (charId != "") ? '${charData.name} [${charId}]' : 'None';
-      };
-      charButton.onMouseOut = _ ->
-      {
+        applyCharacter(currentCharId);
+
+        // Get the actual character data for display (could be variation)
+        var displayCharData:CharacterData = CharacterDataParser.fetchCharacterData(currentCharId);
+        defaultText = (currentCharId != "") ? '${displayCharData.name} [${currentCharId}]' : 'None';
         charIconName.text = defaultText;
+      };
+
+      charButton.onMouseOver = _ -> {
+        var hoverCharData = CharacterDataParser.fetchCharacterData(charId);
+        charIconName.text = (charId != "") ? '${hoverCharData.name} [${charId}]' : 'None';
+      };
+      charButton.onMouseOut = _ -> {
+        // Get the actual character data for display (could be variation)
+        var currentCharData:CharacterData = CharacterDataParser.fetchCharacterData(currentCharId);
+        if (currentCharData != null)
+        {
+          charIconName.text = (currentCharId != "") ? '${currentCharData.name} [${currentCharId}]' : 'None';
+        }
+        else
+        {
+          charIconName.text = defaultText;
+        }
       };
       charGrid.addComponent(charButton);
     }
 
-    charIconName.text = defaultText;
+
+    // todo: fix rebase
+    charVariationDropdown.onChange = function(_) {
+      var selectedItem = charVariationDropdown.selectedItem;
+      if (selectedItem != null)
+      {
+        var selectedId:String = selectedItem.id;
+        currentCharId = selectedId;
+
+        saveVariationForBase(currentBaseCharId, selectedId);
+
+        applyCharacter(selectedId);
+
+        // Get the actual character data for display (could be variation)
+        var selectedCharData:CharacterData = CharacterDataParser.fetchCharacterData(selectedId);
+        var displayName = "";
+
+        if (selectedId == currentBaseCharId)
+        {
+          // For default variation, use base character name
+          displayName = selectedCharData != null ? selectedCharData.name : selectedId;
+        }
+        else if (selectedId == "")
+        {
+          displayName = "None";
+        }
+        else
+        {
+          // For variation, use the variation's own name
+          displayName = selectedCharData != null ? selectedCharData.name : selectedId;
+        }
+
+        charIconName.text = (selectedId != "") ? '${displayName} [${selectedId}]' : 'None';
+      }
+    };
+
+    // Set initial text using current character data (could be variation)
+    var initialCharData:CharacterData = CharacterDataParser.fetchCharacterData(currentCharId);
+    charIconName.text = (currentCharId != "") ? '${initialCharData.name} [${currentCharId}]' : 'None';
+  }
+
+  function applyCharacter(charId:String):Void
+  {
+    switch (charType)
+    {
+      case BF:
+        chartEditorState.currentSongMetadata.playData.characters.player = charId;
+        chartEditorState.playerPreviewDirty = true;
+      case GF:
+        chartEditorState.currentSongMetadata.playData.characters.girlfriend = charId;
+      case DAD:
+        chartEditorState.currentSongMetadata.playData.characters.opponent = charId;
+        chartEditorState.opponentPreviewDirty = true;
+      default:
+        throw 'Invalid charType: ' + charType;
+    };
+
+    chartEditorState.healthIconsDirty = true;
+    chartEditorState.refreshToolbox(ChartEditorState.CHART_EDITOR_TOOLBOX_METADATA_LAYOUT);
   }
 
   public static function build(chartEditorState:ChartEditorState, charType:CharacterType, lockPosition:Bool = false):ChartEditorCharacterIconSelectorMenu


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->
Requires[ FUNK.ASSETS#302](https://github.com/FunkinCrew/funkin.assets/pull/302)
<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
[FUNK#6494](https://github.com/FunkinCrew/Funkin/issues/6494)

## Description
Adds a new dropdown to the character selection menu in the chart editor for selecting character variations.
(EVERYTHING WORKS AUTOMATICALLY, but you can also prevent characters from being automatically added as variations, like with pico-speaker).

Autimaticly converts characters as "variations" for another character.

Rules:
* Character file `bf-car.json` with NO `variationFor` in JSON: 
Auto-detects as variation "Car" of "bf"
* Character file `bf-car.json` with "variationFor": "bf" in JSON: 
Uses the explicitly defined variation
* Character file `bf-car.json` with "variationFor": "None" (or any other non-existent character's id) in JSON:
Skips auto-detection, character is NOT marked as a variation
The hyphen in the filename is ignored
* Character file spooky.json (no hyphen):
Works as normal, no auto-detection attempted

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos
<img width="830" height="397" alt="image" src="https://github.com/user-attachments/assets/5b23a7cc-0a67-44b7-bc1c-e866ae8be632" />

How cool is it hu?