### PR TITLE
[BLEND MODE BRANCH] Don't batch complex blends when coherent blending is unavailable

### DIFF
--- a/source/funkin/graphics/FunkinCamera.hx
+++ b/source/funkin/graphics/FunkinCamera.hx
@@ -17,6 +17,8 @@ import openfl.geom.Matrix;
 import openfl.display.BitmapData;
 import openfl.display.BlendMode;
 import openfl.display3D.textures.TextureBase;
+import flixel.graphics.tile.FlxDrawQuadsItem;
+import flixel.graphics.tile.FlxDrawTrianglesItem;
 
 /**
  * A FlxCamera with additional powerful features:
@@ -248,6 +250,69 @@ class FunkinCamera extends FlxCamera
     {
       super.drawPixels(frame, pixels, matrix, transform, blend, smoothing, shader);
     }
+  }
+
+  override function startQuadBatch(graphic:FlxGraphic, colored:Bool, hasColorOffsets:Bool = false, ?blend:BlendMode, smooth:Bool = false,
+      ?shader:FlxShader):FlxDrawQuadsItem
+  {
+    // Can't batch complex non-coherent blends, so always force a new batch
+    if (hasKhronosExtension && !(OpenGLRenderer.__coherentBlendsSupported ?? false) && KHR_BLEND_MODES.contains(blend))
+    {
+      var itemToReturn = null;
+
+      if (FlxCamera._storageTilesHead != null)
+      {
+        itemToReturn = FlxCamera._storageTilesHead;
+        var newHead = FlxCamera._storageTilesHead.nextTyped;
+        itemToReturn.reset();
+        FlxCamera._storageTilesHead = newHead;
+      }
+      else
+      {
+        itemToReturn = new FlxDrawQuadsItem();
+      }
+
+      // TODO: catch this error when the dev actually messes up, not in the draw phase
+      if (graphic.isDestroyed)
+        throw 'Cannot queue ${graphic.key}. This sprite was destroyed.';
+
+      itemToReturn.graphics = graphic;
+      itemToReturn.antialiasing = smooth;
+      itemToReturn.colored = colored;
+      itemToReturn.hasColorOffsets = hasColorOffsets;
+      itemToReturn.blend = blend;
+      @:nullSafety(Off)
+      itemToReturn.shader = shader;
+
+      itemToReturn.nextTyped = _headTiles;
+      _headTiles = itemToReturn;
+
+      if (_headOfDrawStack == null)
+      {
+        _headOfDrawStack = itemToReturn;
+      }
+
+      if (_currentDrawItem != null)
+      {
+        _currentDrawItem.next = itemToReturn;
+      }
+
+      _currentDrawItem = itemToReturn;
+
+      return itemToReturn;
+    }
+
+    return super.startQuadBatch(graphic, colored, hasColorOffsets, blend, smooth, shader);
+  }
+
+  override function startTrianglesBatch(graphic:FlxGraphic, smoothing:Bool = false, isColored:Bool = false, ?blend:BlendMode, ?hasColorOffsets:Bool,
+      ?shader:FlxShader):FlxDrawTrianglesItem
+  {
+    // Can't batch complex non-coherent blends, so always force a new batch
+    if (hasKhronosExtension && !(OpenGLRenderer.__coherentBlendsSupported ?? false) && KHR_BLEND_MODES.contains(blend))
+      return getNewDrawTrianglesItem(graphic, smoothing, isColored, blend, hasColorOffsets, shader);
+
+    return super.startTrianglesBatch(graphic, smoothing, isColored, blend, hasColorOffsets, shader);
   }
 
   override function destroy():Void


### PR DESCRIPTION
> [!IMPORTANT]
> This requires https://github.com/FunkinCrew/openfl/pull/12

Per the [`KHR_advanced_blend_equation` spec](https://registry.khronos.org/OpenGL/extensions/KHR/KHR_blend_equation_advanced.txt), when non-coherent blending is used, a pixel can only be touched once in a draw call. 
>KHR_blend_equation_advanced: Provides the new blending equations, but guarantees defined results only if each sample is touched no more than once in any single rendering pass.

This means that we can't have any overlapping geometry, and the easiest way to prevent that is to just have every complex blend be a seperate draw call.

This avoids issues where for example atlases would render incorrectly:

<img width="398" height="428" alt="image" src="https://github.com/user-attachments/assets/62692937-3743-4d09-b82b-1c31719b42f4" />
