### PR TITLE
[BUGFIX] Fix Album Roll Not Updating Immediately After Character Select Exit

### DIFF
--- a/source/funkin/ui/freeplay/FreeplayState.hx
+++ b/source/funkin/ui/freeplay/FreeplayState.hx
@@ -2484,7 +2484,7 @@ class FreeplayState extends MusicBeatSubState
 
     // Set the album graphic and play the animation if relevant.
     var newAlbumId:Null<String> = daSong?.data.getAlbumId(currentDifficulty, currentVariation);
-    if (albumRoll.albumId != newAlbumId && (currentVariation != previousVariation || uiStateMachine.canInteract()) && !fromCharSelect)
+    if (albumRoll.albumId != newAlbumId && (currentVariation != previousVariation || uiStateMachine.canInteract()))
     {
       albumRoll.albumId = newAlbumId;
       albumRoll.skipIntro();


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

## Linked Issues

Don't think there's any, but LeGooey brought it up in the Discord.

<!-- Briefly describe the issue(s) fixed. -->
## Description

This PR fixes an issue where the album roll doesn't update if you were to switch the song immediately after reentering freeplay from the character select menu. A good way to test this is having Random selected before entering character select, just like in the videos provided below.

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos

Before:

https://github.com/user-attachments/assets/debf81a2-72a7-4070-adcf-e522e022f9d9

After:

https://github.com/user-attachments/assets/80e9eae1-2929-4b16-b0f9-ac06f783ef36