### PR TITLE
[ENHANCEMENT] Movement-Based Cursor Visibility

### DIFF
--- a/source/funkin/InitState.hx
+++ b/source/funkin/InitState.hx
@@ -169,6 +169,8 @@ class InitState extends FlxState
       // Makes Flixel use frame times instead of locked movements per frame for things like tweens
       FlxG.fixedTimestep = false;
 
+      FlxG.mouse.visible = false;
+
       setupFlixelDebug();
 
       //
@@ -260,6 +262,7 @@ class InitState extends FlxState
       funkin.util.plugins.ReloadAssetsDebugPlugin.initialize();
       #if !mobile
       funkin.util.plugins.VolumePlugin.initialize();
+      funkin.util.plugins.CursorVisibilityPlugin.initialize();
       #end
       funkin.util.plugins.WatchPlugin.initialize();
       #if mobile

--- a/source/funkin/input/Cursor.hx
+++ b/source/funkin/input/Cursor.hx
@@ -16,11 +16,16 @@ class Cursor
   public static var cursorMode(default, set):Null<CursorMode> = null;
 
   /**
+   * Whether the cursor is forced to stay visible, even after cursor movement.
+   */
+  public static var visible:Bool = false;
+
+  /**
    * Show the cursor.
    */
   public static inline function show():Void
   {
-    FlxG.mouse.visible = true;
+    Cursor.visible = true;
     // Reset the cursor mode.
     Cursor.cursorMode = Default;
   }
@@ -28,16 +33,22 @@ class Cursor
   /**
    * Hide the cursor.
    */
-  public static inline function hide():Void
+  public static inline function hide(force:Bool = false):Void
   {
-    FlxG.mouse.visible = false;
+    Cursor.visible = false;
     // Reset the cursor mode.
-    Cursor.cursorMode = null;
+    Cursor.cursorMode = Default;
+
+    if (force)
+    {
+      funkin.util.plugins.CursorVisibilityPlugin.showTimer = 0;
+      funkin.util.plugins.CursorVisibilityPlugin.hideTimer = 0;
+    }
   }
 
   public static inline function toggle():Void
   {
-    if (FlxG.mouse.visible)
+    if (Cursor.visible)
     {
       hide();
     }

--- a/source/funkin/ui/debug/stage/StageBuilderState.hx
+++ b/source/funkin/ui/debug/stage/StageBuilderState.hx
@@ -35,7 +35,7 @@ class StageBuilderState extends MusicBeatState
 
     super.create();
 
-    FlxG.mouse.visible = true;
+    funkin.input.Cursor.show();
 
     // snd = new Sound();
 

--- a/source/funkin/ui/debug/stage/StageOffsetSubState.hx
+++ b/source/funkin/ui/debug/stage/StageOffsetSubState.hx
@@ -49,7 +49,8 @@ class StageOffsetSubState extends HaxeUISubState
 
     var playState = PlayState.instance;
 
-    FlxG.mouse.visible = true;
+    funkin.input.Cursor.show();
+
     playState.pauseMusic();
     playState.cancelAllCameraTweens();
     FlxG.camera.target = null;
@@ -251,7 +252,7 @@ class StageOffsetSubState extends HaxeUISubState
       if (FlxG.keys.justPressed.DOWN) performCommand(new MovePropCommand(0, zoomShitLol));
     }
 
-    FlxG.mouse.visible = true;
+    funkin.input.Cursor.show();
 
     MouseUtil.mouseCamDrag();
 
@@ -272,7 +273,7 @@ class StageOffsetSubState extends HaxeUISubState
       // uiStuff = null;
       PlayState.instance.disableKeys = false;
       PlayState.instance.resetCamera();
-      FlxG.mouse.visible = false;
+      funkin.input.Cursor.hide();
       close();
     }
   }

--- a/source/funkin/ui/title/TitleState.hx
+++ b/source/funkin/ui/title/TitleState.hx
@@ -149,8 +149,6 @@ class TitleState extends MusicBeatState
     ngSpr.updateHitbox();
     ngSpr.screenCenter(X);
 
-    FlxG.mouse.visible = false;
-
     if (initialized) skipIntro();
     else
       initialized = true;

--- a/source/funkin/util/plugins/CursorVisibilityPlugin.hx
+++ b/source/funkin/util/plugins/CursorVisibilityPlugin.hx
@@ -1,0 +1,53 @@
+package funkin.util.plugins;
+
+import openfl.events.MouseEvent;
+import funkin.input.Cursor;
+import flixel.FlxBasic;
+
+/**
+ * A plugin which shows the mouse cursor whenever it moves.
+ * Using `Cursor.show()` will force the cursor to stay visible.
+ */
+class CursorVisibilityPlugin extends FlxBasic
+{
+  public static var showTimer:Float = 0;
+  public static var hideTimer:Float = 0;
+
+  public function new()
+  {
+    super();
+  }
+
+  public static function initialize():Void
+  {
+    FlxG.plugins.addPlugin(new CursorVisibilityPlugin());
+
+    FlxG.stage.addEventListener(MouseEvent.MOUSE_MOVE, onMouseMove);
+  }
+
+  public override function update(elapsed:Float):Void
+  {
+    if (Cursor.visible)
+    {
+      showTimer = 0;
+      hideTimer = 1;
+    }
+    else
+    {
+      showTimer = Math.max(0, showTimer - elapsed);
+
+      if (showTimer == 0) hideTimer = Math.max(0, hideTimer - elapsed * 5);
+    }
+
+    FlxG.mouse.cursor.alpha = hideTimer;
+    FlxG.mouse.visible = hideTimer > 0;
+
+    super.update(elapsed);
+  }
+
+  static function onMouseMove(_):Void
+  {
+    showTimer = 1;
+    hideTimer = 1;
+  }
+}

