### PR TITLE
Fix other `-pixel` musicSuffixes not using RetroCameraFade

### DIFF
--- a/source/funkin/play/GameOverSubState.hx
+++ b/source/funkin/play/GameOverSubState.hx
@@ -408,7 +408,7 @@ class GameOverSubState extends MusicBeatSubState
           close();
         };
 
-        if (musicSuffix == '-pixel')
+        if (musicSuffix.contains('-pixel'))
         {
           RetroCameraFade.fadeToBlack(FlxG.camera, 10, 2);
           new FlxTimer().start(2, _ -> {


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Briefly describe the issue(s) fixed. -->
## Description
The special retro fade-out/fade-in for pixel Game Overs only happens for `bf-pixel` because `musicSuffix` has to be exactly equal to '`-pixel`', which other characters, like say, `pico-pixel`, can't use without sharing the default Game Over theme. This fixes that so that the retro fade-outs can play with different `-pixel` musics.

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos
### Old
https://github.com/user-attachments/assets/cd1b1551-1a21-4578-9390-40a4e55fa47b
### New
https://github.com/user-attachments/assets/4c2c040f-23f5-4940-a4ad-bf66e9d48a15

