### PR TITLE
[MODS] Ignore the `.idea` folder from mods.

### DIFF
--- a/source/funkin/modding/PolymodHandler.hx
+++ b/source/funkin/modding/PolymodHandler.hx
@@ -483,6 +483,7 @@ class PolymodHandler
   {
     var result = Polymod.getDefaultIgnoreList();
 
+    result.push('.idea');
     result.push('.git');
     result.push('.gitignore');
     result.push('.gitattributes');


### PR DESCRIPTION
## Description

This PR adds the `.idea` folder to the `PolymodHandler.buildIgnoreList()` so mods ignore the IDEA Project Files when they are built.

This is useful for those who use IntelliJ for coding mods instead of VSCode.