### PR TITLE
[BUGFIX] Fix Freeplay crash when scrolling through songs rapidly

### DIFF
--- a/source/funkin/ui/freeplay/FreeplayState.hx
+++ b/source/funkin/ui/freeplay/FreeplayState.hx
@@ -2920,9 +2920,13 @@ class FreeplayState extends MusicBeatSubState
       // switchBackingImage(currentCapsule.freeplayData);
     }
 
-    // Small vibrations every selection change.
-    if (change != 0) HapticUtil.vibrate(0, 0.01, 0.5);
-
+    // Clear song previews and add small vibrations every selection change.
+    if (change != 0)
+    {
+      clearPreviews();
+      HapticUtil.vibrate(0, 0.01, 0.5);
+    }
+		
     dispatchEvent(new CapsuleScriptEvent(CAPSULE_SELECTED, currentCapsule, currentDifficulty, currentVariation));
   }
 


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Briefly describe the issue(s) fixed. -->
## Description

This PR fixes a potential crash in the develop branch when quickly scrolling through song capsules.

This crash was caused by the game adding too many song preview timers without clearing them.