### PR TITLE
[BUGFIX] Fix Menu Scrolling Behavior On Web

### DIFF
--- a/source/funkin/ui/freeplay/FreeplayState.hx
+++ b/source/funkin/ui/freeplay/FreeplayState.hx
@@ -1730,12 +1730,12 @@ class FreeplayState extends MusicBeatSubState
 
     handleDirectionalInput(elapsed);
 
-    final wheelAmount:Float = #if !html5 FlxG.mouse.wheel #else FlxG.mouse.wheel / 8 #end;
+    final wheelAmount:Int = Std.int(FlxMath.bound(FlxG.mouse.wheel, -1, 1));
 
     if (wheelAmount != 0)
     {
       dj?.onPlayerAction(); // dj?.resetAFKTimer();
-      changeSelection(-Math.round(wheelAmount));
+      changeSelection(-wheelAmount);
     }
 
     handleDifficultySwitch();

--- a/source/funkin/ui/story/StoryMenuState.hx
+++ b/source/funkin/ui/story/StoryMenuState.hx
@@ -6,6 +6,7 @@ import flixel.group.FlxGroup.FlxTypedGroup;
 import flixel.text.FlxText;
 import flixel.tweens.FlxEase;
 import flixel.tweens.FlxTween;
+import flixel.math.FlxMath;
 import flixel.util.FlxColor;
 import flixel.util.FlxTimer;
 import funkin.audio.FunkinSound;
@@ -372,21 +373,12 @@ class StoryMenuState extends MusicBeatState
           changeDifficulty(0);
         }
 
-        #if !html5
-        if (FlxG.mouse.wheel != 0)
+        final wheelAmount:Int = Std.int(FlxMath.bound(FlxG.mouse.wheel, -1, 1));
+
+        if (wheelAmount != 0)
         {
-          changeLevel(-Math.round(FlxG.mouse.wheel));
+          changeLevel(-wheelAmount);
         }
-        #else
-        if (FlxG.mouse.wheel < 0)
-        {
-          changeLevel(-Math.round(FlxG.mouse.wheel / 8));
-        }
-        else if (FlxG.mouse.wheel > 0)
-        {
-          changeLevel(-Math.round(FlxG.mouse.wheel / 8));
-        }
-        #end
 
         // TODO: Querying UI_RIGHT_P (justPressed) after UI_RIGHT always returns false. Fix it!
         if (controls.UI_RIGHT_P #if FEATURE_TOUCH_CONTROLS


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues

Fixes #3108

<!-- Briefly describe the issue(s) fixed. -->
## Description

This PR fixes an issue on the web version of the game where using your mouse wheel to scroll through songs and weeks is completely broken. This was fixed by limiting the scroll to an integer between -1 and 1 because dividing the mouse wheel value by a number is unreliable.

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos

Below is a video showing the fix for the Freeplay menu. I fixed this for the story menu as well.

https://github.com/user-attachments/assets/861297ad-0be4-4d70-a4ea-39eb3f5fac45