### PR TITLE
[BUGFIX/Modding] Fix requestScores from wrapper and correct trace typo in Leaderboards.hx

### DIFF
--- a/source/funkin/api/newgrounds/Leaderboards.hx
+++ b/source/funkin/api/newgrounds/Leaderboards.hx
@@ -24,7 +24,7 @@ class Leaderboards
     var leaderboardList:Null<ScoreBoardList> = NewgroundsClient.instance.leaderboards;
     if (leaderboardList == null)
     {
-      trace(' NEWGROUNDS '.bold().bg_orange() + ' Not logged in, cannot fetch medal data!');
+      trace(' NEWGROUNDS '.bold().bg_orange() + ' Not logged in, cannot fetch leaderboard data!');
       return [];
     }
 
@@ -161,7 +161,7 @@ class LeaderboardsSandboxed
    * @param leaderboard The leaderboard to fetch scores from.
    * @param params Additional parameters for fetching the score.
    */
-  public function requestScores(leaderboard:Leaderboard, params:RequestScoresParams)
+  public static function requestScores(leaderboard:Leaderboard, params:RequestScoresParams)
   {
     Leaderboards.requestScores(leaderboard, params);
   }


### PR DESCRIPTION
## Description
This PR corrects the `Leaderboards.hx` trace `medals` -> `leaderboard`.
And changes `requestScores` in the `LeaderboardsSandboxed` to be a static function to match the main class `Leaderboards`.