### PR TITLE
[ENHANCEMENT] Set Target Bop Event

### DIFF
--- a/source/funkin/play/PlayState.hx
+++ b/source/funkin/play/PlayState.hx
@@ -1241,8 +1241,6 @@ class PlayState extends MusicBeatSubState
     FlxG.watch.addQuick('health', health);
     FlxG.watch.addQuick('cameraBopIntensity', cameraBopIntensity);
 
-    // TODO: Add a song event for Handle GF dance speed.
-
     // Handle player death.
     if (!isInCutscene && !disableKeys)
     {

--- a/source/funkin/play/character/BaseCharacter.hx
+++ b/source/funkin/play/character/BaseCharacter.hx
@@ -253,6 +253,9 @@ class BaseCharacter extends Bopper
     // Set the x and y to be their original values.
     this.resetPosition();
 
+    // Resets danceEvery value to the original one.
+    this.danceEvery = _data.danceEvery;
+
     this.dance(true); // Force to avoid the old animation playing with the wrong offset at the start of the song.
     // Make sure we are playing the idle animation
     // ...then update the hitbox so that this.width and this.height are correct.

--- a/source/funkin/play/event/SetTargetBopSpeedEvent.hx
+++ b/source/funkin/play/event/SetTargetBopSpeedEvent.hx
@@ -1,0 +1,105 @@
+package funkin.play.event;
+
+import flixel.FlxSprite;
+import funkin.play.character.BaseCharacter;
+import funkin.play.stage.Bopper;
+// Data from the chart
+import funkin.data.song.SongData.SongEventData;
+// Data from the event schema
+import funkin.data.event.SongEventSchema;
+import funkin.data.event.SongEventSchema.SongEventFieldType;
+
+/**
+ * This class handles song events which changes dance speed of specific character or stage prop.
+ */
+class SetTargetBopSpeedSongEvent extends SongEvent
+{
+  public function new()
+  {
+    super('SetTargetBopSpeed');
+  }
+
+  static final DEFAULT_TARGET:String = 'boyfriend';
+
+  public override function handleEvent(data:SongEventData):Void
+  {
+    // Does nothing if there is no PlayState camera or stage.
+    if (PlayState.instance == null || PlayState.instance.currentStage == null) return;
+
+    var targetName:Null<String> = data.getString('target');
+    if (targetName == null) targetName = DEFAULT_TARGET;
+
+    var rate = data.getFloat('rate');
+    if (rate == null) rate = Constants.DEFAULT_PROP_RATE;
+
+    var target:FlxSprite = null;
+
+    switch (targetName)
+    {
+      case 'boyfriend' | 'bf' | 'player':
+        trace('Set dance rate to $rate on boyfriend.');
+        target = PlayState.instance.currentStage.getBoyfriend();
+      case 'dad' | 'opponent':
+        trace('Set dance rate to $rate on dad.');
+        target = PlayState.instance.currentStage.getDad();
+      case 'girlfriend' | 'gf':
+        trace('Set dance rate to $rate on girlfriend.');
+        target = PlayState.instance.currentStage.getGirlfriend();
+      default:
+        target = PlayState.instance.currentStage.getNamedProp(targetName);
+        if (target == null) trace('Unknown target to set dance rate: $targetName');
+        else
+          trace('Set dance rate to $targetName from stage.');
+    }
+
+    if (target != null)
+    {
+      if (Std.isOfType(target, BaseCharacter))
+      {
+        var targetChar:BaseCharacter = cast target;
+        targetChar.danceEvery = rate;
+      }
+      else if (Std.isOfType(target, Bopper))
+      {
+        var targetProp:Bopper = cast target;
+        targetProp.danceEvery = rate;
+      }
+    }
+    else
+    {
+      trace('Unknown SetTargetBopSpeed target: $targetName');
+    }
+  }
+
+  public override function getTitle():String
+  {
+    return "Set Target Bop Speed";
+  }
+
+  /**
+   * ```
+   * {
+   *   "target": STRING, // Name of character or prop to point to.
+   *   "anim": STRING, // Name of animation to play.
+   * }
+   * ```
+   * @return SongEventSchema
+   */
+  public override function getEventSchema():SongEventSchema
+  {
+    return new SongEventSchema([{
+      name: 'target',
+      title: 'Target',
+      type: SongEventFieldType.STRING,
+      defaultValue: DEFAULT_TARGET,
+    }, {
+      name: 'rate',
+      title: 'Rate',
+      defaultValue: Constants.DEFAULT_PROP_RATE,
+      min: 0,
+      step: 0.25,
+      type: SongEventFieldType.FLOAT,
+      units: 'beats/dance'
+    }]);
+  }
+}

--- a/source/funkin/play/stage/Stage.hx
+++ b/source/funkin/play/stage/Stage.hx
@@ -145,6 +145,12 @@ class Stage extends FlxSpriteGroup implements IPlayStateScriptedClass implements
         prop.x = dataProp.position[0];
         prop.y = dataProp.position[1];
         prop.zIndex = dataProp.zIndex;
+
+        // Reset danceEvery value.
+        if (Std.isOfType(prop, Bopper))
+        {
+          cast(prop, Bopper).danceEvery = dataProp.danceEvery;
+        }
       }
     }
 

--- a/source/funkin/util/Constants.hx
+++ b/source/funkin/util/Constants.hx
@@ -242,6 +242,11 @@ class Constants
   public static final DEFAULT_ZOOM_OFFSET:Int = 0;
 
   /**
+   * The default rate for characters or props (in beats per dance).
+   */
+  public static final DEFAULT_PROP_RATE:Int = 1;
+
+  /**
    * The default BPM for charts, so things don't break if none is specified.
    */
   public static final DEFAULT_BPM:Float = 100.0;


### PR DESCRIPTION
## Description
This is the SetTargetBop event, it can change dance rate of characters and props! (Note: dad and boyfriend won't dance faster with high bpm due to how dance works for each character)
This event existed before 0.3.0 but it could change only gf speed and it was used only in Fresh
Decided to add it due to seeing comment on playstate about it
(yeah this is remake of previous pull request cuz im an idiot :p)

## Videos and Screenshots

https://github.com/user-attachments/assets/21be0ac6-f445-4c47-9a9b-0f21cc1034b2

<img width="364" height="165" alt="image" src="https://github.com/user-attachments/assets/92c99727-24ac-4a18-823e-3124f14f72e1" />

