### PR TITLE
[ENHANCEMENT] Moddable Freeplay OST text

### DIFF
--- a/source/funkin/data/freeplay/album/AlbumData.hx
+++ b/source/funkin/data/freeplay/album/AlbumData.hx
@@ -49,4 +49,10 @@ typedef AlbumData =
   @:optional
   @:default([])
   public var albumTitleAnimations:Array<AnimationData>;
+
+  /**
+   * An optional override for the Freeplay OST text.
+   */
+  @:optional
+  public var albumOSTName:String;
 }

--- a/source/funkin/ui/freeplay/Album.hx
+++ b/source/funkin/ui/freeplay/Album.hx
@@ -1,7 +1,6 @@
 package funkin.ui.freeplay;
 
 import funkin.data.freeplay.album.AlbumData;
-import funkin.data.freeplay.album.AlbumRegistry;
 import funkin.data.animation.AnimationData;
 import funkin.data.IRegistryEntry;
 import flixel.graphics.FlxGraphic;
@@ -24,8 +23,7 @@ class Album implements IRegistryEntry<AlbumData>
   }
 
   /**
-   * Return the name of the album.
-   * @
+   * @return The name of the album.
    */
   public function getAlbumName():String
   {
@@ -84,5 +82,13 @@ class Album implements IRegistryEntry<AlbumData>
   public function getAlbumTitleAnimations():Array<AnimationData>
   {
     return _data?.albumTitleAnimations ?? [];
+  }
+
+  /**
+   * @return A name to display for the OST in Freeplay. Will be `null` if not set.
+   */
+  public function getAlbumOSTName():Null<String>
+  {
+    return _data?.albumOSTName;
   }
 }

--- a/source/funkin/ui/freeplay/AlbumRoll.hx
+++ b/source/funkin/ui/freeplay/AlbumRoll.hx
@@ -243,6 +243,26 @@ class AlbumRoll extends FlxSpriteGroup
     difficultyStars.flameCheck();
   }
 
+  /**
+   * Returns the name for the OST associated with the album.
+   * If not specified, returns the default name if this is a base game album.
+   * @return Null<String>
+   */
+  public function getOSTNameOverride():Null<String>
+  {
+    var ostOverride:Null<String> = albumData?.getAlbumOSTName();
+    if (ostOverride != null)
+    {
+      return ostOverride;
+    }
+    else if (albumId == null || AlbumRegistry.instance.listBaseGameEntryIds().contains(albumId))
+    {
+      return Constants.DEFAULT_OST_NAME;
+    }
+
+    return null;
+  }
+
   override function destroy():Void
   {
     newAlbumArt.replaceSymbolGraphic(ALBUM_ART_SYMBOL, null);

--- a/source/funkin/ui/freeplay/FreeplayState.hx
+++ b/source/funkin/ui/freeplay/FreeplayState.hx
@@ -346,7 +346,7 @@ class FreeplayState extends MusicBeatSubState
     sparksADD = new FlxSprite(0, 0);
     txtCompletion = new AtlasText(FlxG.width - (FullScreenScaleMode.gameNotchSize.x + 95), 87, '69', AtlasFont.FREEPLAY_CLEAR);
 
-    ostName = new FlxText(8 - FullScreenScaleMode.gameNotchSize.x, 8, FlxG.width - 8 - 8, 'OFFICIAL OST', 48);
+    ostName = new FlxText(8 - FullScreenScaleMode.gameNotchSize.x, 8, FlxG.width - 8 - 8, Constants.DEFAULT_OST_NAME, 48);
     charSelectHint = new FlxText(-40, 18, FlxG.width - 8 - 8, 'Press [ LOL ] to change characters', 32);
 
     backingImage = FunkinSprite.create(backingCard.pinkBack.width * 0.74, 0, styleData == null ? 'freeplay/freeplayBGweek1-bf' : styleData.getBgAssetKey());
@@ -557,6 +557,7 @@ class FreeplayState extends MusicBeatSubState
     ostName.font = 'VCR OSD Mono';
     ostName.alignment = RIGHT;
     ostName.visible = false;
+    ostName.shader = new StrokeShader(0xFFFFFFFF, 2, 2);
 
     charSelectHint.alignment = CENTER;
     charSelectHint.font = "5by7";
@@ -591,7 +592,6 @@ class FreeplayState extends MusicBeatSubState
     var sillyStroke:StrokeShader = new StrokeShader(0xFFFFFFFF, 2, 2);
     topLeftCornerText.shader = sillyStroke;
     freeplayArrow.shader = sillyStroke;
-    ostName.shader = sillyStroke;
 
     var fnfHighscoreSpr:FlxSprite = new FlxSprite(FlxG.width - (FullScreenScaleMode.gameNotchSize.x + 420), 70);
     fnfHighscoreSpr.frames = Paths.getSparrowAtlas('freeplay/highscore');
@@ -757,6 +757,7 @@ class FreeplayState extends MusicBeatSubState
         freeplayTxtBg.visible = true;
         if (freeplayArrow != null) freeplayArrow.visible = true;
         ostName.visible = true;
+        updateOSTName(true);
         fpScoreDisplay.visible = true;
         fpScoreDisplay.updateScore(0);
 
@@ -1452,6 +1453,26 @@ class FreeplayState extends MusicBeatSubState
     }
 
     prevDotAmount = amount;
