### PR TITLE
[BUGFIX] Fix gameplay using wrong sounds/music for gameover/pause after leaving the editors

### DIFF
--- a/source/funkin/ui/debug/anim/DebugBoundingState.hx
+++ b/source/funkin/ui/debug/anim/DebugBoundingState.hx
@@ -354,6 +354,11 @@ class DebugBoundingState extends FlxState
 
     // Hide the mouse cursor on other states.
     Cursor.hide();
+
+    // Reset the sounds used by some playables.
+    funkin.play.GameOverSubState.reset();
+    funkin.play.PauseSubState.reset();
+    funkin.play.Countdown.reset();
   }
 
   function offsetControls():Void

--- a/source/funkin/ui/debug/charting/ChartEditorState.hx
+++ b/source/funkin/ui/debug/charting/ChartEditorState.hx
@@ -7280,6 +7280,11 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
     if (welcomeMusic != null) welcomeMusic.destroy();
     if (audioInstTrack != null) audioInstTrack.destroy();
     if (audioVocalTrackGroup != null) audioVocalTrackGroup.destroy();
+
+    // Reset the sounds used by some playables.
+    funkin.play.GameOverSubState.reset();
+    funkin.play.PauseSubState.reset();
+    funkin.play.Countdown.reset();
   }
 
   function applyCanQuickSave():Void

--- a/source/funkin/ui/debug/stageeditor/StageEditorState.hx
+++ b/source/funkin/ui/debug/stageeditor/StageEditorState.hx
@@ -1581,6 +1581,16 @@ class StageEditorState extends UIState
     return "image" + id;
   }
 
+  override function destroy():Void
+  {
+    super.destroy();
+
+    // Reset the sounds used by some playables.
+    funkin.play.GameOverSubState.reset();
+    funkin.play.PauseSubState.reset();
+    funkin.play.Countdown.reset();
+  }
+
   public function notifyChange(change:String, notif:String, isError:Bool = false)
   {
     NotificationManager.instance.addNotification(
@@ -1658,6 +1668,7 @@ typedef StageEditorParams =
    * If non-null, load this stage immediately instead of the welcome screen.
    */
   var ?targetStageId:String;
+
   /**
    * If non-null, load this character as Boyfriend.
    */


### PR DESCRIPTION
## Linked Issues
Fixes https://github.com/FunkinCrew/Funkin/issues/6733

## Description
Some scripted characters like Pico override the game over sound when they're spawned (like in the editors), which haven't properly been reset after leaving said editors, meaning that characters that would rather use default sounds like bf would play pico's version of the sounds. This has been fixed in this PR.

## Screenshots/Videos

https://github.com/user-attachments/assets/8fec284b-288a-4f16-b83f-c813a65c5504
