### PR TITLE
[BUGFIX] Fix Char Select Lock Not Playing Reject Animation On Mobile

### DIFF
--- a/source/funkin/ui/charSelect/CharSelectSubState.hx
+++ b/source/funkin/ui/charSelect/CharSelectSubState.hx
@@ -1065,7 +1065,7 @@ class CharSelectSubState extends MusicBeatSubState
               case "idle":
                 lock.anim.play("selected");
               case "selected" | "clicked":
-                if (controls.ACCEPT_P) lock.anim.play("clicked", true);
+                if (controls.ACCEPT_P || mobileAccept) lock.anim.play("clicked", true);
             }
           }
           else


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues

Fixes #6766

<!-- Briefly describe the issue(s) fixed. -->
## Description

This PR fixes an issue on mobile where the character select's lock doesn't play its reject animation. This was because it would only play if the accept key was pressed, rather than also checking if `mobileAccept` was true.
