### PR TITLE
[BUGFIX] Don't dispatch conductor events if substate is active

### DIFF
--- a/source/funkin/ui/MusicBeatState.hx
+++ b/source/funkin/ui/MusicBeatState.hx
@@ -224,6 +224,8 @@ class MusicBeatState extends FlxTransitionableState implements IEventHandler
 
   public function stepHit():Bool
   {
+    if (this.subState != null && !persistentUpdate) return;
+
     var event = new SongTimeScriptEvent(SONG_STEP_HIT, conductorInUse.currentBeat, conductorInUse.currentStep);
 
     dispatchEvent(event);
@@ -235,6 +237,8 @@ class MusicBeatState extends FlxTransitionableState implements IEventHandler
 
   public function beatHit():Bool
   {
+    if (this.subState != null && !persistentUpdate) return;
+
     var event = new SongTimeScriptEvent(SONG_BEAT_HIT, conductorInUse.currentBeat, conductorInUse.currentStep);
 
     dispatchEvent(event);

--- a/source/funkin/ui/MusicBeatSubState.hx
+++ b/source/funkin/ui/MusicBeatSubState.hx
@@ -194,6 +194,8 @@ class MusicBeatSubState extends FlxSubState implements IEventHandler
    */
   public function stepHit():Bool
   {
+    if (this.subState != null && !persistentUpdate) return;
+
     var event:ScriptEvent = new SongTimeScriptEvent(SONG_STEP_HIT, conductorInUse.currentBeat, conductorInUse.currentStep);
 
     dispatchEvent(event);
@@ -210,6 +212,8 @@ class MusicBeatSubState extends FlxSubState implements IEventHandler
    */
   public function beatHit():Bool
   {
+    if (this.subState != null && !persistentUpdate) return;
+
     var event:ScriptEvent = new SongTimeScriptEvent(SONG_BEAT_HIT, conductorInUse.currentBeat, conductorInUse.currentStep);
 
     dispatchEvent(event);


### PR DESCRIPTION
## Linked Issues
Nope.

## Description
When in a SubState, for example after dying in PlayState, the callbacks beatHit and stepHit of the parent state are still attached to the same Conductor instance and get dispatched. This leads to a weird effect where if you die in the week 2 stage, lightning can still strike. 
This PR fixes it by checking if the parent state has a substate attached to it and if it can update with it attached before dispatching the conductor callbacks.

## Screenshots/Videos
<img width="962" height="67" alt="image" src="https://github.com/user-attachments/assets/f2fe03cd-c1ee-4965-82bf-1cea399faa49" />
The trace was added manually to the script and doesn't exist in the original file.