### PR TITLE
[ENHANCEMENT] Don't use the default names for the Stage Editor

### DIFF
--- a/source/funkin/ui/debug/stageeditor/StageEditorState.hx
+++ b/source/funkin/ui/debug/stageeditor/StageEditorState.hx
@@ -442,6 +442,7 @@ class StageEditorState extends UIState
       if (data != null)
       {
         objNameDialog = new NewObjDialog(this, data);
+        objNameDialog.bitmapName = new haxe.io.Path(path).file;
         objNameDialog.showDialog();
 
         objNameDialog.onDialogClosed = function(_) {
@@ -1554,12 +1555,18 @@ class StageEditorState extends UIState
     }
   }
 
-  public function addBitmap(newBitmap:BitmapData):String
+  public function addBitmap(newBitmap:BitmapData, ?name:String):String
   {
     // first we check for existing bitmaps so we dont like add an extra one
     for (name => bitmap in bitmaps)
     {
       if (bitmap == newBitmap) return name;
+    }
+
+    if (name != null && !bitmaps.exists(name))
+    {
+      bitmaps.set(name, newBitmap);
+      return name;
     }
 
     var id:Int = 0;
@@ -1647,6 +1654,7 @@ typedef StageEditorParams =
    * If non-null, load this stage immediately instead of the welcome screen.
    */
   var ?targetStageId:String;
+
   /**
    * If non-null, load this character as Boyfriend.
    */

--- a/source/funkin/ui/debug/stageeditor/components/NewObjDialog.hx
+++ b/source/funkin/ui/debug/stageeditor/components/NewObjDialog.hx
@@ -10,6 +10,8 @@ import haxe.ui.notifications.NotificationManager;
 @:build(haxe.ui.macros.ComponentMacros.build("assets/exclude/data/ui/stage-editor/dialogs/new-object.xml"))
 class NewObjDialog extends Dialog
 {
+  public var bitmapName:Null<String> = null;
+
   var stageEditorState:StageEditorState;
   var bitmap:BitmapData;
 
@@ -55,7 +57,7 @@ class NewObjDialog extends Dialog
 
         if (bitmap != null)
         {
-          var bitToLoad = stageEditorState.addBitmap(bitmap);
+          var bitToLoad = stageEditorState.addBitmap(bitmap, bitmapName);
           spr.loadGraphic(stageEditorState.bitmaps[bitToLoad]);
         }
         else

--- a/source/funkin/ui/debug/stageeditor/handlers/AssetDataHandler.hx
+++ b/source/funkin/ui/debug/stageeditor/handlers/AssetDataHandler.hx
@@ -85,7 +85,7 @@ class AssetDataHandler
     {
       if (data.animations != null && data.animations.length > 0)
       {
-        var bitToLoad = state.addBitmap(data.bitmap.clone());
+        var bitToLoad = state.addBitmap(data.bitmap.clone(), data.name);
         object.frames = FlxAtlasFrames.fromSparrow(state.bitmaps[bitToLoad], data.animData);
       }
       else if (areTheseBitmapsEqual(data.bitmap, getDefaultGraphic()))
@@ -94,7 +94,7 @@ class AssetDataHandler
       }
       else
       {
-        var bitToLoad = state.addBitmap(data.bitmap.clone());
+        var bitToLoad = state.addBitmap(data.bitmap.clone(), data.name);
         object.loadGraphic(state.bitmaps[bitToLoad]);
       }
     }

--- a/source/funkin/ui/debug/stageeditor/handlers/StageDataHandler.hx
+++ b/source/funkin/ui/debug/stageeditor/handlers/StageDataHandler.hx
@@ -145,7 +145,7 @@ class StageDataHandler
     var stageBytes = Bytes.ofString(endData.serialize());
     entryList.push(
       {
-        fileName: "yourstagename.json",
+        fileName: formatStageId(endData.name) + ".json",
         fileSize: stageBytes.length,
         fileTime: Date.now(),
         compressed: false,
@@ -384,6 +384,17 @@ class StageDataHandler
     // no props :p
 
     state.updateMarkerPos();
+  }
+
+  static function formatStageId(name:String)
+  {
+    // Make the name use lowerCamelCase without any special characters.
+    name = name.sanitize();
+    name = name.charAt(0).toLowerCase() + name.substring(1);
+
+    if (name.length == 0) return "unnamed";
+
+    return name;
   }
 }
 #end

--- a/source/funkin/ui/debug/stageeditor/toolboxes/StageEditorObjectGraphicToolbox.hx
+++ b/source/funkin/ui/debug/stageeditor/toolboxes/StageEditorObjectGraphicToolbox.hx
@@ -54,7 +54,8 @@ class StageEditorObjectGraphicToolbox extends StageEditorDefaultToolbox
 
           // This checks if the same image had already been loaded, so that we don't add it twice.
           // Kind of hacky but it is what it is.
-          var bitToLoad:String = state.addBitmap(linkedObj.updateFramePixels());
+          var name:String = haxe.io.Path.withoutExtension(selectedFile.name);
+          var bitToLoad:String = state.addBitmap(linkedObj.updateFramePixels(), name);
           linkedObj.loadGraphic(state.bitmaps[bitToLoad]);
           linkedObj.updateHitbox();
 
@@ -74,7 +75,7 @@ class StageEditorObjectGraphicToolbox extends StageEditorDefaultToolbox
       if (linkedObj == null) return;
 
       state.createURLDialog(function(bytes:lime.utils.Bytes) {
-        var bitToLoad:String = state.addBitmap(BitmapData.fromBytes(bytes));
+        var bitToLoad:String = state.addBitmap(BitmapData.fromBytes(bytes), linkedObj.name);
         linkedObj.loadGraphic(state.bitmaps[bitToLoad]);
         linkedObj.updateHitbox();
 


### PR DESCRIPTION
## Linked Issues
None, but this was brought up a handful of times.

## Description
Adds an optional argument to `addBitmap`, the name that the bitmap should be saved as. Alongside it, instead of saving the stage json as `yourStageName`, it saves it to a lower camel case version of the stage name in the toolbox.

## Screenshots/Videos

https://github.com/user-attachments/assets/e4eff6e9-30ef-4ea8-95c5-1e220bbde8ea
