### PR TITLE
[ENHANCEMENT] Clean up duplicate constants and implement new audio constants.

### DIFF
--- a/source/funkin/Conductor.hx
+++ b/source/funkin/Conductor.hx
@@ -510,7 +510,7 @@ class Conductor
 
       // Update the timestamp for use in-between frames
       prevTime = this.songPosition;
-      prevTimestamp = Std.int(Timer.stamp() * 1000);
+      prevTimestamp = Std.int(Timer.stamp() * Constants.MS_PER_SEC);
     }
 
     if (this == Conductor.instance) @:privateAccess SongSequence.update.dispatch();

--- a/source/funkin/Paths.hx
+++ b/source/funkin/Paths.hx
@@ -29,14 +29,14 @@ class Paths implements ConsoleClass
 
   public static function stripLibrary(path:String):String
   {
-    var parts:Array<String> = path.split(':');
+    var parts:Array<String> = path.split(Constants.LIBRARY_SEPARATOR);
     if (parts.length < 2) return path;
     return parts[1];
   }
 
   public static function getLibrary(path:String):String
   {
-    var parts:Array<String> = path.split(':');
+    var parts:Array<String> = path.split(Constants.LIBRARY_SEPARATOR);
     if (parts.length < 2) return 'preload';
     return parts[0];
   }
@@ -104,7 +104,7 @@ class Paths implements ConsoleClass
 
   public static function json(key:String, ?library:String):String
   {
-    return getPath('data/$key.json', TEXT, library);
+    return getPath('data/$key.${Constants.EXT_DATA}', TEXT, library);
   }
 
   public static function srt(key:String, ?library:String, ?directory:String = 'data/'):String
@@ -161,7 +161,7 @@ class Paths implements ConsoleClass
 
   public static function image(key:String, ?library:String):String
   {
-    return getPath('images/$key.png', IMAGE, library);
+    return getPath('images/$key.${Constants.EXT_IMAGE}', IMAGE, library);
   }
 
   public static function font(key:String):String

--- a/source/funkin/data/song/SongData.hx
+++ b/source/funkin/data/song/SongData.hx
@@ -74,7 +74,7 @@ class SongMetadata implements ICloneable<SongMetadata>
     this.playData.songVariations = [];
     this.playData.difficulties = [];
     this.playData.characters = new SongCharacterData('bf', 'gf', 'dad');
-    this.playData.stage = 'mainStage';
+    this.playData.stage = Constants.DEFAULT_STAGE;
     this.playData.noteStyle = Constants.DEFAULT_NOTE_STYLE;
     this.generatedBy = SongRegistry.DEFAULT_GENERATEDBY;
     // Variation ID.
@@ -600,7 +600,7 @@ class SongChartData implements ICloneable<SongChartData>
 
     if (result == 0.0 && diff != 'default') return getScrollSpeed('default');
 
-    return (result == 0.0) ? 1.0 : result;
+    return (result == 0.0) ? Constants.DEFAULT_SCROLLSPEED : result;
   }
 
   public function setScrollSpeed(value:Float, diff:String = 'default'):Float

--- a/source/funkin/data/song/importer/FNFLegacyImporter.hx
+++ b/source/funkin/data/song/importer/FNFLegacyImporter.hx
@@ -41,7 +41,7 @@ class FNFLegacyImporter
     // Set generatedBy string for debugging.
     songMetadata.generatedBy = 'Chart Editor Import (FNF Legacy)';
 
-    songMetadata.playData.stage = songData.song?.stageDefault ?? 'mainStage';
+    songMetadata.playData.stage = songData.song?.stageDefault ?? Constants.DEFAULT_STAGE;
     songMetadata.songName = songData.song?.song ?? 'Import';
     songMetadata.playData.difficulties = [];
 

--- a/source/funkin/data/song/importer/OsuManiaImporter.hx
+++ b/source/funkin/data/song/importer/OsuManiaImporter.hx
@@ -78,7 +78,7 @@ class OsuManiaImporter
     // Set generatedBy string for debugging.
     songMetadata.generatedBy = 'Chart Editor Import (Osu!Mania)';
 
-    songMetadata.playData.stage = 'mainStage';
+    songMetadata.playData.stage = Constants.DEFAULT_STAGE;
     songMetadata.songName = songData.Metadata.TitleUnicode ?? songData.Metadata.Title ?? 'Import';
     songMetadata.playData.difficulties = [difficulty];
 

