### PR TITLE
[ENHANCEMENT/Chart Editor] Add support for difficulty-based charters in song metadata

### DIFF
--- a/source/funkin/data/song/SongData.hx
+++ b/source/funkin/data/song/SongData.hx
@@ -29,6 +29,10 @@ class SongMetadata implements ICloneable<SongMetadata>
   public var songName:String;
   @:default("Unknown")
   public var artist:String;
+  /**
+   * The charters displayed in pause menu for this song difficulty.
+   * Key is a difficulty ID.
+   */
   @:optional
   public var charter:Null<String> = null;
   @:optional @:default(96)
@@ -59,12 +63,13 @@ class SongMetadata implements ICloneable<SongMetadata>
   @:jignored
   public var variation:String;
 
-  public function new(songName:String, artist:String, ?charter:String, ?variation:String)
+  public function new(songName:String, artist:String, ?charter:String, ?charters:Null<Map<String, String>>, ?variation:String)
   {
     this.version = SongRegistry.SONG_METADATA_VERSION;
     this.songName = songName;
     this.artist = artist;
     this.charter = (charter == null) ? null : charter;
+    this.charters = charters ?? new Map<String, String>();
     this.timeFormat = 'ms';
     this.divisions = null;
     this.offsets = new SongOffsets();
@@ -88,7 +93,7 @@ class SongMetadata implements ICloneable<SongMetadata>
    */
   public function clone():SongMetadata
   {
-    var result:SongMetadata = new SongMetadata(this.songName, this.artist, this.charter, this.variation);
+    var result:SongMetadata = new SongMetadata(this.songName, this.artist, this.charter, this.charters, this.variation);
     result.version = this.version;
     result.timeFormat = this.timeFormat;
     result.divisions = this.divisions;

--- a/source/funkin/data/song/importer/StepManiaImporter.hx
+++ b/source/funkin/data/song/importer/StepManiaImporter.hx
@@ -571,6 +571,7 @@ class StepManiaImporter
       }
       difficulties.push(diff.name);
       metadata.playData.ratings.set(diff.name, diff.difficultyRating);
+      metadata.charters.set(diff.name, songData.Metadata.Credit != "" ? songData.Metadata.Credit : null);
     }
 
     metadata.playData.difficulties = difficulties;

