### PR TITLE
[ENHANCEMENT] Autolocate Animate Atlas library

### DIFF
--- a/source/funkin/Paths.hx
+++ b/source/funkin/Paths.hx
@@ -79,7 +79,8 @@ class Paths implements ConsoleClass
 
   public static function animateAtlas(path:String, ?library:String):String
   {
-    return getLibraryPath('images/$path', library);
+    var animationPath:String = getPath('images/$path/Animation.json', TEXT, library);
+    return Path.directory(animationPath);
   }
 
   public static function txt(key:String, ?library:String):String

--- a/source/funkin/play/ResultState.hx
+++ b/source/funkin/play/ResultState.hx
@@ -226,12 +226,13 @@ class ResultState extends MusicBeatSubState
       }
 
       var animPath:String = "";
-      var animLibrary:String = "";
+      var animLibrary:Null<String> = null;
 
       if (animData.assetPath != null)
       {
         animPath = Paths.stripLibrary(animData.assetPath);
         animLibrary = Paths.getLibrary(animData.assetPath);
+        if (animLibrary == "preload") animLibrary = null;
       }
       var offsets = animData.offsets ?? [0, 0];
       switch (animData.renderType)

--- a/source/funkin/play/character/AnimateAtlasCharacter.hx
+++ b/source/funkin/play/character/AnimateAtlasCharacter.hx
@@ -38,7 +38,8 @@ class AnimateAtlasCharacter extends BaseCharacter
   function loadAtlas():Void
   {
     log('Loading sprite atlas for ${characterId}.');
-    var assetLibrary:String = Paths.getLibrary(_data.assetPath);
+    var assetLibrary:Null<String> = Paths.getLibrary(_data.assetPath);
+    if (assetLibrary == "preload") assetLibrary = null;
     var assetPath:String = Paths.stripLibrary(_data.assetPath);
 
     loadTextureAtlas(assetPath, assetLibrary, getAtlasSettings());

--- a/source/funkin/play/character/MultiAnimateAtlasCharacter.hx
+++ b/source/funkin/play/character/MultiAnimateAtlasCharacter.hx
@@ -47,7 +47,8 @@ class MultiAnimateAtlasCharacter extends BaseCharacter
     var textureList:Array<FlxAtlasFrames> = [];
     var addedAssetPaths:Array<String> = [];
 
-    var baseAssetLibrary:String = Paths.getLibrary(_data.assetPath);
+    var baseAssetLibrary:Null<String> = Paths.getLibrary(_data.assetPath);
+    if (baseAssetLibrary == "preload") baseAssetLibrary = null;
     var baseAssetPath:String = Paths.stripLibrary(_data.assetPath);
 
     var mainTexture:FlxAnimateFrames = Paths.getAnimateAtlas(baseAssetPath, baseAssetLibrary, cast _data.atlasSettings);
@@ -89,7 +90,8 @@ class MultiAnimateAtlasCharacter extends BaseCharacter
 
           if (!_usedAtlases.contains(subTexture)) _usedAtlases.push(subTexture);
         default:
-          var subAssetLibrary:String = Paths.getLibrary(animation.assetPath);
+          var subAssetLibrary:Null<String> = Paths.getLibrary(animation.assetPath);
+          if (subAssetLibrary == "preload") subAssetLibrary = null;
           var subAssetPath:String = Paths.stripLibrary(animation.assetPath);
 
           var subTexture:FlxAnimateFrames = Paths.getAnimateAtlas(subAssetPath, subAssetLibrary, cast animation.atlasSettings ?? _data.atlasSettings);


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

## Associated Funkin Assets PR
### The Associated Assets PR doesn't need to be merged for this PR to work, it is purely optional.
FunkinCrew/funkin.assets#325

<!-- Does this PR close any issues? If so, link them below. -->
<!-- ## Linked Issues -->

<!-- Briefly describe the issue(s) fixed. -->
## Description
This PR changes the way that `Paths.animateAtlas` looks for paths.
It now works by searching for `Animation.json`, and returning it's directory.
