### PR TITLE
[CHORE] Fix typo `AAn` -> `An` in `SongRetryEvent`

### DIFF
--- a/source/funkin/modding/events/ScriptEvent.hx
+++ b/source/funkin/modding/events/ScriptEvent.hx
@@ -476,7 +476,7 @@ class SongLoadScriptEvent extends ScriptEvent
 }
 
 /**
- * AAn event that is fired when the player retries the song.
+ * An event that is fired when the player retries the song.
  */
 class SongRetryEvent extends ScriptEvent
 {


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Briefly describe the issue(s) fixed. -->
## Description
feel like theres even more typos that eric left out, must catch em all...