--- a/source/funkin/data/song/importer/StepManiaImporter.hx
+++ b/source/funkin/data/song/importer/StepManiaImporter.hx
@@ -553,7 +553,7 @@ class StepManiaImporter
   {
     var metadata:SongMetadata = new SongMetadata(songData.Metadata.Title, songData.Metadata.Artist);
 
-    metadata.playData.stage = 'mainStage';
+    metadata.playData.stage = Constants.DEFAULT_STAGE;
     metadata.playData.characters = new SongCharacterData('bf', 'gf', 'dad');
 
     metadata.generatedBy = 'Chart Editor Import (StepMania)';

--- a/source/funkin/data/song/migrator/SongData_v2_1_0.hx
+++ b/source/funkin/data/song/migrator/SongData_v2_1_0.hx
@@ -55,8 +55,8 @@ class SongMetadata_v2_1_0
     this.playData.songVariations = [];
     this.playData.difficulties = [];
     this.playData.characters = new SongCharacterData('bf', 'gf', 'dad');
-    this.playData.stage = 'mainStage';
-    this.playData.noteSkin = 'funkin';
+    this.playData.stage = Constants.DEFAULT_STAGE;
+    this.playData.noteSkin = Constants.DEFAULT_NOTE_STYLE;
     this.generatedBy = SongRegistry.DEFAULT_GENERATEDBY;
     // Variation ID.
     this.variation = (variation == null) ? Constants.DEFAULT_VARIATION : variation;

--- a/source/funkin/input/Cursor.hx
+++ b/source/funkin/input/Cursor.hx
@@ -48,91 +48,91 @@ class Cursor
   }
 
   public static final CURSOR_DEFAULT_PARAMS:CursorParams = {
-    graphic: 'assets/images/cursor/cursor-default.png',
+    graphic: Paths.image("cursor/cursor-default"),
     scale: 1.0,
     offsetX: 0,
     offsetY: 0,
   };
   static var assetCursorDefault:Null<BitmapData> = null;
   public static final CURSOR_CROSS_PARAMS:CursorParams = {
-    graphic: 'assets/images/cursor/cursor-cross.png',
+    graphic: Paths.image("cursor/cursor-cross"),
     scale: 1.0,
     offsetX: 0,
     offsetY: 0,
   };
   static var assetCursorCross:Null<BitmapData> = null;
   public static final CURSOR_ERASER_PARAMS:CursorParams = {
-    graphic: 'assets/images/cursor/cursor-eraser.png',
+    graphic: Paths.image("cursor/cursor-eraser"),
     scale: 1.0,
     offsetX: 0,
     offsetY: 0,
   };
   static var assetCursorEraser:Null<BitmapData> = null;
   public static final CURSOR_GRABBING_PARAMS:CursorParams = {
-    graphic: 'assets/images/cursor/cursor-grabbing.png',
+    graphic: Paths.image("cursor/cursor-grabbing"),
     scale: 1.0,
     offsetX: -8,
     offsetY: 0,
   };
   static var assetCursorGrabbing:Null<BitmapData> = null;
   public static final CURSOR_HOURGLASS_PARAMS:CursorParams = {
-    graphic: 'assets/images/cursor/cursor-hourglass.png',
+    graphic: Paths.image("cursor/cursor-hourglass"),
     scale: 1.0,
     offsetX: 0,
     offsetY: 0,
   };
   static var assetCursorHourglass:Null<BitmapData> = null;
   public static final CURSOR_POINTER_PARAMS:CursorParams = {
-    graphic: 'assets/images/cursor/cursor-pointer.png',
+    graphic: Paths.image("cursor/cursor-pointer"),
     scale: 1.0,
     offsetX: -8,
     offsetY: 0,
   };
   static var assetCursorPointer:Null<BitmapData> = null;
   public static final CURSOR_TEXT_PARAMS:CursorParams = {
-    graphic: 'assets/images/cursor/cursor-text.png',
+    graphic: Paths.image("cursor/cursor-text"),
     scale: 0.2,
     offsetX: 0,
     offsetY: 0,
   };
   static var assetCursorText:Null<BitmapData> = null;
   public static final CURSOR_TEXT_VERTICAL_PARAMS:CursorParams = {
-    graphic: 'assets/images/cursor/cursor-text-vertical.png',
+    graphic: Paths.image("cursor/cursor-text-vertical"),
     scale: 0.2,
     offsetX: 0,
     offsetY: 0,
   };
   static var assetCursorTextVertical:Null<BitmapData> = null;
   public static final CURSOR_ZOOM_IN_PARAMS:CursorParams = {
-    graphic: 'assets/images/cursor/cursor-zoom-in.png',
+    graphic: Paths.image("cursor/cursor-zoom-in"),
     scale: 1.0,
     offsetX: 0,
     offsetY: 0,
   };
   static var assetCursorZoomIn:Null<BitmapData> = null;
   public static final CURSOR_ZOOM_OUT_PARAMS:CursorParams = {
-    graphic: 'assets/images/cursor/cursor-zoom-out.png',
+    graphic: Paths.image("cursor/cursor-zoom-out"),
     scale: 1.0,
     offsetX: 0,
     offsetY: 0,
   };
   static var assetCursorZoomOut:Null<BitmapData> = null;
   public static final CURSOR_CROSSHAIR_PARAMS:CursorParams = {
-    graphic: 'assets/images/cursor/cursor-crosshair.png',
+    graphic: Paths.image("cursor/cursor-crosshair"),
     scale: 1.0,
     offsetX: -16,
     offsetY: -16,
   };
   static var assetCursorCrosshair:Null<BitmapData> = null;
   public static final CURSOR_CELL_PARAMS:CursorParams = {
-    graphic: 'assets/images/cursor/cursor-cell.png',
+    graphic: Paths.image("cursor/cursor-cell"),
     scale: 1.0,
     offsetX: -16,
     offsetY: -16,
   };
   static var assetCursorCell:Null<BitmapData> = null;
   public static final CURSOR_SCROLL_PARAMS:CursorParams = {
-    graphic: 'assets/images/cursor/cursor-scroll.png',
+    graphic: Paths.image("cursor/cursor-scroll"),
     scale: 0.2,
     offsetX: -15,
     offsetY: -15,

--- a/source/funkin/mobile/ui/FunkinBackButton.hx
+++ b/source/funkin/mobile/ui/FunkinBackButton.hx
@@ -115,7 +115,7 @@ class FunkinBackButton extends FunkinButton
     HapticUtil.vibrate(0, 0.05, 0.5);
     animation.play('confirm');
 
-    FunkinSound.playOnce(Paths.sound('cancelMenu'));
+    FunkinSound.playOnce(Paths.sound(Constants.DEFAULT_CANCEL_SOUND));
 
     onConfirmStart.dispatch();
 

--- a/source/funkin/mobile/ui/mainmenu/FunkinOptionsButton.hx
+++ b/source/funkin/mobile/ui/mainmenu/FunkinOptionsButton.hx
@@ -97,7 +97,7 @@ class FunkinOptionsButton extends FunkinButton
     HapticUtil.vibrate(0, 0.05, 0.5);
     animation.play('confirm');
 
-    FunkinSound.playOnce(Paths.sound('confirmMenu'));
+    FunkinSound.playOnce(Paths.sound(Constants.DEFAULT_CONFIRM_SOUND));
 
     new FlxTimer().start(0.05, function(_)
     {

--- a/source/funkin/mobile/ui/options/ControlsSchemeMenu.hx
+++ b/source/funkin/mobile/ui/options/ControlsSchemeMenu.hx
@@ -284,7 +284,7 @@ class ControlsSchemeMenu extends MusicBeatSubState
       return;
     }
 
-    FunkinSound.playOnce(Paths.sound('scrollMenu'), 0.4);
+    FunkinSound.playOnce(Paths.sound(Constants.DEFAULT_SCROLL_SOUND), 0.4);
 
     schemeNameText.text = availableSchemes[currentIndex];
 

--- a/source/funkin/mobile/ui/options/objects/HitboxShowcase.hx
+++ b/source/funkin/mobile/ui/options/objects/HitboxShowcase.hx
@@ -98,7 +98,7 @@ class HitboxShowcase extends FlxSpriteGroup
     {
       busy = true;
 
-      FunkinSound.playOnce(Paths.sound('confirmMenu'));
+      FunkinSound.playOnce(Paths.sound(Constants.DEFAULT_CONFIRM_SOUND));
 
       FlxFlicker.flicker(this, 1, 0.06, true, false, function(_)
       {

--- a/source/funkin/mobile/ui/options/objects/SchemeMenuButton.hx
+++ b/source/funkin/mobile/ui/options/objects/SchemeMenuButton.hx
@@ -67,7 +67,7 @@ class SchemeMenuButton extends FlxSpriteGroup
     {
       busy = true;
 
-      FunkinSound.playOnce(Paths.sound('confirmMenu'));
+      FunkinSound.playOnce(Paths.sound(Constants.DEFAULT_CONFIRM_SOUND));
 
       FlxFlicker.flicker(this, 1, 0.06, true, false, function(_)
       {

--- a/source/funkin/play/GameOverSubState.hx
+++ b/source/funkin/play/GameOverSubState.hx
@@ -601,13 +601,13 @@ class GameOverSubState extends MusicBeatSubState
   {
     blueballed = true;
 
-    if (Assets.exists(Paths.sound('gameplay/gameover/fnf_loss_sfx' + blueBallSuffix)))
+    if (Assets.exists(Paths.sound(Constants.BLUEBALL_SFX + blueBallSuffix)))
     {
-      FunkinSound.playOnce(Paths.sound('gameplay/gameover/fnf_loss_sfx' + blueBallSuffix));
+      FunkinSound.playOnce(Paths.sound(Constants.BLUEBALL_SFX + blueBallSuffix));
     }
     else
     {
-      FlxG.log.error('Missing blue ball sound effect: ' + Paths.sound('gameplay/gameover/fnf_loss_sfx' + blueBallSuffix));
+      FlxG.log.error('Missing blue ball sound effect: ' + Paths.sound(Constants.BLUEBALL_SFX + blueBallSuffix));
     }
   }
 

--- a/source/funkin/play/PauseSubState.hx
+++ b/source/funkin/play/PauseSubState.hx
@@ -807,7 +807,7 @@ class PauseSubState extends MusicBeatSubState
       if (currentEntry >= currentMenuEntries.length) currentEntry = 0;
     }
 
-    if (currentEntry != prevEntry) FunkinSound.playOnce(Paths.sound('scrollMenu'), 0.4);
+    if (currentEntry != prevEntry) FunkinSound.playOnce(Paths.sound(Constants.DEFAULT_SCROLL_SOUND), 0.4);
 
     for (entryIndex in 0...currentMenuEntries.length)
     {

--- a/source/funkin/play/PlayState.hx
+++ b/source/funkin/play/PlayState.hx
@@ -2984,7 +2984,7 @@ class PlayState extends MusicBeatSubState
                 if (vocals.legacyVoiceSystem && !vocals.legacyVoiceUsesPlayer) vocals.opponentVolume = 0;
                 vocals.playerVolume = 0;
               }
-              FunkinSound.playOnce(Paths.soundRandom('missnote', 1, 3), FlxG.random.float(0.5, 0.6));
+              FunkinSound.playOnce(Paths.soundRandom(Constants.SOUND_GAMEPLAY_MISS, 1, 3), FlxG.random.float(0.5, 0.6));
             }
           }
           else
@@ -3192,7 +3192,7 @@ class PlayState extends MusicBeatSubState
     {
       var tempVocals:Bool = currentStage != null && currentStage.getBoyfriend()?.tempVocals;
       if (vocals != null && !tempVocals) vocals.playerVolume = 0;
-      FunkinSound.playOnce(Paths.soundRandom('missnote', 1, 3), FlxG.random.float(0.5, 0.6));
+      FunkinSound.playOnce(Paths.soundRandom(Constants.SOUND_GAMEPLAY_MISS, 1, 3), FlxG.random.float(0.5, 0.6));
     }
   }
 
@@ -3234,7 +3234,7 @@ class PlayState extends MusicBeatSubState
     {
       var tempVocals:Bool = currentStage != null && currentStage.getBoyfriend()?.tempVocals;
       if (vocals != null && !tempVocals) vocals.playerVolume = 0;
-      FunkinSound.playOnce(Paths.soundRandom('missnote', 1, 3), FlxG.random.float(0.1, 0.2));
+      FunkinSound.playOnce(Paths.soundRandom(Constants.SOUND_GAMEPLAY_MISS, 1, 3), FlxG.random.float(0.1, 0.2));
     }
   }
 

--- a/source/funkin/play/ResultState.hx
+++ b/source/funkin/play/ResultState.hx
@@ -595,7 +595,7 @@ class ResultState extends MusicBeatSubState
         {
           // trace('$clearPercentLerp and ${clearPercentCounter.curNumber}');
           clearPercentLerp = clearPercentCounter.curNumber;
-          FunkinSound.playOnce(Paths.sound('scrollMenu'));
+          FunkinSound.playOnce(Paths.sound(Constants.DEFAULT_SCROLL_SOUND));
 
           // Weak vibration each number increase.
           HapticUtil.vibrate(0, 0.01);
@@ -607,7 +607,7 @@ class ResultState extends MusicBeatSubState
         HapticUtil.vibrate(Constants.DEFAULT_VIBRATION_PERIOD, Constants.DEFAULT_VIBRATION_DURATION * 5, Constants.MAX_VIBRATION_AMPLITUDE);
 
         // Play confirm sound.
-        FunkinSound.playOnce(Paths.sound('confirmMenu'));
+        FunkinSound.playOnce(Paths.sound(Constants.DEFAULT_CONFIRM_SOUND));
 
         // Just to be sure that the lerp didn't mess things up.
         clearPercentCounter.curNumber = clearPercentTarget;
@@ -957,7 +957,7 @@ class ResultState extends MusicBeatSubState
           }
           targetState = FreeplayState.build({
             {
-              character: playerCharacterId ?? "bf",
+              character: playerCharacterId ?? Constants.DEFAULT_CHARACTER,
               fromResults: {
                 oldRank: Scoring.calculateRank(params?.prevScoreData),
                 newRank: rank,

--- a/source/funkin/play/cutscene/dialogue/DialogueBox.hx
+++ b/source/funkin/play/cutscene/dialogue/DialogueBox.hx
@@ -289,7 +289,7 @@ class DialogueBox extends FlxSpriteGroup implements IDialogueScriptedClass imple
     textDisplay.borderSize = _data.text.shadowWidth ?? 2;
     // TODO: Add an option to configure this.
     textDisplay.sounds = [
-      FunkinSound.load(Paths.sound('pixelText'), 0.6)
+      FunkinSound.load(Paths.sound(Constants.SOUND_DIALOGUE_TYPING), 0.6)
     ];
 
     textDisplay.completeCallback = onTypingComplete;

--- a/source/funkin/play/song/Song.hx
+++ b/source/funkin/play/song/Song.hx
@@ -30,41 +30,6 @@ import funkin.util.SortUtil;
 @:nullSafety
 class Song implements IPlayStateScriptedClass implements IRegistryEntry<SongMetadata>
 {
-  /**
-   * The default value for the song's name
-   */
-  public static final DEFAULT_SONGNAME:String = 'Unknown';
-
-  /**
-   * The default value for the song's artist
-   */
-  public static final DEFAULT_ARTIST:String = 'Unknown';
-
-  /**
-   * The default value for the song's time format
-   */
-  public static final DEFAULT_TIMEFORMAT:SongTimeFormat = SongTimeFormat.MILLISECONDS;
-
-  /**
-   * The default value for the song's divisions
-   */
-  public static final DEFAULT_DIVISIONS:Null<Int> = null;
-
-  /**
-   * The default value for whether the song loops.
-   */
-  public static final DEFAULT_LOOPED:Bool = false;
-
-  /**
-   * The default value for the song's playable stage.
-   */
-  public static final DEFAULT_STAGE:String = 'mainStage';
-
-  /**
-   * The default value for the song's scroll speed.
-   */
-  public static final DEFAULT_SCROLLSPEED:Float = 1.0;
-
   // key = variation id, value = metadata
   final _metadata:Map<String, SongMetadata>;
 
@@ -103,9 +68,9 @@ class Song implements IPlayStateScriptedClass implements IRegistryEntry<SongMeta
 
   function get_songName():String
   {
-    if (_data != null) return _data?.songName ?? DEFAULT_SONGNAME;
-    if (_metadata.size() > 0) return _metadata.get(Constants.DEFAULT_VARIATION)?.songName ?? DEFAULT_SONGNAME;
-    return DEFAULT_SONGNAME;
+    if (_data != null) return _data?.songName ?? Constants.DEFAULT_SONGNAME;
+    if (_metadata.size() > 0) return _metadata.get(Constants.DEFAULT_VARIATION)?.songName ?? Constants.DEFAULT_SONGNAME;
+    return Constants.DEFAULT_SONGNAME;
   }
 
   /**
@@ -115,9 +80,9 @@ class Song implements IPlayStateScriptedClass implements IRegistryEntry<SongMeta
 
   function get_songArtist():String
   {
-    if (_data != null) return _data?.artist ?? DEFAULT_ARTIST;
-    if (_metadata.size() > 0) return _metadata.get(Constants.DEFAULT_VARIATION)?.artist ?? DEFAULT_ARTIST;
-    return DEFAULT_ARTIST;
+    if (_data != null) return _data?.artist ?? Constants.DEFAULT_ARTIST;
+    if (_metadata.size() > 0) return _metadata.get(Constants.DEFAULT_VARIATION)?.artist ?? Constants.DEFAULT_ARTIST;
+    return Constants.DEFAULT_ARTIST;
   }
 
   /**

--- a/source/funkin/save/Save.hx
+++ b/source/funkin/save/Save.hx
@@ -151,7 +151,7 @@ class Save implements ConsoleClass
       },
       unlocks: {
         // Default to having seen the default character.
-        charactersSeen: ["bf"],
+        charactersSeen: [Constants.DEFAULT_CHARACTER],
         oldChar: false
       },
       optionsChartEditor: {
@@ -458,7 +458,7 @@ class Save implements ConsoleClass
     #end
     if (difficultyList == null)
     {
-      difficultyList = ['easy', 'normal', 'hard'];
+      difficultyList = Constants.DEFAULT_DIFFICULTY_LIST;
     }
     for (difficulty in difficultyList)
     {
@@ -630,7 +630,7 @@ class Save implements ConsoleClass
   {
     if (difficultyList == null)
     {
-      difficultyList = ['easy', 'normal', 'hard'];
+      difficultyList = Constants.DEFAULT_DIFFICULTY_LIST;
     }
     if (variation == null) variation = '';
     for (difficulty in difficultyList)

--- a/source/funkin/ui/MenuList.hx
+++ b/source/funkin/ui/MenuList.hx
@@ -150,7 +150,7 @@ class MenuTypedList<T:MenuListItem> extends FlxTypedGroup<T>
     {
       if (newIndex != selectedIndex)
       {
-        FunkinSound.playOnce(Paths.sound('scrollMenu'), 0.4);
+        FunkinSound.playOnce(Paths.sound(Constants.DEFAULT_SCROLL_SOUND), 0.4);
         selectItem(newIndex);
       }
     }
@@ -177,7 +177,7 @@ class MenuTypedList<T:MenuListItem> extends FlxTypedGroup<T>
           }
           else
           {
-            FunkinSound.playOnce(Paths.sound('scrollMenu'), 0.4);
+            FunkinSound.playOnce(Paths.sound(Constants.DEFAULT_SCROLL_SOUND), 0.4);
             selectItem(i);
           }
 
@@ -213,13 +213,13 @@ class MenuTypedList<T:MenuListItem> extends FlxTypedGroup<T>
 
     if (newIndex != selectedIndex && !_isMainMenuState)
     {
-      FunkinSound.playOnce(Paths.sound('scrollMenu'), 0.4);
+      FunkinSound.playOnce(Paths.sound(Constants.DEFAULT_SCROLL_SOUND), 0.4);
       selectItem(newIndex);
     }
     #else
     if (newIndex != selectedIndex)
     {
-      FunkinSound.playOnce(Paths.sound('scrollMenu'), 0.4);
+      FunkinSound.playOnce(Paths.sound(Constants.DEFAULT_SCROLL_SOUND), 0.4);
       selectItem(newIndex);
     }
     #end
@@ -295,7 +295,7 @@ class MenuTypedList<T:MenuListItem> extends FlxTypedGroup<T>
     else
     {
       busy = true;
-      FunkinSound.playOnce(Paths.sound('confirmMenu'));
+      FunkinSound.playOnce(Paths.sound(Constants.DEFAULT_CONFIRM_SOUND));
       FlxFlicker.flicker(menuItem, 1, 0.06, true, false, function(_)
       {
         busy = false;

--- a/source/funkin/ui/Page.hx
+++ b/source/funkin/ui/Page.hx
@@ -48,7 +48,7 @@ class Page<T:PageName> extends FlxGroup
     if (canExit && controls.BACK_P)
     {
       exit();
-      FunkinSound.playOnce(Paths.sound('cancelMenu'));
+      FunkinSound.playOnce(Paths.sound(Constants.DEFAULT_CANCEL_SOUND));
     }
   }
 

--- a/source/funkin/ui/charSelect/CharSelectSubState.hx
+++ b/source/funkin/ui/charSelect/CharSelectSubState.hx
@@ -306,26 +306,26 @@ class CharSelectSubState extends MusicBeatSubState
     charHitbox.active = false;
     charHitbox.scrollFactor.set();
 
-    selectSound.loadEmbedded(Paths.sound('CS_select'));
+    selectSound.loadEmbedded(Paths.sound(Constants.SOUND_CHARACTER_SELECT));
     selectSound.volume = 0.7;
 
     FlxG.sound.defaultSoundGroup.add(selectSound);
     FlxG.sound.list.add(selectSound);
 
-    unlockSound.loadEmbedded(Paths.sound('CS_unlock'));
+    unlockSound.loadEmbedded(Paths.sound(Constants.SOUND_CHARACTER_UNLOCK));
     unlockSound.volume = 0;
     unlockSound.play(true);
 
     FlxG.sound.defaultSoundGroup.add(unlockSound);
     FlxG.sound.list.add(unlockSound);
 
-    lockedSound.loadEmbedded(Paths.sound('CS_locked'));
+    lockedSound.loadEmbedded(Paths.sound(Constants.SOUND_CHARACTER_LOCKED));
     lockedSound.volume = 1.;
 
     FlxG.sound.defaultSoundGroup.add(lockedSound);
     FlxG.sound.list.add(lockedSound);
 
-    staticSound.loadEmbedded(Paths.sound('static loop'));
+    staticSound.loadEmbedded(Paths.sound(Constants.SOUND_CHARACTER_STATIC));
     staticSound.looped = true;
     staticSound.volume = 0.6;
 
@@ -412,7 +412,7 @@ class CharSelectSubState extends MusicBeatSubState
     add(blackScreen);
 
     introSound = new FunkinSound();
-    introSound.loadEmbedded(Paths.sound('CS_Lights'));
+    introSound.loadEmbedded(Paths.sound(Constants.SOUND_CHARACTER_LIGHTS));
     introSound.volume = 0;
 
     FlxG.sound.defaultSoundGroup.add(introSound);
@@ -890,7 +890,7 @@ class CharSelectSubState extends MusicBeatSubState
 
         cursors.confirm();
 
-        FunkinSound.playOnce(Paths.sound('CS_confirm'));
+        FunkinSound.playOnce(Paths.sound(Constants.SOUND_CHARACTER_CONFIRM));
 
         dispatchEvent(new CharacterSelectScriptEvent(CHARACTER_CONFIRMED, curChar));
 
@@ -966,7 +966,7 @@ class CharSelectSubState extends MusicBeatSubState
     #end
 
     wentBackToFreeplay = true;
-    FunkinSound.playOnce(Paths.sound('cancelMenu'));
+    FunkinSound.playOnce(Paths.sound(Constants.DEFAULT_CANCEL_SOUND));
     FlxTween.tween(FlxG.sound.music, {volume: 0.0}, 0.7, {ease: FlxEase.quadInOut});
     goToFreeplay();
   }

--- a/source/funkin/ui/charSelect/CharacterUnlockState.hx
+++ b/source/funkin/ui/charSelect/CharacterUnlockState.hx
@@ -108,7 +108,7 @@ class CharacterUnlockState extends MusicBeatState
   function handleMusic():Void
   {
     FlxG.sound.music?.stop();
-    FlxG.sound.play(Paths.sound('confirmMenu'));
+    FlxG.sound.play(Paths.sound(Constants.DEFAULT_CONFIRM_SOUND));
   }
 
   override function update(elapsed:Float):Void

--- a/source/funkin/ui/debug/DebugMenuSubState.hx
+++ b/source/funkin/ui/debug/DebugMenuSubState.hx
@@ -89,7 +89,7 @@ class DebugMenuSubState extends MusicBeatSubState
 
     if (controls.BACK_P)
     {
-      FunkinSound.playOnce(Paths.sound('cancelMenu'));
+      FunkinSound.playOnce(Paths.sound(Constants.DEFAULT_CANCEL_SOUND));
       exitDebugMenu();
     }
   }

--- a/source/funkin/ui/debug/charting/ChartEditorState.hx
+++ b/source/funkin/ui/debug/charting/ChartEditorState.hx
@@ -151,6 +151,23 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
   public static final CHART_EDITOR_TOOLBOX_PLAYTEST_PROPERTIES_LAYOUT:String = Paths.ui('chart-editor/toolbox/playtest-properties');
   // Validation
   public static final SUPPORTED_MUSIC_FORMATS:Array<String> = #if sys ['ogg'] #else ['mp3'] #end;
+
+  // Sounds
+  public static final CHART_EDITOR_NOTELAY_SOUND:String = 'chartingSounds/noteLay';
+  public static final CHART_EDITOR_UNDO_SOUND:String = 'chartingSounds/undo';
+  public static final CHART_EDITOR_NOTE_ERASE_SOUND:String = 'chartingSounds/noteErase';
+  public static final CHART_EDITOR_STRETCH_SOUND:String = 'chartingSounds/stretchSNAP_UI';
+  public static final CHART_EDITOR_STRETCH1_SOUND:String = 'chartingSounds/stretch1_UI';
+  public static final CHART_EDITOR_STRETCH2_SOUND:String = 'chartingSounds/stretch2_UI';
+  public static final CHART_EDITOR_OPEN_WINDOW_SOUND:String = 'chartingSounds/openWindow';
+  public static final CHART_EDITOR_EXIT_WINDOW_SOUND:String = 'chartingSounds/exitWindow';
+  public static final CHART_EDITOR_METRONOME_HIGH_SOUND:String = 'chartingSounds/metronome1';
+  public static final CHART_EDITOR_METRONOME_LOW_SOUND:String = 'chartingSounds/metronome2';
+  public static final CHART_EDITOR_PLAYER_NOTE_HIT_SOUND:String = 'chartingSounds/hitNotePlayer';
+  public static final CHART_EDITOR_OPPONENT_NOTE_HIT_SOUND:String = 'chartingSounds/hitNoteOpponent';
+  public static final CHART_EDITOR_CLICK_DOWN_SOUND:String = 'chartingSounds/ClickDown';
+  public static final CHART_EDITOR_CLICK_UP_SOUND:String = 'chartingSounds/ClickUp';
+
   // Layout
 
   /**
@@ -1672,7 +1689,7 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
     if (currentSongMetadata.playData.stage == null)
     {
       // Initialize to the default value if not set.
-      currentSongMetadata.playData.stage = 'mainStage';
+      currentSongMetadata.playData.stage = Constants.DEFAULT_STAGE;
     }
     return currentSongMetadata.playData.stage;
   }
@@ -1720,7 +1737,7 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
     if (currentSongMetadata.artist == null)
     {
       // Initialize to the default value if not set.
-      currentSongMetadata.artist = 'Unknown';
+      currentSongMetadata.artist = Constants.DEFAULT_ARTIST;
     }
     return currentSongMetadata.artist;
   }
@@ -4685,8 +4702,8 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
   function handleCursor():Void
   {
     // Mouse sounds
-    if (FlxG.mouse.justPressed) FunkinSound.playOnce(Paths.sound('chartingSounds/ClickDown'));
-    if (FlxG.mouse.justReleased) FunkinSound.playOnce(Paths.sound('chartingSounds/ClickUp'));
+    if (FlxG.mouse.justPressed) FunkinSound.playOnce(Paths.sound(CHART_EDITOR_CLICK_DOWN_SOUND));
+    if (FlxG.mouse.justReleased) FunkinSound.playOnce(Paths.sound(CHART_EDITOR_CLICK_UP_SOUND));
 
     // Note: If a menu is open in HaxeUI, don't handle cursor behavior.
     var shouldHandleCursor:Bool = !(isHaxeUIFocused || playbarHeadDragging || isHaxeUIDialogOpen)
@@ -5261,7 +5278,7 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
         if ((dragTargetCurrentColumn != dragDistanceColumns && overlapsGrid) || dragTargetCurrentStep != dragDistanceSteps)
         {
           // Play a sound as we drag.
-          this.playSound(Paths.sound('chartingSounds/noteLay'));
+          this.playSound(Paths.sound(CHART_EDITOR_NOTELAY_SOUND));
 
           dragTargetCurrentStep = dragDistanceSteps;
           dragTargetCurrentColumn = dragDistanceColumns;
@@ -5311,7 +5328,7 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
       {
         if (dragLengthSteps > 0)
         {
-          this.playSound(Paths.sound('chartingSounds/stretchSNAP_UI'));
+          this.playSound(Paths.sound(CHART_EDITOR_STRETCH_SOUND));
           // Apply the new length.
           performCommand(new ExtendNoteLengthCommand(currentPlaceNoteData, dragLengthMs));
         }
@@ -5320,7 +5337,7 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
           // Apply the new (zero) length if we are changing the length.
           if (currentPlaceNoteData.length > 0)
           {
-            this.playSound(Paths.sound('chartingSounds/stretchSNAP_UI'));
+            this.playSound(Paths.sound(CHART_EDITOR_STRETCH_SOUND));
             performCommand(new ExtendNoteLengthCommand(currentPlaceNoteData, 0));
           }
         }
@@ -5529,7 +5546,7 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
           else
           {
             // Right click removes hold from the note.
-            this.playSound(Paths.sound('chartingSounds/stretchSNAP_UI'));
+            this.playSound(Paths.sound(CHART_EDITOR_STRETCH_SOUND));
             performCommand(new ExtendNoteLengthCommand(highlightedHoldNote.noteData, 0));
           }
         }
@@ -6004,7 +6021,7 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
     {
       // Extend the note to the playhead position.
       trace('Extending note. ${column}');
-      this.playSound(Paths.sound('chartingSounds/stretchSNAP_UI'));
+      this.playSound(Paths.sound(CHART_EDITOR_STRETCH_SOUND));
       performCommand(new ExtendNoteLengthCommand(currentLiveInputPlaceNoteData[column], newNoteLength));
       currentLiveInputPlaceNoteData[column] = null;
       gridPlayheadGhostHoldNotes[column].noteData = null;
@@ -6752,7 +6769,7 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
    */
   function playMetronomeTick(high:Bool = false):Void
   {
-    this.playSound(Paths.sound('chartingSounds/metronome${high ? '1' : '2'}'), metronomeVolume);
+    this.playSound(Paths.sound(high ? CHART_EDITOR_METRONOME_HIGH_SOUND : CHART_EDITOR_METRONOME_LOW_SOUND), metronomeVolume);
   }
 
   function switchToCurrentInstrumental():Void
@@ -7316,9 +7333,9 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
       if (hitsoundsEnabled) switch (noteData.getStrumlineIndex())
       {
         case 0: // Player
-          if (hitsoundVolumePlayer > 0) this.playSound(Paths.sound('chartingSounds/hitNotePlayer'), hitsoundVolumePlayer);
+          if (hitsoundVolumePlayer > 0) this.playSound(Paths.sound(CHART_EDITOR_PLAYER_NOTE_HIT_SOUND), hitsoundVolumePlayer);
         case 1: // Opponent
-          if (hitsoundVolumeOpponent > 0) this.playSound(Paths.sound('chartingSounds/hitNoteOpponent'), hitsoundVolumeOpponent);
+          if (hitsoundVolumeOpponent > 0) this.playSound(Paths.sound(CHART_EDITOR_OPPONENT_NOTE_HIT_SOUND), hitsoundVolumeOpponent);
       }
     }
     // Clearing memory before next event call.

--- a/source/funkin/ui/debug/charting/commands/AddEventsCommand.hx
+++ b/source/funkin/ui/debug/charting/commands/AddEventsCommand.hx
@@ -36,7 +36,7 @@ class AddEventsCommand implements ChartEditorCommand
       state.currentEventSelection = events;
     }
 
-    state.playSound(Paths.sound('chartingSounds/noteLay'));
+    state.playSound(Paths.sound(ChartEditorState.CHART_EDITOR_NOTELAY_SOUND));
 
     state.saveDataDirty = true;
     state.noteDisplayDirty = true;

--- a/source/funkin/ui/debug/charting/commands/AddNotesCommand.hx
+++ b/source/funkin/ui/debug/charting/commands/AddNotesCommand.hx
@@ -36,7 +36,7 @@ class AddNotesCommand implements ChartEditorCommand
       state.currentEventSelection = [];
     }
 
-    state.playSound(Paths.sound('chartingSounds/noteLay'));
+    state.playSound(Paths.sound(ChartEditorState.CHART_EDITOR_NOTELAY_SOUND));
 
     state.saveDataDirty = true;
     state.noteDisplayDirty = true;
@@ -51,7 +51,7 @@ class AddNotesCommand implements ChartEditorCommand
     state.currentSongChartNoteData = SongDataUtils.subtractNotes(state.currentSongChartNoteData, notes);
     state.currentNoteSelection = [];
     state.currentEventSelection = [];
-    state.playSound(Paths.sound('chartingSounds/undo'));
+    state.playSound(Paths.sound(ChartEditorState.CHART_EDITOR_UNDO_SOUND));
 
     state.saveDataDirty = true;
     state.noteDisplayDirty = true;

--- a/source/funkin/ui/debug/charting/commands/ExtendNoteLengthCommand.hx
+++ b/source/funkin/ui/debug/charting/commands/ExtendNoteLengthCommand.hx
@@ -42,7 +42,7 @@ class ExtendNoteLengthCommand implements ChartEditorCommand
 
   public function undo(state:ChartEditorState):Void
   {
-    state.playSound(Paths.sound('chartingSounds/undo'));
+    state.playSound(Paths.sound(ChartEditorState.CHART_EDITOR_UNDO_SOUND));
 
     // Always use milliseconds for undoing
     this.note.length = oldLength;

--- a/source/funkin/ui/debug/charting/commands/MoveEventsCommand.hx
+++ b/source/funkin/ui/debug/charting/commands/MoveEventsCommand.hx
@@ -51,7 +51,7 @@ class MoveEventsCommand implements ChartEditorCommand
     state.currentSongChartEventData = state.currentSongChartEventData.concat(movedEvents);
     state.currentEventSelection = movedEvents;
 
-    state.playSound(Paths.sound('chartingSounds/noteLay'));
+    state.playSound(Paths.sound(ChartEditorState.CHART_EDITOR_NOTELAY_SOUND));
 
     state.saveDataDirty = true;
     state.noteDisplayDirty = true;

--- a/source/funkin/ui/debug/charting/commands/MoveItemsCommand.hx
+++ b/source/funkin/ui/debug/charting/commands/MoveItemsCommand.hx
@@ -65,7 +65,7 @@ class MoveItemsCommand implements ChartEditorCommand
     state.currentNoteSelection = movedNotes;
     state.currentEventSelection = movedEvents;
 
-    state.playSound(Paths.sound('chartingSounds/noteLay'));
+    state.playSound(Paths.sound(ChartEditorState.CHART_EDITOR_NOTELAY_SOUND));
 
     state.saveDataDirty = true;
     state.noteDisplayDirty = true;

--- a/source/funkin/ui/debug/charting/commands/MoveNotesCommand.hx
+++ b/source/funkin/ui/debug/charting/commands/MoveNotesCommand.hx
@@ -53,7 +53,7 @@ class MoveNotesCommand implements ChartEditorCommand
     state.currentSongChartNoteData = state.currentSongChartNoteData.concat(movedNotes);
     state.currentNoteSelection = movedNotes;
 
-    state.playSound(Paths.sound('chartingSounds/noteLay'));
+    state.playSound(Paths.sound(ChartEditorState.CHART_EDITOR_NOTELAY_SOUND));
 
     state.saveDataDirty = true;
     state.noteDisplayDirty = true;

--- a/source/funkin/ui/debug/charting/commands/PasteItemsCommand.hx
+++ b/source/funkin/ui/debug/charting/commands/PasteItemsCommand.hx
@@ -90,7 +90,7 @@ class PasteItemsCommand implements ChartEditorCommand
 
   public function undo(state:ChartEditorState):Void
   {
-    state.playSound(Paths.sound('chartingSounds/undo'));
+    state.playSound(Paths.sound(ChartEditorState.CHART_EDITOR_UNDO_SOUND));
 
     state.currentSongChartNoteData = SongDataUtils.subtractNotes(state.currentSongChartNoteData, addedNotes).concat(removedNotes);
     state.currentSongChartEventData = SongDataUtils.subtractEvents(state.currentSongChartEventData, addedEvents);

--- a/source/funkin/ui/debug/charting/commands/RemoveEventsCommand.hx
+++ b/source/funkin/ui/debug/charting/commands/RemoveEventsCommand.hx
@@ -25,7 +25,7 @@ class RemoveEventsCommand implements ChartEditorCommand
     state.currentSongChartEventData = SongDataUtils.subtractEvents(state.currentSongChartEventData, events);
     state.currentEventSelection = [];
 
-    state.playSound(Paths.sound('chartingSounds/noteErase'));
+    state.playSound(Paths.sound(ChartEditorState.CHART_EDITOR_NOTE_ERASE_SOUND));
 
     state.saveDataDirty = true;
     state.noteDisplayDirty = true;
@@ -44,7 +44,7 @@ class RemoveEventsCommand implements ChartEditorCommand
       state.currentSongChartEventData.push(event);
     }
     state.currentEventSelection = events;
-    state.playSound(Paths.sound('chartingSounds/undo'));
+    state.playSound(Paths.sound(ChartEditorState.CHART_EDITOR_UNDO_SOUND));
 
     state.saveDataDirty = true;
     state.noteDisplayDirty = true;

--- a/source/funkin/ui/debug/charting/commands/RemoveItemsCommand.hx
+++ b/source/funkin/ui/debug/charting/commands/RemoveItemsCommand.hx
@@ -31,7 +31,7 @@ class RemoveItemsCommand implements ChartEditorCommand
     state.currentNoteSelection = [];
     state.currentEventSelection = [];
 
-    state.playSound(Paths.sound('chartingSounds/noteErase'));
+    state.playSound(Paths.sound(ChartEditorState.CHART_EDITOR_NOTE_ERASE_SOUND));
 
     state.saveDataDirty = true;
     state.noteDisplayDirty = true;
@@ -58,7 +58,7 @@ class RemoveItemsCommand implements ChartEditorCommand
     state.currentNoteSelection = notes;
     state.currentEventSelection = events;
 
-    state.playSound(Paths.sound('chartingSounds/undo'));
+    state.playSound(Paths.sound(ChartEditorState.CHART_EDITOR_UNDO_SOUND));
 
     state.saveDataDirty = true;
     state.noteDisplayDirty = true;

--- a/source/funkin/ui/debug/charting/commands/RemoveNotesCommand.hx
+++ b/source/funkin/ui/debug/charting/commands/RemoveNotesCommand.hx
@@ -26,7 +26,7 @@ class RemoveNotesCommand implements ChartEditorCommand
     state.currentNoteSelection = [];
     state.currentEventSelection = [];
 
-    state.playSound(Paths.sound('chartingSounds/noteErase'));
+    state.playSound(Paths.sound(ChartEditorState.CHART_EDITOR_NOTE_ERASE_SOUND));
 
     state.saveDataDirty = true;
     state.noteDisplayDirty = true;
@@ -46,7 +46,7 @@ class RemoveNotesCommand implements ChartEditorCommand
     }
     state.currentNoteSelection = notes;
     state.currentEventSelection = [];
-    state.playSound(Paths.sound('chartingSounds/undo'));
+    state.playSound(Paths.sound(ChartEditorState.CHART_EDITOR_UNDO_SOUND));
 
     state.saveDataDirty = true;
     state.noteDisplayDirty = true;

--- a/source/funkin/ui/debug/charting/commands/RemoveStackedNotesCommand.hx
+++ b/source/funkin/ui/debug/charting/commands/RemoveStackedNotesCommand.hx
@@ -38,7 +38,7 @@ class RemoveStackedNotesCommand implements ChartEditorCommand
     state.currentNoteSelection = isSelection ? overlappedNotes.copy() : [];
     state.currentEventSelection = [];
 
-    state.playSound(Paths.sound('chartingSounds/noteErase'));
+    state.playSound(Paths.sound(ChartEditorState.CHART_EDITOR_NOTE_ERASE_SOUND));
 
     state.saveDataDirty = true;
     state.noteDisplayDirty = true;
@@ -54,7 +54,7 @@ class RemoveStackedNotesCommand implements ChartEditorCommand
     state.currentSongChartNoteData = state.currentSongChartNoteData.concat(removedNotes);
     state.currentNoteSelection = overlappedNotes.concat(removedNotes).copy();
     state.currentEventSelection = [];
-    state.playSound(Paths.sound('chartingSounds/undo'));
+    state.playSound(Paths.sound(ChartEditorState.CHART_EDITOR_UNDO_SOUND));
 
     state.saveDataDirty = true;
     state.noteDisplayDirty = true;

--- a/source/funkin/ui/debug/charting/components/ChartEditorNotePreview.hx
+++ b/source/funkin/ui/debug/charting/components/ChartEditorNotePreview.hx
@@ -21,10 +21,6 @@ class ChartEditorNotePreview extends FlxSprite
   static final WIDTH:Int = NOTE_WIDTH * 9;
   static final NOTE_HEIGHT:Int = 1;
   static final BG_COLOR:FlxColor = 0xFF606060;
-  static final LEFT_COLOR:FlxColor = 0xFFFF22AA;
-  static final DOWN_COLOR:FlxColor = 0xFF00EEFF;
-  static final UP_COLOR:FlxColor = 0xFF00CC00;
-  static final RIGHT_COLOR:FlxColor = 0xFFCC1111;
   static final EVENT_COLOR:FlxColor = 0xFF111111;
   static final SELECTED_COLOR:FlxColor = 0xFFFFFF00;
   static final OVERLAPPING_COLOR:FlxColor = 0xFF640000;
@@ -152,19 +148,7 @@ class ChartEditorNotePreview extends FlxSprite
    */
   public function drawNote(dir:Int, mustHit:Bool, strumTimeInMs:Int, songLengthInPixels:Int, previewType:NotePreviewType = None):Void
   {
-    var color:FlxColor = switch (dir)
-    {
-      case 0:
-        LEFT_COLOR;
-      case 1:
-        DOWN_COLOR;
-      case 2:
-        UP_COLOR;
-      case 3:
-        RIGHT_COLOR;
-      default:
-        EVENT_COLOR;
-    };
+    var color:FlxColor = (dir >= 0 && dir < Constants.COLOR_NOTES.length) ? Constants.COLOR_NOTES[dir] : EVENT_COLOR;
 
     var noteHeight:Int = NOTE_HEIGHT;
 

--- a/source/funkin/ui/debug/charting/handlers/ChartEditorAudioHandler.hx
+++ b/source/funkin/ui/debug/charting/handlers/ChartEditorAudioHandler.hx
@@ -295,7 +295,8 @@ class ChartEditorAudioHandler
   {
     if (state.stretchySounds)
     {
-      if (state.stretchySound1 == null) state.stretchySound1 = FunkinSound.load(Paths.sound('chartingSounds/stretch1_UI'));
+
+      if (state.stretchySound1 == null) state.stretchySound1 = FunkinSound.load(Paths.sound(ChartEditorState.CHART_EDITOR_STRETCH1_SOUND));
       if (state.stretchySound1 == null) return;
 
       // Prevent spam playing that could cause issues.
@@ -307,7 +308,7 @@ class ChartEditorAudioHandler
     }
     else
     {
-      if (state.stretchySound2 == null) state.stretchySound2 = FunkinSound.load(Paths.sound('chartingSounds/stretch2_UI'));
+      if (state.stretchySound2 == null) state.stretchySound2 = FunkinSound.load(Paths.sound(ChartEditorState.CHART_EDITOR_STRETCH2_SOUND));
       if (state.stretchySound2 == null) return;
 
       // Prevent spam playing that could cause issues.

--- a/source/funkin/ui/debug/charting/handlers/ChartEditorDialogHandler.hx
+++ b/source/funkin/ui/debug/charting/handlers/ChartEditorDialogHandler.hx
@@ -615,7 +615,7 @@ class ChartEditorDialogHandler
     var newSongMetadata:SongMetadata = new SongMetadata('', '', '', Constants.DEFAULT_VARIATION);
 
     newSongMetadata.variation = targetVariation;
-    newSongMetadata.playData.difficulties = (erect) ? ['erect', 'nightmare'] : ['easy', 'normal', 'hard'];
+    newSongMetadata.playData.difficulties = (erect) ? Constants.DEFAULT_DIFFICULTY_LIST_ERECT : Constants.DEFAULT_DIFFICULTY_LIST;
 
     var inputSongName:Null<TextField> = dialog.findComponent('inputSongName', TextField);
     if (inputSongName == null) throw 'Could not locate inputSongName TextField in Song Metadata dialog';

--- a/source/funkin/ui/debug/charting/handlers/ChartEditorToolboxHandler.hx
+++ b/source/funkin/ui/debug/charting/handlers/ChartEditorToolboxHandler.hx
@@ -44,7 +44,7 @@ class ChartEditorToolboxHandler
     {
       toolbox.showDialog(false);
 
-      state.playSound(Paths.sound('chartingSounds/openWindow'));
+      state.playSound(Paths.sound(ChartEditorState.CHART_EDITOR_OPEN_WINDOW_SOUND));
 
       switch (id)
       {
@@ -88,7 +88,7 @@ class ChartEditorToolboxHandler
     {
       toolbox.hideDialog(DialogButton.CANCEL);
 
-      state.playSound(Paths.sound('chartingSounds/exitWindow'));
+      state.playSound(Paths.sound(ChartEditorState.CHART_EDITOR_EXIT_WINDOW_SOUND));
 
       switch (id)
       {

--- a/source/funkin/ui/debug/stageeditor/StageEditorState.hx
+++ b/source/funkin/ui/debug/stageeditor/StageEditorState.hx
@@ -591,7 +591,7 @@ class StageEditorState extends UIState
       findObjDialog.hideDialog(DialogButton.CANCEL);
 
       // cam
-      camGame.follow(camFollow, LOCKON, 0.04);
+      camGame.follow(camFollow, LOCKON, Constants.DEFAULT_CAMERA_FOLLOW_RATE);
       FlxG.camera.zoom = stageZoom;
 
       if (FlxG.keys.justPressed.TAB && !FlxG.keys.pressed.SHIFT) curTestChar++;

--- a/source/funkin/ui/debug/stageeditor/toolboxes/StageEditorDefaultToolbox.hx
+++ b/source/funkin/ui/debug/stageeditor/toolboxes/StageEditorDefaultToolbox.hx
@@ -3,6 +3,7 @@ package funkin.ui.debug.stageeditor.toolboxes;
 #if FEATURE_STAGE_EDITOR
 import haxe.ui.containers.dialogs.CollapsibleDialog;
 import funkin.audio.FunkinSound;
+import funkin.ui.debug.charting.ChartEditorState;
 
 @:access(funkin.ui.debug.stageeditor.StageEditorState)
 class StageEditorDefaultToolbox extends CollapsibleDialog
@@ -28,8 +29,8 @@ class StageEditorDefaultToolbox extends CollapsibleDialog
    */
   public function toggle(on:Bool)
   {
-    if (!dialogVisible && on) FunkinSound.playOnce(Paths.sound('chartingSounds/openWindow'));
-    else if (dialogVisible && !on) FunkinSound.playOnce(Paths.sound('chartingSounds/exitWindow'));
+    if (!dialogVisible && on) FunkinSound.playOnce(Paths.sound(ChartEditorState.CHART_EDITOR_OPEN_WINDOW_SOUND));
+    else if (dialogVisible && !on) FunkinSound.playOnce(Paths.sound(ChartEditorState.CHART_EDITOR_EXIT_WINDOW_SOUND));
 
     if (on) showDialog(false);
     else

--- a/source/funkin/ui/freeplay/Album.hx
+++ b/source/funkin/ui/freeplay/Album.hx
@@ -45,7 +45,7 @@ class Album implements IRegistryEntry<AlbumData>
    */
   public function getAlbumArtAssetKey():String
   {
-    return _data?.albumArtAsset ?? 'freeplay/albumRoll/volume1"';
+    return _data?.albumArtAsset ?? 'freeplay/albumRoll/${Constants.DEFAULT_ALBUM_ID}';
   }
 
   /**
@@ -62,7 +62,7 @@ class Album implements IRegistryEntry<AlbumData>
    */
   public function getAlbumTitleAssetKey():String
   {
-    return _data?.albumTitleAsset ?? "freeplay/albumRoll/volume1-text";
+    return _data?.albumTitleAsset ?? 'freeplay/albumRoll/${Constants.DEFAULT_ALBUM_ID}-text';
   }
 
   /**

--- a/source/funkin/ui/freeplay/FreeplayState.hx
+++ b/source/funkin/ui/freeplay/FreeplayState.hx
@@ -220,7 +220,7 @@ class FreeplayState extends MusicBeatSubState
    * The song we were on when this menu was last accessed.
    * NOTE: `null` if the last song was `Random`.
    */
-  public static var rememberedSongId:Null<String> = 'tutorial';
+  public static var rememberedSongId:Null<String> = Constants.DEFAULT_SONG;
 
   /**
    * The character we were on when this menu was last accessed.
@@ -1187,13 +1187,13 @@ class FreeplayState extends MusicBeatSubState
       switch (fromResultsParams?.newRank)
       {
         case SHIT:
-          FunkinSound.playOnce(Paths.sound('ranks/rankinbad'));
+          FunkinSound.playOnce(Paths.sound(Constants.SOUND_RANK_IN_BAD));
         case PERFECT:
-          FunkinSound.playOnce(Paths.sound('ranks/rankinperfect'));
+          FunkinSound.playOnce(Paths.sound(Constants.SOUND_RANK_IN_PERFECT));
         case PERFECT_GOLD:
-          FunkinSound.playOnce(Paths.sound('ranks/rankinperfect'));
+          FunkinSound.playOnce(Paths.sound(Constants.SOUND_RANK_IN_PERFECT_GOLD));
         default:
-          FunkinSound.playOnce(Paths.sound('ranks/rankinnormal'));
+          FunkinSound.playOnce(Paths.sound(Constants.SOUND_RANK_IN_NORMAL));
       }
       rankCamera.zoom = 1.3;
 
@@ -1233,19 +1233,19 @@ class FreeplayState extends MusicBeatSubState
     switch (fromResultsParams?.newRank)
     {
       case SHIT:
-        FunkinSound.playOnce(Paths.sound('ranks/loss'));
+        FunkinSound.playOnce(Paths.sound(Constants.SOUND_RANK_LOSS));
       case GOOD:
-        FunkinSound.playOnce(Paths.sound('ranks/good'));
+        FunkinSound.playOnce(Paths.sound(Constants.SOUND_RANK_GOOD));
       case GREAT:
-        FunkinSound.playOnce(Paths.sound('ranks/great'));
+        FunkinSound.playOnce(Paths.sound(Constants.SOUND_RANK_GREAT));
       case EXCELLENT:
-        FunkinSound.playOnce(Paths.sound('ranks/excellent'));
+        FunkinSound.playOnce(Paths.sound(Constants.SOUND_RANK_EXCELLENT));
       case PERFECT:
-        FunkinSound.playOnce(Paths.sound('ranks/perfect'));
+        FunkinSound.playOnce(Paths.sound(Constants.SOUND_RANK_PERFECT));
       case PERFECT_GOLD:
-        FunkinSound.playOnce(Paths.sound('ranks/perfect'));
+        FunkinSound.playOnce(Paths.sound(Constants.SOUND_RANK_PERFECT_GOLD));
       default:
-        FunkinSound.playOnce(Paths.sound('ranks/loss'));
+        FunkinSound.playOnce(Paths.sound(Constants.SOUND_RANK_LOSS));
     }
 
     FlxTween.tween(capsuleToRank.targetPos, {x: originalPos.x, y: originalPos.y}, 0.5, {ease: FlxEase.expoOut});
@@ -1488,13 +1488,13 @@ class FreeplayState extends MusicBeatSubState
     else
     {
       trace('Not enough characters unlocked to open character select!');
-      FunkinSound.playOnce(Paths.sound('cancelMenu'));
+      FunkinSound.playOnce(Paths.sound(Constants.DEFAULT_CANCEL_SOUND));
       return;
     }
 
     uiStateMachine.transition(Exiting);
 
-    FunkinSound.playOnce(Paths.sound('confirmMenu'));
+    FunkinSound.playOnce(Paths.sound(Constants.DEFAULT_CONFIRM_SOUND));
 
     dj?.toCharSelect();
 
@@ -1878,7 +1878,7 @@ class FreeplayState extends MusicBeatSubState
         {
           trace('No songs available!');
           uiStateMachine.transition(Idle);
-          FunkinSound.playOnce(Paths.sound('cancelMenu'));
+          FunkinSound.playOnce(Paths.sound(Constants.DEFAULT_CANCEL_SOUND));
           return;
         }
 
@@ -1890,7 +1890,7 @@ class FreeplayState extends MusicBeatSubState
         targetSongID = currentCapsule?.freeplayData?.data.id ?? 'unknown';
       }
       // Play the confirm animation so the user knows they actually did something.
-      FunkinSound.playOnce(Paths.sound('confirmMenu'));
+      FunkinSound.playOnce(Paths.sound(Constants.DEFAULT_CONFIRM_SOUND));
       // if (dj != null) dj.confirm();
       dj?.onConfirm();
       new FlxTimer().start(styleData?.getStartDelay(), function(tmr:FlxTimer)
@@ -1929,7 +1929,7 @@ class FreeplayState extends MusicBeatSubState
         {
           trace('No songs available!');
           uiStateMachine.transition(Idle);
-          FunkinSound.playOnce(Paths.sound('cancelMenu'));
+          FunkinSound.playOnce(Paths.sound(Constants.DEFAULT_CANCEL_SOUND));
           return;
         }
 
@@ -1993,7 +1993,7 @@ class FreeplayState extends MusicBeatSubState
         {
           curSelected = i;
           changeSelection(0);
-          FunkinSound.playOnce(Paths.sound('scrollMenu'), 0.4);
+          FunkinSound.playOnce(Paths.sound(Constants.DEFAULT_SCROLL_SOUND), 0.4);
           HapticUtil.vibrate(0, 0.01, 0.5);
         }
         break;
@@ -2237,7 +2237,7 @@ class FreeplayState extends MusicBeatSubState
 
     dispatchEvent(new FreeplayScriptEvent(FREEPLAY_OUTRO));
 
-    FunkinSound.playOnce(Paths.sound('cancelMenu'));
+    FunkinSound.playOnce(Paths.sound(Constants.DEFAULT_CANCEL_SOUND));
 
     var longestTimer:Float = 0;
 
@@ -2385,7 +2385,7 @@ class FreeplayState extends MusicBeatSubState
     if (change != 0)
     {
       HapticUtil.vibrate(0, 0.01, 0.5, 0.1);
-      FunkinSound.playOnce(Paths.sound('scrollMenu'), 0.4);
+      FunkinSound.playOnce(Paths.sound(Constants.DEFAULT_SCROLL_SOUND), 0.4);
     }
 
     var previousVariation:String = currentVariation;
@@ -2571,7 +2571,7 @@ class FreeplayState extends MusicBeatSubState
       trace('No songs available!');
       uiStateMachine.transition(Idle);
 
-      FunkinSound.playOnce(Paths.sound('cancelMenu'));
+      FunkinSound.playOnce(Paths.sound(Constants.DEFAULT_CANCEL_SOUND));
       return;
     }
 
@@ -2761,7 +2761,7 @@ class FreeplayState extends MusicBeatSubState
     }
 
     // Visual and audio effects.
-    FunkinSound.playOnce(Paths.sound('confirmMenu'));
+    FunkinSound.playOnce(Paths.sound(Constants.DEFAULT_CONFIRM_SOUND));
     dj?.onConfirm();
 
     currentCapsule.forcePosition();
@@ -2879,7 +2879,7 @@ class FreeplayState extends MusicBeatSubState
 
     if (curSelected != prevSelected)
     {
-      FunkinSound.playOnce(Paths.sound('scrollMenu'), 0.4);
+      FunkinSound.playOnce(Paths.sound(Constants.DEFAULT_SCROLL_SOUND), 0.4);
       HapticUtil.vibrate(0, 0.01, 0.5);
       dj?.onPlayerAction(); // dj?.resetAFKTimer();
       _pressedOnSelected = false;
@@ -2912,7 +2912,7 @@ class FreeplayState extends MusicBeatSubState
       #end
     }
 
-    if (!prepForNewRank && curSelected != prevSelected) FunkinSound.playOnce(Paths.sound('scrollMenu'), 0.4);
+    if (!prepForNewRank && curSelected != prevSelected) FunkinSound.playOnce(Paths.sound(Constants.DEFAULT_SCROLL_SOUND), 0.4);
 
     var songScore:Null<SaveScoreData> = Save.instance.getSongScore(currentCapsule.freeplayData?.data.id ?? '', currentDifficulty, currentVariation);
     intendedScore = songScore?.score ?? 0;
@@ -3052,7 +3052,7 @@ class FreeplayState extends MusicBeatSubState
 
   public function switchBackingImage(?freeplaySongData:FreeplaySongData):Void
   {
-    var path = Paths.image('freeplay/freeplayBG${freeplaySongData?.levelId ?? 'week1'}-${currentCharacterId ?? 'bf'}');
+    var path = Paths.image('freeplay/freeplayBG${freeplaySongData?.levelId ?? 'week1'}-${currentCharacterId ?? Constants.DEFAULT_CHARACTER}');
     if (!Assets.exists(path)) path = Paths.image('freeplay/freeplayBGweek1-bf');
     backingImage.loadTextureAsync(path);
   }

--- a/source/funkin/ui/freeplay/LetterSort.hx
+++ b/source/funkin/ui/freeplay/LetterSort.hx
@@ -159,7 +159,7 @@ class LetterSort extends FlxSpriteGroup
     {
       arrowToMove.offset.x = 0;
     });
-    if (playSound && diff != 0) FunkinSound.playOnce(Paths.sound('scrollMenu'), 0.4);
+    if (playSound && diff != 0) FunkinSound.playOnce(Paths.sound(Constants.DEFAULT_SCROLL_SOUND), 0.4);
   }
 
   /**

--- a/source/funkin/ui/mainmenu/MainMenuState.hx
+++ b/source/funkin/ui/mainmenu/MainMenuState.hx
@@ -534,7 +534,7 @@ class MainMenuState extends MusicBeatState
 
     if (InputUtil.allPressedWithDebounce([CONTROL, ALT, SHIFT, W]))
     {
-      FunkinSound.playOnce(Paths.sound('confirmMenu'));
+      FunkinSound.playOnce(Paths.sound(Constants.DEFAULT_CONFIRM_SOUND));
       // Give the user a score of 1 point on Weekend 1 story mode (Easy difficulty).
       // This makes the level count as cleared and displays the songs in Freeplay.
       funkin.save.Save.instance.setLevelScore('weekend1', 'easy', {
@@ -555,10 +555,10 @@ class MainMenuState extends MusicBeatState
 
     if (InputUtil.allPressedWithDebounce([CONTROL, ALT, SHIFT, M]))
     {
-      FunkinSound.playOnce(Paths.sound('confirmMenu'));
+      FunkinSound.playOnce(Paths.sound(Constants.DEFAULT_CONFIRM_SOUND));
       // Give the user a score of 0 points on Weekend 1 story mode (all difficulties).
       // This makes the level count as uncleared and no longer displays the songs in Freeplay.
-      for (diff in ['easy', 'normal', 'hard'])
+      for (diff in Constants.DEFAULT_DIFFICULTY_LIST)
       {
         funkin.save.Save.instance.setLevelScore('weekend1', diff, {
           score: 0,
@@ -625,7 +625,7 @@ class MainMenuState extends MusicBeatState
   {
     uiStateMachine.transition(Exiting);
     rememberedSelectedIndex = menuItems?.selectedIndex ?? 0;
-    FunkinSound.playOnce(Paths.sound('cancelMenu'));
+    FunkinSound.playOnce(Paths.sound(Constants.DEFAULT_CANCEL_SOUND));
 
     FlxG.switchState(() -> new TitleState());
   }

--- a/source/funkin/ui/options/FunkinSoundTray.hx
+++ b/source/funkin/ui/options/FunkinSoundTray.hx
@@ -65,9 +65,9 @@ class FunkinSoundTray extends FlxSoundTray
     screenCenter();
     y = -height - 10;
 
-    volumeUpSound = Paths.sound("soundtray/Volup");
-    volumeDownSound = Paths.sound("soundtray/Voldown");
-    volumeMaxSound = Paths.sound("soundtray/VolMAX");
+    volumeUpSound = Paths.sound(Constants.SOUND_TRAY_VOL_UP);
+    volumeDownSound = Paths.sound(Constants.SOUND_TRAY_VOL_DOWN);
+    volumeMaxSound = Paths.sound(Constants.SOUND_TRAY_VOL_MAX);
   }
 
   override public function update(ms:Float):Void

--- a/source/funkin/ui/options/OffsetMenu.hx
+++ b/source/funkin/ui/options/OffsetMenu.hx
@@ -415,11 +415,11 @@ class OffsetMenu extends Page<OptionsState.OptionsMenuPageName>
       if (calibrating) Preferences.globalOffset = savedOffset;
       #if !mobile
       // mobile would play this twice
-      FunkinSound.playOnce(Paths.sound('cancelMenu'));
+      FunkinSound.playOnce(Paths.sound(Constants.DEFAULT_CANCEL_SOUND));
       #end
     }
     else
-      FunkinSound.playOnce(Paths.sound('confirmMenu'));
+      FunkinSound.playOnce(Paths.sound(Constants.DEFAULT_CONFIRM_SOUND));
     offsetItem.currentValue = Preferences.globalOffset;
     OptionsState.instance.drumsBG.fadeOut(1, 0);
   }

--- a/source/funkin/ui/story/Level.hx
+++ b/source/funkin/ui/story/Level.hx
@@ -200,7 +200,7 @@ class Level implements IRegistryEntry<LevelData>
       }
     }
 
-    if (difficulties.length == 0) difficulties = ['normal'];
+    if (difficulties.length == 0) difficulties = [Constants.DEFAULT_DIFFICULTY];
 
     return difficulties;
   }

--- a/source/funkin/ui/story/StoryMenuState.hx
+++ b/source/funkin/ui/story/StoryMenuState.hx
@@ -37,8 +37,8 @@ class StoryMenuState extends MusicBeatState
   static final DEFAULT_BACKGROUND_COLOR:FlxColor = FlxColor.fromString('#F9CF51');
   static final BACKGROUND_HEIGHT:Int = 400;
 
-  var currentDifficultyId:String = 'normal';
-  var currentLevelId:String = 'tutorial';
+  var currentDifficultyId:String = Constants.DEFAULT_DIFFICULTY;
+  var currentLevelId:String = Constants.DEFAULT_SONG;
   var currentLevel:Level;
   var isLevelUnlocked:Bool;
   var currentLevelTitle:LevelTitle;
@@ -158,7 +158,7 @@ class StoryMenuState extends MusicBeatState
 
     updateBackground();
 
-    var black:FunkinSprite = new FunkinSprite(levelBackground.x, 0).makeSolidColor(FlxG.width, Std.int(400 + levelBackground.y), FlxColor.BLACK);
+    var black:FunkinSprite = new FunkinSprite(levelBackground.x, 0).makeSolidColor(FlxG.width, Std.int(BACKGROUND_HEIGHT + levelBackground.y), FlxColor.BLACK);
     black.zIndex = levelBackground.zIndex - 1;
     add(black);
 
@@ -484,7 +484,7 @@ class StoryMenuState extends MusicBeatState
       }
     }
 
-    if (currentIndex != prevIndex) FunkinSound.playOnce(Paths.sound('scrollMenu'), 0.4);
+    if (currentIndex != prevIndex) FunkinSound.playOnce(Paths.sound(Constants.DEFAULT_SCROLL_SOUND), 0.4);
 
     repositionTitles();
     updateText();
@@ -530,7 +530,7 @@ class StoryMenuState extends MusicBeatState
     if (hasChanged)
     {
       buildDifficultySprite();
-      FunkinSound.playOnce(Paths.sound('scrollMenu'), 0.4);
+      FunkinSound.playOnce(Paths.sound(Constants.DEFAULT_SCROLL_SOUND), 0.4);
       // Disable the funny music thing for now.
       // funnyMusicThing();
     }
@@ -572,7 +572,7 @@ class StoryMenuState extends MusicBeatState
   {
     if (!currentLevel.isUnlocked())
     {
-      FunkinSound.playOnce(Paths.sound('cancelMenu'));
+      FunkinSound.playOnce(Paths.sound(Constants.DEFAULT_CANCEL_SOUND));
       return;
     }
 
@@ -580,7 +580,7 @@ class StoryMenuState extends MusicBeatState
 
     selectedLevel = true;
 
-    FunkinSound.playOnce(Paths.sound('confirmMenu'));
+    FunkinSound.playOnce(Paths.sound(Constants.DEFAULT_CONFIRM_SOUND));
 
     currentLevelTitle.isFlashing = true;
 
@@ -723,7 +723,7 @@ class StoryMenuState extends MusicBeatState
     exitingMenu = true;
     FlxG.keys.enabled = false;
     FlxG.switchState(() -> new MainMenuState());
-    FunkinSound.playOnce(Paths.sound('cancelMenu'));
+    FunkinSound.playOnce(Paths.sound(Constants.DEFAULT_CANCEL_SOUND));
   }
 
   /**

--- a/source/funkin/ui/title/TitleState.hx
+++ b/source/funkin/ui/title/TitleState.hx
@@ -285,7 +285,7 @@ class TitleState extends MusicBeatState
       if (FlxG.sound.music != null) FlxG.sound.music.onComplete = null;
       titleText.animation.play('press');
       FlxG.camera.flash(FlxColor.WHITE, 1);
-      FunkinSound.playOnce(Paths.sound('confirmMenu'), 0.7);
+      FunkinSound.playOnce(Paths.sound(Constants.DEFAULT_CONFIRM_SOUND), 0.7);
       transitioning = true;
 
       #if FEATURE_HAPTICS
@@ -381,7 +381,7 @@ class TitleState extends MusicBeatState
     FlxG.sound.music.fadeIn(4.0, 0.0, 1.0);
 
     FlxG.camera.flash(FlxColor.WHITE, 1);
-    FunkinSound.playOnce(Paths.sound('confirmMenu'), 0.7);
+    FunkinSound.playOnce(Paths.sound(Constants.DEFAULT_CONFIRM_SOUND), 0.7);
 
     #if FEATURE_VIDEO_PLAYBACK
     // Stop the attract timer so you can listen to the whole song!

--- a/source/funkin/ui/transition/LoadingState.hx
+++ b/source/funkin/ui/transition/LoadingState.hx
@@ -109,7 +109,7 @@ class LoadingState extends MusicBeatSubState
     if (!OpenFLAssets.cache.hasSound(path))
     {
       var library = Assets.getLibrary('songs');
-      var symbolPath = path.split(':').pop();
+      var symbolPath = path.split(Constants.LIBRARY_SEPARATOR).pop();
       // @:privateAccess
       // library.types.set(symbolPath, SOUND);
       // @:privateAccess

--- a/source/funkin/util/Constants.hx
+++ b/source/funkin/util/Constants.hx
@@ -167,6 +167,151 @@ class Constants
   public static final COLOR_PRELOADER_LOCK_LINK:FlxColor = 0xEEB211;
 
   /**
+   * AUDIO
+   */
+  // ==============================
+
+  /**
+   * Default sound played when scrolling through menu items.
+   */
+  public static final DEFAULT_SCROLL_SOUND:String = 'scrollMenu';
+
+  /**
+   * Default sound played when confirming a menu selection.
+   */
+  public static final DEFAULT_CONFIRM_SOUND:String = 'confirmMenu';
+
+  /**
+   * Default sound played when cancelling or backing out of a menu.
+   */
+  public static final DEFAULT_CANCEL_SOUND:String = 'cancelMenu';
+
+  /**
+   * Default sound played when Newgrounds medal notifications fade in.
+   */
+  public static final DEFAULT_NG_FADEIN_SOUND:String = 'NGFadeIn';
+
+  /**
+   * Default sound played when Newgrounds medal notifications fade out.
+   */
+  public static final DEFAULT_NG_FADEOUT_SOUND:String = 'NGFadeOut';
+
+  /**
+   * Default rank sound played when entering the results screen for a "Shit" rank.
+   */
+  public static final SOUND_RANK_IN_BAD:String = 'ranks/rankinbad';
+
+  /**
+   * Default rank sound played when entering the results screen for a "Perfect" rank.
+   */
+  public static final SOUND_RANK_IN_PERFECT:String = 'ranks/rankinperfect';
+
+  /**
+   * Default rank sound played when entering the results screen for a "Perfect Gold" rank.
+   */
+  public static final SOUND_RANK_IN_PERFECT_GOLD:String = 'ranks/rankinperfect';
+
+  /**
+   * Default rank sound played when entering the results screen for most standard ranks.
+   */
+  public static final SOUND_RANK_IN_NORMAL:String = 'ranks/rankinnormal';
+
+  /**
+   * Default rank sound played in the results screen after a loss.
+   */
+  public static final SOUND_RANK_LOSS:String = 'ranks/loss';
+
+  /**
+   * Default rank sound played in the results screen for a "Good" rank.
+   */
+  public static final SOUND_RANK_GOOD:String = 'ranks/good';
+
+  /**
+   * Default rank sound played in the results screen for a "Great" rank.
+   */
+  public static final SOUND_RANK_GREAT:String = 'ranks/great';
+
+  /**
+   * Default rank sound played in the results screen for an "Excellent" rank.
+   */
+  public static final SOUND_RANK_EXCELLENT:String = 'ranks/excellent';
+
+  /**
+   * Default rank sound played in the results screen for a "Perfect" rank.
+   */
+  public static final SOUND_RANK_PERFECT:String = 'ranks/perfect';
+
+  /**
+   * Default rank sound played in the results screen for a "Perfect Gold" rank.
+   */
+  public static final SOUND_RANK_PERFECT_GOLD:String = 'ranks/perfect';
+
+  /**
+   * Default sound played when you get blueballed.
+   */
+  public static final BLUEBALL_SFX:String = 'gameplay/gameover/fnf_loss_sfx';
+
+  /**
+   * Default sound played when selecting a character in Character Select.
+   */
+  public static final SOUND_CHARACTER_SELECT:String = 'CS_select';
+
+  /**
+   * Default sound played when unlocking a character in Character Select.
+   */
+  public static final SOUND_CHARACTER_UNLOCK:String = 'CS_unlock';
+
+  /**
+   * Default sound played when attempting to select a locked character.
+   */
+  public static final SOUND_CHARACTER_LOCKED:String = 'CS_locked';
+
+  /**
+   * Default sound played for the static loop effect in Character Select.
+   */
+  public static final SOUND_CHARACTER_STATIC:String = 'static loop';
+
+  /**
+   * Default sound played for the light-on effect in Character Select.
+   */
+  public static final SOUND_CHARACTER_LIGHTS:String = 'CS_Lights';
+
+  /**
+   * Default sound played when confirming a character selection in Character Select.
+   */
+  public static final SOUND_CHARACTER_CONFIRM:String = 'CS_confirm';
+
+  /**
+   * Default sound played when characters type in dialogue boxes.
+   */
+  public static final SOUND_DIALOGUE_TYPING:String = 'pixelText';
+
+  /**
+   * Default sound played when the player misses a note.
+   */
+  public static final SOUND_GAMEPLAY_MISS:String = 'missnote';
+
+  /**
+   * Default sound played when increasing the volume.
+   */
+  public static final SOUND_TRAY_VOL_UP:String = 'soundtray/Volup';
+
+  /**
+   * Default sound played when decreasing the volume.
+   */
+  public static final SOUND_TRAY_VOL_DOWN:String = 'soundtray/Voldown';
+
+  /**
+   * Default sound played when the volume reaches its maximum level.
+   */
+  public static final SOUND_TRAY_VOL_MAX:String = 'soundtray/VolMAX';
+
+  /**
+   * Default sound played when a screenshot is captured.
+   */
+  public static final SOUND_SCREENSHOT:String = 'screenshot';
+
+  /**
    * GAME DEFAULTS
    */
   // ==============================
@@ -316,6 +461,11 @@ class Constants
   public static final DEFAULT_TIMEFORMAT:SongTimeFormat = SongTimeFormat.MILLISECONDS;
 
   /**
+   * The default divisions for songs
+   */
+  public static final DEFAULT_DIVISIONS:Null<Int> = null;
+
+  /**
    * The default scroll speed for songs.
    */
   public static final DEFAULT_SCROLLSPEED:Float = 1.0;
@@ -329,6 +479,11 @@ class Constants
    * Default denominator for the time signature.
    */
   public static final DEFAULT_TIME_SIGNATURE_DEN:Int = 4;
+
+  /**
+   * The default value for whether songs loop.
+   */
+  public static final DEFAULT_LOOPED:Bool = false;
 
   /**
    * ANIMATIONS

--- a/source/funkin/util/plugins/NewgroundsMedalPlugin.hx
+++ b/source/funkin/util/plugins/NewgroundsMedalPlugin.hx
@@ -86,7 +86,7 @@ class NewgroundsMedalPlugin extends FlxTypedContainer<FlxBasic> implements Conso
             moveText = true;
           }
         case "fade":
-          FunkinSound.playOnce(Paths.sound('NGFadeOut'), 1.0);
+          FunkinSound.playOnce(Paths.sound(Constants.DEFAULT_NG_FADEOUT_SOUND), 1.0);
         case "hide":
           pointsLabel.visible = false;
           nameLabel.visible = false;
@@ -170,7 +170,7 @@ class NewgroundsMedalPlugin extends FlxTypedContainer<FlxBasic> implements Conso
       instance.nameLabel.text = name;
       instance.updatePositions();
 
-      FunkinSound.playOnce(Paths.sound('NGFadeIn'), 1.0);
+      FunkinSound.playOnce(Paths.sound(Constants.DEFAULT_NG_FADEIN_SOUND), 1.0);
       instance.medal.anim.play("");
 
       instance.medal.visible = true;

--- a/source/funkin/util/plugins/ScreenshotPlugin.hx
+++ b/source/funkin/util/plugins/ScreenshotPlugin.hx
@@ -313,7 +313,7 @@ class ScreenshotPlugin extends FlxBasic
     flashSprite.alpha = 1;
     FlxTween.tween(flashSprite, {alpha: 0}, 0.15);
 
-    FunkinSound.playOnce(Paths.sound('screenshot'), 1.0);
+    FunkinSound.playOnce(Paths.sound(Constants.SOUND_SCREENSHOT));
   }
 
   static final PREVIEW_INITIAL_DELAY:Float = 0.25; // How long before the preview starts fading in.


### PR DESCRIPTION
## Description
This PR improves the game's codebase by adding audio paths as constants, using already existing constants as values and removing duplicate constants that are found in different classes and contain the same values.

### Modding
Modders can now easily change core engine sounds (like the screenshot, volume sounds or chart editor sounds) by modifying these values. This removes the need to hunt through different states or sound pools to stop or replace the sound.