### PR TITLE
[BUGFIX] Fix hold note covers not following the strumline

### DIFF
--- a/source/funkin/play/notes/NoteHoldCover.hx
+++ b/source/funkin/play/notes/NoteHoldCover.hx
@@ -49,6 +49,7 @@ class NoteHoldCover extends FlxTypedSpriteGroup<FlxSprite>
 
   public function playStart():Void
   {
+    glow.setPosition(this.x, this.y);
     var direction:NoteDirection = holdNote.noteDirection;
     glow.animation.play('holdCoverStart${direction.colorName.toTitleCase()}');
   }


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
#4091

<!-- Briefly describe the issue(s) fixed. -->
## Description
When modifying the position of a `Strumline` object, the hold covers wouldn't follow the strumline. Now, with this PR, they do! I believe this is a problem with recycling from the hold cover pool, and `NoteHoldCover`s being `FlxSpriteGroup`s (and `FlxSpriteGroup` sucks), so this is  most likely a temporary fix for now.

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos

https://github.com/user-attachments/assets/54237e1b-7b5f-4d81-b5ef-429a3c129b6c
