### PR TITLE
[ENHANCEMENT] Adjust Freeplay backingImage size to align with background

### DIFF
--- a/source/funkin/ui/freeplay/FreeplayState.hx
+++ b/source/funkin/ui/freeplay/FreeplayState.hx
@@ -465,8 +465,8 @@ class FreeplayState extends MusicBeatSubState
     add(blackOverlayBullshitLOLXD); // used to mask the text lol!
 
     // this makes the texture sizes consistent, for the angle shader
-    backingImage.setGraphicSize(0, FlxG.height);
-    blackOverlayBullshitLOLXD.setGraphicSize(0, FlxG.height);
+    backingImage.setGraphicSize(0, FlxG.height + 1);
+    blackOverlayBullshitLOLXD.setGraphicSize(0, FlxG.height + 1);
 
     backingImage.updateHitbox();
     blackOverlayBullshitLOLXD.updateHitbox();


### PR DESCRIPTION
## Description
The backing image in the freeplay menu is 1 pixel offset to the top. This PR adds 1 pixel to the graphic's size so it fully fits in the screen.
I don't think this problem can be seen in higher resolution screens, but it happens to me (my monitor's resolution is 1440 x 900)

## Screenshots
Before:
<img width="314" height="59" alt="image" src="https://github.com/user-attachments/assets/ce57de68-38ae-4513-ab66-73e9feda23ec" />
After:
<img width="275" height="61" alt="image" src="https://github.com/user-attachments/assets/8f7daf7e-286b-41f0-8285-4fc8cd75cdd1" />