### PR TITLE
[ADJUSTMENT/BUGFIX] Changed the order that events are dispatched in PlayState

### DIFF
--- a/source/funkin/play/PlayState.hx
+++ b/source/funkin/play/PlayState.hx
@@ -1496,26 +1496,26 @@ class PlayState extends MusicBeatSubState
 
   public override function dispatchEvent(event:ScriptEvent):Void
   {
-    // ORDER: Module, Stage, Character, Song, Conversation, Note
+    // ORDER: Module, Song, Note, Stage, Conversation, Character
     // Modules should get the first chance to cancel the event.
 
     // super.dispatchEvent(event) dispatches event to module scripts.
     super.dispatchEvent(event);
 
-    // Dispatch event to stage script.
-    ScriptEventDispatcher.callEvent(currentStage, event);
-
-    // Dispatch event to character script(s).
-    if (currentStage != null) currentStage.dispatchToCharacters(event);
-
     // Dispatch event to song script.
     ScriptEventDispatcher.callEvent(currentSong, event);
+
+    // Dispatch event to note kind scripts
+    NoteKindManager.callEvent(event);
+
+    // Dispatch event to stage script.
+    ScriptEventDispatcher.callEvent(currentStage, event);
 
     // Dispatch event to conversation script.
     ScriptEventDispatcher.callEvent(currentConversation, event);
 
-    // Dispatch event to note kind scripts
-    NoteKindManager.callEvent(event);
+    // Dispatch event to character script(s).
+    if (currentStage != null) currentStage.dispatchToCharacters(event);
   }
 
   /**


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues

<!-- Briefly describe the issue(s) fixed. -->
## Description
Changes the order that the PlayState dispatches events from 
`Module, Stage, Character, Song, Conversation, Note` to `Module, Song, Note, Stage, Conversation, Character`

The current order in which events are dispatched currently allows Note Kind or Song scripts that cancel the onNoteMiss / onNoteHit event to still play the note animations for the characters. The new order, recommended by both Kade & KoloInDaCrib, should fix this issue

> [!CAUTION]
> This is most likely a breaking change for scripts that were written with the original order in mind.