### PR TITLE
[OPTIMIZATION] Use streamed audio for Freeplay Song Previews

### DIFF
--- a/source/funkin/audio/FunkinSound.hx
+++ b/source/funkin/audio/FunkinSound.hx
@@ -17,6 +17,9 @@ import lime.media.AudioSource;
 import openfl.events.Event;
 import openfl.media.SoundChannel;
 import openfl.media.SoundMixer;
+#if lime_vorbis
+import lime.media.vorbis.VorbisFile;
+#end
 
 /**
  * A FlxSound which adds additional functionality:
@@ -344,8 +347,40 @@ class FunkinSound extends FlxSound implements ICloneable<FunkinSound>
 
     if (shouldLoadPartial)
     {
-      var music = FunkinSound.loadPartial(pathToUse, params.partialParams?.start ?? 0.0, params.partialParams?.end ?? 1.0, params?.startingVolume ?? 1.0,
-        params.loop ?? true, false, false, params.onComplete);
+      var start:Float = params.partialParams?.start ?? 0.0;
+      var end:Float = params.partialParams?.end ?? 1.0;
+
+      // If partial, attempt to load from vorbis first.
+      #if lime_vorbis
+      var vorbisFile:Null<VorbisFile> = VorbisFile.fromFile(Paths.stripLibrary(pathToUse));
+      if (vorbisFile != null)
+      {
+        var vorbisSound:Null<Sound> = Sound.fromAudioBuffer(lime.media.AudioBuffer.fromVorbisFile(vorbisFile));
+
+        if (vorbisSound != null)
+        {
+          var sound:Null<FunkinSound> = FunkinSound.load(vorbisSound, params?.startingVolume ?? 1.0, params.loop ?? true, false, true, false,
+            params.onComplete);
+          if (sound != null)
+          {
+            sound._label = pathToUse;
+
+            FlxG.sound.music = sound;
+            FlxG.sound.list.remove(FlxG.sound.music);
+
+            // Apply the partial limits for the sound.
+            sound.loopTime = sound.length * start;
+            sound.endTime = sound.length * end;
+
+            if (FlxG.sound.music != null && params.onLoad != null) params.onLoad();
+
+            return true;
+          }
+        }
+      }
+      #end
+
+      var music = FunkinSound.loadPartial(pathToUse, start, end, params?.startingVolume ?? 1.0, params.loop ?? true, false, false, params.onComplete);
 
       if (music != null)
       {

--- a/source/funkin/ui/freeplay/FreeplayState.hx
+++ b/source/funkin/ui/freeplay/FreeplayState.hx
@@ -3020,14 +3020,17 @@ class FreeplayState extends MusicBeatSubState
         {
           FlxG.sound.music.fadeIn(2, 0, previewVolume);
 
-          var fadeStart:Float = (FlxG.sound.music.length / Constants.MS_PER_SEC) - 2;
+          var musicLength:Float = FlxG.sound.music.length;
+          if (FlxG.sound.music.endTime != null) musicLength = (FlxG.sound.music.endTime - FlxG.sound.music.loopTime);
+
+          var fadeStart:Float = (musicLength / Constants.MS_PER_SEC) - 2;
 
           previewTimers.push(new FlxTimer().start(fadeStart, function(_)
           {
             FlxG.sound.music.fadeOut(2, 0);
           }));
 
-          previewTimers.push(new FlxTimer().start(FlxG.sound.music.length / Constants.MS_PER_SEC, function(_)
+          previewTimers.push(new FlxTimer().start(musicLength / Constants.MS_PER_SEC, function(_)
           {
             playCurSongPreview();
           }));


### PR DESCRIPTION
## Linked Issues
Nothing, heh, it's like that one soyjak gif.

## Description
This PR makes it so that on targets that have the `lime_vorbis` feature flag enabled, freeplay previews will attempt to be loaded through the vorbis file first before using the regular partial sound method.

I'd love to make more things use streamed audio for optimization, though there are some roadblocks to this:
1. Bugs, like a lot of them. From my testing, using too much streamed audio can sometimes cause the game to remove every audio, making the game silent, which I hope is an incredibly obvious problem for a rhythm game. The test was basically putting the vorbis loading method in FunkinSound's `load` and `loadPartial` functions, which also affected sound effects played through the `playOnce` function.
2. Nene and her malice break the game, since streamed audio doesn't have any data to use for the A-Bot visualizer. ACrazyTown has made a PR on the funkVis repository https://github.com/FunkinCrew/funkVis/pull/13 to fix the issue but it's been sitting there since april of this year.

Also if the code looks a bit ugly, that's because I had to apply `endTime` to the loaded sound so that it's actually a partial sound in a very specific position, since fading in the sound calls `play` without any arguments, which means that `endTime` is set to null and it makes the previews not partial anymore, spoiling the entire instrumental in the preview.............

## Screenshots/Videos

https://github.com/user-attachments/assets/a25e4b13-5d63-4a6b-931b-577b4f775171
