### PR TITLE
[MODDING] Add an event dispatch for `MusicBeatSubState` creation `onSubStateCreate`

### DIFF
--- a/source/funkin/modding/events/ScriptEventDispatcher.hx
+++ b/source/funkin/modding/events/ScriptEventDispatcher.hx
@@ -40,6 +40,13 @@ class ScriptEventDispatcher
           t.onStateCreate(event);
         }
         return;
+      case SUB_STATE_CREATE:
+        if (Std.isOfType(target, Module))
+        {
+          var t:Module = cast(target, Module);
+          t.onSubStateCreate(event);
+        }
+        return;
       case DESTROY:
         target.onDestroy(event);
         return;

--- a/source/funkin/modding/events/ScriptEventType.hx
+++ b/source/funkin/modding/events/ScriptEventType.hx
@@ -18,6 +18,14 @@ enum abstract ScriptEventType(String) from String to String
    *
    * This event is not cancelable.
    */
+  public var SUB_STATE_CREATE = 'SUB_STATE_CREATE';
+
+  /**
+   * Called when the relevant object is fully created and ready to be used.
+   * This assumes all data is loaded and ready to go.
+   *
+   * This event is not cancelable.
+   */
   public var STATE_CREATE = 'STATE_CREATE';
 
   /**

--- a/source/funkin/modding/module/Module.hx
+++ b/source/funkin/modding/module/Module.hx
@@ -306,6 +306,11 @@ class Module implements IPlayStateScriptedClass implements IStateChangingScripte
   }
 
   /**
+   * Called when any sub state is created.
+   */
+  public function onSubStateCreate(event:ScriptEvent) {}
+
+  /**
    * Called when a capsule is selected.
    */
   public function onCapsuleSelected(event:CapsuleScriptEvent):Void

--- a/source/funkin/ui/MusicBeatSubState.hx
+++ b/source/funkin/ui/MusicBeatSubState.hx
@@ -120,6 +120,7 @@ class MusicBeatSubState extends FlxSubState implements IEventHandler
     Conductor.stepHit.add(this.stepHit);
 
     initConsoleHelpers();
+    dispatchEvent(new ScriptEvent(SUB_STATE_CREATE));
   }
 
   override public function destroy():Void


### PR DESCRIPTION
## Linked Issues
- Closes #6895

## Description
This PR adds a `onSubStateCreate` to address the lack of creation event for `MusicBeatSubStates`, since `onStateCreate` only dispatches in `MusicBeatStates`.

## Screenshots/Videos

[DispatchExample.webm](https://github.com/user-attachments/assets/9b365ca1-ee7e-4e55-b8d6-5f8a7e926572)
