### PR TITLE
[CHORE] Two typos in `CharacterData.hx`

### DIFF
--- a/source/funkin/data/character/CharacterData.hx
+++ b/source/funkin/data/character/CharacterData.hx
@@ -705,7 +705,7 @@ enum abstract CharacterRenderType(String) from String to String
 typedef CharacterData =
 {
   /**
-   * The sematic version number of the character data JSON format.
+   * The semantic version number of the character data JSON format.
    */
   var version:String;
 
@@ -723,7 +723,7 @@ typedef CharacterData =
   /**
    * Behavior varies by render type:
    * - SPARROW: Path to retrieve both the spritesheet and the XML data from.
-   * - PACKER: Path to retrieve both the spritsheet and the TXT data from.
+   * - PACKER: Path to retrieve both the spritesheet and the TXT data from.
    */
   var assetPath:String;
 


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Briefly describe the issue(s) fixed. -->
## Description
Two typos in the CharacterData class.
`sematic` -> `semantic`
`spritsheet` -> `spritesheet`

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos
<img width="330" height="360" alt="Screenshot (266)" src="https://github.com/user-attachments/assets/16574626-9161-4a81-b699-e121470140e4" />

It's the little things that count