### PR TITLE
[BUGFIX] Fix Chart Editor Difficulty Toolbox Displaying Any Variation Song Name

### DIFF
--- a/source/funkin/ui/debug/charting/toolboxes/ChartEditorDifficultyToolbox.hx
+++ b/source/funkin/ui/debug/charting/toolboxes/ChartEditorDifficultyToolbox.hx
@@ -208,7 +208,7 @@ class ChartEditorDifficultyToolbox extends ChartEditorBaseToolbox
     difficultyToolboxTree.clearNodes();
 
     // , icon: 'haxeui-core/styles/default/haxeui_tiny.png'
-    var treeSong:TreeViewNode = difficultyToolboxTree.addNode({id: 'stv_song', text: 'S: ${chartEditorState.currentSongName}'});
+    var treeSong:TreeViewNode = difficultyToolboxTree.addNode({id: 'stv_song', text: 'S: ${chartEditorState.songMetadata.get('default').songName}'});
     treeSong.expanded = true;
 
     for (curVariation in chartEditorState.availableVariations)


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Briefly describe the issue(s) fixed. -->
## Description

This PR fixes a problem where the Chart Editor's difficulty toolbox displays the song name of the variation that was first loaded. This means that if you were to load a song such as Lit Up (BF Mix), the song name shown in the toolbox will be that instead of the song's default song name.

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos

Before:

<img width="163" height="43" alt="image" src="https://github.com/user-attachments/assets/63085fea-eedd-440a-acec-2b0fa141dd06" />

After:

<img width="900" height="624" alt="image" src="https://github.com/user-attachments/assets/f21052d1-49fd-4006-8225-b49de29a51b3" />
