### PR TITLE
[BUGFIX] Fix Sticker Transition Playing Over Soundtray

### DIFF
--- a/source/funkin/ui/transition/stickers/StickerSubState.hx
+++ b/source/funkin/ui/transition/stickers/StickerSubState.hx
@@ -294,7 +294,8 @@ class StickerTransitionSprite extends openfl.display.Sprite
 
   public function insert():Void
   {
-    FlxG.addChildBelowMouse(this, 9999);
+    FlxG.addChildBelowMouse(this, 1);
+
     visible = true;
     onResize();
   }


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues

Fixes #6726

<!-- Briefly describe the issue(s) fixed. -->
## Description

This PR fixes an issue where the sticker transition plays over the game's volume soundtray.

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos

Before:

<img width="1280" height="720" alt="screenshot-2026-01-09-16-35-37" src="https://github.com/user-attachments/assets/23c6ac5f-d370-4024-becb-340e2d45faa1" />

After:

<img width="1280" height="720" alt="screenshot-2026-01-09-18-39-54" src="https://github.com/user-attachments/assets/2cdea625-341f-4311-8fd9-ecfa16bbee60" />
