### PR TITLE
[BUGFIX] Fix Weekend 1 Rain Not Fading Out With Results Transition

### DIFF
--- a/source/funkin/play/PlayState.hx
+++ b/source/funkin/play/PlayState.hx
@@ -628,6 +628,11 @@ class PlayState extends MusicBeatSubState
   public var camPause:FunkinCamera;
 
   /**
+   * The camera which contains, and controls visibility of, the fade out to the results screen.
+   */
+  public var camTransition:FunkinCamera;
+
+  /**
    * The combo popups. Includes the real-time combo counter and the rating.
    */
   public var comboPopUps:PopUpStuff;
@@ -795,6 +800,7 @@ class PlayState extends MusicBeatSubState
     camCutouts = new FunkinCamera('playStateCamCutouts');
     camSubtitles = new FunkinCamera('playStateCamSubtitles');
     camPause = new FunkinCamera('playStateCamPause');
+    camTransition = new FunkinCamera('playStateCamTransition');
 
     var currentChart = currentSong.getDifficulty(currentDifficulty, currentVariation);
     var noteStyleId:Null<String> = currentChart?.noteStyle;
@@ -1360,7 +1366,7 @@ class PlayState extends MusicBeatSubState
      */
   function pause(mode:PauseMode = Standard, lostFocus:Bool = false):Void
   {
-    if (!mayPauseGame || justUnpaused || isGamePaused || isPlayerDying) return;
+    if (!mayPauseGame || justUnpaused || isGamePaused || isPlayerDying || isSongEnd) return;
 
     switch (mode)
     {
@@ -1965,12 +1971,14 @@ class PlayState extends MusicBeatSubState
     camCutouts.bgColor.alpha = 0; // Show the game scene behind the camera.
     if (Preferences.subtitles) camSubtitles.bgColor.alpha = 0; // Show the game scene behind the camera.
     camPause.bgColor.alpha = 0; // Show the game scene behind the camera.
+    camTransition.bgColor.alpha = 0;
 
     FlxG.cameras.reset(camGame);
     FlxG.cameras.add(camHUD, false);
     FlxG.cameras.add(camCutscene, false);
     FlxG.cameras.add(camCutouts, false);
     if (Preferences.subtitles) FlxG.cameras.add(camSubtitles, false);
+    FlxG.cameras.add(camTransition, false);
     FlxG.cameras.add(camPause, false);
 
     // Configure camera follow point.
@@ -3775,13 +3783,10 @@ class PlayState extends MusicBeatSubState
     FlxG.camera.targetOffset.x += 20;
 
     // Replace zoom animation with a fade out for now.
-    FlxG.camera.fade(FlxColor.BLACK, 0.6);
+    FlxTween.tween(camHUD, {alpha: 0}, 0.6);
 
-    FlxTween.tween(camHUD, {alpha: 0}, 0.6, {
-      onComplete: function(_)
-      {
-        moveToResultsScreen(isNewHighscore, prevScoreData);
-      }
+    camTransition.fade(FlxColor.BLACK, 0.6, false, function() {
+      moveToResultsScreen(isNewHighscore, prevScoreData);
     });
 
     // Zoom in on Girlfriend (or BF if no GF)


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues

Fixes #4339

<!-- Briefly describe the issue(s) fixed. -->
## Description

This PR fixes an issue with Weekend 1, where the rain doesn't fade out with the transition to the results screen. This was fixed by using a unique camera for the fade out, rather than the game's main camera.

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos

<img width="1280" height="720" alt="screenshot-2026-01-15-21-43-37" src="https://github.com/user-attachments/assets/5cbb098f-3ffa-48d9-a568-e936009d0ece" />
