### PR TITLE
[OPTIMIZATION] Fix a memory leak in the Freeplay Menu

### DIFF
--- a/source/funkin/ui/freeplay/FreeplayState.hx
+++ b/source/funkin/ui/freeplay/FreeplayState.hx
@@ -4,7 +4,6 @@ import flixel.FlxCamera;
 import flixel.FlxObject;
 import flixel.FlxSprite;
 import flixel.addons.transition.FlxTransitionableState;
-import flixel.group.FlxGroup.FlxTypedGroup;
 import flixel.group.FlxSpriteGroup.FlxTypedSpriteGroup;
 import flixel.math.FlxMath;
 import flixel.math.FlxPoint;
@@ -198,7 +197,7 @@ class FreeplayState extends MusicBeatSubState
     return grpCapsules.members[curSelected];
   }
 
-  var grpCapsules:FlxTypedGroup<SongMenuItem>;
+  var grpCapsules:SongItemGroup;
 
   var dj:Null<BaseFreeplayDJ> = null;
   #if FEATURE_TOUCH_CONTROLS
@@ -335,7 +334,7 @@ class FreeplayState extends MusicBeatSubState
     fpScoreDisplay = new FreeplayScore(FlxG.width - (FullScreenScaleMode.gameNotchSize.x + 353), 60, 7, 100, styleData);
     rankCamera = new FunkinCamera('rankCamera', 0, 0, FlxG.width, FlxG.height);
     funnyCam = new FunkinCamera('freeplayFunny', 0, 0, FlxG.width, FlxG.height);
-    grpCapsules = new FlxTypedGroup<SongMenuItem>();
+    grpCapsules = new SongItemGroup();
     grpDifficulties = new FlxTypedSpriteGroup<DifficultySprite>(-300, 80);
 
     difficultyDots = new FlxTypedSpriteGroup<DifficultyDot>(DEFAULT_DOTS_GROUP_POS[0], DEFAULT_DOTS_GROUP_POS[1]);

--- a/source/funkin/ui/freeplay/SongItemGroup.hx
+++ b/source/funkin/ui/freeplay/SongItemGroup.hx
@@ -1,0 +1,62 @@
+package funkin.ui.freeplay;
+
+import flixel.FlxCamera;
+import flixel.FlxSprite;
+import flixel.group.FlxGroup.FlxTypedGroup;
+import funkin.graphics.shaders.GaussianBlurShader;
+
+/**
+ * A FlxTypedGroup for capsules that does drawing in batches. This prevents memory leaks due to too many assets being rendered.
+ */
+@:nullSafety
+class SongItemGroup extends FlxTypedGroup<SongMenuItem>
+{
+  var rankBlurredShader:GaussianBlurShader = new GaussianBlurShader(1);
+  var favIconBlurredShader:GaussianBlurShader = new GaussianBlurShader(1.2);
+
+  override function recycle(?cls:Class<SongMenuItem>, ?factory:Void->SongMenuItem, force:Bool = false, revive:Bool = true):SongMenuItem
+  {
+    var capsule:SongMenuItem = super.recycle(cls, factory, force, revive);
+
+    // Apply the same shader instance to some elements so that we can use one draw call to render multiple of them.
+    capsule.fakeBlurredRanking.shader = rankBlurredShader;
+    capsule.blurredRanking.shader = rankBlurredShader;
+    capsule.favIconBlurred.shader = favIconBlurredShader;
+
+    return capsule;
+  }
+
+  @:access(flixel.FlxCamera)
+  override function draw():Void
+  {
+    // Temporarily store the default cameras so we can replace them with the group's cameras.
+    final oldDefaultCameras = FlxCamera._defaultCameras;
+    if (_cameras != null)
+    {
+      FlxCamera._defaultCameras = _cameras;
+    }
+
+    final capsulesToRender:Array<SongMenuItem> = [];
+
+    for (capsule in this.members)
+    {
+      if (capsule != null && capsule.exists && capsule.visible) capsulesToRender.push(capsule);
+    }
+
+    if (capsulesToRender.length == 0) return;
+
+    final memberCount:Int = capsulesToRender[0].length; // Capsules always have a constant number of members to render.
+    for (i in 0...memberCount)
+    {
+      for (capsule in capsulesToRender)
+      {
+        var member:FlxSprite = capsule.members[i];
+        if (member == null || !member.visible) continue;
+
+        member.draw();
+      }
+    }
+
+    FlxCamera._defaultCameras = oldDefaultCameras;
+  }
+}

--- a/source/funkin/ui/freeplay/SongMenuItem.hx
+++ b/source/funkin/ui/freeplay/SongMenuItem.hx
@@ -150,7 +150,6 @@ class SongMenuItem extends FlxSpriteGroup
     add(fakeRanking);
 
     fakeBlurredRanking = new FreeplayRank(fakeRanking.x, fakeRanking.y);
-    fakeBlurredRanking.shader = new GaussianBlurShader(1);
     add(fakeBlurredRanking);
 
     fakeRanking.visible = false;
@@ -162,7 +161,6 @@ class SongMenuItem extends FlxSpriteGroup
     add(ranking);
 
     blurredRanking = new FreeplayRank(ranking.x, ranking.y);
-    blurredRanking.shader = new GaussianBlurShader(1);
     add(blurredRanking);
 
     sparkle = new FlxSprite(ranking.x, ranking.y);
@@ -218,7 +216,6 @@ class SongMenuItem extends FlxSpriteGroup
 
     favIconBlurred.setGraphicSize(50, 50);
     favIconBlurred.blend = BlendMode.ADD;
-    favIconBlurred.shader = new GaussianBlurShader(1.2);
     favIconBlurred.visible = false;
     add(favIconBlurred);
 


### PR DESCRIPTION
## Linked Issues
None, I think? I feel like a memory leak like this must've been reported before.

## Description
Hyper told me that his Tracy session revealed that the memory leak happening from doing anything in Freeplay stemmed from a bunch of `drawQuad` calls, He suggested using quad batching to fix this. This PR utilizes that by implementing a group that changes how the capsules are rendered, rendering an element type per viable capsule before moving onto the next element.

The code for this was adopted from MaybeMaru's implementation that they showcased a long time ago, just modified for funkin's codebase, hence why they're one of the co-authors.

## Screenshots/Videos

https://github.com/user-attachments/assets/73212d33-db3f-4c35-ac9e-17638619378a
