### PR TITLE
[BUGFIX] Fix Chart Editor Waveforms desyncing on BPM change

### DIFF
--- a/source/funkin/ui/debug/charting/ChartEditorState.hx
+++ b/source/funkin/ui/debug/charting/ChartEditorState.hx
@@ -384,7 +384,7 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
 
         for (member in audioWaveforms.members)
         {
-          member.time = Conductor.instance.songPosition / Constants.MS_PER_SEC;
+          member.time = scrollPositionInMs / Constants.MS_PER_SEC;
           member.duration = (Conductor.instance.stepLengthMs * 16) / Constants.MS_PER_SEC;
 
           // Doing this desyncs the waveforms from the grid.


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
Couldn't find any.

<!-- Briefly describe the issue(s) fixed. -->
## Description
Vocals waveform didn't stretch/compress when the song tempo/bpm changes midway, making them impossible to use.

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos

https://github.com/user-attachments/assets/3f93f3d0-6bfa-4bfe-8b13-da10d22cb4b5

_Before, audio waveforms being shorter than they should, turning almost useless_


https://github.com/user-attachments/assets/f4b81877-2758-41a7-a4ff-4c051e75cddf

_After, audio waveforms getting stretched to match the current tempo_