--- a/source/funkin/play/PauseSubState.hx
+++ b/source/funkin/play/PauseSubState.hx
@@ -556,7 +556,7 @@ class PauseSubState extends MusicBeatSubState
       {
         if (PlayState.instance?.currentChart != null)
         {
-          metadataArtist.text = 'Charter: ${PlayState.instance.currentChart.charter ?? 'Unknown'}';
+          metadataArtist.text = 'Charter: ${PlayState.instance.currentChart.charter ?? Constants.DEFAULT_CHARTER}';
         }
         else
         {

--- a/source/funkin/play/song/Song.hx
+++ b/source/funkin/play/song/Song.hx
@@ -121,15 +121,27 @@ class Song implements IPlayStateScriptedClass implements IRegistryEntry<SongMeta
   }
 
   /**
-   * The artist of the song.
+   * The charter of the song.
    */
   public var charter(get, never):String;
 
   function get_charter():String
   {
-    if (_data != null) return _data?.charter ?? 'Unknown';
-    if (_metadata.size() > 0) return _metadata.get(Constants.DEFAULT_VARIATION)?.charter ?? 'Unknown';
+    if (_data != null) return _data?.charter ?? Constants.DEFAULT_CHARTER;
+    if (_metadata.size() > 0) return _metadata.get(Constants.DEFAULT_VARIATION)?.charter ?? Constants.DEFAULT_CHARTER;
     return Constants.DEFAULT_CHARTER;
+  }
+
+  /**
+   * The charters of the song.
+   */
+  public var charters(get, never):Map<String, String>;
+
+  function get_charters():Map<String, String>
+  {
+    if (_data != null) return _data?.charters ?? ["normal" => Constants.DEFAULT_CHARTER];
+    if (_metadata.size() > 0) return _metadata.get(Constants.DEFAULT_VARIATION)?.charters ?? ["normal" => Constants.DEFAULT_CHARTER];
+    return ["normal" => Constants.DEFAULT_CHARTER];
   }
 
   public var variation:Null<String> = null;
@@ -321,7 +333,7 @@ class Song implements IPlayStateScriptedClass implements IRegistryEntry<SongMeta
 
         difficulty.songName = metadata.songName;
         difficulty.songArtist = metadata.artist;
-        difficulty.charter = metadata.charter ?? Constants.DEFAULT_CHARTER;
+        difficulty.charter = metadata?.charters?.get(diffId) ?? metadata.charter ?? Constants.DEFAULT_CHARTER;
         difficulty.timeFormat = metadata.timeFormat;
         difficulty.divisions = metadata.divisions;
         difficulty.timeChanges = metadata.timeChanges;
@@ -388,7 +400,7 @@ class Song implements IPlayStateScriptedClass implements IRegistryEntry<SongMeta
         {
           difficulty.songName = metadata.songName;
           difficulty.songArtist = metadata.artist;
-          difficulty.charter = metadata.charter ?? Constants.DEFAULT_CHARTER;
+          difficulty.charter = metadata?.charters?.get(diffId) ?? metadata.charter ?? Constants.DEFAULT_CHARTER;
           difficulty.timeFormat = metadata.timeFormat;
           difficulty.divisions = metadata.divisions;
           difficulty.timeChanges = metadata.timeChanges;

--- a/source/funkin/ui/debug/charting/ChartEditorState.hx
+++ b/source/funkin/ui/debug/charting/ChartEditorState.hx
@@ -1494,6 +1494,26 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
   }
 
   /**
+   * Convenience property to get the charter for this difficulty.
+   */
+  public var currentSongChartDifficultyCharter(get, set):String;
+
+  function get_currentSongChartDifficultyCharter():String
+  {
+    return currentSongMetadata.charters?.get(selectedDifficulty)
+    ?? currentSongMetadata.charter
+    ?? Constants.DEFAULT_CHARTER;
+  }
+
+  function set_currentSongChartDifficultyCharter(value:String):String
+  {
+    if (currentSongMetadata.charters == null) currentSongMetadata.charters = new Map<String, String>();
+
+    currentSongMetadata.charters.set(selectedDifficulty, value);
+    return value;
+  }
+
+  /**
    * Convenience property to get (and set) the scroll speed for the current difficulty.
    */
   var currentSongChartScrollSpeed(get, set):Float;

--- a/source/funkin/ui/debug/charting/handlers/ChartEditorDialogHandler.hx
+++ b/source/funkin/ui/debug/charting/handlers/ChartEditorDialogHandler.hx
@@ -659,14 +659,15 @@ class ChartEditorDialogHandler
     {
       var valid:Bool = event.target.text != null && event.target.text != '';
 
+      if (newSongMetadata.charters == null) newSongMetadata.charters = new Map<String, String>();
       if (valid)
       {
         inputSongCharter.removeClass('invalid-value');
-        newSongMetadata.charter = event.target.text;
+        newSongMetadata.charters.set(state.selectedDifficulty, event.target.text);
       }
       else
       {
-        newSongMetadata.charter = "";
+        newSongMetadata.charters.set(state.selectedDifficulty, "");
       }
     };
     inputSongCharter.text = "";
@@ -1355,7 +1356,7 @@ class ChartEditorDialogHandler
 
     var dialogSongCharter:Null<TextField> = dialog.findComponent('dialogSongCharter', TextField);
     if (dialogSongCharter == null) throw 'Could not locate dialogSongCharter TextField in Add Variation dialog';
-    dialogSongCharter.value = state.currentSongMetadata.charter;
+    dialogSongCharter.value = state.currentSongMetadata.charters?.get(state.selectedDifficulty) ?? "";
 
     var dialogStage:Null<DropDown> = dialog.findComponent('dialogStage', DropDown);
     if (dialogStage == null) throw 'Could not locate dialogStage DropDown in Add Variation dialog';

--- a/source/funkin/ui/debug/charting/toolboxes/ChartEditorMetadataToolbox.hx
+++ b/source/funkin/ui/debug/charting/toolboxes/ChartEditorMetadataToolbox.hx
@@ -125,11 +125,11 @@ class ChartEditorMetadataToolbox extends ChartEditorBaseToolbox
       if (valid)
       {
         inputSongCharter.removeClass('invalid-value');
-        chartEditorState.currentSongMetadata.charter = event.target.text;
+        chartEditorState.currentSongChartDifficultyCharter = event.target.text;
       }
       else
       {
-        chartEditorState.currentSongMetadata.charter = null;
+        chartEditorState.currentSongChartDifficultyCharter = Constants.DEFAULT_CHARTER;
       }
     };
 
@@ -367,7 +367,7 @@ class ChartEditorMetadataToolbox extends ChartEditorBaseToolbox
     inputSongId.value = chartEditorState.songManifestData.songId;
     inputSongName.value = chartEditorState.currentSongMetadata.songName;
     inputSongArtist.value = chartEditorState.currentSongMetadata.artist;
-    inputSongCharter.value = chartEditorState.currentSongMetadata.charter;
+    inputSongCharter.value = chartEditorState.currentSongChartDifficultyCharter;
     inputStage.value = chartEditorState.currentSongMetadata.playData.stage;
     inputNoteStyle.value = chartEditorState.currentSongMetadata.playData.noteStyle;
     inputAlbum.value = chartEditorState.currentSongMetadata.playData.album;


### PR DESCRIPTION
## Linked Issues
- Closes #3372

## Description
This PR adds support for difficulty-based charters in song metadata. This allows different difficulties within the same variation to credit different charters.

> [!IMPORTANT]  
> Requires [FunkinCrew/funkin.assets#343](https://github.com/FunkinCrew/funkin.assets/pull/343)

### Changes:
- Updated the Chart Editor to save charter data per-difficulty when generating
- Pause will use the Charter based on difficulty, if not found it falls back to the default `charter` field, if neither work it falls back to "Unknown"

### Example:
In `tutorial-metadata.json` we add this:
```diff
{
  "version": "2.2.4",
  "timeFormat": "ms",
  "artist": "Kawai Sprite",
  "charter": "ninjamuffin99 + MtH",
+ "charters": { "easy": "ninjamuffin99", "normal": "MtH" },
  <...>
}
```
Now the behavior in Pause or other code logic will be:
- Easy: "ninjamuffin99"
- Normal: "MtH"
- Hard/Other: "ninjamuffin99 + MtH" (fallback)

## Example Use Videos

[DiffBasedCharacterCE.webm](https://github.com/user-attachments/assets/2bf60d83-546d-40bb-ac20-f47e885bab10)

https://github.com/user-attachments/assets/397bbc5b-e293-4c9e-be91-091eafebfcc4