### PR TITLE
[BUGFIX] Fix NOR when deleting save data

### DIFF
--- a/source/funkin/save/Save.hx
+++ b/source/funkin/save/Save.hx
@@ -67,7 +67,7 @@ class Save implements ConsoleClass
   @:nullSafety(Off)
   public function new(?data:RawSaveData)
   {
-    this.data = data ?? Save.getDefaultData();
+    this.data = data ??= Save.getDefaultData();
     // Build macro will inject SaveProperty initialization here automatically
 
     // Make sure the verison number is up to date before we flush.


### PR DESCRIPTION
<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
... There's nothing ...
<!-- Briefly describe the issue(s) fixed. -->
## Description
This one is quite interesting because at first it doesn't even make any sense until you discover it's related to SaveProperties.

Let's keep in mind `this.data` and `data` are different variables. The issue is that due to the equal name, the `data` argument is incorrectly referenced by the "body" of the properties (this becomes evident in the generated code) which is null when deleting the data. And so only `this.data` gets set, the other one will stay null, which causes the error.
<img width="756" height="178" alt="image" src="https://github.com/user-attachments/assets/c35d06af-0216-456c-bb6d-2089acd01fd4" />

The fix I used was making the argument also be set, which isn't an issue because it's passed by reference, which means that changes to `data` will also apply to `this.data`.
There was an other fix which involved forcing the macro to reference `this.data` but also required disabling null-safety for each property (either manually or automatically by adding the meta using the macro).

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos
Screenshot of the crash
<img width="1205" height="669" alt="Screenshot of the crash" src="https://github.com/user-attachments/assets/a103dd95-4831-414c-9aef-bebdb5ad29fa" />
