### PR TITLE
[BUGFIX] Fix Alpha Not Being Applied To Animation Editor Onion Skin Upon Character Change

### DIFF
--- a/source/funkin/ui/debug/anim/DebugBoundingState.hx
+++ b/source/funkin/ui/debug/anim/DebugBoundingState.hx
@@ -546,6 +546,7 @@ class DebugBoundingState extends FlxState
       trace('ERROR: Failed to load character ${char}!');
     }
 
+    updateOnionSkin();
     generateOutlines(swagChar.frames.frames);
     bf.pixels = swagChar.pixels;
 


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Briefly describe the issue(s) fixed. -->
## Description

This PR fixes an issue with the current version of the develop branch where the animation editor's onion skin doesn't have its alpha applied upon changing the character. It would instead only apply it when the character's animation gets changed.

<img width="883" height="615" alt="image" src="https://github.com/user-attachments/assets/298b65ee-c810-4de4-b7ac-f5fbbbfd2b6d" />

I bet you can't tell which one is the real Girlfriend (Christmas).