### PR TITLE
[BUGFIX] Fix Crash When Closing Game From Stage Editor

### DIFF
--- a/source/funkin/ui/debug/stageeditor/StageEditorState.hx
+++ b/source/funkin/ui/debug/stageeditor/StageEditorState.hx
@@ -854,7 +854,7 @@ class StageEditorState extends UIState
     if (!saved)
     {
       trace("You haven't saved recently, so a backup will be made.");
-      saveBackup();
+      saveBackup(true);
     }
   }
 
@@ -865,7 +865,7 @@ class StageEditorState extends UIState
     if (!saved)
     {
       trace("You haven't saved recently, so a backup will be made.");
-      saveBackup();
+      saveBackup(true);
     }
   }
 
@@ -1497,7 +1497,7 @@ class StageEditorState extends UIState
     }
   }
 
-  function saveBackup()
+  function saveBackup(isClose:Bool = false)
   {
     FileUtil.createDirIfNotExists(BACKUPS_PATH);
 
@@ -1508,12 +1508,16 @@ class StageEditorState extends UIState
     ]);
 
     FileUtil.writeBytesToPath(path, data);
-    saved = true;
+
+    if (!isClose)
+    {
+      saved = true;
+
+      notifyChange("Auto-Save", "A Backup of this Stage has been made.");
+    }
 
     Save.instance.stageEditorHasBackup.value = true;
     Save.system.flush();
-
-    notifyChange("Auto-Save", "A Backup of this Stage has been made.");
   }
 
   public function clearAssets()
@@ -1647,6 +1651,7 @@ typedef StageEditorParams =
    * If non-null, load this stage immediately instead of the welcome screen.
    */
   var ?targetStageId:String;
+
   /**
    * If non-null, load this character as Boyfriend.
    */


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Briefly describe the issue(s) fixed. -->
## Description

This PR fixes an issue where closing the game within the stage editor causes it to crash. This is because of the autosaving that the game does when it closes. This means that to reproduce this bug, you gotta move some stuff around in the stage editor real quick before closing the game.

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos

<img width="1277" height="745" alt="image" src="https://github.com/user-attachments/assets/9ad07df1-d562-471c-8f52-7e3006a05493" />

Thank you Mighty for the screenshot.
