### PR TITLE
[ENHANCEMENT] Clean up `GRhythmUtil.mirrorNoteDirection()` Along With A Few Other Changes

### DIFF
--- a/source/funkin/play/PlayState.hx
+++ b/source/funkin/play/PlayState.hx
@@ -2486,10 +2486,7 @@ class PlayState extends MusicBeatSubState
         if (noteKind != null) scoreable = noteKind.scoreable;
       }
 
-      var noteData:Int = songNote.getDirection();
-      var playerNote:Bool = true;
-
-      if (noteData > 3) playerNote = false;
+      var noteData:Int = songNote.data;
 
       switch (songNote.getStrumlineIndex())
       {

--- a/source/funkin/play/notes/Strumline.hx
+++ b/source/funkin/play/notes/Strumline.hx
@@ -45,7 +45,7 @@ class Strumline extends FlxSpriteGroup
   static final INITIAL_OFFSET:Float = -0.275 * STRUMLINE_SIZE;
   static final NUDGE:Float = 2.0;
 
-  static final KEY_COUNT:Int = 4;
+  public static final KEY_COUNT:Int = 4;
   static final NOTE_SPLASH_CAP:Int = 6;
 
   var renderDistanceMs(get, never):Float;

--- a/source/funkin/util/GRhythmUtil.hx
+++ b/source/funkin/util/GRhythmUtil.hx
@@ -1,6 +1,7 @@
 package funkin.util;
 
 import funkin.play.notes.NoteSprite;
+import funkin.play.notes.Strumline;
 import funkin.Conductor;
 
 /**
@@ -40,29 +41,7 @@ class GRhythmUtil
    */
   public static function mirrorNoteDirection(noteData:Int):Int
   {
-    return switch (noteData)
-    {
-      case 0:
-        3;
-      case 1:
-        2;
-      case 2:
-        1;
-      case 3:
-        0;
-
-      case 4:
-        7;
-      case 5:
-        6;
-      case 6:
-        5;
-      case 7:
-        4;
-
-      default:
-        noteData;
-    }
+    return (noteData < Strumline.KEY_COUNT ? Strumline.KEY_COUNT : Strumline.KEY_COUNT * 2) - 1 - noteData % (Strumline.KEY_COUNT);
   }
 
   /**
@@ -97,7 +76,7 @@ class GRhythmUtil
 
     if (note.hasMissed || note.hasBeenHit)
     {
-      return {botplayHit: false, cont: false };
+      return {botplayHit: false, cont: false};
     }
 
     // Treat notes as not in window if they are greater or less than the hit window
@@ -111,8 +90,7 @@ class GRhythmUtil
     }
 
     // Check if we're not being controlled (ie, botplay/opponent)
-    if (!isControlled && inUseConductor.songPosition >= windowCenter)
-      return {botplayHit: true, cont: true };
+    if (!isControlled && inUseConductor.songPosition >= windowCenter) return {botplayHit: true, cont: true};
 
     if (note.holdNoteSprite != null) note.holdNoteSprite.missedNote = false;
 
@@ -121,15 +99,16 @@ class GRhythmUtil
       note.tooEarly = false;
       note.hasMissed = false;
       note.mayHit = true;
-      return {botplayHit: false, cont: true };
+      return {botplayHit: false, cont: true};
     }
 
     note.tooEarly = true;
     note.mayHit = false;
     note.hasMissed = false;
 
-    return {botplayHit: false, cont: true };
+    return {botplayHit: false, cont: true};
   }
+
   /**
    * Get the y-position of a note based on its strum time.
    * @param strumTime The strum time of the note.


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Briefly describe the issue(s) fixed. -->
## Description
> [!IMPORTANT]
> Co-authored by @Starexify and @ADA-Funni.

This PR cleans up `GRhythmUtil.mirrorNoteDirection()` due to how monstrous it currently looks, along with adding checks for `Strumline.KEY_COUNT` instead of hard coding it into the function (so source coders don't have to rewrite the function themselves).

This PR also removes an unused temporary variable in `PlayState`, makes `Strumline.KEY_COUNT` public, changes a temporary `noteData` variable to use `songNote.data` instead of `songNote.getDirection()`, and formats `GRhythmUtil.hx`.
