### PR TITLE
[BUGFIX] Consistent game over camera focus point

### DIFF
--- a/source/funkin/play/GameOverSubState.hx
+++ b/source/funkin/play/GameOverSubState.hx
@@ -168,7 +168,7 @@ class GameOverSubState extends MusicBeatSubState
         boyfriend.canPlayOtherAnims = true;
         boyfriend.isDead = true;
         add(boyfriend);
-        boyfriend.resetCharacter();
+        boyfriend.resetCharacter(false);
       }
     }
 
@@ -199,8 +199,18 @@ class GameOverSubState extends MusicBeatSubState
 
     // Assign a camera follow point to the boyfriend's position.
     cameraFollowPoint = new FlxObject(parentPlayState.cameraFollowPoint.x, parentPlayState.cameraFollowPoint.y, 1, 1);
-    cameraFollowPoint.x = getMidPointOld(boyfriend).x;
-    cameraFollowPoint.y = getMidPointOld(boyfriend).y;
+    cameraFollowPoint.x = boyfriend.cameraFocusPoint.x;
+    cameraFollowPoint.y = boyfriend.cameraFocusPoint.y;
+
+    @:privateAccess
+    {
+      cameraFollowPoint.x -= Std.int(boyfriend._data.cameraOffsets[0]);
+      cameraFollowPoint.y -= Std.int(boyfriend._data.cameraOffsets[1]);
+
+      cameraFollowPoint.x -= Std.int((parentPlayState?.currentStage?._data?.characters?.bf?.cameraOffsets ?? [0, 0])[0]);
+      cameraFollowPoint.y -= Std.int((parentPlayState?.currentStage?._data?.characters?.bf?.cameraOffsets ?? [0, 0])[1]);
+    }
+
     var offsets:Array<Float> = boyfriend.getDeathCameraOffsets();
     cameraFollowPoint.x += offsets[0];
     cameraFollowPoint.y += offsets[1];
@@ -210,21 +220,6 @@ class GameOverSubState extends MusicBeatSubState
     FlxG.camera.target = null;
     FlxG.camera.follow(cameraFollowPoint, LOCKON, Constants.DEFAULT_CAMERA_FOLLOW_RATE / 2);
     targetCameraZoom = (parentPlayState?.currentStage?.camZoom ?? 1.0) * boyfriend.getDeathCameraZoom();
-  }
-
-  /**
-   * FlxSprite.getMidpoint(); calculations changed in this git commit
-   * https://github.com/HaxeFlixel/flixel/commit/1553b5af0871462fcefedc091b7885437d6c36d2
-   * https://github.com/HaxeFlixel/flixel/pull/3125
-   *
-   * So we use this to do the old math that gets the midpoint of our graphics
-   * Luckily, we don't use getGraphicMidpoint() much in the code, so it's fine being in GameoverSubState here.
-   * @return FlxPoint
-   */
-  function getMidPointOld(spr:FlxSprite, ?point:FlxPoint):FlxPoint
-  {
-    if (point == null) point = FlxPoint.get();
-    return point.set(spr.x + spr.frameWidth * 0.5 * spr.scale.x, spr.y + spr.frameHeight * 0.5 * spr.scale.y);
   }
 
   /**


### PR DESCRIPTION
## Linked Issues
None, though LeGooey brought this up earlier today.

## Description
The game over menu would focus on the character's mid-point when dying, however it failed to account for the idle animation not playing correctly, which makes the game over menu focus point dependant on the animation that was played before the death sequence started.
This PR fixes it by basing the character middle point to focus on from the pre-established character camera focus point, minus the offsets, since camera focus point position is based on the idle animation of the character.

## Screenshots/Videos

Pre-fix:

https://github.com/user-attachments/assets/c5b4f8d7-e60b-4d11-95f8-b88ac9f466b6

Post-fix:

https://github.com/user-attachments/assets/8660d385-09c3-44e9-aeba-38fb242224f0
