### PR TITLE
[ENHANCEMENT] Save the User's Preference for the Results Screen During Chart Playtest

### DIFF
--- a/source/funkin/save/Save.hx
+++ b/source/funkin/save/Save.hx
@@ -171,6 +171,7 @@ class Save implements ConsoleClass
           theme: ChartEditorTheme.Light,
           playtestStartTime: false,
           playtestAudioSettings: false,
+          playtestResultsSettings: false,
           downscroll: false,
           showNoteKinds: true,
           metronomeVolume: 1.0,
@@ -284,6 +285,9 @@ class Save implements ConsoleClass
 
   @:saveProperty(data.optionsChartEditor.playtestAudioSettings, false)
   public var chartEditorPlaytestAudioSettings:SaveProperty<Bool>;
+
+  @:saveProperty(data.optionsChartEditor.playtestResultsSettings, false)
+  public var chartEditorPlaytestResultsSettings:SaveProperty<Bool>;
 
   @:saveProperty(data.optionsChartEditor.theme, ChartEditorTheme.Light)
   public var chartEditorTheme:SaveProperty<ChartEditorTheme>;
@@ -1470,6 +1474,12 @@ typedef SaveDataChartEditorOptions =
    * @default `false`
    */
   var ?playtestAudioSettings:Bool;
+
+  /**
+   * If true, playtest songs will play the results screen on completion.
+   * @default `false`
+   */
+  var ?playtestResultsSettings:Bool;
 
   /**
    * Theme music in the Chart Editor.

--- a/source/funkin/ui/debug/charting/ChartEditorState.hx
+++ b/source/funkin/ui/debug/charting/ChartEditorState.hx
@@ -2550,6 +2550,7 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
     showSubtitles = save.chartEditorShowSubtitles.value;
     playtestStartTime = save.chartEditorPlaytestStartTime.value;
     playtestAudioSettings = save.chartEditorPlaytestAudioSettings.value;
+    playtestShowResults = save.chartEditorPlaytestResultsSettings.value;
     currentTheme = save.chartEditorTheme.value;
     metronomeVolume = save.chartEditorMetronomeVolume.value;
     hitsoundVolumePlayer = save.chartEditorHitsoundVolumePlayer.value;
@@ -2581,6 +2582,7 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
     save.chartEditorShowNoteKinds.value = showNoteKindIndicators;
     save.chartEditorPlaytestStartTime.value = playtestStartTime;
     save.chartEditorPlaytestAudioSettings.value = playtestAudioSettings;
+    save.chartEditorPlaytestResultsSettings.value = playtestShowResults;
     save.chartEditorTheme.value = currentTheme;
     save.chartEditorMetronomeVolume.value = metronomeVolume;
     save.chartEditorHitsoundVolumePlayer.value = hitsoundVolumePlayer;


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Briefly describe the issue(s) fixed. -->
## Description
This PR adds a field to the Chart Editor's save data that will then be used to set the playtest option.

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos
Upon entering the Chart Editor the first time:

<img width="846" height="478" alt="Screenshot (324)" src="https://github.com/user-attachments/assets/505afd29-b751-420c-adf6-04ff12dbcfbf" />

Then turning playtest on, leaving the Chart Editor, and returning:

<img width="641" height="328" alt="Screenshot (325)" src="https://github.com/user-attachments/assets/6e933346-deae-4049-8f65-385b4fe02f47" />

Then closing the game and returning:

<img width="478" height="283" alt="Screenshot (326)" src="https://github.com/user-attachments/assets/8f076866-5b9e-4617-bc16-ce17316d0e87" />