### PR TITLE
[BUGFIX] Fix 2nd measure number not being rendered

### DIFF
--- a/source/funkin/ui/debug/charting/ChartEditorState.hx
+++ b/source/funkin/ui/debug/charting/ChartEditorState.hx
@@ -7104,6 +7104,7 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
 
     Conductor.instance.mapTimeChanges(this.currentSongMetadata.timeChanges);
     updateTimeSignature();
+    @:privateAccess measureTicks?.updateMeasureNumbers(true);
 
     this.songLengthInMs = (audioInstTrack?.length ?? 1000.0) + Conductor.instance.instrumentalOffset;
     Conductor.instance.currentTimeChange.bpm = currentSongMetadata.timeChanges[0].bpm;

--- a/source/funkin/ui/debug/charting/components/ChartEditorMeasureTicks.hx
+++ b/source/funkin/ui/debug/charting/components/ChartEditorMeasureTicks.hx
@@ -152,7 +152,7 @@ class ChartEditorMeasureTicks extends FlxTypedSpriteGroup<FlxSprite>
   }
 
   // The last measure number we updated the ticks on.
-  var previousMeasure:Int = 0;
+  var previousMeasure:Int = -1;
 
   function updateMeasureNumbers(force:Bool = false):Void
   {
@@ -163,6 +163,8 @@ class ChartEditorMeasureTicks extends FlxTypedSpriteGroup<FlxSprite>
     var currentMeasure:Int = Math.floor(Conductor.instance.getTimeInMeasures(chartEditorState.scrollPositionInMs));
     if (previousMeasure == currentMeasure && !force) return;
     if (currentMeasure < 0) currentMeasure = previousMeasure = 0;
+    else
+      previousMeasure = currentMeasure;
 
     // Remove existing measure numbers.
     measureNumbers.forEachAlive(function(measureNumber:FlxText) {


### PR DESCRIPTION
## Description
This fixes an issue where the 2nd measure tick would not be rendered when first entering the chart editor because, since a song has not been loaded yet, it will fallback to just generate measures for a song of a very short length. This fixes it by triggering an update when a song is loaded.

This could've been an one line banger but I've also addressed an issue where the previous to current measure checking was useless 'cause the previous value was never updated.

## Screenshots/Videos

https://github.com/user-attachments/assets/46c3ac9b-ab4a-4c87-b92a-47f69ddd06d4

