### PR TITLE
[OPTIMIZATION] Disable Char Select fade shader when unused

### DIFF
--- a/source/funkin/ui/charSelect/CharSelectSubState.hx
+++ b/source/funkin/ui/charSelect/CharSelectSubState.hx
@@ -398,7 +398,14 @@ class CharSelectSubState extends MusicBeatSubState
 
     camFollow.screenCenter();
     camFollow.y -= 150;
-    fadeShader.fade(0.0, 1.0, 0.8, {ease: FlxEase.quadOut});
+    FlxG.camera.filtersEnabled = true;
+    fadeShader.fade(0.0, 1.0, 0.8,
+      {
+        ease: FlxEase.quadOut,
+        onComplete: (twn) -> {
+          FlxG.camera.filtersEnabled = false;
+        }
+      });
     FlxTween.tween(camFollow, {y: camFollow.y + 150}, 1.5,
       {
         ease: FlxEase.expoOut,
@@ -700,6 +707,7 @@ class CharSelectSubState extends MusicBeatSubState
     FlxTween.cancelTweensOf(camFollow);
 
     FlxTween.tween(transitionGradient, {y: -150}, 0.8, {ease: FlxEase.backIn});
+    FlxG.camera.filtersEnabled = true;
     fadeShader.fade(1.0, 0, 0.8, {ease: FlxEase.quadIn});
     FlxTween.tween(camFollow, {y: camFollow.y - 150}, 0.8,
       {


### PR DESCRIPTION
## Description
The way flixel applies filters to a camera is by applying the filter to the canvas openfl sprite object where things get rendered to. By doing this, all the commands from the camera need to be rendered first to a seperate texture buffer and later actually rendered ingame. The blue fade shader was never disabled so on normal rendering the game was constantly re rendering the whole screen each frame to a texture even though it has no actual visual reason to. This PR makes it so the shader (and therefore the extra calculations) get disabled when not used visually game. Similarly to the optimization I did way back in https://github.com/FunkinCrew/Funkin/pull/5773

Here you can see the reduced number on necessary opengl commands:
<img width="434" height="224" alt="image" src="https://github.com/user-attachments/assets/acb99afb-7209-46f5-81f2-81327854d0f5" />
<img width="300" height="193" alt="image" src="https://github.com/user-attachments/assets/4e80f126-9a36-43d2-8ac4-9d48a9e1408c" />
