### PR TITLE
[CHORE] Typo in `Save.hx`

### DIFF
--- a/source/funkin/save/Save.hx
+++ b/source/funkin/save/Save.hx
@@ -393,7 +393,7 @@ class Save implements ConsoleClass
     return data.optionsStageEditor.dadChar;
   }
 
-  /// UTIL FUNCITONS
+  /// UTIL FUNCTIONS
 
   /**
    * Call this to make sure the save data is written to disk.


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Briefly describe the issue(s) fixed. -->
## Description
Singular typo in the `Save` class.

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos
<img width="252" height="65" alt="image" src="https://github.com/user-attachments/assets/580890d3-4f08-4744-a4a7-3d6e8bae2785" />
