### PR TITLE
[ENHANCEMENT] Add decimal value support for camera bopping rate and offset

### DIFF
--- a/source/funkin/play/PlayState.hx
+++ b/source/funkin/play/PlayState.hx
@@ -347,14 +347,14 @@ class PlayState extends MusicBeatSubState
    * How many beats (quarter notes) between camera zooms.
    * @default One camera zoom per measure (four beats).
    */
-  public var cameraZoomRate:Int = Constants.DEFAULT_ZOOM_RATE;
+  public var cameraZoomRate:Float = Constants.DEFAULT_ZOOM_RATE;
 
   /**
    * How many beats (quarter notes) the zoom rate is offset.
    * For if you want the zoom to happen off-beat.
    * @default Zero beats (on-beat).
    */
-  public var cameraZoomRateOffset:Int = Constants.DEFAULT_ZOOM_OFFSET;
+  public var cameraZoomRateOffset:Float = Constants.DEFAULT_ZOOM_OFFSET;
 
   /**
    * Whether the game is currently in the countdown before the song resumes.
@@ -1828,6 +1828,19 @@ class PlayState extends MusicBeatSubState
     iconP1?.onStepHit(Std.int(Conductor.instance.currentStep));
     iconP2?.onStepHit(Std.int(Conductor.instance.currentStep));
 
+    // Only bop camera if zoom level is below 135%
+    if (Preferences.zoomCamera
+      && FlxG.camera.zoom < (1.35 * FlxCamera.defaultZoom)
+      && cameraZoomRate > 0
+      && (Conductor.instance.currentStep + cameraZoomRateOffset * Constants.STEPS_PER_BEAT) % (cameraZoomRate * Constants.STEPS_PER_BEAT) == 0)
+    {
+      // Set zoom multiplier for camera bop.
+      cameraBopMultiplier = cameraBopIntensity;
+      // HUD camera zoom still uses old system. To change. (+3%)
+      camHUD.zoom += hudCameraZoomIntensity * defaultHUDCameraZoom;
+    }
+    // trace('Not bopping camera: ${FlxG.camera.zoom} < ${(1.35 * defaultCameraZoom)} && ${cameraZoomRate} > 0 && ${Conductor.instance.currentBeat} % ${cameraZoomRate} == ${Conductor.instance.currentBeat % cameraZoomRate}}');
+
     // Try to call hold note haptics each step hit. Works if atleast one note status is NoteStatus.isHoldNotePressed.
     playerStrumline.noteVibrations.tryHoldNoteVibration();
 
@@ -1887,19 +1900,6 @@ class PlayState extends MusicBeatSubState
         resyncVocals();
       }
     }
-
-    // Only bop camera if zoom level is below 135%
-    if (Preferences.zoomCamera
-      && FlxG.camera.zoom < (1.35 * FlxCamera.defaultZoom)
-      && cameraZoomRate > 0
-      && (Conductor.instance.currentBeat + cameraZoomRateOffset) % cameraZoomRate == 0)
-    {
-      // Set zoom multiplier for camera bop.
-      cameraBopMultiplier = cameraBopIntensity;
-      // HUD camera zoom still uses old system. To change. (+3%)
-      camHUD.zoom += hudCameraZoomIntensity * defaultHUDCameraZoom;
-    }
-    // trace('Not bopping camera: ${FlxG.camera.zoom} < ${(1.35 * defaultCameraZoom)} && ${cameraZoomRate} > 0 && ${Conductor.instance.currentBeat} % ${cameraZoomRate} == ${Conductor.instance.currentBeat % cameraZoomRate}}');
 
     if (playerStrumline != null) playerStrumline.onBeatHit();
     if (opponentStrumline != null) opponentStrumline.onBeatHit();

--- a/source/funkin/play/event/SetCameraBopSongEvent.hx
+++ b/source/funkin/play/event/SetCameraBopSongEvent.hx
@@ -40,12 +40,9 @@ class SetCameraBopSongEvent extends SongEvent
     // Does nothing if there is no PlayState camera or stage.
     if (PlayState.instance == null) return;
 
-    var rate:Null<Int> = data.getInt('rate');
-    if (rate == null) rate = Constants.DEFAULT_ZOOM_RATE;
-    var offset:Null<Int> = data.getInt('offset');
-    if (rate == null) offset = Constants.DEFAULT_ZOOM_OFFSET;
-    var intensity:Null<Float> = data.getFloat('intensity');
-    if (intensity == null) intensity = 1.0;
+    var rate:Float = data.getFloat('rate') ?? Constants.DEFAULT_ZOOM_RATE;
+    var offset:Float = data.getFloat('offset') ?? Constants.DEFAULT_ZOOM_OFFSET;
+    var intensity:Float = data.getFloat('intensity') ?? 1.0;
 
     PlayState.instance.cameraBopIntensity = (Constants.DEFAULT_BOP_INTENSITY - 1.0) * intensity + 1.0;
     PlayState.instance.hudCameraZoomIntensity = (Constants.DEFAULT_BOP_INTENSITY - 1.0) * intensity * 2.0;
@@ -84,8 +81,8 @@ class SetCameraBopSongEvent extends SongEvent
         name: 'offset',
         title: 'Offset',
         defaultValue: Constants.DEFAULT_ZOOM_OFFSET,
-        step: 1,
-        type: SongEventFieldType.INTEGER,
+        step: 0.25,
+        type: SongEventFieldType.FLOAT,
         units: 'beats'
       },
       {
@@ -93,8 +90,8 @@ class SetCameraBopSongEvent extends SongEvent
         title: 'Rate',
         defaultValue: Constants.DEFAULT_ZOOM_RATE,
         min: 0,
-        step: 1,
-        type: SongEventFieldType.INTEGER,
+        step: 0.25,
+        type: SongEventFieldType.FLOAT,
         units: 'beats/zoom'
       }
     ]);


### PR DESCRIPTION
## Linked Issues
Implements https://github.com/FunkinCrew/Funkin/issues/6667
Implements https://github.com/FunkinCrew/Funkin/issues/4716

## Description
This PR turns the camera bop zoom and rate into values that support decimals up to .25 precision, considering every beat has four steps, allowing for further customization of the camera bopping behavior.

## Screenshots/Videos

https://github.com/user-attachments/assets/3d56152f-a003-4f18-a8f4-cb545cec84f5

https://github.com/user-attachments/assets/16524967-11d5-4d50-aa1e-fe162128a247
