### PR TITLE
[ENHANCEMENT] Auto Detect Rimlight Alt Masks For Characters

### DIFF
--- a/source/funkin/graphics/shaders/DropShadowShader.hx
+++ b/source/funkin/graphics/shaders/DropShadowShader.hx
@@ -2,6 +2,7 @@ package funkin.graphics.shaders;
 
 import flixel.system.FlxAssets.FlxShader;
 import flixel.util.FlxColor;
+import funkin.play.character.BaseCharacter;
 import funkin.graphics.FunkinSprite;
 import flixel.math.FlxAngle;
 import flixel.graphics.frames.FlxFrame;
@@ -203,6 +204,20 @@ class DropShadowShader extends FlxShader
     if (attachedSprite.isAnimate && !attachedSprite.useRenderTexture)
     {
       attachedSprite.useRenderTexture = true;
+    }
+
+    if (Std.isOfType(spr, BaseCharacter))
+    {
+      var character:BaseCharacter = cast spr;
+      var charId:String = character.characterId;
+
+      var maskPath:String = Paths.image('masks/' + charId);
+
+      if (Assets.exists(maskPath))
+      {
+        loadAltMask(maskPath);
+        useAltMask = true;
+      }
     }
 
     return spr;


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

> [!WARNING]
> FunkinCrew/funkin.assets#322 is required!

<!-- Briefly describe the issue(s) fixed. -->
## Description

This PR makes it so that character rimlight alt masks are checked for automatically. That means instead of having to do a million character id checks, you simply just have to include an alt mask image that's named after the character id in the newly created `masks` folder.

This PR also removes Nene's alt mask as not only is it outdated, but a change was made that makes it so that the alt mask isn't needed at all.

Tankman (Bloody)'s alt mask was updated, but it doesn't work due to an issue with `useRenderTexture`. Sure that change was completely useless, but it should work fine if alt masks on texture atlases gets fixed. I did test Tankman's alt mask with `useRenderTexture` disabled and the alt mask works fine apart from the lack of `useRenderTexture` problems.