### PR TITLE
[BUGFIX] Prevent game from becoming ghost background process

### DIFF
--- a/source/Main.hx
+++ b/source/Main.hx
@@ -87,6 +87,26 @@ class Main extends Sprite
       removeEventListener(Event.ADDED_TO_STAGE, init);
     }
 
+    #if (sys && !html5)
+    // Force-kill the game to prevent background processing.
+    Lib.current.stage.window.onClose.add(function()
+    {
+      trace(' EXITING '.bold().bg_red + ' Game is exiting, cleaning up resources...');
+
+      #if hxvlc
+      // Clean up VLC threads to prevent memory leaks.
+      hxvlc.util.Handle.dispose();
+      #end
+
+      #if discord_rpc
+      // Just incase you have `discord_rpc` enabled, dispose of the RPC manager.
+      funkin.util.discord.RichPresenceManager.dispose();
+      #end
+
+      Sys.exit(0);
+    });
+    #end
+
     // Manually crash the game when using a software renderer in order to give a nicer error message.
     var context = stage.window.context.type;
     if (context != WEBGL && context != OPENGL && context != OPENGLES)


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
Closes [#6801](https://github.com/FunkinCrew/Funkin/issues/6801) (Issue where game becomes a Background Task after closing)

<!-- Briefly describe the issue(s) fixed. -->
## Description
This PR fixes 'ghost' background processing upon closing the game. 
(For some odd reason BG Threads (e.g., VLC or Discord) aren't always shutting down properly when the window closed).

### Key Changes
- Added an exit listener to `lime.app.Application.`
- Included a `Handle.dispose()` call for `hxvlc` and `discord_rpc` to clean up video and  rich presence resources.

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos

### Original Bug Report
<img width="718" height="66" alt="image" src="https://github.com/user-attachments/assets/a2bf6f00-4826-4fd0-afd7-2c9ac69ef2e2" />

### Bug Fix
https://github.com/user-attachments/assets/1ef47010-7198-42d0-b8b9-c7e3e0c54afc