### PR TITLE
[ENHANCEMENT] Notesplashes in Offsets Menu on Perfect Hit

### DIFF
--- a/source/funkin/ui/options/OffsetMenu.hx
+++ b/source/funkin/ui/options/OffsetMenu.hx
@@ -19,6 +19,7 @@ import funkin.graphics.FunkinSprite;
 import funkin.data.song.SongData.SongNoteData;
 import funkin.data.notestyle.NoteStyleRegistry;
 import funkin.play.notes.notestyle.NoteStyle;
+import funkin.play.notes.NoteSplash;
 import funkin.ui.options.items.NumberPreferenceItem;
 import haxe.Int64;
 import flixel.FlxSprite;
@@ -903,6 +904,10 @@ class OffsetMenu extends Page<OptionsState.OptionsMenuPageName>
     {
       // \n to signify a line break (because the original text has 3 lines)
       jumpInText.text = 'Perfect!\n';
+      var notesplash:NoteSplash = new NoteSplash(NoteStyleRegistry.instance.fetchEntry(Constants.DEFAULT_NOTE_STYLE));
+      notesplash.play(note.direction, 0);
+      notesplash.setPosition(note.x, note.y);
+      add(notesplash);
     }
     else
     {


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
No Linked Issues.
<!-- Briefly describe the issue(s) fixed. -->
## Description
Adds notesplashes when hitting a Perfect! on the testing menu for offsets.
(Huge thanks to @JVNpixels for help on this.)
<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos
https://github.com/user-attachments/assets/7e172253-e80b-43c1-a72d-4dc1791e1d4a

[THIS VIDEO SHOWS A MODIFICATION OF THE PULL REQUEST. NOTESPLASHES ONLY APPLY ON PERFECT HITS]


