### PR TITLE
[ENHANCEMENT] Gamepad binds now are showed in Freeplay's hint

### DIFF
--- a/source/funkin/input/Controls.hx
+++ b/source/funkin/input/Controls.hx
@@ -1,5 +1,6 @@
 package funkin.input;
 
+import funkin.util.InputUtil;
 import flixel.input.gamepad.FlxGamepad;
 import flixel.util.FlxDirectionFlags;
 import flixel.input.FlxInput.FlxInputState;
@@ -433,22 +434,22 @@ class Controls extends FlxActionSet
   public function getDialogueName(action:FlxActionDigital, ?ignoreSurrounding:Bool = false):String
   {
     if (action.inputs.length == 0) return 'N/A';
-    var input = action.inputs[0];
+    var input = FunkinAction.lastDeviceUsed == KEYBOARD ? action.inputs[0] : action.inputs[1];
     if (ignoreSurrounding == false)
     {
-      return switch (input.device)
+      return switch (FunkinAction.lastDeviceUsed)
       {
-        case KEYBOARD: return '[${(input.inputID : FlxKey)}]';
-        case GAMEPAD: return '(${(input.inputID : FlxGamepadInputID)})';
+        case KEYBOARD: return '[${InputUtil.format(input.inputID, Keys).toUpperCase()}]';
+        case GAMEPAD: return '(${InputUtil.format(input.inputID, Gamepad(input.deviceID)).toUpperCase()})';
         case device: throw 'unhandled device: $device';
       }
     }
     else
     {
-      return switch (input.device)
+      return switch (FunkinAction.lastDeviceUsed)
       {
-        case KEYBOARD: return '${(input.inputID : FlxKey)}';
-        case GAMEPAD: return '${(input.inputID : FlxGamepadInputID)}';
+        case KEYBOARD: return InputUtil.format(input.inputID, Keys).toUpperCase();
+        case GAMEPAD: return InputUtil.format(input.inputID, Gamepad(input.deviceID)).toUpperCase();
         case device: throw 'unhandled device: $device';
       }
     }
@@ -1290,6 +1291,7 @@ class FunkinAction extends FlxActionDigital
    */
   public function checkPressed():Bool
   {
+    if (checkFiltered(PRESSED)) updateLastDeviceUsed();
     return checkFiltered(PRESSED);
   }
 
@@ -1298,6 +1300,7 @@ class FunkinAction extends FlxActionDigital
    */
   public function checkJustPressed():Bool
   {
+    if (checkFiltered(JUST_PRESSED)) updateLastDeviceUsed();
     return checkFiltered(JUST_PRESSED);
   }
 
@@ -1314,6 +1317,7 @@ class FunkinAction extends FlxActionDigital
    */
   public function checkJustReleased():Bool
   {
+    if (checkFiltered(JUST_RELEASED)) updateLastDeviceUsed();
     return checkFiltered(JUST_RELEASED);
   }
 
@@ -1439,6 +1443,29 @@ class FunkinAction extends FlxActionDigital
     cache.set(key, {timestamp: FlxG.game.ticks, value: triggered});
 
     return triggered;
+  }
+
+  public static var lastDeviceUsed:FlxInputDevice;
+
+  /**
+   * Checks which is the last device you have used and stores the value in `lastDeviceUsed`.
+   */
+  public function updateLastDeviceUsed()
+  {
+    if (FlxG.keys.pressed.ANY)
+    {
+      lastDeviceUsed = FlxInputDevice.KEYBOARD;
+      return;
+    }
+
+    if (FlxG.gamepads.lastActive != null)
+    {
+      lastDeviceUsed = FlxInputDevice.GAMEPAD;
+      return;
+    }
+
+    // Default value (just in case everything's null somehow)
+    lastDeviceUsed = FlxInputDevice.KEYBOARD;
   }
 }
 

--- a/source/funkin/ui/freeplay/FreeplayState.hx
+++ b/source/funkin/ui/freeplay/FreeplayState.hx
@@ -1728,6 +1728,15 @@ class FreeplayState extends MusicBeatSubState
     handleTouchSelectionScroll(elapsed);
     #end
 
+    #if FEATURE_TOUCH_CONTROLS
+    if (ControlsHandler.usingExternalInputDevice)
+      charSelectHint.text = 'Press [ ${controls.getDialogueNameFromControl(FREEPLAY_CHAR_SELECT, true)} ] to change characters';
+    else
+      charSelectHint.text = 'Tap the DJ to change characters';
+    #else
+    charSelectHint.text = 'Press [ ${controls.getDialogueNameFromControl(FREEPLAY_CHAR_SELECT, true)} ] to change characters';
+    #end
+
     handleDirectionalInput(elapsed);
 
     final wheelAmount:Int = Std.int(FlxMath.bound(FlxG.mouse.wheel, -1, 1));

--- a/source/funkin/util/InputUtil.hx
+++ b/source/funkin/util/InputUtil.hx
@@ -18,7 +18,7 @@ class InputUtil
     return switch (device)
     {
       case Keys: getKeyName(id);
-      case Gamepad(gamepadID): getButtonName(id, FlxG.gamepads.getByID(gamepadID));
+      case Gamepad(gamepadID): FlxG.gamepads.getByID(gamepadID) != null ? getButtonName(id, FlxG.gamepads.getByID(gamepadID)) : 'N/A';
     }
   }
 


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
#6608 

<!-- Briefly describe the issue(s) fixed. -->
## Description
This PR adds a method called `updateLastDeviceUsed` to check in Freeplay if we are using the gamepad or the keyboard and update the hint text properly. Also updates the hint text if you change the device in the menu

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos

https://github.com/user-attachments/assets/e47dab79-5ac0-45ae-8dee-4ef6e52c1be6


