### PR TITLE
[BUGFIX] Fix Welcome Music Playing After Unfocusing in Chart Editor Playtest

### DIFF
--- a/source/funkin/ui/debug/charting/ChartEditorState.hx
+++ b/source/funkin/ui/debug/charting/ChartEditorState.hx
@@ -3614,7 +3614,7 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
     super.onFocusLost();
 
     // Stop the song upon tabbing out.
-    if (Preferences.autoPause)
+    if (Preferences.autoPause && subState == null)
     {
       stopAudioPlayback();
     }


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
Nerp.

<!-- Briefly describe the issue(s) fixed. -->
## Description
Unfocusing in Chart Editor's Playtest makes it so the welcome music timer starts because it doesn't check to see if it has a substate open so we check that now.

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos
The fixed bug in question:

https://github.com/user-attachments/assets/604d3b85-9c33-4566-ae7d-3fb7a688ccc3