### PR TITLE
[CHORE] Bump example_mods's API version to 0.8.0

### DIFF
--- a/example_mods/introMod/_polymod_meta.json
+++ b/example_mods/introMod/_polymod_meta.json
@@ -6,7 +6,7 @@
       "name": "EliteMasterEric"
     }
   ],
-  "api_version": "0.7.0",
+  "api_version": "0.8.0",
   "mod_version": "1.0.0",
   "license": "Apache-2.0"
 }

--- a/example_mods/testing123/_polymod_meta.json
+++ b/example_mods/testing123/_polymod_meta.json
@@ -6,7 +6,7 @@
       "name": "EliteMasterEric"
     }
   ],
-  "api_version": "0.7.0",
+  "api_version": "0.8.0",
   "mod_version": "1.0.0",
   "license": "Apache-2.0"
 }


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
None

<!-- Briefly describe the issue(s) fixed. -->
## Description
Update example mod's API version so it actually loads. Exact same tiny change like [my last commit 1d8ed51](https://github.com/FunkinCrew/Funkin/commit/1d8ed5198c0a336406a8db88a2be61c72096c050), but for most recent 0.8.0 version. I find this change very important for whole fnf modding in general.


<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos
None