### PR TITLE
[BUGFIX] Fix Long Song Names Causing Capsules To Go Offset During Rank Animation

### DIFF
--- a/source/funkin/ui/freeplay/FreeplayState.hx
+++ b/source/funkin/ui/freeplay/FreeplayState.hx
@@ -1140,7 +1140,7 @@ class FreeplayState extends MusicBeatSubState
     // capsuleToRank.targetPos.set((FlxG.width / 2) - (capsuleToRank.width / 2),
     //  (FlxG.height / 2) - (capsuleToRank.height / 2));
 
-    capsuleToRank.setPosition((FlxG.width / 2) - (capsuleToRank.width / 2), (FlxG.height / 2) - (capsuleToRank.height / 2));
+    capsuleToRank.setPosition((FlxG.width / 2) - (capsuleToRank.capsule.width / 2), (FlxG.height / 2) - (capsuleToRank.capsule.height / 2));
 
     new FlxTimer().start(0.5, _ -> {
       rankDisplayNew(fromResults, capsuleToRank);


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues

Fixes https://github.com/FunkinCrew/Funkin/issues/6662

<!-- Briefly describe the issue(s) fixed. -->
## Description

This PR fixes a bug where long song names cause capsules to go offset during the new rank animation. This issue is fixed by using the width and height of the capsule sprite rather than the entire capsule object.

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos

Before:

https://github.com/user-attachments/assets/fdaef861-b907-40ca-b5d8-6b23a887bdb2

After:

https://github.com/user-attachments/assets/0a23112b-f3cd-4dfb-a931-80d3b38733f0
