### PR TITLE
Improve the math for the Results State song name position

### DIFF
--- a/source/funkin/play/ResultState.hx
+++ b/source/funkin/play/ResultState.hx
@@ -733,7 +733,8 @@ class ResultState extends MusicBeatSubState
     }
 
     songName.y = -songName.height;
-    var fuckedupnumber = (10) * (songName.text.length / 15);
+    final DEG_TO_RAD:Float = Math.PI / 180;
+    var fuckedupnumber:Float = -(songName.width * 0.5) * Math.sin(songName.angle * DEG_TO_RAD) - 10;
     FlxTween.tween(songName, {y: (diffYTween - 25 - fuckedupnumber) + ((blackTopBar.height - 148) / 1)}, 0.5, {ease: FlxEase.expoOut, startDelay: 0.9});
     songName.x = clearPercentSmall.x + 94;
 


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
Fixes #4188
<!-- Briefly describe the issue(s) fixed. -->
## Description
I've noticed this funny looking variable in the code that offsets the position of the song name as if to fix https://github.com/FunkinCrew/Funkin/issues/4188 but it doesn't really do much, so I played around with it until shit hit the ceiling just right, which means I have no idea how the math I put really works :D

~Might be worth mentioning that I'm using cosine (a function for the X-axis) to offset an object on the Y-axis, but when I change it to sine the offset is too small.~ nvm I was being stoopid

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos

(The text gets offset after I change it, that's because the math only applies after the scrolling cycle repeats)

https://github.com/user-attachments/assets/514c5d2b-93cc-47b0-a435-5bdd5e42af31

