### PR TITLE
[ENHANCEMENT] Improve Multiply Shader

### DIFF
--- a/source/funkin/graphics/shaders/MultiplyShader.hx
+++ b/source/funkin/graphics/shaders/MultiplyShader.hx
@@ -1,31 +1,31 @@
 package funkin.graphics.shaders;
 
 import flixel.system.FlxAssets.FlxShader;
+import flixel.util.FlxColor;
 
 class MultiplyShader extends FlxShader
 {
-  @:glFragmentSource('
-		#pragma header
-        uniform sampler2D funnyImage;
-		uniform vec4 uBlendColor;
+    @:glFragmentSource('
+        #pragma header
+        uniform vec4 uBlendColor;
 
-		vec4 blendMultiply(vec4 base, vec4 blend)
-		{
-			return base * blend;
-		}
+        void main()
+        {
+            vec4 base = texture2D(bitmap, openfl_TextureCoordv);
 
-		vec4 blendMultiply(vec4 base, vec4 blend, float opacity)
-		{
-			return (blendMultiply(base, blend) * opacity + base * (1.0 - opacity));
-		}
+            vec3 rgb = mix(base.rgb, base.rgb * uBlendColor.rgb, uBlendColor.a);
 
-		void main()
-		{
-			vec4 base = texture2D(bitmap, openfl_TextureCoordv);
-			gl_FragColor = blendMultiply(base, uBlendColor, uBlendColor.a);
-		}')
-  public function new()
-  {
-    super();
-  }
+            gl_FragColor = vec4(rgb, base.a);
+        }')
+
+      public function new()
+      {
+        super();
+      }
+
+    public function set_blendColor(color:FlxColor):FlxColor
+    {
+        uBlendColor.value = [color.red / 255, color.green / 255, color.blue / 255, color.alpha / 255];
+        return color;
+    }
 }


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
None

<!-- Briefly describe the issue(s) fixed. -->
## Description
Rewrites MultiplyShader.hx and adds a function to apply a multiply blending mode color over a sprite with it set as its shader. As far as I'm aware, it was not possible to use this shader in a stage script prior to these changes.

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos
<img width="1920" height="1080" alt="multiply" src="https://github.com/user-attachments/assets/4b66b776-2a3f-43e5-a5e0-3caa94af640e" />
