### PR TITLE
[BUGFIX / ENHANCEMENT] reset corrupted save data on load

### DIFF
--- a/source/funkin/save/Save.hx
+++ b/source/funkin/save/Save.hx
@@ -804,11 +804,16 @@ class Save implements ConsoleClass
     var msg = 'There was an error loading your save data in slot ${slot}.';
     msg += '\nPlease report this issue to the developers.';
     funkin.util.WindowUtil.showError("Save Data Failure", msg);
-    // Don't touch that slot anymore.
-    // Instead, load the next available slot.
-    var nextSlot:Int = slot + 1;
-    if (nextSlot > 1000) throw "End of save data slots. Can't load any more.";
-    return loadFromSlot(nextSlot);
+
+    // FIX: If the save data is corrupted, reset it back to it's default values.
+    trace('[SAVE] Save Data Failure in slot ${slot}. Resetting to deafult save data...');
+
+    var freshSave:Save = new Save();
+
+    FlxG.save.mergeData(freshSave.data, true);
+    FlxG.save.flush();
+
+    return freshSave;
   }
 
   public static function debug_queryBadSaveData():Void


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
Closes [#6884](https://github.com/FunkinCrew/Funkin/issues/6884) (whenever i load the game up, it says: "there was an error loading your save data in slot 1. please report this issue to the developers.)

<!-- Briefly describe the issue(s) fixed. -->
## Description
This PR fixes save data corruption on v0.7.5 builds.

Instead of making a completely new slot, which may inevitably break, I implemented a feature where the game would just make a completely new save slot, if it encounters anything is wrong with it.

### Key Changes
- Stopped slot skipping
    -  No more incrementing to `slot + 1` which prevents the crashes.
- Auto reset on failure 
     - Instead of crashing, the game automatically makes a new save file and continues running.
- Completely wipe corrupted data
     - Used `mergeData` and `flush` to force-overwrite the existing bad data the game had.
- Error loop should be fixed also.

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos
### Original Bug:

<img width="1279" height="753" alt="image" src="https://github.com/user-attachments/assets/6d7e8a74-108b-4abd-a074-1833bab056a1" />

