### PR TITLE
[BUGFIX] Fix GF bopping when switching levels in the story menu

### DIFF
--- a/source/funkin/ui/story/Level.hx
+++ b/source/funkin/ui/story/Level.hx
@@ -202,10 +202,13 @@ class Level implements IRegistryEntry<LevelData>
 
     if (_data.props.length == 0) return props;
 
-    var hiddenProps:Array<LevelProp> = props.splice(_data.props.length - 1, props.length - 1);
-    for (hiddenProp in hiddenProps)
+    // Hides unused props
+    if (_data.props.length < props.length)
     {
-      hiddenProp.visible = false;
+      for (i in _data.props.length...props.length)
+      {
+        props[i].visible = false;
+      }
     }
 
     for (propIndex in 0..._data.props.length)


### PR DESCRIPTION
## Linked Issues
N/A

## Description
When changing a week in the story menu, the animation is always reset for the gf, even when LevelPropData has an identical database with neighboring weeks.

## Screenshots/Videos
|BEFORE | AFTER|
|--|--|
|![Funkin_K7OqOf6tfO](https://github.com/user-attachments/assets/c3350526-7a21-4ff9-8866-65da7d396a4f)|![Funkin_4dfaFqnlIh](https://github.com/user-attachments/assets/cfcf5d30-ae06-4054-9b9d-87c79396c688)|
