### PR TITLE
[ENHANCEMENT] Add more `toString()` functions in classes to improve logging and debugging

### DIFF
--- a/source/funkin/modding/module/Module.hx
+++ b/source/funkin/modding/module/Module.hx
@@ -79,7 +79,12 @@ class Module implements IPlayStateScriptedClass implements IStateChangingScripte
 
   public function toString():String
   {
-    return 'Module(' + this.moduleId + ')';
+    return 'Module(' +
+    'id: $moduleId | ' +
+    'priority: $priority | ' +
+    'active: $active' +
+    '${state != null ? " | state: " + Type.getClassName(state) : ""}' +
+    ')';
   }
 
   // TODO: Half of these aren't actually being called!!!!!!!

--- a/source/funkin/play/components/HealthIcon.hx
+++ b/source/funkin/play/components/HealthIcon.hx
@@ -470,6 +470,19 @@ class HealthIcon extends FunkinSprite
 
     // If we don't have an animation, we're done.
   }
+
+  public override function toString():String
+  {
+    var flxDebug:String = super.toString();
+    return 'HealthIcon(' +
+    'characterId: $characterId | ' +
+    'autoUpdate: $autoUpdate | ' +
+    'playerId: $playerId | ' +
+    'isPixel: $isPixel | ' +
+    'isLegacy: $isLegacyStyle | ' +
+    'debug: $flxDebug' +
+    ')';
+  }
 }
 
 /**

--- a/source/funkin/play/cutscene/dialogue/Conversation.hx
+++ b/source/funkin/play/cutscene/dialogue/Conversation.hx
@@ -647,6 +647,12 @@ class Conversation extends FlxSpriteGroup implements IDialogueScriptedClass impl
       outroTween = null;
     }
   }
+
+  public override function toString():String
+  {
+    var flxDebug:String = super.toString();
+    return 'Conversation(id: $id | debug: $flxDebug)';
+  }
 }
 
 // Managing things with a single enum is a lot easier than a multitude of flags.

--- a/source/funkin/play/cutscene/dialogue/Speaker.hx
+++ b/source/funkin/play/cutscene/dialogue/Speaker.hx
@@ -305,4 +305,10 @@ class Speaker extends FlxSprite implements IDialogueScriptedClass implements IRe
   public function onScriptEvent(event:ScriptEvent):Void
   {
   }
+
+  public override function toString():String
+  {
+    var flxDebug:String = super.toString();
+    return 'Speaker(id: $id | speakerName: $speakerName | debug: $flxDebug)';
+  }
 }

--- a/source/funkin/play/notes/Strumline.hx
+++ b/source/funkin/play/notes/Strumline.hx
@@ -1501,4 +1501,10 @@ class Strumline extends FlxSpriteGroup
     }
     return value;
   }
+
+  public override function toString():String
+  {
+    var flxDebug:String = super.toString();
+    return 'Strumline(isPlayer: $isPlayer | isDownscroll: $isDownscroll | scrollSpeed: $scrollSpeed | debug: $flxDebug)';
+  }
 }

--- a/source/funkin/play/notes/notekind/NoteKind.hx
+++ b/source/funkin/play/notes/notekind/NoteKind.hx
@@ -57,7 +57,14 @@ class NoteKind implements INoteScriptedClass
 
   public function toString():String
   {
-    return noteKind;
+    return 'NoteKind(' +
+    'id: $noteKind | ' +
+    'description: "$description"' +
+    '${noteStyleId != null ? " | noteStyleId: " + noteStyleId : ""}' +
+    '${params.length > 0 ? " | params: " + params : ""}' +
+    ' | noanim: $noanim' +
+    '${suffix != "" ? " | suffix: " + suffix : ""}' +
+    ')';
   }
 
   /**

--- a/source/funkin/play/song/Song.hx
+++ b/source/funkin/play/song/Song.hx
@@ -740,6 +740,11 @@ class Song implements IPlayStateScriptedClass implements IRegistryEntry<SongMeta
     return VARIATION_REGEX.match(variation);
   }
 
+  public function toString():String
+  {
+    return 'Song(id: $id | name: $songName)';
+  }
+
   static function log(message:String):Void
   {
     trace(' SONG '.bold().bg_note_down() + ' $message');

--- a/source/funkin/play/stage/Stage.hx
+++ b/source/funkin/play/stage/Stage.hx
@@ -932,6 +932,12 @@ class Stage extends FlxSpriteGroup implements IPlayStateScriptedClass implements
   {
   }
 
+  public override function toString():String
+  {
+    var flxDebug:String = super.toString();
+    return 'Stage(id: $id | name: $stageName | debug: $flxDebug)';
+  }
+
   static function log(message:String):Void
   {
     trace(' STAGE '.bold().bg_red() + ' $message');

--- a/source/funkin/ui/story/Level.hx
+++ b/source/funkin/ui/story/Level.hx
@@ -240,4 +240,15 @@ class Level implements IRegistryEntry<LevelData>
 
     return props;
   }
+
+  public function toString():String
+  {
+    return 'Level(' +
+    'id: $id | ' +
+    'title: ${getTitle()} | ' +
+    'songs: ${getSongs()} | ' +
+    'visible: ${isVisible()} | ' +
+    'unlocked: ${isUnlocked()}' +
+    ')';
+  }
 }


### PR DESCRIPTION
## Description
This PR improves and adds the `toString()` function in more classes to allow better logging and debugging for those respective classes.

This also standardizes the formatting of `toString()` to be a pipe-separated output style like flixel's: 
`Class(arg1: value | arg2: value)`

## Screenshots/Videos
Example of how this would look in console:

<img width="1459" height="534" alt="image" src="https://github.com/user-attachments/assets/257c0046-f9a5-466d-8996-a96b5e636f0e" />