+  }
+
+  /**
+   * Updates the OST text according to the album data for the current song and performs an outline animation.
+   * @param forceAnimation Whether to force the animation to play even if the text is the same.
+   */
+  function updateOSTName(forceAnimation:Bool = false):Void
+  {
+    var newName:String = albumRoll.getOSTNameOverride() ?? '';
+    if (forceAnimation || ostName.text != newName)
+    {
+      ostName.text = newName;
+
+      var sillyStroke:StrokeShader = cast ostName.shader;
+      sillyStroke.width = sillyStroke.height = 2;
+      FlxTimer.wait(1.5 / 24, () ->
+      {
+        sillyStroke.width = sillyStroke.height = 0;
+      });
+    }
   }
 
   function tryOpenCharSelect():Void
@@ -2506,6 +2527,7 @@ class FreeplayState extends MusicBeatSubState
       albumRoll.albumId = newAlbumId;
       albumRoll.skipIntro();
     }
+    updateOSTName();
 
     // Set difficulty star count.
     albumRoll.setDifficultyStars(daSong?.data.getDifficulty(currentDifficulty, currentVariation)?.difficultyRating ?? 0);

--- a/source/funkin/util/Constants.hx
+++ b/source/funkin/util/Constants.hx
@@ -287,6 +287,11 @@ class Constants
   public static final DEFAULT_ALBUM_ID:String = 'volume1';
 
   /**
+   * The default name for the OST in Freeplay.
+   */
+  public static final DEFAULT_OST_NAME:String = 'OFFICIAL OST';
+
+  /**
    * The default timing format for songs.
    */
   public static final DEFAULT_TIMEFORMAT:SongTimeFormat = SongTimeFormat.MILLISECONDS;


### PR DESCRIPTION
<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
* #6558
<!-- Briefly describe the issue(s) fixed. -->
## Description
Adds an optional `albumOSTName` property to – you've guessed it – album data, that replaces the "OFFICIAL OST" text in Freeplay.

The behaviour I've defined is like so:
- Base game albums will show "OFFICIAL OST" by default, and that is done automatically so. The JSON can still override it though.
- Modded albums will not display any text by default, but one can still be defined via JSON.

It can be useful because mods can try to override the text themselves but will force the default one when other mods attempt to do the same. This will not fix that issue though, only prevent it in future mods.
<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos

https://github.com/user-attachments/assets/5f568a15-bb2a-4ca8-bcf2-1ec72d378179