--- a/source/funkin/util/plugins/ScreenshotPlugin.hx
+++ b/source/funkin/util/plugins/ScreenshotPlugin.hx
@@ -190,10 +190,10 @@ class ScreenshotPlugin extends FlxBasic
         openScreenshotsFolder();
         return; // We're only opening the screenshots folder (we don't want to accidentally take a screenshot after this)
       }
-      if (Preferences.shouldHideMouse && !wasMouseHidden && FlxG.mouse.visible)
+      if (Preferences.shouldHideMouse && !wasMouseHidden)
       {
-        wasMouseHidden = true;
-        Cursor.hide();
+        if (Cursor.visible) wasMouseHidden = true;
+        Cursor.hide(true);
       }
       for (sprite in [flashSprite, previewSprite])
       {
@@ -208,7 +208,7 @@ class ScreenshotPlugin extends FlxBasic
           // The player's stopped spamming shots, so we can stop the screenshot spam mode too
           screenshotBeingSpammed = false;
           if (screenshotBuffer[0] != null) saveBufferedScreenshots(screenshotBuffer, screenshotNameBuffer);
-          if (!Preferences.fancyPreview && wasMouseHidden && !FlxG.mouse.visible)
+          if (!Preferences.fancyPreview && wasMouseHidden && !Cursor.visible)
           {
             wasMouseHidden = false;
             Cursor.show();
@@ -288,7 +288,7 @@ class ScreenshotPlugin extends FlxBasic
         throw "You've tried taking more than 100 screenshots at a time. Give the game a funkin break! Jeez. If you wanted those screenshots, well too bad!";
       }
       showCaptureFeedback();
-      if (wasMouseHidden && !FlxG.mouse.visible && Preferences.flashingLights) // Just in case
+      if (wasMouseHidden && !Cursor.visible && Preferences.flashingLights) // Just in case
       {
         wasMouseHidden = false;
         Cursor.show();
@@ -301,7 +301,7 @@ class ScreenshotPlugin extends FlxBasic
       saveScreenshot(shot, 'screenshot-${DateUtil.generateTimestamp()}', 1, false);
       // Show some feedback.
       showCaptureFeedback();
-      if (wasMouseHidden && !FlxG.mouse.visible)
+      if (wasMouseHidden && !Cursor.visible)
       {
         wasMouseHidden = false;
         Cursor.show();
@@ -348,7 +348,7 @@ class ScreenshotPlugin extends FlxBasic
 
     // ermmm stealing this??
 
-    if (!wasMouseShown && !wasMouseHidden && !FlxG.mouse.visible)
+    if (!wasMouseShown && !wasMouseHidden && !Cursor.visible)
     {
       wasMouseShown = true;
       Cursor.show();
@@ -403,12 +403,12 @@ class ScreenshotPlugin extends FlxBasic
               ease: FlxEase.quartInOut,
               onComplete: function(_)
               {
-                if (wasMouseShown && FlxG.mouse.visible)
+                if (wasMouseShown && Cursor.visible)
                 {
                   wasMouseShown = false;
-                  Cursor.hide();
+                  Cursor.hide(true);
                 }
-                else if (wasMouseHidden && !FlxG.mouse.visible)
+                else if (wasMouseHidden && !Cursor.visible)
                 {
                   wasMouseHidden = false;
                   Cursor.show();
@@ -605,12 +605,12 @@ class ScreenshotPlugin extends FlxBasic
     }
 
     // Undo the mouse stuff - we don't know what the next state will do with it
-    if (wasMouseShown && FlxG.mouse.visible)
+    if (wasMouseShown && Cursor.visible)
     {
       wasMouseShown = false;
-      Cursor.hide();
+      Cursor.hide(true);
     }
-    else if (wasMouseHidden && !FlxG.mouse.visible)
+    else if (wasMouseHidden && !Cursor.visible)
     {
       wasMouseHidden = false;
       Cursor.show();


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Briefly describe the issue(s) fixed. -->
## Description

This PR implements a feature where the mouse cursor becomes visible when moved. To prevent any confusion in the editors, I made it so that when the cursor is shown with `Cursor.show()`, it stays visible, even if the player isn't moving their cursor.

In summary, moving your mouse cursor will cause it to become visible for a certain amount of time, and editors force the cursor to stay visible.

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos

In the video below, my cursor becomes visible when I move it. I keep it still and it stays visible until a certain amount of time has passed.

https://github.com/user-attachments/assets/b577e7ce-9c5e-4de8-b406-5d028ebbd091