### PR TITLE
[BUGFIX] Fix Freeplay Pixel Icon Not Playing Confirm Animation When Mashing

### DIFF
--- a/source/funkin/ui/PixelatedIcon.hx
+++ b/source/funkin/ui/PixelatedIcon.hx
@@ -9,9 +9,14 @@ import funkin.graphics.FlxFilteredSprite;
 @:nullSafety
 class PixelatedIcon extends FlxFilteredSprite
 {
+  public var char:String;
+
   public function new(x:Float, y:Float)
   {
     super(x, y);
+
+    this.char = '';
+
     this.makeGraphic(32, 32, 0x00000000);
     this.antialiasing = false;
     this.active = false;
@@ -19,6 +24,9 @@ class PixelatedIcon extends FlxFilteredSprite
 
   public function setCharacter(char:String):Void
   {
+    if (this.char == char) return;
+    this.char = char;
+
     var charPath:String = "freeplay/icons/";
 
     final charIDParts:Array<String> = char.split("-");


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues

Fixes #6711

<!-- Briefly describe the issue(s) fixed. -->
## Description

This PR fixes an issue where immediately selecting a song upon accessing freeplay from the main menu causes the pixel icon to not play its confirm animation.

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos

https://github.com/user-attachments/assets/01454f90-de46-4396-811f-b065bc347c4e
