### PR TITLE
[Modding] Add `Reflect.makeVarArgs` to `ReflectUtil`

### DIFF
--- a/source/funkin/util/ReflectUtil.hx
+++ b/source/funkin/util/ReflectUtil.hx
@@ -416,4 +416,13 @@ class ReflectUtil
     if (cls == null) return "Unknown";
     return Type.getClassName(cls);
   }
+
+  /**
+   * Transform a function taking an array of arguments into a function that can
+   * be called with any number of arguments.
+   */
+  public static function makeVarArgs(f:Array<Dynamic>->Dynamic):Dynamic
+  {
+    return Reflect.makeVarArgs(f);
+  }
 }


### PR DESCRIPTION
## Description
This PR exposes the `Reflect.makeVarArgs` function via `ReflectUtil`, allowing modders to create functions with variable numbers of arguments.

## Example usage
```haxe
override public function onCreate(event:ScriptEvent) {
    var internalFunction = (args) -> trace(args);
    var variableFunc:Dynamic = ReflectUtil.makeVarArgs(internalFunction);
    variableFunc();
    variableFunc("Test");
    variableFunc("A", 1, true);
}
```

## Visual example with output

<img width="711" height="272" alt="image" src="https://github.com/user-attachments/assets/5763c233-7a47-43c4-bf57-c8843153d2b8" />
