### PR TITLE
[MODDING] Add more default imports used by mods

### DIFF
--- a/source/funkin/modding/PolymodHandler.hx
+++ b/source/funkin/modding/PolymodHandler.hx
@@ -247,8 +247,18 @@ class PolymodHandler
   static function buildImports():Void
   {
     // Add default imports for common classes.
-    Polymod.addDefaultImport(funkin.Assets);
-    Polymod.addDefaultImport(funkin.Paths);
+    static final DEFAULT_IMPORTS:Array<Class<Dynamic>> = [
+      funkin.Assets,
+      funkin.Paths,
+      funkin.Preferences,
+      funkin.util.Constants,
+      flixel.FlxG
+    ];
+
+    for (cls in DEFAULT_IMPORTS)
+    {
+      Polymod.addDefaultImport(cls);
+    }
 
     // Add import aliases for certain classes.
     // NOTE: Scripted classes are automatically aliased to their parent class.


### PR DESCRIPTION
## Description

This PR converts the repetitive `Polymod.addDefaultImport` for default imports into an Array loop and adds several commonly used default imports by mods for convenience:
`flixel.FlxG`
`funkin.util.Constants`
`funkin.Preferences`