### PR TITLE
[BUGFIX] Make Rimlight Shader Better For Texture Atlases

### DIFF
--- a/source/funkin/graphics/shaders/DropShadowShader.hx
+++ b/source/funkin/graphics/shaders/DropShadowShader.hx
@@ -192,7 +192,7 @@ class DropShadowShader extends FlxShader
   function set_attachedSprite(spr:FlxSprite):FlxSprite
   {
     attachedSprite = spr;
-    updateFrameInfo(attachedSprite.frame);
+    updateFrameInfo(attachedSprite.frameWidth, attachedSprite.frameHeight, attachedSprite.frame.angle);
     return spr;
   }
 
@@ -217,19 +217,18 @@ class DropShadowShader extends FlxShader
    */
   public function onAttachedFrame(name, frameNum, frameIndex)
   {
-    if (attachedSprite != null) updateFrameInfo(attachedSprite.frame);
+    if (attachedSprite != null) updateFrameInfo(attachedSprite.frameWidth, attachedSprite.frameHeight, attachedSprite.frame.angle);
   }
 
   /*
     Updates the frame bounds and angle offset of the sprite for the shader.
    */
-  public function updateFrameInfo(frame:FlxFrame)
+  public function updateFrameInfo(width:Float, height:Float, angle:Float)
   {
-    // NOTE: uv.right is actually the right pos and uv.bottom is the bottom pos
-    uFrameBounds.value = [frame.uv.left, frame.uv.top, frame.uv.right, frame.uv.bottom];
+    uFrameBounds.value = [0, 0, width, height];
 
     // if a frame is rotated the shader will look completely wrong lol
-    angOffset.value = [frame.angle * FlxAngle.TO_RAD];
+    angOffset.value = [angle * FlxAngle.TO_RAD];
   }
 
   function set_altMaskImage(_bitmapData:BitmapData):BitmapData


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Briefly describe the issue(s) fixed. -->
## Description

With characters being converted to texture atlases, there comes a problem where some characters have to be skipped due to the rimlight shader that's used in Week 7 Erect songs.

Well what's the problem? Uh um uh uh ummm uhh...

<img width="1280" height="720" alt="screenshot-2025-12-04-14-56-56" src="https://github.com/user-attachments/assets/2aa6cd41-acb5-4ea4-88b7-3c99e4ec2ae9" />

Yeah that's right.. the one and only piss colors. By the way, I'm using Boyfriend's car variant for this as it is the closest thing we got for a texture atlas BF so far.

So anyways, instead of using the frame's UV for applying the shader each animation frame, frameWidth and frameHeight are used instead.

Now this isn't perfect, but it's better than before.

<img width="1280" height="720" alt="screenshot-2025-12-04-15-31-57" src="https://github.com/user-attachments/assets/522792ef-fe38-4803-b9b1-c28c4fd3b88f" />

However, using an alt mask helps. Setting the mask threshold to 1, you'll get a much better result. I'm not going to provide the alt mask due to it being a character that isn't used for Week 7 Erect, but I made it to see how these types of problems can be solved.

<img width="1280" height="720" alt="screenshot-2025-12-04-16-19-13" src="https://github.com/user-attachments/assets/66e10668-e68b-47d3-8b28-952bb18848cc" />

I know this is out of FunkinCrew's control, but if MaybeMaru/flixel-animate#15 gets merged, the alt mask likely won't be needed for texture atlases. Yes, this PR would still be needed.

Thanks to Abnormal for figuring out this problem and explaining a way to fix it. Really all I'm doing is making the PR.

!! FunkinCrew/funkin.assets#304 is required !!

Edit: MaybeMaru/flixel-animate#15 has been merged and now alt masks won't be needed!