### PR TITLE
[BUGFIX] Fix Inconsistent Spacing of the Last Digit of Capsule BPM Values

### DIFF
--- a/source/funkin/ui/freeplay/SongMenuItem.hx
+++ b/source/funkin/ui/freeplay/SongMenuItem.hx
@@ -371,6 +371,8 @@ class SongMenuItem extends FlxSpriteGroup
           }
         case 2:
           bpmNumbers[i].digit = newBPM % 10;
+
+          if (Math.floor(newBPM) % 10 == 1) tempShift -= 4;
         default:
           trace('why the fuck is this being called');
       }


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues

Fixes #6661

<!-- Briefly describe the issue(s) fixed. -->
## Description

This PR fixes an issue where the last digit of a capsule's BPM is positioned incorrectly. This bug is mainly noticeable for SPAGHETTI, but it really just has to do with how the last digit is spaced when it's 1.

In the screenshots provided below, I used the same exact BPM that was used for SPAGHETTI. Yes, I tested this with other BPMs and the result is just how it should be. Reviewing this PR is still appreciated because this game is dumb and you never know I guess.

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos

Before:

<img width="1280" height="720" alt="screenshot-2026-01-06-18-02-20" src="https://github.com/user-attachments/assets/c29baa08-858a-4779-8a80-847b1cb523a4" />

After:

<img width="1280" height="720" alt="screenshot-2026-01-06-18-41-14" src="https://github.com/user-attachments/assets/7fdd2edd-bcee-4c42-ac6e-61341fb45ff0" />