### PR TITLE
[ENHANCEMENT] Add a Dispatcher for `onPause` for Both Cutscenes and Conversations

### DIFF
--- a/source/funkin/play/PlayState.hx
+++ b/source/funkin/play/PlayState.hx
@@ -1366,11 +1366,19 @@ class PlayState extends MusicBeatSubState
     {
       case Conversation:
         preparePauseUI();
-        openPauseSubState(Conversation, camPause, lostFocus, () -> currentConversation?.pauseMusic());
+
+        final event = new PauseScriptEvent(false);
+        dispatchEvent(event);
+
+        if (!event.eventCanceled) openPauseSubState(Conversation, camPause, lostFocus, () -> currentConversation?.pauseMusic());
 
       case Cutscene:
         preparePauseUI();
-        openPauseSubState(Cutscene, camPause, lostFocus, () -> VideoCutscene.pauseVideo());
+
+        final event = new PauseScriptEvent(false);
+        dispatchEvent(event);
+
+        if (!event.eventCanceled) openPauseSubState(Cutscene, camPause, lostFocus, () -> VideoCutscene.pauseVideo());
 
       default: // also known as standard
         if (!isInCountdown || isInCutscene) return;


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Briefly describe the issue(s) fixed. -->
## Description
This PR does what the title says.

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos
<img width="966" height="286" alt="Screenshot (297)" src="https://github.com/user-attachments/assets/cf5a58df-ff61-4219-aecc-cd7ccd5b52a7" />
<img width="1267" height="839" alt="Screenshot (298)" src="https://github.com/user-attachments/assets/335bb744-4d52-4d45-9360-0333a4372f22" />
<img width="1278" height="834" alt="Screenshot (300)" src="https://github.com/user-attachments/assets/3d0ceafe-613a-4db5-9968-eccf15538917" />
<img width="1287" height="834" alt="Screenshot (301)" src="https://github.com/user-attachments/assets/9e6ebbec-6749-4e87-865e-e16a59ed5071" />