### PR TITLE
[ENHANCEMENT] Audio Overhaul (More Audio Formats, Streaming, etc.)

### DIFF
--- a/.github/actions/upload-itch/action.yml
+++ b/.github/actions/upload-itch/action.yml
@@ -61,7 +61,7 @@ runs:
   - name: Get latest butler version
     shell: bash
     run: |
-      LATEST=$(curl -sfL https://broth.itch.ovh/butler/$OS_AND_ARCH/LATEST)
+      LATEST=$(curl -sfL https://broth.itch.zone/butler/$OS_AND_ARCH/LATEST)
       echo BUTLER_LATEST=$LATEST >> "$GITHUB_ENV"
 
       command -v butler \
@@ -70,7 +70,7 @@ runs:
 
   - name: Try to get butler from cache
     id: cache-butler
-    uses: actions/cache@v4
+    uses: actions/cache@v5
     with:
       path: ${{ env.BUTLER_INSTALL_PATH }}
       key: butler-${{ runner.os }}-${{ env.BUTLER_LATEST }}
@@ -88,7 +88,7 @@ runs:
       mkdir -p $BUTLER_INSTALL_PATH
       cd $BUTLER_INSTALL_PATH
 
-      curl -L -o butler.zip https://broth.itch.ovh/butler/$OS_AND_ARCH/LATEST/archive/default
+      curl -L -o butler.zip https://broth.itch.zone/butler/$OS_AND_ARCH/LATEST/archive/default
       unzip butler.zip
       chmod +x butler
 

--- a/.github/workflows/build-game.yml
+++ b/.github/workflows/build-game.yml
@@ -24,10 +24,10 @@ jobs:
       trigger-build: ${{ steps.should-trigger.outputs.result }}
     steps:
       - name: Checkout repo
-        uses: funkincrew/ci-checkout@v7.3.3
+        uses: funkincrew/ci-checkout@v7.4
         with:
           submodules: false
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@v4
         id: filter
         with:
           base: ${{ github.ref }}
@@ -59,7 +59,7 @@ jobs:
       list: ${{ steps.build-tags.outputs.list }}
     steps:
       - name: Gather build tags
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         id: build-tags
         with:
           script: |
@@ -96,17 +96,20 @@ jobs:
       packages: write
     steps:
       - name: Checkout repo
-        uses: funkincrew/ci-checkout@v7.3.3
+        uses: funkincrew/ci-checkout@v7.4
         with:
           submodules: false
       - name: Log into GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push Docker image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
+        env:
+          DOCKER_BUILD_SUMMARY: false
+          DOCKER_BUILD_RECORD_UPLOAD: false
         with:
           context: ./build
           push: true
@@ -143,14 +146,14 @@ jobs:
         run: |
           git config --global --replace-all safe.directory $GITHUB_WORKSPACE
       - name: Get checkout token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v3
         id: app_token
         with:
           app-id: ${{ vars.APP_ID }}
           private-key: ${{ secrets.APP_PEM }}
           owner: ${{ github.repository_owner }}
       - name: Checkout repo
-        uses: funkincrew/ci-checkout@v7.3.3
+        uses: funkincrew/ci-checkout@v7.4
         with:
           submodules: 'recursive'
           token: ${{ steps.app_token.outputs.token }}
@@ -184,7 +187,7 @@ jobs:
         timeout-minutes: 120
       - name: Save build artifact to Github Actions
         if: ${{ github.event.inputs.save-artifact }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: build-${{ matrix.target }}
           path: export/release/${{matrix.target}}/bin/
@@ -212,14 +215,14 @@ jobs:
       BUILD_DEFINES: ${{ github.event.inputs.build-defines || '-DGITHUB_BUILD' }}
     steps:
       - name: Get checkout token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v3
         id: app_token
         with:
           app-id: ${{ vars.APP_ID }}
           private-key: ${{ secrets.APP_PEM }}
           owner: ${{ github.repository_owner }}
       - name: Checkout repo
-        uses: funkincrew/ci-checkout@v7.3.3
+        uses: funkincrew/ci-checkout@v7.4
         with:
           submodules: 'recursive'
           token: ${{ steps.app_token.outputs.token }}
@@ -233,7 +236,7 @@ jobs:
           echo "HAXEPATH=$(haxelib config)" >> "$GITHUB_ENV"
       - name: Restore cached dependencies
         id: cache-hmm
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: .haxelib
           key: haxe-hmm-${{ runner.os }}-${{ hashFiles('**/hmm.json') }}
@@ -242,15 +245,35 @@ jobs:
         run: |
           git config --global 'url.https://x-access-token:${{ steps.app_token.outputs.token }}@github.com/.insteadOf' https://github.com/
           git config --global advice.detachedHead false
+          haxelib --global git haxelib https://github.com/FunkinCrew/haxelib.git
+          haxelib --global git hmm  https://github.com/FunkinCrew/hmm.git
           haxelib --global run hmm install -q
-          cd .haxelib/hxcpp/git/tools/hxcpp && haxe compile.hxml
+          haxelib --global fixrepo
+          haxelib --global list
+          pushd .haxelib/hxcpp/git/tools/hxcpp && haxe compile.hxml && popd
       - if: ${{ matrix.target != 'html5' }}
         name: Restore hxcpp cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: /usr/share/hxcpp
           key: haxe-hxcpp-${{ runner.os }}-${{ github.ref_name }}-${{ github.sha }}
           restore-keys: haxe-hxcpp-${{ runner.os }}-${{ github.ref_name }}
+      - name: Restore lime rebuild cache
+        id: cache-lime
+        uses: actions/cache@v5
+        with:
+          path: .haxelib/lime/git/ndll/Linux64
+          key: haxe-lime-linux64-${{ runner.os }}-${{ hashFiles('**/hmm.json') }}-${{ github.sha }}
+          restore-keys: haxe-lime-linux64-${{ runner.os }}-${{ hashFiles('**/hmm.json') }}
+      - name: Setup lime
+        run: |
+          haxelib --always run lime setup
+          haxelib run lime rebuild hxcpp
+      - if: ${{ steps.cache-lime.outputs.cache-hit != 'true' }}
+        name: Rebuild lime
+        run: |
+          haxelib run lime rebuild cpp -64
+          git -C .haxelib/lime/git status || true
       - name: Populate .env
         run: |
           touch .env
@@ -262,7 +285,7 @@ jobs:
         timeout-minutes: 120
       - name: Save build artifact to Github Actions
         if: ${{ github.event.inputs.save-artifact }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: build-${{ matrix.target }}
           path: export/release/${{matrix.target}}/bin/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -689,6 +689,7 @@ The LE SSERAFIM collab update!
 
 ## New Contributors for 0.7.4
 
+* @Trofem made their first contribution in [#5476](https://github.com/FunkinCrew/Funkin/pull/5476)
 * @ThatOneCalculator made their first contribution in [#5507](https://github.com/FunkinCrew/Funkin/pull/5507)
 * @SrtHero278 made their first contribution in [#5565](https://github.com/FunkinCrew/Funkin/pull/5565)
 * @VirtuGuy made their first contribution in [#5598](https://github.com/FunkinCrew/Funkin/pull/5598)

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,8 +1,8 @@
 FROM ubuntu:noble
 
-ARG haxe_version=4.3.6
-ARG haxelib_version=4.1.0
-ARG neko_version=2.4.0
+ARG haxe_version=4.3.7
+ARG haxelib_version=4.2.0
+ARG neko_version=2.4.1
 
 # prepare runner
 ENV GITHUB_HOME="/github/home"
@@ -80,11 +80,13 @@ EOF
 # Haxe native dependencies
 RUN <<EOF
 apt-fast install -y --no-install-recommends \
-  libc6-dev libffi-dev \
-  libx11-dev libxi-dev libxext-dev libxinerama-dev libxrandr-dev \
-  libgl-dev libgl1-mesa-dev \
+  build-essential \
+  libc6-dev libffi-dev libdbus-1-dev libudev-dev libgbm-dev \
+  libx11-dev libxi-dev libxext-dev libxinerama-dev libxrandr-dev libxcursor-dev libxss-dev \
+  libgl-dev libgl1-mesa-dev libglu1-mesa-dev libdrm-dev \
   libasound2-dev libpulse-dev \
-  libvlc-dev libvlccore-dev
+  libvlc-dev libvlccore-dev \
+  gcc-multilib g++-multilib
 EOF
 
 # Janky libffi.6 fix
@@ -98,11 +100,11 @@ EOF
 # neko
 # https://github.com/HaxeFoundation/neko/releases/download/v2-3-0/neko-2.3.0-linux64.tar.gz
 RUN <<EOF
-#neko_url=$(curl https://api.github.com/repos/HaxeFoundation/neko/releases -fL \
-#  | jq '.[] | select(.name == "'"$neko_version"'")' \
-#  | jq '.assets[] | select(.name | endswith("linux64.tar.gz"))' \
-#  | jq -r '.browser_download_url')
-neko_url="https://geo.thei.rs/funkin/neko-2.4.1-linux64.tar.gz"
+neko_url=$(curl https://api.github.com/repos/HaxeFoundation/neko/releases -fL \
+  | jq '.[] | select(.name == "'"$neko_version"'")' \
+  | jq '.assets[] | select(.name | endswith("linux64.tar.gz"))' \
+  | jq -r '.browser_download_url')
+#neko_url="https://geo.thei.rs/funkin/neko-2.4.1-linux64.tar.gz"
 curl -fL "$neko_url" | tar -xz -C /usr/local
 EOF
 
@@ -112,16 +114,16 @@ ln -s "$neko_path" /usr/local/neko
 EOF
 
 ENV NEKOPATH="/usr/local/neko"
-ENV LD_LIBRARY_PATH="$NEKOPATH:$LD_LIBRARY_PATH"
+ENV LD_LIBRARY_PATH="$NEKOPATH"
 ENV PATH="$NEKOPATH:$PATH"
 
 # haxe
 # https://github.com/HaxeFoundation/haxe/releases/download/4.0.5/haxe-4.0.5-linux64.tar.gz
 RUN <<EOF
-#haxe_url=$(curl https://api.github.com/repos/HaxeFoundation/haxe/releases -fL \
-#  | jq '.[] | select(.name == "'"$haxe_version"'")' \
-#  | jq '.assets[] | select(.name | endswith("linux64.tar.gz"))' \
-#  | jq -r '.browser_download_url')
+haxe_url=$(curl https://api.github.com/repos/HaxeFoundation/haxe/releases -fL \
+  | jq '.[] | select(.name == "'"$haxe_version"'")' \
+  | jq '.assets[] | select(.name | endswith("linux64.tar.gz"))' \
+  | jq -r '.browser_download_url')
 haxe_url="https://geo.thei.rs/funkin/haxe-4.3.6-linux64.tar.gz"
 curl -fL "$haxe_url" | tar -xz -C /usr/local
 EOF

--- a/hmm.json
+++ b/hmm.json
@@ -52,7 +52,7 @@
       "name": "flixel",
       "type": "git",
       "dir": null,
-      "ref": "f7b94eebf7dbb452a929d0c67ab31a9cbd71d3a0",
+      "ref": "622bb65e7f49f0e1a03826b6593369d3ad5e54fa",
       "url": "https://github.com/FunkinCrew/flixel"
     },
     {
@@ -169,7 +169,7 @@
       "name": "lime",
       "type": "git",
       "dir": null,
-      "ref": "842f6904d25d58b7c443c9fcc1b204e8ff3f1a7e",
+      "ref": "89cef3a2283e364e3ec175d567beb3e6ff2adfbe",
       "url": "https://github.com/FunkinCrew/lime"
     },
     {
@@ -183,7 +183,7 @@
       "name": "openfl",
       "type": "git",
       "dir": null,
-      "ref": "98d90a22a98fdc6819b2de48bc57fc5c49a664a8",
+      "ref": "aa7209d704d40b4c44b9a72593dc59496854da4c",
       "url": "https://github.com/FunkinCrew/openfl"
     },
     {

--- a/hmm.json
+++ b/hmm.json
@@ -72,7 +72,7 @@
     {
       "name": "format",
       "type": "haxelib",
-      "version": "3.5.0"
+      "version": "3.8.0"
     },
     {
       "name": "funkin.vis",

--- a/hmm.json
+++ b/hmm.json
@@ -169,7 +169,7 @@
       "name": "lime",
       "type": "git",
       "dir": null,
-      "ref": "58dd49b018729f86600f719a98728ffb024724e3",
+      "ref": "842f6904d25d58b7c443c9fcc1b204e8ff3f1a7e",
       "url": "https://github.com/FunkinCrew/lime"
     },
     {
@@ -183,7 +183,7 @@
       "name": "openfl",
       "type": "git",
       "dir": null,
-      "ref": "88534506595a32c3f02b21b3987e789a24074ae7",
+      "ref": "98d90a22a98fdc6819b2de48bc57fc5c49a664a8",
       "url": "https://github.com/FunkinCrew/openfl"
     },
     {

--- a/hmm.json
+++ b/hmm.json
@@ -169,7 +169,7 @@
       "name": "lime",
       "type": "git",
       "dir": null,
-      "ref": "89cef3a2283e364e3ec175d567beb3e6ff2adfbe",
+      "ref": "69109037bf9e31c7b6f6cf9679a5f67f5e5f3a50",
       "url": "https://github.com/FunkinCrew/lime"
     },
     {

--- a/project.hxp
+++ b/project.hxp
@@ -906,9 +906,10 @@ class Project extends HXProject
     // Should be true except on web builds (some asset stuff breaks it)
     FEATURE_LAG_ADJUSTMENT.apply(this, !isWeb());
 
-    // Should be true except on web and mobile builds.
-    // Screenshots doesn't work there, and mobile has its own screenshots anyway.
-    FEATURE_SCREENSHOTS.apply(this, !(isWeb() || isMobile()));
+    // Should be true only on Desktop builds.
+    // Mobile has its own screenshot methods.
+    // Web has it disabled due to performance cost of `preserveDrawingBuffer`.
+    FEATURE_SCREENSHOTS.apply(this, isDesktop());
 
     // Should be true except on mobile builds.
     FEATURE_FILE_DROP.apply(this, !isMobile());

--- a/project.hxp
+++ b/project.hxp
@@ -910,8 +910,7 @@ class Project extends HXProject
     // Screenshots doesn't work there, and mobile has its own screenshots anyway.
     FEATURE_SCREENSHOTS.apply(this, !(isWeb() || isMobile()));
 
-    // Should be true except on MacOS and mobile builds.
-    // Dragging and dropping files onto the window doesn't work there.
+    // Should be true except on mobile builds.
     FEATURE_FILE_DROP.apply(this, !isMobile());
 
     // Audio context issues only exist on web builds.

--- a/project.hxp
+++ b/project.hxp
@@ -912,7 +912,7 @@ class Project extends HXProject
 
     // Should be true except on MacOS and mobile builds.
     // Dragging and dropping files onto the window doesn't work there.
-    FEATURE_FILE_DROP.apply(this, !(isMac() || isMobile()));
+    FEATURE_FILE_DROP.apply(this, !isMobile());
 
     // Audio context issues only exist on web builds.
     FEATURE_TOUCH_HERE_TO_PLAY.apply(this, isWeb());

--- a/project.hxp
+++ b/project.hxp
@@ -1131,6 +1131,9 @@ class Project extends HXProject
     // Ensure all Flixel classes are available at runtime.
     // Explicitly ignore packages which require additional dependencies.
     addHaxeMacro("include('flixel', true, [ 'flixel.addons.editors.spine.*', 'flixel.addons.nape.*', 'flixel.system.macros.*', 'flixel.addons.tile.FlxRayCastTilemap' ])");
+
+    // Ensure all Lime audio effects classes are available at runtime.
+    addHaxeMacro("include('lime.media')");
   }
 
   /**

--- a/source/funkin/Conductor.hx
+++ b/source/funkin/Conductor.hx
@@ -112,9 +112,6 @@ class Conductor
    */
   var songPositionDelta(default, null):Float = 0;
 
-  var prevTimestamp:Float = 0;
-  var prevTime:Float = 0;
-
   /**
    * Beats per minute of the current song at the current time.
    */
@@ -421,16 +418,7 @@ class Conductor
    */
   public function update(?songPos:Float, applyOffsets:Bool = true, forceDispatch:Bool = false):Void
   {
-    var currentTime:Float = (FlxG.sound.music != null) ? FlxG.sound.music.time : 0.0;
-    var currentLength:Float = (FlxG.sound.music != null) ? FlxG.sound.music.length : 0.0;
-
-    if (songPos == null)
-    {
-      songPos = currentTime;
-    }
-
-    // Take into account instrumental and file format song offsets.
-    songPos += applyOffsets ? (combinedOffset) : 0;
+    if (songPos == null) songPos = (FlxG.sound.music != null) ? FlxG.sound.music.time : 0.0;
 
     var oldMeasure:Float = this.currentMeasure;
     var oldBeat:Float = this.currentBeat;
@@ -439,11 +427,16 @@ class Conductor
     // If the song is playing, limit the song position to the length of the song or beginning of the song.
     if (FlxG.sound.music != null && FlxG.sound.music.playing)
     {
-      this.songPosition = Math.min(this.combinedOffset, 0).clamp(songPos, currentLength);
-      this.songPositionDelta += FlxG.elapsed * 1000 * FlxG.sound.music.pitch;
+      // Take into account instrumental and file format song offsets.
+      songPos += applyOffsets ? (combinedOffset * FlxG.sound.music.pitch) : 0;
+
+      this.songPosition = Math.min(this.combinedOffset, 0).clamp(songPos, FlxG.sound.music.length);
     }
     else
     {
+      // Take into account instrumental and file format song offsets.
+      songPos += applyOffsets ? (combinedOffset) : 0;
+
       this.songPosition = songPos;
     }
 
@@ -502,17 +495,6 @@ class Conductor
       this.onMeasureHit.dispatch();
     }
 
-    // only update the timestamp if songPosition actually changed
-    // which it doesn't do every frame!
-    if (prevTime != this.songPosition)
-    {
-      this.songPositionDelta = 0;
-
-      // Update the timestamp for use in-between frames
-      prevTime = this.songPosition;
-      prevTimestamp = Std.int(Timer.stamp() * 1000);
-    }
-
     if (this == Conductor.instance) @:privateAccess SongSequence.update.dispatch();
   }
 
@@ -522,7 +504,7 @@ class Conductor
    */
   public function getTimeWithDelta():Float
   {
-    return this.songPosition + this.songPositionDelta;
+    return this.songPosition;
   }
 
   /**
@@ -536,10 +518,10 @@ class Conductor
   public function getTimeWithDiff(?soundToCheck:FlxSound):Float
   {
     if (soundToCheck == null) soundToCheck = FlxG.sound.music;
-
-    @:privateAccess
-    this.songPosition = soundToCheck._channel.position;
-    return this.songPosition;
+    return soundToCheck.getActualTime();
+    //@:privateAccess
+    //this.songPosition = soundToCheck.getActualTime();
+    //return this.songPosition;
   }
 
   /**

--- a/source/funkin/FunkinMemory.hx
+++ b/source/funkin/FunkinMemory.hx
@@ -82,9 +82,6 @@ class FunkinMemory
     permanentCacheSound(Paths.sound("soundtray/Voldown"));
     permanentCacheSound(Paths.sound("soundtray/VolMAX"));
     permanentCacheSound(Paths.sound("soundtray/Volup"));
-    permanentCacheSound(Paths.music("freakyMenu/freakyMenu"));
-    permanentCacheSound(Paths.music("offsetsLoop/offsetsLoop"));
-    permanentCacheSound(Paths.music("offsetsLoop/drumsLoop"));
     permanentCacheSound(Paths.sound("missnote1", "shared"));
     permanentCacheSound(Paths.sound("missnote2", "shared"));
     permanentCacheSound(Paths.sound("missnote3", "shared"));

--- a/source/funkin/FunkinMemory.hx
+++ b/source/funkin/FunkinMemory.hx
@@ -21,10 +21,6 @@ class FunkinMemory
   static var currentCachedTextures:Map<String, FlxGraphic> = [];
   static var previousCachedTextures:Map<String, FlxGraphic> = [];
 
-  static var permanentCachedSounds:Map<String, Sound> = [];
-  static var currentCachedSounds:Map<String, Sound> = [];
-  static var previousCachedSounds:Map<String, Sound> = [];
-
   static var purgeFilter:Array<String> = ["/week", "/characters", "/charSelect", "/results"];
 
   /**
@@ -102,8 +98,6 @@ class FunkinMemory
   {
     preparePurgeTextureCache();
     purgeTextureCache();
-    preparePurgeSoundCache();
-    purgeSoundCache();
     #if (cpp || neko || hl)
     if (callGarbageCollector) funkin.util.MemoryUtil.collect(true);
     #end
@@ -331,21 +325,7 @@ class FunkinMemory
    */
   public static function cacheSound(key:String):Void
   {
-    if (currentCachedSounds.exists(key)) return;
-
-    if (previousCachedSounds.exists(key))
-    {
-      // Move the texture from the previous cache to the current cache.
-      var sound:Null<Sound> = previousCachedSounds.get(key);
-      previousCachedSounds.remove(key);
-      if (sound != null) currentCachedSounds.set(key, sound);
-      return;
-    }
-
-    var sound:Null<Sound> = Assets.getSound(key, true);
-    if (sound == null) return;
-    else
-      currentCachedSounds.set(key, sound);
+    flixel.sound.FlxSoundData.fromAssetKey(key);
   }
 
   /**
@@ -354,64 +334,8 @@ class FunkinMemory
    */
   public static function permanentCacheSound(key:String):Void
   {
-    if (permanentCachedSounds.exists(key)) return;
-
-    var sound:Null<Sound> = Assets.getSound(key, true);
-    if (sound == null) return;
-    else
-      permanentCachedSounds.set(key, sound);
-
-    if (sound != null) currentCachedSounds.set(key, sound);
-  }
-
-  /**
-   * Prepares the cache for purging unused sounds.
-   */
-  public static function preparePurgeSoundCache():Void
-  {
-    previousCachedSounds = currentCachedSounds.copy();
-
-    for (key in previousCachedSounds.keys())
-    {
-      if (permanentCachedSounds.exists(key))
-      {
-        previousCachedSounds.remove(key);
-      }
-    }
-
-    currentCachedSounds = permanentCachedSounds.copy();
-  }
-
-  /**
-   * Purges unused sounds from the cache.
-   */
-  public static inline function purgeSoundCache():Void
-  {
-    for (key in previousCachedSounds.keys())
-    {
-      if (permanentCachedSounds.exists(key))
-      {
-        previousCachedSounds.remove(key);
-        continue;
-      }
-
-      var sound:Null<Sound> = previousCachedSounds.get(key);
-      if (sound != null)
-      {
-        Assets.cache.removeSound(key);
-        previousCachedSounds.remove(key);
-      }
-    }
-    Assets.cache.clear("songs");
-    Assets.cache.clear("music");
-    // Felt lazy.
-    var key = Paths.music("freakyMenu/freakyMenu");
-    var sound:Null<Sound> = Assets.getSound(key, true);
-    if (sound != null)
-    {
-      permanentCachedSounds.set(key, sound);
-      currentCachedSounds.set(key, sound);
-    }
+    var soundData = flixel.sound.FlxSoundData.fromAssetKey(key, false);
+    if (soundData != null) soundData.persist = true;
   }
 
   ///// MISC /////
@@ -445,9 +369,6 @@ class FunkinMemory
       if (currentCachedTextures.exists(key)) currentCachedTextures.remove(key);
       Assets.cache.clear(key);
     }
-
-    preparePurgeSoundCache();
-    purgeSoundCache();
   }
 
   /**

--- a/source/funkin/InitState.hx
+++ b/source/funkin/InitState.hx
@@ -415,6 +415,9 @@ class InitState extends FlxState
     #elseif LATENCY
     // -DLATENCY
     FlxG.switchState(() -> new funkin.LatencyState());
+    #elseif AUDIO
+    // -DAUDIO
+    FlxG.switchState(() -> new funkin.ui.debug.AudioTestState());
     #else
     startGameNormally();
     #end

--- a/source/funkin/Paths.hx
+++ b/source/funkin/Paths.hx
@@ -29,25 +29,33 @@ class Paths implements ConsoleClass
 
   public static function stripLibrary(path:String):String
   {
-    var parts:Array<String> = path.split(':');
-    if (parts.length < 2) return path;
-    return parts[1];
+    var idx = path.indexOf(":");
+    return if (idx == -1) path; else path.substr(idx + 1);
   }
 
   public static function getLibrary(path:String):String
   {
-    var parts:Array<String> = path.split(':');
-    if (parts.length < 2) return 'preload';
-    return parts[0];
+    var idx = path.indexOf(":");
+    return if (idx == -1) "preload"; else path.substr(0, idx);
   }
 
-  static function getPath(file:String, type:AssetType, library:Null<String>):String
+  public static function fixPathExtension(path:String, defaultExtension:String):String
+  {
+    return if (path.lastIndexOf(".") == -1) '${path}.$defaultExtension'; else path;
+  }
+
+  public static function normalizePath(path:String, ?defaultExtension:String):String
+  {
+    return if (defaultExtension == null) Path.normalize(path); else fixPathExtension(Path.normalize(path), defaultExtension);
+  }
+
+  public static function getPath(file:String, ?type:AssetType, ?library:String):String
   {
     if (library != null) return getLibraryPath(file, library);
 
     if (currentLevel != null)
     {
-      var levelPath:String = getLibraryPathForce(file, currentLevel);
+      var levelPath:String = getLibraryPath(file, currentLevel);
       if (Assets.exists(levelPath, type)) return levelPath;
     }
 
@@ -72,7 +80,7 @@ class Paths implements ConsoleClass
     return 'assets/$file';
   }
 
-  public static function file(file:String, type:AssetType = TEXT, ?library:String):String
+  public static function file(file:String, ?type:AssetType, ?library:String):String
   {
     return getPath(file, type, library);
   }
@@ -84,47 +92,84 @@ class Paths implements ConsoleClass
 
   public static function txt(key:String, ?library:String):String
   {
-    return getPath('data/$key.txt', TEXT, library);
+    return getPath(normalizePath('data/$key', 'txt'), TEXT, library);
   }
 
   public static function frag(key:String, ?library:String):String
   {
-    return getPath('shaders/$key.frag', TEXT, library);
+    return getPath(normalizePath('shaders/$key', 'frag'), TEXT, library);
   }
 
   public static function vert(key:String, ?library:String):String
   {
-    return getPath('shaders/$key.vert', TEXT, library);
+    return getPath(normalizePath('shaders/$key', 'vert'), TEXT, library);
   }
 
   public static function xml(key:String, ?library:String):String
   {
-    return getPath('data/$key.xml', TEXT, library);
+    return getPath(normalizePath('data/$key', 'xml'), TEXT, library);
   }
 
   public static function json(key:String, ?library:String):String
   {
-    return getPath('data/$key.json', TEXT, library);
+    return getPath(normalizePath('data/$key', 'json'), TEXT, library);
   }
 
-  public static function srt(key:String, ?library:String, ?directory:String = "data/"):String
+  public static function srt(key:String, ?library:String, ?directory:String = "data"):String
   {
-    return getPath('$directory$key.srt', TEXT, library);
+    return getPath(normalizePath('${directory}/$key', 'srt'), TEXT, library);
   }
 
-  public static function sound(key:String, ?library:String):String
+  public static function sound(key:String, ?library:String, ?directory:String = 'sounds', ?extension:String):String
   {
-    return getPath('sounds/$key.${Constants.EXT_SOUND}', SOUND, library);
+    if (extension == null)
+    {
+      var idx = key.lastIndexOf(".");
+      if (idx != -1)
+      {
+        extension = key.substr(idx + 1);
+        key = key.substr(0, idx);
+      }
+    }
+
+    var normalizedPath = Path.normalize((directory == '' ? '' : directory + '/') + key);
+    if (extension != null) return getPath(fixPathExtension(normalizedPath, extension), SOUND, library);
+
+    // Attempt to find the sound by looping through the supported file formats.
+    var path:String;
+    for (extension in Constants.EXT_SOUNDS)
+    {
+      // no need to check if its exists in MUSIC type, as Openfl/Lime AssetLibrary have the same returns for SOUND and MUSIC internally.
+      if (library != null)
+      {
+        path = getLibraryPath(fixPathExtension(normalizedPath, extension), library);
+        if (Assets.exists(path, SOUND)/* || Assets.exists(path, MUSIC)*/) return path;
+      }
+      else
+      {
+        if (currentLevel != null)
+        {
+          path = getLibraryPath(fixPathExtension(normalizedPath, extension), currentLevel);
+          if (Assets.exists(path, SOUND)/* || Assets.exists(path, MUSIC)*/) return path;
+        }
+
+        path = getLibraryPathForce(fixPathExtension(normalizedPath, extension), 'shared');
+        if (Assets.exists(path, SOUND)/* || Assets.exists(path, MUSIC)*/) return path;
+      }
+    }
+
+    if (library != null) return getLibraryPath(fixPathExtension(normalizedPath, Constants.EXT_SOUND), library);
+    else return getPreloadPath(fixPathExtension(normalizedPath, Constants.EXT_SOUND));
   }
 
-  public static function soundRandom(key:String, min:Int, max:Int, ?library:String):String
+  public static function soundRandom(key:String, min:Int, max:Int, ?library:String, ?extension:String):String
   {
-    return sound(key + FlxG.random.int(min, max), library);
+    return sound(key + FlxG.random.int(min, max), library, null, extension);
   }
 
-  public static function music(key:String, ?library:String):String
+  public static function music(key:String, ?library:String, ?extension:String):String
   {
-    return getPath('music/$key.${Constants.EXT_SOUND}', MUSIC, library);
+    return sound(key, library, 'music', extension);
   }
 
   public static function videos(key:String, ?library:String):String
@@ -139,24 +184,29 @@ class Paths implements ConsoleClass
     return getPath('videos/$key.${Constants.EXT_VIDEO}', BINARY, library ?? 'videos');
   }
 
-  public static function voices(song:String, ?suffix:String = ''):String
+  public static function song(key:String, ?extension:String):String
+  {
+    // For web platform that haven't loaded the library "songs" yet.
+    if (Assets.getLibrary("songs") != null) return sound(key, 'songs', '', extension);
+    else return getLibraryPathForce(normalizePath(key, extension ?? Constants.EXT_SOUND), 'songs');
+  }
+
+  public static function voices(song:String, ?suffix:String = '', ?extension:String):String
   {
     if (suffix == null) suffix = ''; // no suffix, for a sorta backwards compatibility with older-ish voice files
-
-    return 'songs:assets/songs/${song.toLowerCase()}/Voices$suffix.${Constants.EXT_SOUND}';
+    return Paths.song('${song.toLowerCase()}/Voices$suffix', extension);
   }
 
   /**
    * Gets the path to an `Inst.mp3/ogg` song instrumental from songs:assets/songs/`song`/
    * @param song name of the song to get instrumental for
    * @param suffix any suffix to add to end of song name, used for `-erect` variants usually
-   * @param withExtension if it should return with the audio file extension `.mp3` or `.ogg`.
+   * @param extension The audio file extension of the track. If empty, it'll attempt to find a supported audio file format.
    * @return String
    */
-  public static function inst(song:String, ?suffix:String = '', withExtension:Bool = true):String
+  public static function inst(song:String, ?suffix:String = '', ?extension:String):String
   {
-    var ext:String = withExtension ? '.${Constants.EXT_SOUND}' : '';
-    return 'songs:assets/songs/${song.toLowerCase()}/Inst$suffix$ext';
+    return Paths.song('${song.toLowerCase()}/Inst$suffix', extension);
   }
 
   public static function image(key:String, ?library:String):String
@@ -172,6 +222,30 @@ class Paths implements ConsoleClass
   public static function ui(key:String, ?library:String):String
   {
     return xml('ui/$key', library);
+  }
+
+  public static function fromPathsFunction(key:String, ?pathsFunction:PathsFunction):String
+  {
+    return switch (pathsFunction)
+    {
+      case FILE: file(key);
+      case ATLAS: animateAtlas(key);
+      case TXT: txt(key);
+      case FRAG: frag(key);
+      case VERT: vert(key);
+      case XML: xml(key);
+      case JSON: json(key);
+      case SRT: srt(key);
+      case SOUND: sound(key);
+      case MUSIC: music(key);
+      case VIDEOS: videos(key);
+      case SONG: song(key);
+      case INST: inst(key);
+      case VOICES: voices(key);
+      case FONT: font(key);
+      case UI: ui(key);
+      default: key;
+    }
   }
 
   public static function getSparrowAtlas(key:String, ?library:String):FlxAtlasFrames
@@ -229,8 +303,21 @@ class Paths implements ConsoleClass
 
 enum abstract PathsFunction(String)
 {
+  var NONE;
+  var FILE;
+  var ATLAS;
+  var TXT;
+  var FRAG;
+  var VERT;
+  var XML;
+  var JSON;
+  var SRT;
+  var SOUND;
   var MUSIC;
+  var VIDEOS;
+  var SONG;
   var INST;
   var VOICES;
-  var SOUND;
+  var FONT;
+  var UI;
 }

--- a/source/funkin/Preferences.hx
+++ b/source/funkin/Preferences.hx
@@ -439,6 +439,55 @@ class Preferences
     return value;
   }
 
+  #if desktop
+  /**
+   * What audio device should it playback sounds to.
+   * @default Default
+   */
+  public static var audioDevice(get, set):String;
+
+  static function get_audioDevice():String
+  {
+    return Save?.instance?.options?.audioDevice ?? "Default";
+  }
+
+  static function set_audioDevice(value:String):String
+  {
+    var save:Save = Save.instance;
+    if (value == save.options.audioDevice) return value;
+
+    FlxG.sound.automaticDefaultDevice = value == "Default" || (FlxG.sound.deviceName = value) != value;
+
+    save.options.audioDevice = FlxG.sound.automaticDefaultDevice ? "Default" : value;
+    Save.system.flush();
+
+    return value;
+  }
+  #end
+
+  #if native
+  /**
+   * Should the musics be loaded as streamable instead of static.
+   * @default `true`
+   */
+  public static var streamedMusic(get, set):Bool;
+
+  static function get_streamedMusic():Bool
+  {
+    return Save?.instance?.options?.streamedMusic ?? true;
+  }
+
+  static function set_streamedMusic(value:Bool):Bool
+  {
+    flixel.sound.FlxSoundData.allowStreaming = value;
+
+    var save:Save = Save.instance;
+    save.options.streamedMusic = value;
+    Save.system.flush();
+    return value;
+  }
+  #end
+
   /**
    * If enabled, the game will hide the mouse when taking a screenshot.
    * @default `true`
@@ -507,6 +556,24 @@ class Preferences
     // Apply the debugDisplay setting (enables the FPS and RAM display).
     setDebugDisplayMode(Preferences.debugDisplay);
     setDebugDisplayBGOpacity(Preferences.debugDisplayBGOpacity / 100);
+
+    #if desktop
+    // Apply audio device preference, if failed, fallback to Default.
+    FlxG.sound.deviceName = Preferences.audioDevice;
+    if (FlxG.sound.deviceName == Preferences.audioDevice)
+    {
+      FlxG.sound.automaticDefaultDevice = false;
+    }
+    else
+    {
+      Preferences.audioDevice = "Default";
+      FlxG.sound.automaticDefaultDevice = true;
+    }
+    #end
+
+    #if native
+    flixel.sound.FlxSoundData.allowStreaming = Preferences.streamedMusic;
+    #end
 
     toggleFramerateCap(Preferences.unlockedFramerate);
 

--- a/source/funkin/api/newgrounds/Leaderboards.hx
+++ b/source/funkin/api/newgrounds/Leaderboards.hx
@@ -24,7 +24,7 @@ class Leaderboards
     var leaderboardList:Null<ScoreBoardList> = NewgroundsClient.instance.leaderboards;
     if (leaderboardList == null)
     {
-      trace(' NEWGROUNDS '.bold().bg_orange() + ' Not logged in, cannot fetch medal data!');
+      trace(' NEWGROUNDS '.bold().bg_orange() + ' Not logged in, cannot fetch leaderboard data!');
       return [];
     }
 
@@ -161,7 +161,7 @@ class LeaderboardsSandboxed
    * @param leaderboard The leaderboard to fetch scores from.
    * @param params Additional parameters for fetching the score.
    */
-  public function requestScores(leaderboard:Leaderboard, params:RequestScoresParams)
+  public static function requestScores(leaderboard:Leaderboard, params:RequestScoresParams)
   {
     Leaderboards.requestScores(leaderboard, params);
   }

--- a/source/funkin/audio/FlxStreamSound.hx
+++ b/source/funkin/audio/FlxStreamSound.hx
@@ -1,14 +1,15 @@
 package funkin.audio;
 
-import flash.media.Sound;
+import lime.media.AudioBuffer;
+import openfl.Assets;
+import openfl.media.Sound;
+import openfl.utils.AssetType;
 import flixel.sound.FlxSound;
 import flixel.system.FlxAssets.FlxSoundAsset;
-import openfl.Assets;
-#if (openfl >= "8.0.0")
-import openfl.utils.AssetType;
-#end
 
 /**
+ * USE flixel.sound.FlxSoundData or FlxSound.loadStreamed instead!
+ * 
  * a FlxSound that just overrides loadEmbedded to allow for "streamed" sounds to load with better performance!
  */
 @:nullSafety
@@ -19,29 +20,16 @@ class FlxStreamSound extends FlxSound
     super();
   }
 
-  override public function loadEmbedded(EmbeddedSound:Null<FlxSoundAsset>, Looped:Bool = false, AutoDestroy:Bool = false, ?OnComplete:Void->Void):FlxSound
+  override public function loadEmbedded(asset:FlxSoundAsset, ?looped:Bool, ?loopTime:Float, ?endTime:Float, autoDestroy = false, ?onComplete:Void->Void):FlxStreamSound
   {
-    if (EmbeddedSound == null) return this;
-
-    cleanup(true);
-
-    if ((EmbeddedSound is Sound))
+    if ((asset is String))
     {
-      _sound = EmbeddedSound;
+      super.loadStreamed(asset, looped, loopTime, endTime, autoDestroy, onComplete);
     }
-    else if ((EmbeddedSound is Class))
+    else
     {
-      _sound = Type.createInstance(EmbeddedSound, []);
+      super.loadEmbedded(asset, looped, loopTime, endTime, autoDestroy, onComplete);
     }
-    else if ((EmbeddedSound is String))
-    {
-      if (Assets.exists(EmbeddedSound, AssetType.SOUND)
-        || Assets.exists(EmbeddedSound, AssetType.MUSIC)) _sound = Assets.getMusic(EmbeddedSound);
-      else
-        FlxG.log.error('Could not find a Sound asset with an ID of \'$EmbeddedSound\'.');
-    }
-
-    // NOTE: can't pull ID3 info from embedded sound currently
-    return init(Looped, AutoDestroy, OnComplete);
+    return this;
   }
 }

--- a/source/funkin/audio/FunkinSound.hx
+++ b/source/funkin/audio/FunkinSound.hx
@@ -28,8 +28,6 @@ import openfl.media.SoundMixer;
 @:nullSafety
 class FunkinSound extends FlxSound implements ICloneable<FunkinSound>
 {
-  static final MAX_VOLUME:Float = 1.0;
-
   /**
    * An FlxSignal which is dispatched when the volume changes.
    */
@@ -56,64 +54,22 @@ class FunkinSound extends FlxSound implements ICloneable<FunkinSound>
   static var pool(default, null):FlxTypedGroup<FunkinSound> = new FlxTypedGroup<FunkinSound>();
 
   /**
-   * Calculate the current time of the sound.
-   * NOTE: You need to `add()` the sound to the scene for `update()` to increment the time.
-   */
-  //
-  public var muted(default, set):Bool = false;
-
-  function set_muted(value:Bool):Bool
-  {
-    if (value == muted) return value;
-    muted = value;
-    updateTransform();
-    return value;
-  }
-
-  override function set_volume(value:Float):Float
-  {
-    // Uncap the volume.
-    _volume = value.clamp(0.0, MAX_VOLUME);
-    updateTransform();
-    return _volume;
-  }
-
-  public var paused(get, never):Bool;
-
-  function get_paused():Bool
-  {
-    return this._paused;
-  }
-
-  public var isPlaying(get, never):Bool;
-
-  function get_isPlaying():Bool
-  {
-    return this.playing || this._shouldPlay;
-  }
-
-  /**
    * Waveform data for this sound.
    * This is lazily loaded, so it will be built the first time it is accessed.
    */
-  public var waveformData(get, never):WaveformData;
+  public var waveformData(get, never):Null<WaveformData>;
 
   var _waveformData:Null<WaveformData> = null;
 
-  function get_waveformData():WaveformData
+  function get_waveformData():Null<WaveformData>
   {
     if (_waveformData == null)
     {
       _waveformData = WaveformDataParser.interpretFlxSound(this);
-      if (_waveformData == null) throw 'Could not interpret waveform data!';
+      if (_waveformData == null) trace('Could not interpret waveform data!');
     }
     return _waveformData;
   }
-
-  /**
-   * If true, the game will forcefully add this sound's channel to the list of playing sounds.
-   */
-  public var important:Bool = false;
 
   /**
    * Are we in a state where the song should play but time is negative?
@@ -121,46 +77,33 @@ class FunkinSound extends FlxSound implements ICloneable<FunkinSound>
   var _shouldPlay:Bool = false;
 
   /**
-   * For debug purposes.
+   * The used variable for time when _shoudPlay is true.
    */
-  var _label:String = "unknown";
+  var _time:Float = 0;
 
   public function new()
   {
     super();
   }
 
-  public override function update(elapsedSec:Float)
+  public override function update(elapsedSec:Float):Void
   {
-    if (!playing && !_shouldPlay) return;
-
-    if (_time < 0)
+    if (this._shouldPlay && !this._paused)
     {
-      var elapsedMs = elapsedSec * Constants.MS_PER_SEC;
-      _time += elapsedMs;
-      if (_time >= 0)
+      this._time += elapsedSec * Constants.MS_PER_SEC;
+      if (this._time >= -this.offset)
       {
-        super.play();
-        _shouldPlay = false;
+        this._shouldPlay = false;
+        super.play(true, -offset);
       }
     }
-    else
-    {
-      super.update(elapsedSec);
 
-      @:privateAccess
-      {
-        if (important && _channel != null && !SoundMixer.__soundChannels.contains(_channel))
-        {
-          SoundMixer.__soundChannels.push(_channel);
-        }
-      }
-    }
+    super.update(elapsedSec);
   }
 
   public function togglePlayback():FunkinSound
   {
-    if (playing)
+    if (this.playing)
     {
       pause();
     }
@@ -171,105 +114,145 @@ class FunkinSound extends FlxSound implements ICloneable<FunkinSound>
     return this;
   }
 
-  public override function play(forceRestart:Bool = false, startTime:Float = 0, ?endTime:Float):FunkinSound
+  public override function play(forceRestart = false, startTime = 0.0, ?endTime:Float, ?volume:Float, ?pitch:Float, ?pan:Float):FunkinSound
   {
-    if (!exists) return this;
+    if (!this.loaded) return this;
 
-    if (forceRestart)
+    if (forceRestart || !this.playing)
     {
-      cleanup(false, true);
-    }
-    else if (playing)
-    {
-      return this;
-    }
-
-    if (startTime < 0)
-    {
-      this.active = true;
-      this._shouldPlay = true;
-      this._time = startTime;
-      this.endTime = endTime;
-      return this;
-    }
-    else
-    {
-      if (_paused)
+      if (this._paused && !forceRestart)
       {
-        resume();
+        if (this._shouldPlay)
+        {
+          startTime = this.time;
+        }
       }
-      else
+      else if (!_paused)
       {
-        startSound(startTime);
+        loopCount = 0;
       }
 
-      this.endTime = endTime;
-      return this;
+      if (startTime < -this.offset)
+      {
+        if (volume != null) this._volume = volume;
+        #if FLX_PITCH
+        if (pitch != null) this._pitch = pitch;
+        #end
+        if (pan != null) this._pan = pan;
+        if (endTime != null) this._endTime = endTime;
+
+        this.active = true;
+        this._shouldPlay = true;
+        this._time = startTime;
+
+        _updateVolume();
+        #if FLX_PITCH
+        _updatePitch();
+        #end
+        _updatePan();
+        _updateLoop();
+
+        source.prepare(0);
+
+        return this;
+      }
     }
+
+    this._shouldPlay = false;
+    super.play(forceRestart, startTime, endTime, volume, pitch, pan);
+    return this;
   }
 
-  public override function pause():FunkinSound
+  public override function prepare(startTime = 0.0, ?endTime:Float, ?volume:Float, ?pitch:Float, ?pan:Float):FunkinSound
   {
-    if (_shouldPlay)
+    if (!this.loaded) return this;
+
+    if (startTime < -this.offset)
     {
-      // This sound will eventually play, but is still at a negative timestamp.
-      // Manually set the paused flag to ensure proper focus/unfocus behavior.
-      _shouldPlay = false;
-      _paused = true;
-      active = false;
+      if (volume != null) this._volume = volume;
+      #if FLX_PITCH
+      if (pitch != null) this._pitch = pitch;
+      #end
+      if (pan != null) this._pan = pan;
+      if (endTime != null) this._endTime = endTime;
+
+      this.active = false;
+      this._shouldPlay = true;
+      this._time = startTime;
+
+      _updateVolume();
+      #if FLX_PITCH
+      _updatePitch();
+      #end
+      _updatePan();
+      _updateLoop();
+
+      source.prepare(0);
     }
     else
     {
-      super.pause();
+      this._shouldPlay = false;
+      super.prepare(startTime);
     }
+
     return this;
   }
 
   public override function resume():FunkinSound
   {
-    if (this._time < 0)
+    if (this._shouldPlay)
     {
-      // Sound with negative timestamp, restart the timer.
-      _shouldPlay = true;
-      _paused = false;
-      active = true;
+      // Sound with negative timestamp, resume the timer.
+      this._paused = false;
     }
     else
     {
       super.resume();
     }
+
     return this;
   }
 
-  /**
-   * Call after adjusting the volume to update the sound channel's settings.
-   */
-  @:allow(flixel.sound.FlxSoundGroup)
-  override function updateTransform():Void
+  public override function pause():FunkinSound
   {
-    if (_transform != null)
+    if (this._shouldPlay)
     {
-      _transform.volume = #if FLX_SOUND_SYSTEM ((FlxG.sound.muted || this.muted) ? 0 : 1) * FlxG.sound.volume * #end
-        (group != null ? group.volume : 1) * _volume * _volumeAdjust;
+      // This sound will eventually play, but is still at a negative timestamp.
+      // Manually set the paused flag to ensure proper focus/unfocus behavior.
+      this._paused = true;
+    }
+    else
+    {
+      super.pause();
     }
 
-    if (_channel != null)
+    return this;
+  }
+
+  public override function stop():FunkinSound
+  {
+    if (this._shouldPlay)
     {
-      _channel.soundTransform = _transform;
+      // Stops the timer to play for negative timer sounds.
+      this._shouldPlay = false;
+      this._paused = true;
+      this.active = false;
     }
+    else
+    {
+      super.stop();
+    }
+
+    return this;
   }
 
   public function clone():FunkinSound
   {
     var sound:FunkinSound = new FunkinSound();
 
-    // Clone the sound by creating one with the same data buffer.
-    // Reusing the `Sound` object directly causes issues with playback.
-    @:privateAccess
-    sound._sound = openfl.media.Sound.fromAudioBuffer(this._sound.__buffer);
-
     // Call init to ensure the FlxSound is properly initialized.
-    sound.init(this.looped, this.autoDestroy, this.onComplete);
+    @:privateAccess
+    sound.init(this.data, this.looped, this.loopTime, this.endTime, this.autoDestroy, this.onComplete);
 
     // Oh yeah, the waveform data is the same too!
     @:privateAccess
@@ -290,13 +273,24 @@ class FunkinSound extends FlxSound implements ICloneable<FunkinSound>
   {
     if (!(params.overrideExisting ?? false) && (FlxG.sound.music?.exists ?? false) && FlxG.sound.music.playing) return false;
 
+    if (params.suffix != null) key += params.suffix;
+    var pathsFunction = params.pathsFunction ?? MUSIC;
+
+    // Maybe make a comprehensive music system sometime in the future instead of doing this?
+    var path = new haxe.io.Path(key);
+    var pathToUse:String = Paths.fromPathsFunction(
+      (path.dir == null ? "" : path.dir + "/") + '${path.file}/${path.file}' + (path.ext == null ? "" : "." + path.ext),
+      pathsFunction
+    );
+    if (!Assets.exists(pathToUse)) pathToUse = Paths.fromPathsFunction(key, pathsFunction);
+
     if (!(params.restartTrack ?? false) && FlxG.sound.music?.playing)
     {
       if (FlxG.sound.music != null && Std.isOfType(FlxG.sound.music, FunkinSound))
       {
         var existingSound:FunkinSound = cast FlxG.sound.music;
         // Stop here if we would play a matching music track.
-        if (existingSound._label == Paths.music('$key/$key'))
+        if (existingSound.data != null && existingSound.data.key == pathToUse)
         {
           return false;
         }
@@ -306,8 +300,7 @@ class FunkinSound extends FlxSound implements ICloneable<FunkinSound>
     if (FlxG.sound.music != null)
     {
       FlxG.sound.music.fadeTween?.cancel();
-      FlxG.sound.music.stop();
-      FlxG.sound.music.kill();
+      FlxG.sound.music.destroy();
     }
 
     if (params?.mapTimeChanges ?? true)
@@ -325,14 +318,6 @@ class FunkinSound extends FlxSound implements ICloneable<FunkinSound>
         FlxG.log.warn('Tried and failed to find music metadata for $key');
       }
     }
-    var pathsFunction = params.pathsFunction ?? MUSIC;
-    var suffix = params.suffix ?? '';
-    var pathToUse = switch (pathsFunction)
-    {
-      case MUSIC: Paths.music('$key/$key');
-      case INST: Paths.inst('$key', suffix);
-      default: Paths.music('$key/$key');
-    }
 
     var shouldLoadPartial = params.partialParams?.loadPartial ?? false;
 
@@ -343,28 +328,20 @@ class FunkinSound extends FlxSound implements ICloneable<FunkinSound>
 
     if (shouldLoadPartial)
     {
-      var music = FunkinSound.loadPartial(pathToUse, params.partialParams?.start ?? 0.0, params.partialParams?.end ?? 1.0, params?.startingVolume ?? 1.0,
+      var promise = FunkinSound.loadPartial(pathToUse, params.partialParams?.start ?? 0.0, params.partialParams?.end ?? 1.0, params?.startingVolume ?? 1.0,
         params.loop ?? true, false, false, params.onComplete);
 
-      if (music != null)
+      partialQueue.push(promise);
+
+      @:nullSafety(Off)
+      promise.future.onComplete(function(partialMusic:Null<FunkinSound>)
       {
-        partialQueue.push(music);
+        setMusic(partialMusic);
 
-        @:nullSafety(Off)
-        music.future.onComplete(function(partialMusic:Null<FunkinSound>)
-        {
-          FlxG.sound.music = partialMusic;
-          FlxG.sound.list.remove(FlxG.sound.music);
+        if (partialMusic != null && params.onLoad != null) params.onLoad();
+      });
 
-          if (FlxG.sound.music != null && params.onLoad != null) params.onLoad();
-        });
-
-        return true;
-      }
-      else
-      {
-        return false;
-      }
+      return true;
     }
     else
     {
@@ -373,7 +350,7 @@ class FunkinSound extends FlxSound implements ICloneable<FunkinSound>
       {
         setMusic(music);
 
-        if (FlxG.sound.music != null && params.onLoad != null) params.onLoad();
+        if (params.onLoad != null) params.onLoad();
 
         return true;
       }
@@ -420,39 +397,22 @@ class FunkinSound extends FlxSound implements ICloneable<FunkinSound>
    * @param persist         Whether to keep this `FunkinSound` between states, or destroy it.
    * @param onComplete      Called when the sound finished playing.
    * @param onLoad          Called when the sound finished loading.  Called immediately for succesfully loaded embedded sounds.
-   * @param important       If `true`, the sound channel will forcefully be added onto the channel array, even if full. Use sparingly!
    * @return A `FunkinSound` object, or `null` if the sound could not be loaded.
    */
-  public static function load(embeddedSound:FlxSoundAsset, volume:Float = 1.0, looped:Bool = false, autoDestroy:Bool = false, autoPlay:Bool = false,
-      persist:Bool = false, ?onComplete:Void->Void, ?onLoad:Void->Void, important:Bool = false):Null<FunkinSound>
+  public static function load(embeddedSound:Null<FlxSoundAsset>, volume:Float = 1.0, looped:Bool = false, autoDestroy:Bool = false, autoPlay:Bool = false,
+      persist:Bool = false, ?onComplete:Void->Void, ?onLoad:Void->Void):FunkinSound
   {
-    @:privateAccess
-    if (SoundMixer.__soundChannels.length >= SoundMixer.MAX_ACTIVE_CHANNELS && !important)
-    {
-      FlxG.log.error('FunkinSound could not play sound, channels exhausted! Found ${SoundMixer.__soundChannels.length} active sound channels.');
-      return null;
-    }
-
     var sound:FunkinSound = pool.recycle(construct);
+
+    // Force it to be exists so it doesn't get claimed by FlxG.sound.load or pool.
+    sound.alive = true;
+    sound.exists = true;
 
     // Load the sound.
     // Sets `exists = true` as a side effect.
+    @:nullSafety(Off)
     sound.loadEmbedded(embeddedSound, looped, autoDestroy, onComplete);
-
-    if (embeddedSound is String)
-    {
-      sound._label = embeddedSound;
-    }
-    else
-    {
-      sound._label = 'unknown';
-    }
-
-    if (autoPlay) sound.play();
-    sound.volume = volume;
     FlxG.sound.defaultSoundGroup.add(sound);
-    sound.persist = persist;
-    sound.important = important;
 
     // Make sure to add the sound to the list.
     // If it's already in, it won't get re-added.
@@ -460,8 +420,12 @@ class FunkinSound extends FlxSound implements ICloneable<FunkinSound>
     // it will get re-added (then if this was called by playMusic(), removed again)
     FlxG.sound.list.add(sound);
 
+    sound.volume = volume;
+    sound.persist = persist;
+    if (autoPlay) sound.play(true, 0);
+
     // Call onLoad() because the sound already loaded
-    if (onLoad != null && sound._sound != null) onLoad();
+    if (onLoad != null && sound.data != null) onLoad();
 
     return sound;
   }
@@ -516,51 +480,44 @@ class FunkinSound extends FlxSound implements ICloneable<FunkinSound>
   @:nullSafety(Off)
   public override function destroy():Void
   {
-    // trace('[FunkinSound] Destroying sound "${this._label}"');
     super.destroy();
-    if (fadeTween != null)
-    {
-      fadeTween.cancel();
-      fadeTween = null;
-    }
     FlxTween.cancelTweensOf(this);
-    this._label = 'unknown';
     this._waveformData = null;
   }
 
-  @:access(openfl.media.Sound)
-  @:access(openfl.media.SoundChannel)
-  @:access(openfl.media.SoundMixer)
-  override function startSound(startTime:Float)
+  override function get_playing():Bool
   {
-    if (!important)
+    return loaded && (source.playing || _pausedPlay || _shouldPlay);
+  }
+
+  override function get_time():Float
+  {
+    if (this._shouldPlay)
     {
-      super.startSound(startTime);
-      return;
+      return this._time;
     }
+    else
+    {
+      return super.get_time();
+    }
+  }
 
-    _time = startTime;
-    _paused = false;
-
-    if (_sound == null) return;
-
-    // Create a channel manually if the sound is considered important.
-    var pan:Float = (SoundMixer.__soundTransform.pan + _transform.pan).clamp(-1, 1);
-    var volume:Float = (SoundMixer.__soundTransform.volume * _transform.volume).clamp(0, MAX_VOLUME);
-
-    var audioSource:AudioSource = new AudioSource(_sound.__buffer);
-    audioSource.offset = Std.int(startTime);
-    audioSource.gain = volume;
-
-    var position:lime.math.Vector4 = audioSource.position;
-    position.x = pan;
-    position.z = -1 * Math.sqrt(1 - Math.pow(pan, 2));
-    audioSource.position = position;
-
-    _channel = new SoundChannel(_sound, audioSource, _transform);
-    _channel.addEventListener(Event.SOUND_COMPLETE, stopped);
-    pitch = _pitch;
-    active = true;
+  override function set_time(value:Float):Float
+  {
+    if (this._shouldPlay)
+    {
+      this._time = value;
+      if (this.time >= -offset)
+      {
+        this._shouldPlay = false;
+        super.play(true, -offset);
+      }
+      return value;
+    }
+    else
+    {
+      return super.set_time(value);
+    }
   }
 
   /**
@@ -569,9 +526,9 @@ class FunkinSound extends FlxSound implements ICloneable<FunkinSound>
    * @param volume
    * @return A `FunkinSound` object, or `null` if the sound could not be loaded.
    */
-  public static function playOnce(key:String, volume:Float = 1.0, ?onComplete:Void->Void, ?onLoad:Void->Void, important:Bool = false):Null<FunkinSound>
+  public static function playOnce(key:String, volume:Float = 1.0, ?onComplete:Void->Void, ?onLoad:Void->Void):Null<FunkinSound>
   {
-    var result:Null<FunkinSound> = FunkinSound.load(key, volume, false, true, true, false, onComplete, onLoad, important);
+    var result:Null<FunkinSound> = FunkinSound.load(key, volume, false, true, true, false, onComplete, onLoad);
     return result;
   }
 
@@ -604,7 +561,7 @@ class FunkinSound extends FlxSound implements ICloneable<FunkinSound>
    */
   public override function toString():String
   {
-    return 'FunkinSound(${this._label})';
+    return 'FunkinSound(${this.data != null ? this.data.key : "unknown"})';
   }
 }
 

--- a/source/funkin/audio/PreviewMusicData.hx
+++ b/source/funkin/audio/PreviewMusicData.hx
@@ -17,7 +17,6 @@ import lime.utils.ArrayBufferView;
 import lime.utils.ArrayBufferView.ArrayBufferIO;
 import lime.utils.Int8Array;
 import lime.utils.Int16Array;
-import lime.utils.Int32Array;
 #elseif web
 import js.html.audio.AudioBuffer as JSAudioBuffer;
 import lime.utils.Float32Array;
@@ -216,10 +215,8 @@ private class PreviewMusicDecoder extends AudioDecoder
   var fadeEndSamples:Int64;
   var fadeEndStartSampleOffset:Int64;
   var fadeEndEndSampleOffset:Int64;
-  var bufferView:ArrayBufferView;
   var bufferInt8View:Int8Array;
   var bufferInt16View:Int16Array;
-  var bufferInt32View:Int32Array;
   var mutex:Mutex;
 
   public function new(parent:PreviewMusicData)
@@ -250,16 +247,10 @@ private class PreviewMusicDecoder extends AudioDecoder
       var realTotal = decoder.total();
       if (realTotal < totalSamples) totalSamples = realTotal;
 
-      bytePerSample = bitsPerSample >> 3;
       fadeStartSamples = Int64.fromFloat(PreviewMusicData.FADE_IN_DURATION * sampleRate);
       fadeEndEndSampleOffset = endSamples - startSamples;
       fadeEndSamples = Int64.fromFloat(PreviewMusicData.FADE_OUT_DURATION * sampleRate);
       fadeEndStartSampleOffset = fadeEndEndSampleOffset - fadeEndSamples;
-
-      // 24 bitsPerSample are incompatible, nor it should be in openal too.
-      if (bytePerSample == 1) bufferView = bufferInt8View = new Int8Array(0);
-      else if (bytePerSample == 2) bufferView = bufferInt16View = new Int16Array(0);
-      else if (bytePerSample == 4) bufferView = bufferInt32View = new Int32Array(0);
 
       rewind();
     }
@@ -275,71 +266,78 @@ private class PreviewMusicDecoder extends AudioDecoder
   override function dispose():Void
   {
     super.dispose();
+
+    bufferInt16View = null;
+    bufferInt8View = null;
   }
 
-  override function decode(buffer:ArrayBuffer, pos:Int, len:Int):Int
+  override function decode(buffer:ArrayBuffer, pos:Int, len:Int, word:Int):Int
   {
     if (decoder == null) return 0;
 
     mutex.acquire();
 
     var currentSampleOffset = decoder.tell() - startSamples;
-    var remainingBytes = (endSamples - currentSampleOffset) * channels * bytePerSample;
+    var remainingBytes = (endSamples - currentSampleOffset) * channels * word;
 
     var result:Int;
     if (remainingBytes < len)
     {
-      result = decoder.decode(buffer, pos, Int64.toInt(remainingBytes));
+      result = decoder.decode(buffer, pos, Int64.toInt(remainingBytes), word);
       eof = true;
     }
     else
     {
-      result = decoder.decode(buffer, pos, len);
+      result = decoder.decode(buffer, pos, len, word);
       eof = decoder.eof;
     }
 
-    if (bytePerSample == 3)
+    // 24 and 32 bits per sample are incompatible, and never get decoded with for playbacks.
+    if (word > 2)
     {
       mutex.release();
       return result;
     }
+    else if (word == 2)
+    {
+      if (bufferInt16View == null) bufferInt16View = new Int16Array(buffer);
+      else if (bufferInt16View.buffer != buffer) bufferInt16View.initBuffer(buffer);
+    }
+    else if (word == 1)
+    {
+      if (bufferInt8View == null) bufferInt8View = new Int8Array(buffer);
+      else if (bufferInt8View.buffer != buffer) bufferInt8View.initBuffer(buffer);
+    }
 
-    // Fading processing
-    if (bufferView.buffer != buffer) bufferView.initBuffer(buffer);
+    // Fading processing starts here
+    pos = Std.int(pos / word);
+    len = pos + Std.int(result / word);
 
-    pos = Std.int(pos / bytePerSample);
-    len = pos + Std.int(result / bytePerSample);
     var channel = 0, b:Int;
     while (pos < len)
     {
       if (currentSampleOffset < fadeStartSamples)
       {
-        switch (bytePerSample)
+        switch (word)
         {
           case 1:
             bufferInt8View[pos] = Std.int(bufferInt8View[pos] *
               PreviewMusicData.FADE_IN_EASE_FUNCTION(currentSampleOffset.low / fadeStartSamples.low).clamp(0, 1));
           case 2:
             bufferInt16View[pos] = Std.int(bufferInt16View[pos] *
-              PreviewMusicData.FADE_IN_EASE_FUNCTION(currentSampleOffset.low / fadeStartSamples.low).clamp(0, 1));
-          case 4:
-            bufferInt32View[pos] = Std.int(bufferInt32View[pos] *
               PreviewMusicData.FADE_IN_EASE_FUNCTION(currentSampleOffset.low / fadeStartSamples.low).clamp(0, 1));
           default:
         }
       }
       else if (currentSampleOffset > fadeEndStartSampleOffset)
       {
-        switch (bytePerSample)
+        switch (word)
         {
           case 1:
             bufferInt8View[pos] = Std.int(bufferInt8View[pos] *
               PreviewMusicData.FADE_OUT_EASE_FUNCTION((fadeEndEndSampleOffset - currentSampleOffset).low / fadeEndSamples.low).clamp(0, 1));
           case 2:
             bufferInt16View[pos] = Std.int(bufferInt16View[pos] *
-              PreviewMusicData.FADE_OUT_EASE_FUNCTION((fadeEndEndSampleOffset - currentSampleOffset).low / fadeEndSamples.low).clamp(0, 1));
-          case 4:
-            bufferInt32View[pos] = Std.int(bufferInt32View[pos] *
               PreviewMusicData.FADE_OUT_EASE_FUNCTION((fadeEndEndSampleOffset - currentSampleOffset).low / fadeEndSamples.low).clamp(0, 1));
           default:
         }

--- a/source/funkin/audio/PreviewMusicData.hx
+++ b/source/funkin/audio/PreviewMusicData.hx
@@ -1,0 +1,392 @@
+package funkin.audio;
+
+import haxe.io.Bytes;
+import lime._internal.format.Base64;
+import lime.media.AudioBuffer;
+import openfl.utils.Assets;
+import flixel.sound.FlxSoundData;
+import flixel.tweens.FlxEase;
+
+#if native
+import sys.thread.Mutex;
+
+import haxe.Int64;
+import lime.media.AudioDecoder;
+import lime.utils.ArrayBuffer;
+import lime.utils.ArrayBufferView;
+import lime.utils.ArrayBufferView.ArrayBufferIO;
+import lime.utils.Int8Array;
+import lime.utils.Int16Array;
+import lime.utils.Int32Array;
+#elseif web
+import js.html.audio.AudioBuffer as JSAudioBuffer;
+import lime.utils.Float32Array;
+import funkin.util.flixel.sound.FlxPartialSound;
+#end
+
+class PreviewMusicData extends FlxSoundData
+{
+  /**
+   * For the audio preview, the duration of the fade-in effect.
+   */
+  public static final FADE_IN_DURATION:Float = 2.0;
+
+  /**
+   * For the audio preview, the duration of the fade-out effect.
+   */
+  public static final FADE_OUT_DURATION:Float = 2.0;
+
+  /**
+   * For the audio preview, what easing function to use for fading of the fade-in effect.
+   */
+  public static final FADE_IN_EASE_FUNCTION:EaseFunction = FlxEase.quadOut;
+
+  /**
+   * For the audio preview, what easing function to use for fading of the fade-out effect.
+   */
+  public static final FADE_OUT_EASE_FUNCTION:EaseFunction = FlxEase.quadIn;
+
+  #if native
+  var audioBufferProcess:AudioBuffer;
+  var audioDecoderProcess:PreviewMusicDecoder;
+  #end
+
+  public function new()
+  {
+    super('PreviewMusicData', null, true);
+
+    #if native
+    audioBufferProcess = new AudioBuffer();
+    audioBufferProcess.decoder = audioDecoderProcess = new PreviewMusicDecoder(this);
+    #end
+  }
+
+  public function setAssetPath(path:String, startPercentage:Float = 0, endPercentage:Float = 0.15, ?stream:Bool, ?onLoad:PreviewMusicData->Void):Void
+  {
+    var cacheName = 'PreviewMusicData-$path-$startPercentage-$endPercentage';
+
+    var cache = FlxG.sound.getCache(cacheName);
+    if (cache != null)
+    {
+      buffer = cache.buffer;
+      if (onLoad != null) onLoad(this);
+      return;
+    }
+
+    #if native
+    final openflAssetExists = Assets.exists(path);
+    var decoder = AudioDecoder.fromFile(openflAssetExists ? Assets.getPath(path) : path);
+    if (decoder == null)
+    {
+      if (!openflAssetExists) return;
+
+      decoder = AudioDecoder.fromBytes(Assets.getBytes(path));
+      if (decoder == null) return;
+    }
+
+    final total = decoder.total();
+    final duration = (total.high * 4294967296.0 + total.low) / decoder.sampleRate * 1000.0;
+    final startTime = startPercentage * duration;
+    final endTime = endPercentage * duration;
+
+    audioDecoderProcess.resetDecoder(decoder, startTime, endTime);
+
+    if (stream == null) stream = FlxSoundData.allowStreaming && (endTime - startTime) >= FlxSoundData.streamMinimumLength;
+    if (stream && decoder.seekable())
+    {
+      audioBufferProcess.bitsPerSample = audioDecoderProcess.bitsPerSample;
+      audioBufferProcess.channels = audioDecoderProcess.channels;
+      audioBufferProcess.sampleRate = audioDecoderProcess.sampleRate;
+      buffer = audioBufferProcess;
+
+      if (onLoad != null) onLoad(this);
+    }
+    else
+    {
+      var cache = FlxSoundData.fromAudioBuffer(buffer = new AudioBuffer(), cacheName, true);
+      buffer.decoder = audioDecoderProcess;
+
+      buffer.loadAsync((_) -> {
+        buffer.decoder = null;
+
+        // Reset the buffer in the sound datas.
+        buffer = buffer;
+        cache.buffer = buffer;
+
+        // DEBUG TESTING THE AUDIO.
+        // var output = sys.io.File.write("../../../../tempPartial.wav", true);
+        // output.writeString("RIFF");
+        // output.writeInt32(36 + buffer.data.byteLength);
+        // output.writeString("WAVE"); // 4
+        // output.writeString("fmt "); // 4 + 4
+        // output.writeInt32(16); // 8 + 4
+        // output.writeUInt16(1); // 12 + 2
+        // output.writeUInt16(buffer.channels); // 14 + 2
+        // output.writeInt32(buffer.sampleRate); // 16 + 4
+        // output.writeInt32(buffer.sampleRate * buffer.channels * (buffer.bitsPerSample >> 3)); // 20 + 4
+        // output.writeUInt16(buffer.channels * (buffer.bitsPerSample >> 3)); // 24 + 2
+        // output.writeUInt16(buffer.bitsPerSample); // 26 + 2
+        // output.writeString("data"); // 28 + 4
+        // output.writeInt32(buffer.data.byteLength); // 32 + 4 = 36
+        // output.write(buffer.data.buffer);
+        // output.close();
+
+        if (onLoad != null) onLoad(this);
+      });
+    }
+    #elseif web
+    // apparently we have to split the path from the library? according to FunkinSound.loadPartial
+    var promise = FlxPartialSound.partialLoadFromFile(Paths.stripLibrary(path), startPercentage, endPercentage);
+    if (promise == null) return;
+
+    @:privateAccess
+    var soundData = FlxSoundData.createSoundData(null, cacheName, true);
+    soundData.persist = true; // make it persist, or partialLoadFromFile will fail in next clearCache cycle.
+
+    promise.future.onComplete(function(partialSound)
+    @:privateAccess {
+      soundData.buffer = buffer = partialSound.__buffer;
+      if (buffer.__srcAudioBuffer != null)
+      {
+        processFading(buffer.__srcAudioBuffer);
+        onLoad(this);
+      }
+      else
+      {
+        buffer.loadAsync((_) -> {
+          if (buffer.__srcAudioBuffer != null) processFading(buffer.__srcAudioBuffer);
+          onLoad(this);
+        });
+      }
+    });
+    #end
+  }
+
+  #if web
+  private function processFading(buffer:JSAudioBuffer):Void
+  {
+    inline function processChannel(arr:Float32Array)
+    {
+      var n = Std.int(FADE_IN_DURATION * buffer.sampleRate);
+      var step = 0;
+      for (i in 0...n)
+      {
+        arr[i] = arr[i] * FADE_IN_EASE_FUNCTION(step / n);
+        step++;
+      }
+
+      step = n = Std.int(FADE_OUT_DURATION * buffer.sampleRate);
+      for (i in (arr.length - n)...arr.length)
+      {
+        arr[i] = arr[i] * FADE_OUT_EASE_FUNCTION(step / n);
+        step--;
+      }
+    }
+
+    processChannel(buffer.getChannelData(0));
+    processChannel(buffer.getChannelData(1));
+  }
+  #end
+
+  override function destroy():Void
+  {
+    #if native
+    if (audioBufferProcess != null)
+    {
+      audioBufferProcess.dispose();
+      audioBufferProcess = null;
+    }
+    #end
+    buffer = null;
+  }
+}
+
+#if native
+@:access(lime.utils.ArrayBufferView)
+private class PreviewMusicDecoder extends AudioDecoder
+{
+  public var parent:PreviewMusicData;
+  public var decoder(default, null):AudioDecoder;
+
+  var bytePerSample:Int;
+  var startSamples:Int64;
+  var endSamples:Int64;
+  var totalSamples:Int64;
+  var fadeStartSamples:Int64;
+  var fadeEndSamples:Int64;
+  var fadeEndStartSampleOffset:Int64;
+  var fadeEndEndSampleOffset:Int64;
+  var bufferView:ArrayBufferView;
+  var bufferInt8View:Int8Array;
+  var bufferInt16View:Int16Array;
+  var bufferInt32View:Int32Array;
+  var mutex:Mutex;
+
+  public function new(parent:PreviewMusicData)
+  {
+    super();
+    this.parent = parent;
+    mutex = new Mutex();
+  }
+
+  public function resetDecoder(decoder:AudioDecoder, startTime:Float, endTime:Float):Void
+  {
+    mutex.acquire();
+
+    var oldDecoder = this.decoder;
+    if (oldDecoder != null) oldDecoder.dispose();
+    
+    this.decoder = decoder;
+    if (decoder != null)
+    {
+      bitsPerSample = decoder.bitsPerSample;
+      channels = decoder.channels;
+      sampleRate = decoder.sampleRate;
+
+      startSamples = Int64.fromFloat(startTime / 1000 * sampleRate);
+      endSamples = Int64.fromFloat(endTime / 1000 * sampleRate);
+      totalSamples = Int64.fromFloat((endTime - startTime) / 1000 * sampleRate);
+
+      var realTotal = decoder.total();
+      if (realTotal < totalSamples) totalSamples = realTotal;
+
+      bytePerSample = bitsPerSample >> 3;
+      fadeStartSamples = Int64.fromFloat(PreviewMusicData.FADE_IN_DURATION * sampleRate);
+      fadeEndEndSampleOffset = endSamples - startSamples;
+      fadeEndSamples = Int64.fromFloat(PreviewMusicData.FADE_OUT_DURATION * sampleRate);
+      fadeEndStartSampleOffset = fadeEndEndSampleOffset - fadeEndSamples;
+
+      // 24 bitsPerSample are incompatible, nor it should be in openal too.
+      if (bytePerSample == 1) bufferView = bufferInt8View = new Int8Array(0);
+      else if (bytePerSample == 2) bufferView = bufferInt16View = new Int16Array(0);
+      else if (bytePerSample == 4) bufferView = bufferInt32View = new Int32Array(0);
+
+      rewind();
+    }
+
+    mutex.release();
+  }
+
+  override function clone():PreviewMusicDecoder
+  {
+    return null;
+  }
+
+  override function dispose():Void
+  {
+    super.dispose();
+  }
+
+  override function decode(buffer:ArrayBuffer, pos:Int, len:Int):Int
+  {
+    if (decoder == null) return 0;
+
+    mutex.acquire();
+
+    var currentSampleOffset = decoder.tell() - startSamples;
+    var remainingBytes = (endSamples - currentSampleOffset) * channels * bytePerSample;
+
+    var result:Int;
+    if (remainingBytes < len)
+    {
+      result = decoder.decode(buffer, pos, Int64.toInt(remainingBytes));
+      eof = true;
+    }
+    else
+    {
+      result = decoder.decode(buffer, pos, len);
+      eof = decoder.eof;
+    }
+
+    if (bytePerSample == 3)
+    {
+      mutex.release();
+      return result;
+    }
+
+    // Fading processing
+    if (bufferView.buffer != buffer) bufferView.initBuffer(buffer);
+
+    pos = Std.int(pos / bytePerSample);
+    len = pos + Std.int(result / bytePerSample);
+    var channel = 0, b:Int;
+    while (pos < len)
+    {
+      if (currentSampleOffset < fadeStartSamples)
+      {
+        switch (bytePerSample)
+        {
+          case 1:
+            bufferInt8View[pos] = Std.int(bufferInt8View[pos] *
+              PreviewMusicData.FADE_IN_EASE_FUNCTION(currentSampleOffset.low / fadeStartSamples.low).clamp(0, 1));
+          case 2:
+            bufferInt16View[pos] = Std.int(bufferInt16View[pos] *
+              PreviewMusicData.FADE_IN_EASE_FUNCTION(currentSampleOffset.low / fadeStartSamples.low).clamp(0, 1));
+          case 4:
+            bufferInt32View[pos] = Std.int(bufferInt32View[pos] *
+              PreviewMusicData.FADE_IN_EASE_FUNCTION(currentSampleOffset.low / fadeStartSamples.low).clamp(0, 1));
+          default:
+        }
+      }
+      else if (currentSampleOffset > fadeEndStartSampleOffset)
+      {
+        switch (bytePerSample)
+        {
+          case 1:
+            bufferInt8View[pos] = Std.int(bufferInt8View[pos] *
+              PreviewMusicData.FADE_OUT_EASE_FUNCTION((fadeEndEndSampleOffset - currentSampleOffset).low / fadeEndSamples.low).clamp(0, 1));
+          case 2:
+            bufferInt16View[pos] = Std.int(bufferInt16View[pos] *
+              PreviewMusicData.FADE_OUT_EASE_FUNCTION((fadeEndEndSampleOffset - currentSampleOffset).low / fadeEndSamples.low).clamp(0, 1));
+          case 4:
+            bufferInt32View[pos] = Std.int(bufferInt32View[pos] *
+              PreviewMusicData.FADE_OUT_EASE_FUNCTION((fadeEndEndSampleOffset - currentSampleOffset).low / fadeEndSamples.low).clamp(0, 1));
+          default:
+        }
+      }
+
+      if (++channel == channels)
+      {
+        channel = 0;
+        currentSampleOffset++;
+      }
+      pos++;
+    }
+
+    mutex.release();
+
+    return result;
+  }
+
+  override function rewind():Bool
+  {
+    var result = startSamples == 0 ? decoder.rewind() : decoder.seek(startSamples);
+    eof = decoder.eof;
+
+    return result;
+  }
+
+  override function seek(samples:Int64):Bool
+  {
+    var result = decoder.seek(samples + startSamples);
+    eof = decoder.eof;
+
+    return result;
+  }
+
+  override function seekable():Bool
+  {
+    return true;
+  }
+
+  override function tell():Int64
+  {
+    return decoder.tell() - startSamples;
+  }
+
+  override function total():Int64
+  {
+    return totalSamples;
+  }
+}
+#end

--- a/source/funkin/audio/SoundGroup.hx
+++ b/source/funkin/audio/SoundGroup.hx
@@ -1,12 +1,14 @@
 package funkin.audio;
 
 import flixel.group.FlxGroup.FlxTypedGroup;
+import flixel.sound.FlxSound;
 import flixel.tweens.FlxTween;
 
 /**
  * A group of FunkinSounds that are all synced together.
  * Unlike FlxSoundGroup, you can also control their time and pitch.
  */
+@:access(funkin.audio.FunkinSound)
 @:nullSafety
 class SoundGroup extends FlxTypedGroup<FunkinSound>
 {
@@ -60,10 +62,10 @@ class SoundGroup extends FlxTypedGroup<FunkinSound>
 
     forEachAlive(function(snd)
     {
-      if (targetTime == null) targetTime = snd.time;
+      if (targetTime == null) targetTime = snd.getActualTime();
       else
       {
-        var diff:Float = snd.time - targetTime;
+        var diff:Float = snd.getActualTime() - targetTime;
         if (Math.abs(diff) > Math.abs(error)) error = diff;
       }
     });
@@ -107,10 +109,7 @@ class SoundGroup extends FlxTypedGroup<FunkinSound>
    */
   public function pause()
   {
-    forEachAlive(function(sound:FunkinSound)
-    {
-      sound.pause();
-    });
+    if (members != null) FlxSound.pauseSounds(cast members);
   }
 
   /**
@@ -118,15 +117,20 @@ class SoundGroup extends FlxTypedGroup<FunkinSound>
    */
   public function play(forceRestart:Bool = false, startTime:Float = 0.0, ?endTime:Float)
   {
+    var sounds:Array<FlxSound> = [];
+
     forEachAlive(function(sound:FunkinSound)
     {
-      if (sound.length < startTime)
+      if (sound.playing && !forceRestart || sound.length < startTime)
       {
-        // trace('Queuing sound (${sound.toString()} past its length! Skipping...)');
         return;
       }
-      sound.play(forceRestart, startTime, endTime);
+
+      sound.prepare(startTime, endTime);
+      sounds.push(sound);
     });
+
+    FlxSound.playSounds(sounds);
   }
 
   /**
@@ -134,10 +138,20 @@ class SoundGroup extends FlxTypedGroup<FunkinSound>
    */
   public function resume()
   {
+    var sounds:Array<FlxSound> = [];
+
     forEachAlive(function(sound:FunkinSound)
     {
-      sound.resume();
+      if (sound.playing || !sound._paused)
+      {
+        return;
+      }
+
+      sound.prepare(sound.time);
+      sounds.push(sound);
     });
+
+    FlxSound.playSounds(sounds);
   }
 
   /**
@@ -169,13 +183,7 @@ class SoundGroup extends FlxTypedGroup<FunkinSound>
    */
   public function stop():Void
   {
-    if (members != null)
-    {
-      forEachAlive(function(sound:FunkinSound)
-      {
-        sound.stop();
-      });
-    }
+    if (members != null) FlxSound.stopSounds(cast members);
   }
 
   public override function destroy():Void
@@ -194,6 +202,7 @@ class SoundGroup extends FlxTypedGroup<FunkinSound>
     super.clear();
   }
 
+  @:nullSafety(Off)
   function get_time():Float
   {
     if (getFirstAlive() != null)
@@ -208,15 +217,27 @@ class SoundGroup extends FlxTypedGroup<FunkinSound>
 
   function set_time(time:Float):Float
   {
-    forEachAlive(function(snd:FunkinSound)
+    // account for different offsets per sound?
+
+    var sounds:Array<FlxSound> = [];
+
+    forEachAlive(function(sound:FunkinSound)
     {
-      // account for different offsets per sound?
-      snd.time = time;
+      if (!sound.loaded || sound.length < time || !sound.playing)
+      {
+        return;
+      }
+
+      sound.prepare(time);
+      sounds.push(sound);
     });
+
+    FlxSound.playSounds(sounds);
 
     return time;
   }
 
+  @:nullSafety(Off)
   function get_playing():Bool
   {
     if (getFirstAlive() != null)
@@ -229,6 +250,7 @@ class SoundGroup extends FlxTypedGroup<FunkinSound>
     }
   }
 
+  @:nullSafety(Off)
   function get_volume():Float
   {
     if (getFirstAlive() != null)
@@ -252,11 +274,17 @@ class SoundGroup extends FlxTypedGroup<FunkinSound>
     return volume;
   }
 
+  @:nullSafety(Off)
   function get_muted():Bool
   {
-    if (getFirstAlive() != null) return getFirstAlive()?.muted ?? false;
+    if (getFirstAlive() != null)
+    {
+      return getFirstAlive().muted;
+    }
     else
+    {
       return false;
+    }
   }
 
   function set_muted(muted:Bool):Bool
@@ -269,6 +297,7 @@ class SoundGroup extends FlxTypedGroup<FunkinSound>
     return muted;
   }
 
+  @:nullSafety(Off)
   function get_pitch():Float
   {
     #if FLX_PITCH

--- a/source/funkin/audio/VoicesGroup.hx
+++ b/source/funkin/audio/VoicesGroup.hx
@@ -1,8 +1,10 @@
 package funkin.audio;
 
 import flixel.group.FlxGroup.FlxTypedGroup;
+import flixel.sound.FlxSound;
 import funkin.audio.waveform.WaveformData;
 
+@:access(funkin.audio.FunkinSound)
 @:nullSafety
 class VoicesGroup extends SoundGroup
 {
@@ -61,22 +63,48 @@ class VoicesGroup extends SoundGroup
     return playerVolume = volume;
   }
 
-  override function set_time(time:Float):Float
+  override function play(forceRestart:Bool = false, startTime:Float = 0.0, ?endTime:Float)
   {
-    forEachAlive(function(snd)
-    {
-      // account for different offsets per sound?
-      snd.time = time;
+    var sounds:Array<FlxSound> = [];
+
+    forEachAlive(function(sound:FunkinSound) {
+      var localTime = startTime;
+
+      if (playerVoices?.members.contains(sound) ?? false) localTime -= playerVoicesOffset;
+      else if (opponentVoices?.members.contains(sound) ?? false) localTime -= opponentVoicesOffset;
+
+      if (sound.playing && !forceRestart || sound.length < localTime)
+      {
+        return;
+      }
+
+      sound.prepare(localTime, endTime);
+      sounds.push(sound);
     });
 
-    playerVoices?.forEachAlive(function(voice:FunkinSound)
+    FlxSound.playSounds(sounds);
+  }
+
+  override function set_time(time:Float):Float
+  {
+    // account for different offsets per sound?
+
+    var sounds:Array<FlxSound> = [];
+
+    forEachAlive(function(sound:FunkinSound)
     {
-      voice.time -= playerVoicesOffset;
+      var localTime = time;
+
+      if (playerVoices?.members.contains(sound) ?? false) localTime -= playerVoicesOffset;
+      else if (opponentVoices?.members.contains(sound) ?? false) localTime -= opponentVoicesOffset;
+
+      if (!sound.loaded || sound.length < localTime || !sound.playing) return;
+
+      sound.prepare(localTime);
+      sounds.push(sound);
     });
-    opponentVoices?.forEachAlive(function(voice:FunkinSound)
-    {
-      voice.time -= opponentVoicesOffset;
-    });
+
+    FlxSound.playSounds(sounds);
 
     return time;
   }
@@ -85,8 +113,7 @@ class VoicesGroup extends SoundGroup
   {
     playerVoices?.forEachAlive(function(voice:FunkinSound)
     {
-      voice.time += playerVoicesOffset;
-      voice.time -= offset;
+      voice.time += playerVoicesOffset - offset;
     });
     return playerVoicesOffset = offset;
   }
@@ -95,8 +122,7 @@ class VoicesGroup extends SoundGroup
   {
     opponentVoices?.forEachAlive(function(voice:FunkinSound)
     {
-      voice.time += opponentVoicesOffset;
-      voice.time -= offset;
+      voice.time += opponentVoicesOffset - offset;
     });
     return opponentVoicesOffset = offset;
   }

--- a/source/funkin/audio/visualize/ABotVis.hx
+++ b/source/funkin/audio/visualize/ABotVis.hx
@@ -89,9 +89,6 @@ class ABotVis extends FlxTypedSpriteGroup<FlxSprite>
     analyzer = null;
   }
 
-  var visTimer:Float = -1;
-  var visTimeMax:Float = 1 / 30;
-
   override function update(elapsed:Float)
   {
     super.update(elapsed);

--- a/source/funkin/audio/visualize/ABotVis.hx
+++ b/source/funkin/audio/visualize/ABotVis.hx
@@ -65,7 +65,7 @@ class ABotVis extends FlxTypedSpriteGroup<FlxSprite>
     if (snd == null) return;
 
     @:privateAccess
-    analyzer = new SpectralAnalyzer(snd._channel.__audioSource, BAR_COUNT, 0.1, 40);
+    analyzer = new SpectralAnalyzer(snd.source, BAR_COUNT, 0.1, 40);
     // A-Bot tuning...
     analyzer.minDb = -65;
     analyzer.maxDb = -25;

--- a/source/funkin/audio/visualize/VisShit.hx
+++ b/source/funkin/audio/visualize/VisShit.hx
@@ -115,8 +115,7 @@ class VisShit
       if (!setBuffer)
       {
         // Math.pow3
-        @:privateAccess
-        var buf = snd._channel.__audioSource.buffer;
+        var buf = snd.data.buffer;
 
         // @:privateAccess
         audioData = cast buf.data; // jank and hacky lol! kinda busted on HTML5 also!!

--- a/source/funkin/audio/waveform/WaveformData.hx
+++ b/source/funkin/audio/waveform/WaveformData.hx
@@ -195,6 +195,8 @@ class WaveformData
       var thatChannel = that.channel(channelIndex);
       var resultChannel = result.channel(channelIndex);
 
+      if (thatChannel == null) return this.clone();
+
       for (index in 0...this.length)
       {
         var thisMinSample = thisChannel.minSample(index);

--- a/source/funkin/audio/waveform/WaveformDataParser.hx
+++ b/source/funkin/audio/waveform/WaveformDataParser.hx
@@ -17,30 +17,8 @@ class WaveformDataParser
   {
     if (sound == null) return null;
 
-    // Method 1. This only works if the sound has been played before.
-    @:privateAccess
-    var soundBuffer:Null<lime.media.AudioBuffer> = sound?._channel?.__audioSource?.buffer;
-
-    if (soundBuffer == null)
-    {
-      // Method 2. This works if the sound has not been played before.
-      @:privateAccess
-      soundBuffer = sound?._sound?.__buffer;
-
-      if (soundBuffer == null)
-      {
-        trace('[WAVEFORM] Failed to interpret FlxSound: ${sound}');
-        return null;
-      }
-      else
-      {
-        // trace('[WAVEFORM] Method 2 worked.');
-      }
-    }
-    else
-    {
-      // trace('[WAVEFORM] Method 1 worked.');
-    }
+    var soundBuffer:Null<lime.media.AudioBuffer> = sound?.data.buffer;
+    if (soundBuffer == null) return null;
 
     return interpretAudioBuffer(soundBuffer);
   }

--- a/source/funkin/data/character/CharacterData.hx
+++ b/source/funkin/data/character/CharacterData.hx
@@ -460,6 +460,7 @@ class CharacterDataParser
   public static final DEFAULT_NAME:String = 'Untitled Character';
   public static final DEFAULT_OFFSETS:Array<Float> = [0, 0];
   public static final DEFAULT_HEALTHICON_OFFSETS:Array<Int> = [0, 25];
+  public static final DEFAULT_SHOULDBOP:Bool = true;
   public static final DEFAULT_RENDERTYPE:CharacterRenderType = CharacterRenderType.Sparrow;
   public static final DEFAULT_SCALE:Float = 1;
   public static final DEFAULT_SCROLL:Array<Float> = [0, 0];
@@ -532,6 +533,7 @@ class CharacterDataParser
     {
       input.healthIcon = {
         id: null,
+        shouldBop: null,
         scale: null,
         flipX: null,
         isPixel: null,
@@ -542,6 +544,11 @@ class CharacterDataParser
     if (input.healthIcon.id == null)
     {
       input.healthIcon.id = id;
+    }
+
+    if (input.healthIcon.shouldBop == null)
+    {
+      input.healthIcon.shouldBop = DEFAULT_SHOULDBOP;
     }
 
     if (input.healthIcon.scale == null)
@@ -832,6 +839,12 @@ typedef HealthIconData =
    * @default The character's ID
    */
   var id:Null<String>;
+
+  /**
+   * Whether the health icon should bop or not.
+   * @default true
+   */
+  var shouldBop:Null<Bool>;
 
   /**
    * The scale of the health icon.

--- a/source/funkin/data/freeplay/player/PlayerData.hx
+++ b/source/funkin/data/freeplay/player/PlayerData.hx
@@ -150,6 +150,10 @@ class PlayerFreeplayDJData
   @:default([0, 0])
   var offsets:Array<Float>;
 
+  @:optional
+  @:default(funkin.util.Constants.DEFAULT_RANDOM_CAPSULE_MUSIC)
+  public var randomCapsuleMusic:String;
+
   public function new()
   {
     animationMap = new Map();

--- a/source/funkin/data/song/SongRegistry.hx
+++ b/source/funkin/data/song/SongRegistry.hx
@@ -491,13 +491,6 @@ using funkin.data.song.migrator.SongDataMigrator;
     return {fileName: entryFilePath, contents: rawJson};
   }
 
-  function hasMusicDataFile(id:String, ?variation:String):Bool
-  {
-    variation = variation == null ? Constants.DEFAULT_VARIATION : variation;
-    var entryFilePath:String = Paths.file('music/$id/$id-metadata${variation == Constants.DEFAULT_VARIATION ? '' : '-$variation'}.json');
-    return openfl.Assets.exists(entryFilePath);
-  }
-
   function loadEntryChartFile(id:String, ?variation:String):Null<JsonFile>
   {
     variation = variation == null ? Constants.DEFAULT_VARIATION : variation;

--- a/source/funkin/data/song/importer/ChartManifestData.hx
+++ b/source/funkin/data/song/importer/ChartManifestData.hx
@@ -1,5 +1,7 @@
 package funkin.data.song.importer;
 
+import haxe.io.Path;
+
 /**
  * A helper JSON blob found in `.fnfc` files.
  */
@@ -47,18 +49,32 @@ class ChartManifestData
     return '$songId-chart${variation == Constants.DEFAULT_VARIATION ? '' : '-$variation'}.${Constants.EXT_DATA}';
   }
 
-  public function getInstFileName(?variation:String):String
+  public function getInstFileName(?variation:String, fileEntries:Array<haxe.zip.Entry>):String
   {
     if (variation == null || variation == '') variation = Constants.DEFAULT_VARIATION;
 
-    return 'Inst${variation == Constants.DEFAULT_VARIATION ? '' : '-$variation'}.${Constants.EXT_SOUND}';
+    var instFile = fileEntries.filter(function(file:haxe.zip.Entry):Bool
+    {
+      return Path.withoutExtension(file.fileName) == 'Inst${variation == Constants.DEFAULT_VARIATION ? '' : '-$variation'}';
+    });
+
+    if (instFile[0] == null) return 'Inst${variation == Constants.DEFAULT_VARIATION ? '' : '-$variation'}.${Constants.EXT_SOUND}';
+    else
+      return instFile[0].fileName;
   }
 
-  public function getVocalsFileName(charId:String, ?variation:String):String
+  public function getVocalsFileName(charId:String, ?variation:String, fileEntries:Array<haxe.zip.Entry>):String
   {
     if (variation == null || variation == '') variation = Constants.DEFAULT_VARIATION;
 
-    return 'Voices-$charId${variation == Constants.DEFAULT_VARIATION ? '' : '-$variation'}.${Constants.EXT_SOUND}';
+    var vocalFile = fileEntries.filter(function(file:haxe.zip.Entry):Bool
+    {
+      return Path.withoutExtension(file.fileName) == 'Voices-$charId${variation == Constants.DEFAULT_VARIATION ? '' : '-$variation'}';
+    });
+
+    if (vocalFile[0] == null) return 'Voices-$charId${variation == Constants.DEFAULT_VARIATION ? '' : '-$variation'}.${Constants.EXT_SOUND}';
+    else
+      return vocalFile[0].fileName;
   }
 
   /**

--- a/source/funkin/group/FunkinGroup.hx
+++ b/source/funkin/group/FunkinGroup.hx
@@ -20,7 +20,7 @@ class FunkinGroup<T:FlxSprite> extends FlxSprite
   /**
    * The children of this FunkinGroup.
    */
-  public var children:Null<Array<T>>;
+  public var children:Array<T>;
 
   /**
    * The size of this FunkinGroup. Read only.

--- a/source/funkin/group/FunkinGroup.hx
+++ b/source/funkin/group/FunkinGroup.hx
@@ -20,7 +20,7 @@ class FunkinGroup<T:FlxSprite> extends FlxSprite
   /**
    * The children of this FunkinGroup.
    */
-  public var children:Array<T>;
+  public var children:Null<Array<T>>;
 
   /**
    * The size of this FunkinGroup. Read only.

--- a/source/funkin/input/Controls.hx
+++ b/source/funkin/input/Controls.hx
@@ -448,11 +448,6 @@ class Controls extends FlxActionSet
     }
   }
 
-  static function init():Void
-  {
-    FlxG.inputs.addUniqueType(new FlxActionManager());
-  }
-
   /**
    * Calls a function passing each action bound by the specified control
    * @param control

--- a/source/funkin/modding/IScriptedClass.hx
+++ b/source/funkin/modding/IScriptedClass.hx
@@ -248,3 +248,24 @@ interface IDialogueScriptedClass extends IScriptedClass
   public function onDialogueSkip(event:DialogueScriptEvent):Void;
   public function onDialogueEnd(event:DialogueScriptEvent):Void;
 }
+
+/**
+ * Defines a set of callbacks activated in a Game Over screen.
+ */
+interface IGameOverScriptedClass extends IScriptedClass
+{
+  /**
+   * Called when the game has entered to game over screen.
+   */
+  public function onGameOverStart(event:ScriptEvent):Void;
+
+  /**
+   * Called when the game is continuing to gameplay from game over screen.
+   */
+  public function onGameOverConfirm(event:ScriptEvent):Void;
+
+  /**
+   * Called when the game is about to start the game over music.
+   */
+  public function onGameOverMusicStart(event:ScriptEvent):Void;
+}

--- a/source/funkin/modding/PolymodHandler.hx
+++ b/source/funkin/modding/PolymodHandler.hx
@@ -496,6 +496,9 @@ class PolymodHandler
     Polymod.blacklistImport('funkin.external.android.CallbackUtil');
     Polymod.blacklistImport('funkin.external.android.DataFolderUtil');
     Polymod.blacklistImport('funkin.external.android.JNIUtil');
+
+    // Blacklists accessing the interp for polymod hscript
+    Polymod.blacklistInstanceFields(polymod.hscript._internal.PolymodScriptClass.PolymodScriptClass, ['_interp']);
   }
 
   /**

--- a/source/funkin/modding/events/ScriptEventDispatcher.hx
+++ b/source/funkin/modding/events/ScriptEventDispatcher.hx
@@ -288,6 +288,33 @@ class ScriptEventDispatcher
       if ([ScriptEventType.CHARACTER_SELECTED, ScriptEventType.CHARACTER_DESELECTED, ScriptEventType.CHARACTER_CONFIRMED].contains(event.type)) return;
     }
 
+    if (Std.isOfType(target, IGameOverScriptedClass))
+    {
+      var t:IGameOverScriptedClass = cast target;
+      switch (event.type)
+      {
+        case GAME_OVER_START:
+          t.onGameOverStart(cast event);
+          return;
+        case GAME_OVER_CONFIRM:
+          t.onGameOverConfirm(cast event);
+          return;
+        case GAME_OVER_MUSIC_START:
+          t.onGameOverMusicStart(cast event);
+          return;
+        default: // Continue;
+      }
+    }
+    else
+    {
+      // If the target doesn't support the event, stop trying to dispatch.
+      if ([
+        ScriptEventType.GAME_OVER_START,
+        ScriptEventType.GAME_OVER_CONFIRM,
+        ScriptEventType.GAME_OVER_MUSIC_START
+      ].contains(event.type)) return;
+    }
+
     // If we reach this line, it means a script event was dispatched while not being properly handled.
     // Throw an error so we know to add additional fallbacks.
     throw 'No corresponding function called for dispatched event type: ${event.type}';

--- a/source/funkin/modding/events/ScriptEventType.hx
+++ b/source/funkin/modding/events/ScriptEventType.hx
@@ -355,6 +355,27 @@ enum abstract ScriptEventType(String) from String to String
   var DIALOGUE_END = 'DIALOGUE_END';
 
   /**
+   * Called when the game has entered to game over screen.
+   * 
+   * This event is not cancelable.
+   */
+  var GAME_OVER_START = 'GAME_OVER_START';
+
+  /**
+   * Called when the game is continuing to gameplay from game over screen.
+   * 
+   * This event IS cancelable! Canceling this event will prevent continuing to play from the game over screen.
+   */
+  var GAME_OVER_CONFIRM = 'GAME_OVER_CONFIRM';
+
+  /**
+   * Called when the game is about to start the game over music.
+   * 
+   * This event IS cancelable! Canceling this event will prevent playing the game over music.
+   */
+  var GAME_OVER_MUSIC_START = 'GAME_OVER_MUSIC_START';
+
+  /**
    * Allow for comparing `ScriptEventType` to `String`.
    */
   @:op(A == B) private static inline function equals(a:ScriptEventType, b:String):Bool

--- a/source/funkin/play/Countdown.hx
+++ b/source/funkin/play/Countdown.hx
@@ -33,8 +33,6 @@ class Countdown
 
   static var noteStyle:NoteStyle;
 
-  static var fallbackNoteStyle:Null<NoteStyle>;
-
   /**
    * The currently running countdown. This will be null if there is no countdown running.
    */

--- a/source/funkin/play/Countdown.hx
+++ b/source/funkin/play/Countdown.hx
@@ -254,7 +254,7 @@ class Countdown
     var path = noteStyle.getCountdownSoundPath(step);
     if (path == null) return null;
 
-    return FunkinSound.playOnce(path, Constants.COUNTDOWN_VOLUME, null, null, true);
+    return FunkinSound.playOnce(path, Constants.COUNTDOWN_VOLUME, null, null);
   }
 
   public static function decrement(step:CountdownStep):CountdownStep

--- a/source/funkin/play/GameOverSubState.hx
+++ b/source/funkin/play/GameOverSubState.hx
@@ -144,6 +144,8 @@ class GameOverSubState extends MusicBeatSubState
 
     parentPlayState = cast _parentState;
 
+    gameOverMusic = FunkinSound.load(null);
+
     //
     // Set up the visuals
     //
@@ -194,6 +196,9 @@ class GameOverSubState extends MusicBeatSubState
     {
       canInput = true;
     });
+
+    var event:ScriptEvent = new ScriptEvent(GAME_OVER_START, false);
+    dispatchEvent(event);
   }
 
   function setCameraTarget():Void
@@ -359,6 +364,11 @@ class GameOverSubState extends MusicBeatSubState
   {
     if (!isEnding)
     {
+      var event:ScriptEvent = new ScriptEvent(GAME_OVER_CONFIRM, true);
+      dispatchEvent(event);
+
+      if (event.eventCanceled) return;
+
       isEnding = true;
 
       // Stop death quotes immediately.
@@ -464,6 +474,11 @@ class GameOverSubState extends MusicBeatSubState
   {
     super.dispatchEvent(event);
 
+    if (parentPlayState != null)
+    {
+      ScriptEventDispatcher.callEvent(parentPlayState.currentSong, event);
+    }
+
     ScriptEventDispatcher.callEvent(boyfriend, event);
   }
 
@@ -495,6 +510,11 @@ class GameOverSubState extends MusicBeatSubState
    */
   public function startDeathMusic(startingVolume:Float = 1, force:Bool = false):Void
   {
+    var event:ScriptEvent = new ScriptEvent(GAME_OVER_MUSIC_START, true);
+    dispatchEvent(event);
+
+    if (event.eventCanceled) return;
+
     var musicPath:Null<String> = resolveMusicPath(musicSuffix, isStarting, isEnding);
     var onComplete:Void->Void = () -> {};
 
@@ -524,10 +544,11 @@ class GameOverSubState extends MusicBeatSubState
     }
     else if (gameOverMusic == null || !gameOverMusic.playing || force)
     {
-      if (gameOverMusic != null) gameOverMusic.stop();
-
-      gameOverMusic = FunkinSound.load(musicPath);
-      if (gameOverMusic == null) return;
+      if (gameOverMusic == null) gameOverMusic = FunkinSound.load(musicPath);
+      {
+        gameOverMusic.stop();
+        gameOverMusic.loadEmbedded(musicPath);
+      }
 
       gameOverMusic.volume = startingVolume;
       gameOverMusic.looped = !(isEnding || isStarting);
@@ -537,7 +558,7 @@ class GameOverSubState extends MusicBeatSubState
     else
     {
       @:privateAccess
-      trace('Music already playing! ${gameOverMusic?._label}');
+      trace('Music already playing! ${gameOverMusic?.data?.key}');
     }
   }
 

--- a/source/funkin/play/PauseSubState.hx
+++ b/source/funkin/play/PauseSubState.hx
@@ -803,7 +803,6 @@ class PauseSubState extends MusicBeatSubState
     // If targetMode is null, keep the current mode.
     if (targetMode == null) targetMode = this.currentMode;
 
-    var previousMode:PauseMode = this.currentMode;
     this.currentMode = targetMode;
 
     resetSelection();

--- a/source/funkin/play/PauseSubState.hx
+++ b/source/funkin/play/PauseSubState.hx
@@ -905,7 +905,7 @@ class PauseSubState extends MusicBeatSubState
         var text:AtlasText = new AtlasText(0, yPos, entry.text, AtlasFont.BOLD);
         text.scrollFactor.set(0, 0);
         text.alpha = 0;
-        for (letter in text.children)
+        for (letter in text)
         {
           letter.width *= 2;
           letter.height *= 2;

--- a/source/funkin/play/PauseSubState.hx
+++ b/source/funkin/play/PauseSubState.hx
@@ -906,7 +906,7 @@ class PauseSubState extends MusicBeatSubState
         var text:AtlasText = new AtlasText(0, yPos, entry.text, AtlasFont.BOLD);
         text.scrollFactor.set(0, 0);
         text.alpha = 0;
-        for (letter in text)
+        for (letter in text.children)
         {
           letter.width *= 2;
           letter.height *= 2;

--- a/source/funkin/play/PauseSubState.hx
+++ b/source/funkin/play/PauseSubState.hx
@@ -359,7 +359,7 @@ class PauseSubState extends MusicBeatSubState
     }
 
     // Start playing at a random point in the song.
-    pauseMusic.play(false, FlxG.random.int(0, Std.int(pauseMusic.length / 2)));
+    pauseMusic.play(true, FlxG.random.float(0, pauseMusic.length / 2));
     pauseMusic.fadeIn(MUSIC_FADE_IN_TIME, 0, MUSIC_FINAL_VOLUME);
   }
 

--- a/source/funkin/play/PlayState.hx
+++ b/source/funkin/play/PlayState.hx
@@ -3152,7 +3152,7 @@ class PlayState extends MusicBeatSubState
 
     if (playSound)
     {
-      if (vocals != null) vocals.playerVolume = 0;
+      if (vocals != null && currentStage != null && currentStage.getBoyfriend() != null && !currentStage.getBoyfriend().tempVocals) vocals.playerVolume = 0;
       FunkinSound.playOnce(Paths.soundRandom('missnote', 1, 3), FlxG.random.float(0.5, 0.6));
     }
   }
@@ -3193,7 +3193,7 @@ class PlayState extends MusicBeatSubState
 
     if (event.playSound)
     {
-      if (vocals != null) vocals.playerVolume = 0;
+      if (vocals != null && currentStage != null && currentStage.getBoyfriend() != null && !currentStage.getBoyfriend().tempVocals) vocals.playerVolume = 0;
       FunkinSound.playOnce(Paths.soundRandom('missnote', 1, 3), FlxG.random.float(0.1, 0.2));
     }
   }

--- a/source/funkin/play/PlayState.hx
+++ b/source/funkin/play/PlayState.hx
@@ -3152,7 +3152,8 @@ class PlayState extends MusicBeatSubState
 
     if (playSound)
     {
-      if (vocals != null && currentStage != null && currentStage.getBoyfriend() != null && !currentStage.getBoyfriend().tempVocals) vocals.playerVolume = 0;
+      var tempVocals:Bool = currentStage != null && currentStage.getBoyfriend().tempVocals;
+      if (vocals != null && !tempVocals) vocals.playerVolume = 0;
       FunkinSound.playOnce(Paths.soundRandom('missnote', 1, 3), FlxG.random.float(0.5, 0.6));
     }
   }
@@ -3193,7 +3194,8 @@ class PlayState extends MusicBeatSubState
 
     if (event.playSound)
     {
-      if (vocals != null && currentStage != null && currentStage.getBoyfriend() != null && !currentStage.getBoyfriend().tempVocals) vocals.playerVolume = 0;
+      var tempVocals:Bool = currentStage != null && currentStage.getBoyfriend().tempVocals;
+      if (vocals != null && !tempVocals) vocals.playerVolume = 0;
       FunkinSound.playOnce(Paths.soundRandom('missnote', 1, 3), FlxG.random.float(0.1, 0.2));
     }
   }

--- a/source/funkin/play/PlayState.hx
+++ b/source/funkin/play/PlayState.hx
@@ -1166,30 +1166,11 @@ class PlayState extends MusicBeatSubState
         Conductor.instance.formatOffset = 0.0;
       }
 
-      // Lime has some precision loss when getting the sound current position
-      // Since the notes scrolling is dependant on the sound time that caused it to appear "stuttery" for some people
-      // As a workaround for that, we lerp the conductor position to the music time to fill the gap in this lost precision making the scrolling smoother
-      // The previous method where it "guessed" the song position based on the elapsed time had some flaws
-      // Somtimes the songPosition would exceed the music length causing issues in other places
-      // And it was frame dependant which we don't like!!
       if (FlxG.sound.music.playing)
       {
-        final audioDiff:Float = Math.round(Math.abs(FlxG.sound.music.time - (Conductor.instance.songPosition - Conductor.instance.combinedOffset)));
-        if (audioDiff <= CONDUCTOR_DRIFT_THRESHOLD)
-        {
-          // Only do neat & smooth lerps as long as the lerp doesn't fuck up and go WAY behind the music time triggering false resyncs
-          final easeRatio:Float = 1.0 - Math.exp(-(MUSIC_EASE_RATIO * playbackRate) * elapsed);
-          Conductor.instance.update(FlxMath.lerp(Conductor.instance.songPosition, FlxG.sound.music.time + Conductor.instance.combinedOffset, easeRatio), false);
-        }
-        else
-        {
-          // Fallback to properly update the conductor incase the lerp messed up
-          // Shouldn't be fallen back to unless you're lagging alot
-          trace(' WARNING '.bg_yellow().bold() + ' Normal Conductor Update!! are you lagging?');
           Conductor.instance.update();
         }
       }
-    }
 
     var pauseButtonCheck:Bool = false;
     var androidPause:Bool = false;
@@ -1553,6 +1534,7 @@ class PlayState extends MusicBeatSubState
           FlxG.sound.music.pause();
           musicPausedBySubState = true;
         }
+        vocals?.pause();
 
         // Pause any sounds that are playing and keep track of them.
         // Vocals are also paused here but are not included as they are handled separately.
@@ -1560,26 +1542,12 @@ class PlayState extends MusicBeatSubState
         {
           FlxG.sound.list.forEachAlive(function(sound:FlxSound)
           {
-            if (!sound.active || sound == FlxG.sound.music) return;
-            // In case it's a scheduled sound
-            if (Std.isOfType(sound, FunkinSound))
-            {
-              var funkinSound:FunkinSound = cast sound;
-              if (funkinSound != null && !funkinSound.isPlaying) return;
-            }
-            if (!sound.playing && sound.time >= 0) return;
-            sound.pause();
+            if (!sound.playing || !sound.active || sound == FlxG.sound.music) return;
             soundsPausedBySubState.add(sound);
           });
+          vocals?.forEach(function(voice:FunkinSound) soundsPausedBySubState.remove(voice));
 
-          vocals?.forEach(function(voice:FunkinSound)
-          {
-            soundsPausedBySubState.remove(voice);
-          });
-        }
-        else
-        {
-          vocals?.pause();
+          for (sound in soundsPausedBySubState) sound.pause();
         }
       }
 
@@ -1633,47 +1601,11 @@ class PlayState extends MusicBeatSubState
 
       if (event.eventCanceled) return;
 
-      // Pause any sounds that are playing and keep track of them.
-      // Vocals are also paused here but are not included as they are handled separately.
-      if (!isGameOverState)
-      {
-        FlxG.sound.list.forEachAlive(function(sound:FlxSound)
-        {
-          if (!sound.active || sound == FlxG.sound.music) return;
-          // In case it's a scheduled sound
-          if (Std.isOfType(sound, FunkinSound))
-          {
-            var funkinSound:FunkinSound = cast sound;
-            if (funkinSound != null && !funkinSound.isPlaying) return;
-          }
-          if (!sound.playing && sound.time >= 0) return;
-          sound.pause();
-          soundsPausedBySubState.add(sound);
-        });
-
-        vocals?.forEach(function(voice:FunkinSound)
-        {
-          soundsPausedBySubState.remove(voice);
-        });
-      }
-      else
-      {
-        vocals?.pause();
-      }
-
       // Resume vwooshTimer
       if (!vwooshTimer.finished) vwooshTimer.active = true;
 
-      // Resume music if we paused it.
-      if (musicPausedBySubState)
-      {
-        if (FlxG.sound.music != null) FlxG.sound.music.play();
-        musicPausedBySubState = false;
-      }
-
-      // The logic here is that if this sound doesn't auto-destroy
-      // then it's gonna be reused somewhere, so we just stop it instead.
-      forEachPausedSound(s -> needsReset ? (s.autoDestroy ? s.destroy() : s.stop()) : s.resume());
+      // Stopping a sound will kills itself anyway if s.autoDestroy is true.
+      forEachPausedSound(s -> needsReset ? s.stop() : s.resume());
 
       // Resume camera tweens if we paused any.
       for (camTween in cameraTweensPausedBySubState)
@@ -1693,8 +1625,10 @@ class PlayState extends MusicBeatSubState
         currentConversation.resumeMusic();
       }
 
-      // Re-sync vocals.
-      if (FlxG.sound.music != null && !startingSong && !isInCutscene) resyncVocals();
+      // If we have started the song, resync it instead that plays the song, else resume music if we paused it.
+      if (FlxG.sound.music != null && !startingSong && !isInCutscene) resyncVocals(true);
+      else if (musicPausedBySubState) FlxG.sound.music?.play();
+      musicPausedBySubState = false;
 
       // Resume the countdown.
       Countdown.resumeCountdown();
@@ -1885,7 +1819,7 @@ class PlayState extends MusicBeatSubState
 
     if (FlxG.sound.music != null)
     {
-      var correctSync:Float = Math.min(FlxG.sound.music.length, Math.max(0, Conductor.instance.songPosition - Conductor.instance.combinedOffset));
+      var correctSync:Float = FlxG.sound.music.getActualTime();
       var playerVoicesError:Float = 0;
       var opponentVoicesError:Float = 0;
       if (vocals != null && vocals.playing)
@@ -1895,22 +1829,22 @@ class PlayState extends MusicBeatSubState
         {
           vocals.playerVoices?.forEachAlive(function(voice:FunkinSound)
           {
-            var currentRawVoiceTime:Float = voice.time + vocals.playerVoicesOffset;
-            if (Math.abs(currentRawVoiceTime - correctSync) > Math.abs(playerVoicesError)) playerVoicesError = currentRawVoiceTime - correctSync;
+            var currentRawVoiceTime:Float = voice.getActualTime() + vocals.playerVoicesOffset + Conductor.instance.instrumentalOffset;
+            if (Math.abs(currentRawVoiceTime - correctSync) > Math.abs(playerVoicesError) && voice.playing) playerVoicesError = currentRawVoiceTime - correctSync;
           });
 
           vocals.opponentVoices?.forEachAlive(function(voice:FunkinSound)
           {
-            var currentRawVoiceTime:Float = voice.time + vocals.opponentVoicesOffset;
-            if (Math.abs(currentRawVoiceTime - correctSync) > Math.abs(opponentVoicesError)) opponentVoicesError = currentRawVoiceTime - correctSync;
+            var currentRawVoiceTime:Float = voice.getActualTime() + vocals.opponentVoicesOffset + Conductor.instance.instrumentalOffset;
+            if (Math.abs(currentRawVoiceTime - correctSync) > Math.abs(opponentVoicesError) && voice.playing) opponentVoicesError = currentRawVoiceTime - correctSync;
           });
         }
       }
 
       if (!startingSong
-        && (Math.abs(FlxG.sound.music.time - correctSync) > RESYNC_THRESHOLD
-          || Math.abs(playerVoicesError) > RESYNC_THRESHOLD
-          || Math.abs(opponentVoicesError) > RESYNC_THRESHOLD))
+        && (Math.abs(FlxG.sound.music.getActualTime() - correctSync) / FlxG.sound.music.pitch > RESYNC_THRESHOLD
+          || Math.abs(playerVoicesError) / FlxG.sound.music.pitch > RESYNC_THRESHOLD
+          || Math.abs(opponentVoicesError) / FlxG.sound.music.pitch > RESYNC_THRESHOLD))
       {
         trace("VOCALS NEED RESYNC");
         if (vocals != null)
@@ -1918,7 +1852,6 @@ class PlayState extends MusicBeatSubState
           trace(playerVoicesError);
           trace(opponentVoicesError);
         }
-        trace(FlxG.sound.music.time);
         trace(correctSync);
         resyncVocals();
       }
@@ -2595,7 +2528,7 @@ class PlayState extends MusicBeatSubState
 
     if (!overrideMusic && !isGamePaused && currentChart != null)
     {
-      currentChart?.playInst(1.0, currentInstrumental, false);
+      currentChart?.buildInst(1.0, currentInstrumental, false);
     }
 
     if (FlxG.sound.music == null)
@@ -2603,15 +2536,6 @@ class PlayState extends MusicBeatSubState
       FlxG.log.error('PlayState failed to initialize instrumental!');
       return;
     }
-
-    FlxG.sound.music.onComplete = function()
-    {
-      if (mayPauseGame) endSong(skipEndingTransition);
-    };
-
-    FlxG.sound.music.pause();
-    FlxG.sound.music.time = startTimestamp;
-    FlxG.sound.music.pitch = playbackRate;
 
     if (Preferences.subtitles)
     {
@@ -2623,27 +2547,26 @@ class PlayState extends MusicBeatSubState
       if (subtitles != null) subtitles.assignSubtitles(subtitlesFile, FlxG.sound.music);
     }
 
-    // Prevent the volume from being wrong.
+    FlxG.sound.music.onComplete = function()
+    {
+      if (mayPauseGame) endSong(skipEndingTransition);
+    };
+
+    FlxG.sound.music.pitch = playbackRate;
     FlxG.sound.music.volume = instrumentalVolume;
-    if (FlxG.sound.music.fadeTween != null) FlxG.sound.music.fadeTween.cancel();
+    FlxG.sound.music.fadeTween?.cancel();
 
     if (vocals != null)
     {
       add(vocals);
 
-      vocals.time = startTimestamp - Conductor.instance.instrumentalOffset;
       vocals.pitch = playbackRate;
       vocals.playerVolume = playerVocalsVolume;
       vocals.opponentVolume = opponentVocalsVolume;
-
-      // trace('STARTING SONG AT:');
-      // trace('${FlxG.sound.music.time}');
-      // trace('${vocals.time}');
-
-      vocals.play();
     }
 
-    FlxG.sound.music.play();
+    Conductor.instance.update(startTimestamp, true);
+    resyncVocals(true);
 
     #if FEATURE_DISCORD_RPC
     // Updating Discord Rich Presence (with Time Left)
@@ -2668,32 +2591,38 @@ class PlayState extends MusicBeatSubState
     #if FEATURE_NEWGROUNDS
     Events.logStartSong(currentSong.id, currentVariation);
     #end
-
-    resyncVocals();
   }
 
   /**
      * Resynchronize the vocal tracks if they have become offset from the instrumental.
      */
-  function resyncVocals():Void
+  function resyncVocals(force = false):Void
   {
-    if (vocals == null) return;
+    if (FlxG.sound.music != null && (force || vocals != null && FlxG.sound.music.playing))
+    {
+      var timeToPlayAt:Float = (Conductor.instance.songPosition - Conductor.instance.combinedOffset).clamp(0, FlxG.sound.music.length);
+      trace('Resyncing vocals to ${timeToPlayAt}');
 
-    // Skip this if the music is paused (GameOver, Pause menu, start-of-song offset, etc.)
-    if (!(FlxG.sound.music?.playing ?? false)) return;
+      //FlxG.sound.music.play(true, timeToPlayAt);
+      //vocals?.play(true, timeToPlayAt - Conductor.instance.instrumentalOffset);
 
-    var timeToPlayAt:Float = Math.min(FlxG.sound.music.length,
-      Math.max(Math.min(Conductor.instance.combinedOffset, 0), Conductor.instance.songPosition) - Conductor.instance.combinedOffset);
-    trace('Resyncing vocals to ${timeToPlayAt}');
+      // Use FlxSound.prepare and FlxSound.playSounds so every sounds is played at the same time in hardware.
 
-    FlxG.sound.music.pause();
-    vocals.pause();
+      var sounds:Array<FlxSound> = [FlxG.sound.music];
 
-    FlxG.sound.music.time = timeToPlayAt;
-    FlxG.sound.music.play(false, timeToPlayAt);
+      FlxG.sound.music.prepare(timeToPlayAt);
+      if (vocals != null)
+      {
+        var vocalsTimeToPlayAt:Float = timeToPlayAt - Conductor.instance.instrumentalOffset;
+        vocals.forEachAlive(function(sound:FunkinSound)
+        {
+          sounds.push(sound);
+          sound.prepare(vocalsTimeToPlayAt);
+        });
+      }
 
-    vocals.time = timeToPlayAt;
-    vocals.play(false, timeToPlayAt);
+      FlxSound.playSounds(sounds);
+    }
   }
 
   /**
@@ -3414,8 +3343,9 @@ class PlayState extends MusicBeatSubState
      */
   public function endSong(rightGoddamnNow:Bool = false):Void
   {
-    if (FlxG.sound.music != null) FlxG.sound.music.volume = 0;
-    if (vocals != null) vocals.volume = 0;
+    FlxG.sound.music?.stop();
+    vocals?.stop();
+
     mayPauseGame = false;
     isSongEnd = true;
 
@@ -3843,7 +3773,6 @@ class PlayState extends MusicBeatSubState
     }
 
     persistentUpdate = false;
-    vocals?.stop();
     camHUD.alpha = 1;
 
     var talliesToUse:Tallies = PlayStatePlaylist.isStoryMode ? Highscore.talliesLevel : Highscore.tallies;
@@ -4088,7 +4017,7 @@ class PlayState extends MusicBeatSubState
 
     handleSkippedNotes();
     SongEventRegistry.handleSkippedEvents(songEvents, Conductor.instance.songPosition);
-    if (FlxG.sound.music != null && FlxG.sound.music.playing && preventDeath) regenNoteData(FlxG.sound.music.time);
+    if (FlxG.sound.music != null && FlxG.sound.music.playing && preventDeath) regenNoteData(FlxG.sound.music.getActualTime());
 
     Conductor.instance.update(FlxG.sound?.music?.time ?? 0.0);
 

--- a/source/funkin/play/PlayState.hx
+++ b/source/funkin/play/PlayState.hx
@@ -1168,9 +1168,9 @@ class PlayState extends MusicBeatSubState
 
       if (FlxG.sound.music.playing)
       {
-          Conductor.instance.update();
-        }
+        Conductor.instance.update();
       }
+    }
 
     var pauseButtonCheck:Bool = false;
     var androidPause:Bool = false;

--- a/source/funkin/play/ResultScore.hx
+++ b/source/funkin/play/ResultScore.hx
@@ -17,7 +17,7 @@ class ResultScore extends FlxTypedSpriteGroup<ScoreNum>
     if (group == null || group.members == null) return val;
     var loopNum:Int = group.members.length - 1;
     var dumbNumb = Std.parseInt(Std.string(val));
-    var prevNum:ScoreNum;
+    //var prevNum:ScoreNum;
 
     dumbNumb = Std.int(Math.min(dumbNumb, Math.pow(10, group.members.length) - 1));
 

--- a/source/funkin/play/ResultState.hx
+++ b/source/funkin/play/ResultState.hx
@@ -566,7 +566,6 @@ class ResultState extends MusicBeatSubState
     return playerCharacter?.getResultsMusicPath(rank) ?? 'resultsNORMAL';
   }
 
-  var rankTallyTimer:Null<FlxTimer> = null;
   var clearPercentTarget:Int = 100;
   var clearPercentLerp:Int = 0;
 

--- a/source/funkin/play/ResultState.hx
+++ b/source/funkin/play/ResultState.hx
@@ -561,6 +561,16 @@ class ResultState extends MusicBeatSubState
     super.create();
   }
 
+  override public function destroy():Void
+  {
+    // Kill all music types to prevent audio overlap into new states.
+    if (resultsMusic != null) resultsMusic.stop();
+    if (introMusicAudio != null) introMusicAudio.stop();
+    if (FlxG.sound.music != null) FlxG.sound.music.stop();
+
+    super.destroy();
+  }
+
   function getMusicPath(playerCharacter:Null<PlayableCharacter>, rank:ScoringRank):String
   {
     return playerCharacter?.getResultsMusicPath(rank) ?? 'resultsNORMAL';

--- a/source/funkin/play/ResultState.hx
+++ b/source/funkin/play/ResultState.hx
@@ -520,7 +520,7 @@ class ResultState extends MusicBeatSubState
 
         // preload the loop music
         @:nullSafety(Off)
-        var musicLoop:FunkinSound = FunkinSound.load(mainMusic, 1.0, true, true, false, false, null, null, true);
+        var musicLoop:FunkinSound = FunkinSound.load(mainMusic, 1.0, true, true, false, false, null, null);
 
         // Play the intro music.
         introMusicAudio = FunkinSound.load(introMusic, 1.0, false, true, true, () ->

--- a/source/funkin/play/character/BaseCharacter.hx
+++ b/source/funkin/play/character/BaseCharacter.hx
@@ -77,6 +77,11 @@ class BaseCharacter extends Bopper
   final singTimeSteps:Float;
 
   /**
+   * When set to true, the next animation to play will temporarily force the character's vocals to play.
+   */
+  public var tempVocals:Bool = false;
+
+  /**
    * The offset between the corner of the sprite and the origin of the sprite (at the character's feet).
    * cornerPosition = stageData - characterOrigin
    */
@@ -325,6 +330,20 @@ class BaseCharacter extends Bopper
     {
       // Force the character to play the idle after the animation ends.
       this.dance(true);
+    }
+    if (tempVocals)
+    {
+      // stop the temporary vocals
+      if (characterType == BF && PlayState.instance.vocals.playerVolume == 1)
+      {
+        PlayState.instance.vocals.playerVolume = 0;
+      }
+
+      if (characterType == DAD && PlayState.instance.vocals.opponentVolume == 1)
+      {
+        PlayState.instance.vocals.opponentVolume = 0;
+      }
+      tempVocals = false;
     }
   }
 
@@ -700,6 +719,21 @@ class BaseCharacter extends Bopper
 
   public override function playAnimation(name:String, restart:Bool = false, ignoreOther:Bool = false, reversed:Bool = false):Void
   {
+    if (tempVocals)
+    {
+      // restart the character's vocals for the duration of the animation
+      if (characterType == BF && PlayState.instance.vocals.playerVolume == 0)
+      {
+        PlayState.instance.vocals.playerVolume = 1;
+      }
+      else if (characterType == DAD && PlayState.instance.vocals.opponentVolume == 0)
+      {
+        PlayState.instance.vocals.opponentVolume = 1;
+      }
+      else if (characterType != BF || characterType != DAD)
+        tempVocals = false;
+    }
+
     super.playAnimation(name, restart, ignoreOther, reversed);
   }
 

--- a/source/funkin/play/components/ClearPercentCounter.hx
+++ b/source/funkin/play/components/ClearPercentCounter.hx
@@ -51,8 +51,6 @@ class ClearPercentCounter extends FlxTypedSpriteGroup<FlxSprite>
     flashShader.colorSet = enabled;
   }
 
-  var tmr:Float = 0;
-
   override function update(elapsed:Float):Void
   {
     super.update(elapsed);

--- a/source/funkin/play/components/HealthIcon.hx
+++ b/source/funkin/play/components/HealthIcon.hx
@@ -81,6 +81,11 @@ class HealthIcon extends FunkinSprite
   var isLegacyStyle:Bool = false;
 
   /**
+   * Whether this icon should bop or not.
+   */
+  var shouldBop:Bool = true;
+
+  /**
    * At this amount of health, play the Winning animation instead of the idle.
    */
   static final WINNING_THRESHOLD:Float = 0.8 * 2;
@@ -199,6 +204,7 @@ class HealthIcon extends FunkinSprite
     {
       this.characterId = data.id;
       this.isPixel = data.isPixel ?? false;
+      this.shouldBop = data.shouldBop ?? true;
 
       loadCharacter(characterId);
 
@@ -294,7 +300,7 @@ class HealthIcon extends FunkinSprite
   public function onStepHit(curStep:Int):Void
   {
     // Make the icons bop.
-    if (bopEvery != 0 && curStep % bopEvery == 0 && isLegacyStyle)
+    if (bopEvery != 0 && curStep % bopEvery == 0 && shouldBop)
     {
       bopTween?.cancel();
       setGraphicSize(Std.int(this.width + (HEALTH_ICON_SIZE * this.size.x * BOP_SCALE)), 0);

--- a/source/funkin/play/components/TallyCounter.hx
+++ b/source/funkin/play/components/TallyCounter.hx
@@ -31,8 +31,6 @@ class TallyCounter extends FlxTypedSpriteGroup<FlxSprite>
     if (curNumber == neededNumber) drawNumbers();
   }
 
-  var tmr:Float = 0;
-
   override function update(elapsed:Float)
   {
     super.update(elapsed);

--- a/source/funkin/play/event/PlayAnimationSongEvent.hx
+++ b/source/funkin/play/event/PlayAnimationSongEvent.hx
@@ -61,6 +61,7 @@ class PlayAnimationSongEvent extends SongEvent
       if (Std.isOfType(target, BaseCharacter))
       {
         var targetChar:BaseCharacter = cast target;
+        targetChar.tempVocals = force;
         targetChar.playAnimation(anim, force, force);
       }
       else

--- a/source/funkin/play/event/SetHealthIconSongEvent.hx
+++ b/source/funkin/play/event/SetHealthIconSongEvent.hx
@@ -38,6 +38,7 @@ class SetHealthIconSongEvent extends SongEvent
   static final DEFAULT_SCALE:Float = 1.0;
   static final DEFAULT_FLIPX:Bool = false;
   static final DEFAULT_ISPIXEL:Bool = false;
+  static final DEFAULT_SHOULDBOP:Bool = true;
 
   static final DEFAULT_X_OFFSET:Float = 0.0;
   static final DEFAULT_Y_OFFSET:Float = 0.0;
@@ -54,6 +55,7 @@ class SetHealthIconSongEvent extends SongEvent
 
     var healthIconData:HealthIconData = {
       id: data.value.id ?? Constants.DEFAULT_HEALTH_ICON,
+      shouldBop: data.value.shouldBop ?? DEFAULT_SHOULDBOP,
       scale: data.value.scale ?? DEFAULT_SCALE,
       flipX: data.value.flipX ?? DEFAULT_FLIPX,
       isPixel: data.value.isPixel ?? DEFAULT_ISPIXEL,
@@ -97,6 +99,11 @@ class SetHealthIconSongEvent extends SongEvent
       title: 'Health Icon ID',
       defaultValue: Constants.DEFAULT_HEALTH_ICON,
       type: SongEventFieldType.STRING,
+    }, {
+      name: 'shouldBop',
+      title: 'Should Bop?',
+      defaultValue: DEFAULT_SHOULDBOP,
+      type: SongEventFieldType.BOOL,
     }, {
       name: 'scale',
       title: 'Scale',

--- a/source/funkin/play/notes/NoteSplash.hx
+++ b/source/funkin/play/notes/NoteSplash.hx
@@ -10,8 +10,6 @@ class NoteSplash extends FlxSprite
   public var splashFramerate:Int = 24;
   public var splashFramerateVariance:Int = 2;
 
-  static var frameCollection:FlxFramesCollection;
-
   public function new(noteStyle:NoteStyle)
   {
     super(0, 0);

--- a/source/funkin/play/song/Song.hx
+++ b/source/funkin/play/song/Song.hx
@@ -13,6 +13,7 @@ import funkin.data.song.SongData.SongTimeChange;
 import funkin.data.song.SongData.SongTimeFormat;
 import funkin.data.song.SongRegistry;
 import funkin.modding.IScriptedClass.IPlayStateScriptedClass;
+import funkin.modding.IScriptedClass.IGameOverScriptedClass;
 import funkin.modding.events.ScriptEvent;
 import funkin.ui.freeplay.charselect.PlayableCharacter;
 import funkin.data.freeplay.player.PlayerRegistry;
@@ -28,7 +29,7 @@ import funkin.util.SortUtil;
  * can be used to perform custom gameplay behaviors only on specific songs.
  */
 @:nullSafety
-class Song implements IPlayStateScriptedClass implements IRegistryEntry<SongMetadata>
+class Song implements IPlayStateScriptedClass implements IGameOverScriptedClass implements IRegistryEntry<SongMetadata>
 {
   /**
    * The default value for the song's name
@@ -711,6 +712,18 @@ class Song implements IPlayStateScriptedClass implements IRegistryEntry<SongMeta
   {
   };
 
+  public function onGameOverStart(event:ScriptEvent):Void
+  {
+  };
+
+  public function onGameOverConfirm(event:ScriptEvent):Void
+  {
+  };
+
+  public function onGameOverMusicStart(event:ScriptEvent):Void
+  {
+  };
+
   static function _fetchData(id:String):Null<SongMetadata>
   {
     var version:Null<thx.semver.Version> = SongRegistry.instance.fetchEntryMetadataVersion(id);
@@ -850,12 +863,17 @@ class SongDifficulty
 
   public function playInst(volume:Float = 1.0, instId:String = '', looped:Bool = false):Void
   {
+    buildInst(volume, instId, looped).play(true, 0);
+  }
+
+  public function buildInst(volume:Float = 1.0, instId:String = '', looped:Bool = false):FunkinSound
+  {
     var suffix:String = (instId != '') ? '-$instId' : '';
 
-    FlxG.sound.music = FunkinSound.load(Paths.inst(this.song.id, suffix), volume, looped, false, true, false, null, null, true);
+    var snd = FunkinSound.load(Paths.inst(this.song.id, suffix), volume, looped, false, false, false, null, null);
+    FunkinSound.setMusic(snd);
 
-    // Workaround for a bug where FlxG.sound.music.update() was being called twice.
-    FlxG.sound.list.remove(FlxG.sound.music);
+    return snd;
   }
 
   /**
@@ -1008,14 +1026,14 @@ class SongDifficulty
     for (playerVoice in playerVoiceList)
     {
       if (!Assets.exists(playerVoice)) continue;
-      result.addPlayerVoice(FunkinSound.load(playerVoice, 1.0, false, false, false, false, null, null, true));
+      result.addPlayerVoice(FunkinSound.load(playerVoice, 1.0, false, false, false, false, null, null));
     }
 
     // Add opponent vocals.
     for (opponentVoice in opponentVoiceList)
     {
       if (!Assets.exists(opponentVoice)) continue;
-      result.addOpponentVoice(FunkinSound.load(opponentVoice, 1.0, false, false, false, false, null, null, true));
+      result.addOpponentVoice(FunkinSound.load(opponentVoice, 1.0, false, false, false, false, null, null));
     }
 
     if (result.members.length == 0)
@@ -1025,7 +1043,7 @@ class SongDifficulty
       var legacyPath = Paths.voices(this.song.id, '$suffix');
       if (Assets.exists(legacyPath))
       {
-        result.addPlayerVoice(FunkinSound.load(legacyPath, 1.0, false, false, false, false, null, null, true));
+        result.addPlayerVoice(FunkinSound.load(legacyPath, 1.0, false, false, false, false, null, null));
       }
     }
 
@@ -1034,9 +1052,6 @@ class SongDifficulty
       result.legacyVoiceSystem = true;
       result.legacyVoiceUsesPlayer = result.getPlayerVoice(0) != null;
     }
-
-    // Sometimes the sounds don't set their important value to true, so we have to do this manually.
-    result.forEach((snd:FunkinSound) -> snd.important = true);
 
     result.playerVoicesOffset = offsets.getVocalOffset(characters.player, instId);
     result.opponentVoicesOffset = offsets.getVocalOffset(characters.opponent, instId);

--- a/source/funkin/save/Save.hx
+++ b/source/funkin/save/Save.hx
@@ -919,7 +919,7 @@ class Save implements ConsoleClass
 
   public function debug_dumpSaveJsonSave():Void
   {
-    FileUtil.saveFile(haxe.io.Bytes.ofString(this.serializeJson()), [FileUtil.FILE_FILTER_JSON], null, null, './save.json', 'Write save data as JSON...');
+    FileUtil.saveFile('Write save data as JSON...', haxe.io.Bytes.ofString(this.serializeJson()), [FileUtil.FILE_FILTER_JSON], null, null, './save.json');
   }
 
   public function debug_dumpSaveJsonPrint():Void

--- a/source/funkin/save/Save.hx
+++ b/source/funkin/save/Save.hx
@@ -116,6 +116,8 @@ class Save implements ConsoleClass
         globalOffset: 0,
         audioVisualOffset: 0,
         unlockedFramerate: false,
+        audioDevice: 'Default',
+        streamedMusic: true,
         screenshot: {
           shouldHideMouse: true,
           fancyPreview: true,
@@ -1227,6 +1229,18 @@ typedef SaveDataOptions =
    * @default `false`
    */
   var unlockedFramerate:Bool;
+
+  /**
+   * What audio device should it playback sounds to.
+   * @default 'Default'
+   */
+  var audioDevice:String;
+
+  /**
+   * Should the musics be loaded as streamable instead of static.
+   * @default 'true'
+   */
+  var streamedMusic:Bool;
 
   /**
    * Screenshot options

--- a/source/funkin/ui/AtlasText.hx
+++ b/source/funkin/ui/AtlasText.hx
@@ -2,7 +2,7 @@ package funkin.ui;
 
 import flixel.FlxSprite;
 import flixel.graphics.frames.FlxAtlasFrames;
-import funkin.group.FunkinGroup;
+import flixel.group.FlxSpriteGroup.FlxTypedSpriteGroup;
 import flixel.util.FlxStringUtil;
 
 /**
@@ -10,7 +10,7 @@ import flixel.util.FlxStringUtil;
  * It supports animations on the letters, and is less buggy than Alphabet.
  */
 @:nullSafety
-class AtlasText extends FunkinGroup<AtlasChar>
+class AtlasText extends FlxTypedSpriteGroup<AtlasChar>
 {
   static var fonts:Map<AtlasFont, AtlasFontData> = new Map<AtlasFont, AtlasFontData>();
   static var casesAllowed:Map<AtlasFont, Case> = new Map<AtlasFont, Case>();
@@ -60,7 +60,7 @@ class AtlasText extends FunkinGroup<AtlasChar>
 
     value = caseValue;
 
-    this.kill();
+    group.kill();
 
     if (value == "") return this.text;
 
@@ -101,16 +101,16 @@ class AtlasText extends FunkinGroup<AtlasChar>
    */
   function appendTextCased(str:String):Void
   {
-    var charCount:Int = countLiving();
+    var charCount:Int = group.countLiving();
     var xPos:Float = 0;
     var yPos:Float = 0;
     // `countLiving` returns -1 if group is empty
     if (charCount == -1) charCount = 0;
     else if (charCount > 0)
     {
-      var lastChar:AtlasChar = children[charCount - 1];
-      xPos = lastChar.localX + lastChar.width - x;
-      yPos = lastChar.localY + lastChar.height - maxHeight - y;
+      var lastChar:AtlasChar = group.members[charCount - 1];
+      xPos = lastChar.x + lastChar.width - x;
+      yPos = lastChar.y + lastChar.height - maxHeight - y;
     }
 
     for (splitStr in str.split(""))
@@ -124,16 +124,16 @@ class AtlasText extends FunkinGroup<AtlasChar>
           yPos += maxHeight;
         case char:
           var charSprite:AtlasChar;
-          if (children.length <= charCount) charSprite = new AtlasChar(atlas, char);
+          if (group.members.length <= charCount) charSprite = new AtlasChar(atlas, char);
           else
           {
-            charSprite = children[charCount];
+            charSprite = group.members[charCount];
             charSprite.revive();
             charSprite.char = char;
             charSprite.alpha = 1; // gets multiplied when added
           }
-          charSprite.localX = xPos;
-          charSprite.localY = yPos + maxHeight - charSprite.height;
+          charSprite.x = xPos;
+          charSprite.y = yPos + maxHeight - charSprite.height;
           add(charSprite);
 
           xPos += charSprite.width;

--- a/source/funkin/ui/AtlasText.hx
+++ b/source/funkin/ui/AtlasText.hx
@@ -2,7 +2,7 @@ package funkin.ui;
 
 import flixel.FlxSprite;
 import flixel.graphics.frames.FlxAtlasFrames;
-import flixel.group.FlxSpriteGroup.FlxTypedSpriteGroup;
+import funkin.group.FunkinGroup;
 import flixel.util.FlxStringUtil;
 
 /**
@@ -10,7 +10,7 @@ import flixel.util.FlxStringUtil;
  * It supports animations on the letters, and is less buggy than Alphabet.
  */
 @:nullSafety
-class AtlasText extends FlxTypedSpriteGroup<AtlasChar>
+class AtlasText extends FunkinGroup<AtlasChar>
 {
   static var fonts:Map<AtlasFont, AtlasFontData> = new Map<AtlasFont, AtlasFontData>();
   static var casesAllowed:Map<AtlasFont, Case> = new Map<AtlasFont, Case>();
@@ -60,7 +60,7 @@ class AtlasText extends FlxTypedSpriteGroup<AtlasChar>
 
     value = caseValue;
 
-    group.kill();
+    this.kill();
 
     if (value == "") return this.text;
 
@@ -101,16 +101,16 @@ class AtlasText extends FlxTypedSpriteGroup<AtlasChar>
    */
   function appendTextCased(str:String):Void
   {
-    var charCount:Int = group.countLiving();
+    var charCount:Int = countLiving();
     var xPos:Float = 0;
     var yPos:Float = 0;
     // `countLiving` returns -1 if group is empty
     if (charCount == -1) charCount = 0;
     else if (charCount > 0)
     {
-      var lastChar:AtlasChar = group.members[charCount - 1];
-      xPos = lastChar.x + lastChar.width - x;
-      yPos = lastChar.y + lastChar.height - maxHeight - y;
+      var lastChar:AtlasChar = children[charCount - 1];
+      xPos = lastChar.localX + lastChar.width - x;
+      yPos = lastChar.localY + lastChar.height - maxHeight - y;
     }
 
     for (splitStr in str.split(""))
@@ -124,16 +124,16 @@ class AtlasText extends FlxTypedSpriteGroup<AtlasChar>
           yPos += maxHeight;
         case char:
           var charSprite:AtlasChar;
-          if (group.members.length <= charCount) charSprite = new AtlasChar(atlas, char);
+          if (children.length <= charCount) charSprite = new AtlasChar(atlas, char);
           else
           {
-            charSprite = group.members[charCount];
+            charSprite = children[charCount];
             charSprite.revive();
             charSprite.char = char;
             charSprite.alpha = 1; // gets multiplied when added
           }
-          charSprite.x = xPos;
-          charSprite.y = yPos + maxHeight - charSprite.height;
+          charSprite.localX = xPos;
+          charSprite.localY = yPos + maxHeight - charSprite.height;
           add(charSprite);
 
           xPos += charSprite.width;

--- a/source/funkin/ui/MusicBeatState.hx
+++ b/source/funkin/ui/MusicBeatState.hx
@@ -223,6 +223,8 @@ class MusicBeatState extends FlxTransitionableState implements IEventHandler
 
   public function stepHit():Bool
   {
+    if (this.subState != null && !persistentUpdate) return;
+
     var event = new SongTimeScriptEvent(SONG_STEP_HIT, conductorInUse.currentBeat, conductorInUse.currentStep);
 
     dispatchEvent(event);
@@ -234,6 +236,8 @@ class MusicBeatState extends FlxTransitionableState implements IEventHandler
 
   public function beatHit():Bool
   {
+    if (this.subState != null && !persistentUpdate) return;
+
     var event = new SongTimeScriptEvent(SONG_BEAT_HIT, conductorInUse.currentBeat, conductorInUse.currentStep);
 
     dispatchEvent(event);

--- a/source/funkin/ui/MusicBeatState.hx
+++ b/source/funkin/ui/MusicBeatState.hx
@@ -223,7 +223,7 @@ class MusicBeatState extends FlxTransitionableState implements IEventHandler
 
   public function stepHit():Bool
   {
-    if (this.subState != null && !persistentUpdate) return;
+    if (this.subState != null && !persistentUpdate) return false;
 
     var event = new SongTimeScriptEvent(SONG_STEP_HIT, conductorInUse.currentBeat, conductorInUse.currentStep);
 
@@ -236,7 +236,7 @@ class MusicBeatState extends FlxTransitionableState implements IEventHandler
 
   public function beatHit():Bool
   {
-    if (this.subState != null && !persistentUpdate) return;
+    if (this.subState != null && !persistentUpdate) return false;
 
     var event = new SongTimeScriptEvent(SONG_BEAT_HIT, conductorInUse.currentBeat, conductorInUse.currentStep);
 

--- a/source/funkin/ui/MusicBeatSubState.hx
+++ b/source/funkin/ui/MusicBeatSubState.hx
@@ -195,7 +195,7 @@ class MusicBeatSubState extends FlxSubState implements IEventHandler
    */
   public function stepHit():Bool
   {
-    if (this.subState != null && !persistentUpdate) return;
+    if (this.subState != null && !persistentUpdate) return false;
 
     var event:ScriptEvent = new SongTimeScriptEvent(SONG_STEP_HIT, conductorInUse.currentBeat, conductorInUse.currentStep);
 
@@ -213,7 +213,7 @@ class MusicBeatSubState extends FlxSubState implements IEventHandler
    */
   public function beatHit():Bool
   {
-    if (this.subState != null && !persistentUpdate) return;
+    if (this.subState != null && !persistentUpdate) return false;
 
     var event:ScriptEvent = new SongTimeScriptEvent(SONG_BEAT_HIT, conductorInUse.currentBeat, conductorInUse.currentStep);
 

--- a/source/funkin/ui/MusicBeatSubState.hx
+++ b/source/funkin/ui/MusicBeatSubState.hx
@@ -195,6 +195,8 @@ class MusicBeatSubState extends FlxSubState implements IEventHandler
    */
   public function stepHit():Bool
   {
+    if (this.subState != null && !persistentUpdate) return;
+
     var event:ScriptEvent = new SongTimeScriptEvent(SONG_STEP_HIT, conductorInUse.currentBeat, conductorInUse.currentStep);
 
     dispatchEvent(event);
@@ -211,6 +213,8 @@ class MusicBeatSubState extends FlxSubState implements IEventHandler
    */
   public function beatHit():Bool
   {
+    if (this.subState != null && !persistentUpdate) return;
+
     var event:ScriptEvent = new SongTimeScriptEvent(SONG_BEAT_HIT, conductorInUse.currentBeat, conductorInUse.currentStep);
 
     dispatchEvent(event);

--- a/source/funkin/ui/charSelect/CharSelectSubState.hx
+++ b/source/funkin/ui/charSelect/CharSelectSubState.hx
@@ -466,7 +466,7 @@ class CharSelectSubState extends MusicBeatSubState
           allowInput = true;
 
           @:privateAccess
-          gfChill.analyzer = new SpectralAnalyzer(FlxG.sound.music._channel.__audioSource, 7, 0.1);
+          gfChill.analyzer = new SpectralAnalyzer(FlxG.sound.music.source, 7, 0.1);
           #if sys
           // On native it uses FFT stuff that isn't as optimized as the direct browser stuff we use on HTML5
           // So we want to manually change it!
@@ -623,7 +623,7 @@ class CharSelectSubState extends MusicBeatSubState
               allowInput = true;
 
               @:privateAccess
-              gfChill.analyzer = new SpectralAnalyzer(FlxG.sound.music._channel.__audioSource, 7, 0.1);
+              gfChill.analyzer = new SpectralAnalyzer(FlxG.sound.music.source, 7, 0.1);
               #if sys
               // On native it uses FFT stuff that isn't as optimized as the direct browser stuff we use on HTML5
               // So we want to manually change it!

--- a/source/funkin/ui/charSelect/Nametag.hx
+++ b/source/funkin/ui/charSelect/Nametag.hx
@@ -106,17 +106,6 @@ class Nametag extends FlxSprite
     }
   }
 
-  function setBlockTimer(frame:Int, ?forceX:Float, ?forceY:Float):Void
-  {
-    var daX:Float = forceX ?? 10 * FlxG.random.int(1, 4);
-    var daY:Float = forceY ?? 10 * FlxG.random.int(1, 4);
-
-    FlxTimer.wait(frame / 30, () ->
-    {
-      mosaicShader.setBlockSize(daX, daY);
-    });
-  }
-
   function set_midpointX(val:Float):Float
   {
     this.midpointX = val;

--- a/source/funkin/ui/debug/AudioTestState.hx
+++ b/source/funkin/ui/debug/AudioTestState.hx
@@ -58,7 +58,11 @@ class AudioTestState extends MusicBeatState
   {
     super.update(elapsed);
 
-    if (FlxG.keys.justPressed.SPACE)
+    if (FlxG.keys.justPressed.ESCAPE)
+    {
+      FlxG.switchState(() -> new funkin.ui.mainmenu.MainMenuState());
+    }
+    else if (FlxG.keys.justPressed.SPACE)
     {
       if (audio.playing) audio.pause();
       else audio.play();

--- a/source/funkin/ui/debug/AudioTestState.hx
+++ b/source/funkin/ui/debug/AudioTestState.hx
@@ -1,0 +1,188 @@
+package funkin.ui.debug;
+
+import lime.media.effects.FilterEffect;
+
+import flixel.math.FlxMath;
+import flixel.sound.FlxSound;
+import flixel.text.FlxText;
+import flixel.FlxSprite;
+
+class AudioTestState extends MusicBeatState
+{
+  var audio:FlxSound;
+  var box:FlxSprite;
+  var label:FlxText;
+  var label2:FlxText;
+  var filter:FilterEffect;
+  var filterTypeNum:Int = 0;
+
+  override function create():Void
+  {
+    super.create();
+
+    label = new FlxText(0, 0, 0, "", 38);
+    add(label);
+
+    box = new FlxSprite(0, 0).makeGraphic(1, 1, 0xFFFFFFFF);
+    add(box);
+
+    label2 = new FlxText(0, FlxG.height * 0.5 + 200, 0, "", 24);
+    add(label2);
+
+    audio = FlxG.sound.load(Paths.music("chartEditorLoop/chartEditorLoop"));
+    audio.addEffect(filter = new FilterEffect());
+
+    lime.app.Application.current.window.onDropFile.add(onDropFile);
+
+    audio.looped = true;
+    audio.play();
+  }
+
+  private function numToFilterType(num:Int):FilterEffectType
+  {
+    return switch (num)
+    {
+      case 0: LOWPASS;
+      case 1: HIGHPASS;
+      case 2: BANDPASS;
+      default: LOWPASS;
+      //case 3: LOWSHELF;
+      //case 4: HIGHSHELF;
+      //case 5: PEAKING;
+      //case 6: NOTCH;
+      //default: LOWPASS;
+    }
+  }
+
+  override function update(elapsed:Float):Void
+  {
+    super.update(elapsed);
+
+    if (FlxG.keys.justPressed.SPACE)
+    {
+      if (audio.playing) audio.pause();
+      else audio.play();
+    }
+
+    if (FlxG.keys.justPressed.Q)
+    {
+      audio.time -= 1000;
+    }
+    else if (FlxG.keys.justPressed.W)
+    {
+      audio.time += 1000;
+    }
+    else if (FlxG.keys.justPressed.E)
+    {
+      audio.time = 0;
+    }
+
+    if (FlxG.keys.justPressed.A)
+    {
+      filterTypeNum--;
+      if (filterTypeNum < 0) filterTypeNum = 2;
+      filter.type = numToFilterType(filterTypeNum);
+    }
+    else if (FlxG.keys.justPressed.S)
+    {
+      filterTypeNum++;
+      if (filterTypeNum > 2) filterTypeNum = 0;
+      filter.type = numToFilterType(filterTypeNum);
+    }
+    else if (FlxG.keys.justPressed.D)
+    {
+      filter.type = numToFilterType(filterTypeNum = 0);
+    }
+
+    if (FlxG.keys.pressed.Z)
+    {
+      filter.frequency -= elapsed * (FlxG.keys.pressed.SHIFT ? 20000 : 10000);
+    }
+    else if (FlxG.keys.pressed.X)
+    {
+      filter.frequency += elapsed * (FlxG.keys.pressed.SHIFT ? 20000 : 10000);
+    }
+    else if (FlxG.keys.justPressed.C)
+    {
+      filter.frequency = 1000;
+    }
+
+    if (FlxG.keys.pressed.R)
+    {
+      audio.pan -= elapsed;
+    }
+    else if (FlxG.keys.pressed.T)
+    {
+      audio.pan += elapsed;
+    }
+    else if (FlxG.keys.justPressed.Y)
+    {
+      audio.pan = 0;
+    }
+
+    if (FlxG.keys.pressed.F)
+    {
+      audio.volume -= elapsed;
+    }
+    else if (FlxG.keys.pressed.G)
+    {
+      audio.volume += elapsed;
+    }
+    else if (FlxG.keys.justPressed.H)
+    {
+      audio.volume = 1;
+    }
+
+    if (FlxG.keys.pressed.V)
+    {
+      audio.pitch -= elapsed;
+    }
+    else if (FlxG.keys.pressed.B)
+    {
+      audio.pitch += elapsed;
+    }
+    else if (FlxG.keys.justPressed.N)
+    {
+      audio.pitch = 1;
+    }
+
+    var peak = audio.amplitude;
+
+    box.scale.set(200, peak * 400);
+    box.updateHitbox();
+    box.setPosition((FlxG.width - 200) * 0.5, FlxG.height * 0.5 + 180 - box.scale.y);
+
+    //label.text = "Time Position: " + FlxMath.roundDecimal(audio.time / 1000, 2);
+    //label.screenCenter();
+    //label.y -= 90;
+
+    label2.text = "Frequency: " + filter.frequency + ", Type: " + (cast filter.type);
+    label2.screenCenter(X);
+  }
+
+  function onDropFile(#if (js && html5) _path:String #else path:String #end, source:String, x:Float, y:Float):Void
+  {
+    #if (js && html5)
+    var fileReader = new js.html.FileReader();
+    var file = untyped _path;
+
+    fileReader.onload = function(data) {
+      audio.loadEmbedded(openfl.media.Sound.fromAudioBuffer(lime.media.AudioBuffer.fromBase64(untyped fileReader.result)));
+      audio.looped = true;
+      audio.play();
+    };
+
+    fileReader.readAsDataURL(file);
+    trace(untyped file.name);
+    #else
+    audio.unload();
+    audio.data?.destroy();
+
+    trace(path);
+
+    audio.loadEmbedded(path);
+    audio.looped = true;
+    audio.play();
+    #end
+  }
+}

--- a/source/funkin/ui/debug/DebugMenuSubState.hx
+++ b/source/funkin/ui/debug/DebugMenuSubState.hx
@@ -66,6 +66,9 @@ class DebugMenuSubState extends MusicBeatSubState
     #if FEATURE_RESULTS_DEBUG
     createItem("RESULTS SCREEN DEBUG", openTestResultsScreen);
     #end
+    #if AUDIO
+    createItem("AUDIO TEST DEBUG", openAudioTest);
+    #end
     #if sys
     createItem("OPEN CRASH LOG FOLDER", openLogFolder);
     #end
@@ -143,6 +146,13 @@ class DebugMenuSubState extends MusicBeatSubState
   function openTestResultsScreen():Void
   {
     FlxG.switchState(() -> new funkin.ui.debug.results.ResultsDebugSubState());
+  }
+  #end
+
+  #if AUDIO
+  function openAudioTest():Void
+  {
+    FlxG.switchState(() -> new funkin.ui.debug.AudioTestState());
   }
   #end
 

--- a/source/funkin/ui/debug/WaveformTestState.hx
+++ b/source/funkin/ui/debug/WaveformTestState.hx
@@ -74,7 +74,7 @@ class WaveformTestState extends MusicBeatState
 
     if (FlxG.keys.justPressed.SPACE)
     {
-      if (waveformAudio.isPlaying)
+      if (waveformAudio.playing)
       {
         waveformAudio.stop();
       }
@@ -98,7 +98,7 @@ class WaveformTestState extends MusicBeatState
       // }
     }
 
-    if (waveformAudio.isPlaying)
+    if (waveformAudio.playing)
     {
       // waveformSprite takes a time in fractional seconds, not milliseconds.
       var timeSeconds = waveformAudio.time / 1000;

--- a/source/funkin/ui/debug/anim/DebugBoundingState.hx
+++ b/source/funkin/ui/debug/anim/DebugBoundingState.hx
@@ -39,7 +39,6 @@ class DebugBoundingState extends FlxState
     - Cleaner UI
    */
   var bg:FlxBackdrop;
-  var fileInfo:FlxText;
 
   var txtGrp:FlxTypedGroup<FlxText>;
 
@@ -277,23 +276,6 @@ class DebugBoundingState extends FlxState
   function clearInfo()
   {
     txtGrp.clear();
-  }
-
-  function checkLibrary(library:String)
-  {
-    trace(Assets.hasLibrary(library));
-    if (Assets.getLibrary(library) == null)
-    {
-      @:privateAccess
-      if (!LimeAssets.libraryPaths.exists(library)) throw "Missing library: " + library;
-
-      // var callback = callbacks.add("library:" + library);
-      Assets.loadLibrary(library).onComplete(function(_)
-      {
-        trace('LOADED... awesomeness...');
-        // callback();
-      });
-    }
   }
 
   override function update(elapsed:Float)

--- a/source/funkin/ui/debug/charting/ChartEditorState.hx
+++ b/source/funkin/ui/debug/charting/ChartEditorState.hx
@@ -1572,6 +1572,44 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
     return currentSongMetadata.playData.noteStyle = value;
   }
 
+  var currentSongAlbum(get, set):Null<String>;
+
+  function get_currentSongAlbum():Null<String>
+  {
+    if (currentSongMetadata.playData.album == null
+    || currentSongMetadata.playData.album == ''
+    || currentSongMetadata.playData.album == 'item')
+    {
+      // Initialize to the default value if not set.
+      currentSongMetadata.playData.album = Constants.DEFAULT_ALBUM_ID;
+    }
+    return currentSongMetadata.playData.album;
+  }
+
+  function set_currentSongAlbum(value:String):Null<String>
+  {
+    return currentSongMetadata.playData.album = value;
+  }
+
+  var currentSongStickerPack(get, set):Null<String>;
+
+  function get_currentSongStickerPack():Null<String>
+  {
+    if (currentSongMetadata.playData.stickerPack == null
+    || currentSongMetadata.playData.stickerPack == ''
+    || currentSongMetadata.playData.stickerPack == 'item')
+    {
+      // Initialize to the default value if not set.
+      currentSongMetadata.playData.stickerPack = Constants.DEFAULT_STICKER_PACK;
+    }
+    return currentSongMetadata.playData.stickerPack;
+  }
+
+  function set_currentSongStickerPack(value:String):Null<String>
+  {
+    return currentSongMetadata.playData.stickerPack = value;
+  }
+
   var currentSongFreeplayPreviewStart(get, set):Float;
 
   function get_currentSongFreeplayPreviewStart():Float

--- a/source/funkin/ui/debug/charting/ChartEditorState.hx
+++ b/source/funkin/ui/debug/charting/ChartEditorState.hx
@@ -606,11 +606,6 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
   var playtestAudioSettings:Bool = false;
 
   /**
-   * Enables or disables the "debugger" popup that appears when you run into a flixel error.
-   */
-  var enabledDebuggerPopup:Bool = true;
-
-  /**
    * Whether song scripts should be enabled during playtesting.
    * You should probably check the box if the song has custom mechanics.
    */
@@ -1126,12 +1121,6 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
    * This happens when we add/remove difficulties.
    */
   var difficultySelectDirty:Bool = true;
-
-  /**
-   * Whether the character select view in the toolbox has been modified and needs to be updated.
-   * This happens when we add/remove characters.
-   */
-  var characterSelectDirty:Bool = true;
 
   /**
    * Whether the player preview toolbox have been modified and need to be updated.
@@ -2203,25 +2192,9 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
   var buttonSelectEvent:Button;
 
   /**
-   * The slider above the grid that sets the volume of the player's sounds.
-   * Constructed manually and added to the layout so we can control its position.
-   */
-  var sliderVolumePlayer:Slider;
-
-  /**
-   * The slider above the grid that sets the volume of the opponent's sounds.
-   * Constructed manually and added to the layout so we can control its position.
-   */
-  var sliderVolumeOpponent:Slider;
-
-  /**
    * RENDER OBJECTS
    */
   // ==============================
-
-  /**
-   * The group containing the visulizers! */
-  var visulizerGrps:FlxTypedGroup<PolygonSpectogram> = null;
 
   /**
    * The IMAGE used for the grid. Updated by ChartEditorThemeHandler.
@@ -2740,8 +2713,6 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
     menuBG.scrollFactor.set(0, 0);
     menuBG.zIndex = -100;
   }
-
-  var oppSpectogram:PolygonSpectogram;
 
   /**
    * Builds and displays the chart editor grid, including the playhead and cursor.

--- a/source/funkin/ui/debug/charting/ChartEditorState.hx
+++ b/source/funkin/ui/debug/charting/ChartEditorState.hx
@@ -150,9 +150,6 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
   public static final CHART_EDITOR_TOOLBOX_FREEPLAY_LAYOUT:String = Paths.ui('chart-editor/toolbox/freeplay');
   public static final CHART_EDITOR_TOOLBOX_PLAYTEST_PROPERTIES_LAYOUT:String = Paths.ui('chart-editor/toolbox/playtest-properties');
 
-  // Validation
-  public static final SUPPORTED_MUSIC_FORMATS:Array<String> = #if sys ['ogg'] #else ['mp3'] #end;
-
   // Layout
 
   /**
@@ -2692,9 +2689,9 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
       return;
     }
 
-    if ((audioInstTrack != null && audioInstTrack.isPlaying) || audioVocalTrackGroup.playing) return;
+    if ((audioInstTrack != null && audioInstTrack.playing) || audioVocalTrackGroup.playing) return;
 
-    if (welcomeMusic.isPlaying) return;
+    if (welcomeMusic.playing) return;
 
     if (!welcomeMusic.exists) setupWelcomeMusic();
 
@@ -3013,7 +3010,7 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
     {
       playbarHeadDragging = true;
 
-      if ((audioInstTrack != null && audioInstTrack.isPlaying) || audioVocalTrackGroup.playing)
+      if ((audioInstTrack != null && audioInstTrack.playing) || audioVocalTrackGroup.playing)
       {
         playbarHeadDraggingWasPlaying = true;
         stopAudioPlayback();
@@ -3804,7 +3801,7 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
     // dispatchEvent gets called here.
     if (!super.beatHit()) return false;
 
-    if (metronomeVolume > 0.0 && !isPlaytesting && ((audioInstTrack != null && audioInstTrack.isPlaying) || audioVocalTrackGroup.playing))
+    if (metronomeVolume > 0.0 && !isPlaytesting && ((audioInstTrack != null && audioInstTrack.playing) || audioVocalTrackGroup.playing))
     {
       var currentMeasureTime:Float = Conductor.instance.getMeasureTimeInMs(Conductor.instance.currentMeasure);
       var currentStepTime:Float = Conductor.instance.getStepTimeInMs(Conductor.instance.currentStep);
@@ -3827,7 +3824,7 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
     // dispatchEvent gets called here.
     if (!super.stepHit()) return false;
 
-    if ((audioInstTrack != null && audioInstTrack.isPlaying) || audioVocalTrackGroup.playing)
+    if ((audioInstTrack != null && audioInstTrack.playing) || audioVocalTrackGroup.playing)
     {
       if (healthIconDad != null) healthIconDad.onStepHit(Conductor.instance.currentStep);
       if (healthIconBF != null) healthIconBF.onStepHit(Conductor.instance.currentStep);
@@ -3867,11 +3864,11 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
         }
       }
 
-      if ((!audioInstTrack.isPlaying || (audioVocalTrackGroup.length > 0 && !audioVocalTrackGroup.playing))
+      if ((!audioInstTrack.playing || (audioVocalTrackGroup.length > 0 && !audioVocalTrackGroup.playing))
         && currentScrollEase != scrollPositionInPixels) easeSongToScrollPosition(currentScrollEase);
     }
 
-    if ((audioInstTrack != null && audioInstTrack.isPlaying) || audioVocalTrackGroup.playing)
+    if ((audioInstTrack != null && audioInstTrack.playing) || audioVocalTrackGroup.playing)
     {
       currentScrollEase = scrollPositionInPixels;
 
@@ -4595,7 +4592,7 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
 
     shouldEase = true;
     if (shouldPause
-      && (audioInstTrack?.isPlaying || audioVocalTrackGroup.playing)) stopAudioPlayback(); // Only do this once, not every frame
+      && (audioInstTrack?.playing || audioVocalTrackGroup.playing)) stopAudioPlayback(); // Only do this once, not every frame
 
     // Resync the conductor and audio tracks.
     if (playheadAmount != 0) this.playheadPositionInPixels += playheadAmount;
@@ -4784,7 +4781,7 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
       {
         gridPlayheadScrollAreaPressed = true;
         // Stop audio playback while dragging on the grid playhead.
-        if ((audioInstTrack != null && audioInstTrack.isPlaying) || audioVocalTrackGroup.playing)
+        if ((audioInstTrack != null && audioInstTrack.playing) || audioVocalTrackGroup.playing)
         {
           playbarHeadDraggingWasPlaying = true;
           stopAudioPlayback();
@@ -5085,7 +5082,7 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
     {
       notePreviewPlayHeadDragging = true;
       // Stop audio playback while dragging on the note preview playhead.
-      if ((audioInstTrack != null && audioInstTrack.isPlaying) || audioVocalTrackGroup.playing)
+      if ((audioInstTrack != null && audioInstTrack.playing) || audioVocalTrackGroup.playing)
       {
         playbarHeadDraggingWasPlaying = true;
         stopAudioPlayback();
@@ -7307,7 +7304,7 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
 
     currentScrollEase = this.scrollPositionInPixels;
 
-    if (audioInstTrack.isPlaying || audioVocalTrackGroup.playing)
+    if (audioInstTrack.playing || audioVocalTrackGroup.playing)
     {
       // Pause
       stopAudioPlayback();

--- a/source/funkin/ui/debug/charting/components/ChartEditorEventSprite.hx
+++ b/source/funkin/ui/debug/charting/components/ChartEditorEventSprite.hx
@@ -29,11 +29,6 @@ class ChartEditorEventSprite extends FlxSprite
    */
   public var eventData(default, set):Null<SongEventData> = null;
 
-  /**
-   * The image used for all song events. Cached for performance.
-   */
-  static var eventSpriteBasic:Null<BitmapData> = null;
-
   public var overrideStepTime(default, set):Null<Float> = null;
 
   public var tooltip:ToolTipRegionOptions;

--- a/source/funkin/ui/debug/charting/components/ChartEditorMeasureTicks.hx
+++ b/source/funkin/ui/debug/charting/components/ChartEditorMeasureTicks.hx
@@ -39,11 +39,6 @@ class ChartEditorMeasureTicks extends FlxTypedSpriteGroup<FlxSprite>
   var measureDividers:FlxTypedSpriteGroup<FlxSprite> = new FlxTypedSpriteGroup<FlxSprite>();
 
   /**
-   * The positions of each measure tick, in pixels, relative to the start of the song.
-   */
-  var measurePositions:Array<Float> = [];
-
-  /**
    * A map of the
    * @param value
    * @return Float

--- a/source/funkin/ui/debug/charting/components/ChartEditorNotePreview.hx
+++ b/source/funkin/ui/debug/charting/components/ChartEditorNotePreview.hx
@@ -186,19 +186,6 @@ class ChartEditorNotePreview extends FlxSprite
     drawRect(noteX, noteY, NOTE_WIDTH, noteHeight, color);
   }
 
-  function eraseNote(dir:Int, mustHit:Bool, strumTimeInMs:Int, songLengthInPixels:Int):Void
-  {
-    var noteX:Float = NOTE_WIDTH * dir;
-    if (mustHit) noteX += NOTE_WIDTH * 4;
-    if (dir == -1) noteX = NOTE_WIDTH * 8;
-
-    var strumTimeInPixels:Int = Std.int(Conductor.instance.getTimeInSteps(strumTimeInMs) * ChartEditorState.GRID_SIZE);
-
-    var noteY:Float = FlxMath.remapToRange(strumTimeInPixels, 0, songLengthInPixels, 0, previewHeight);
-
-    drawRect(noteX, noteY, NOTE_WIDTH, NOTE_HEIGHT, BG_COLOR);
-  }
-
   inline function drawRect(noteX:Float, noteY:Float, width:Int, height:Int, color:FlxColor):Void
   {
     FlxSpriteUtil.drawRect(this, noteX, noteY, width, height, color);

--- a/source/funkin/ui/debug/charting/components/ChartEditorNoteSprite.hx
+++ b/source/funkin/ui/debug/charting/components/ChartEditorNoteSprite.hx
@@ -294,7 +294,6 @@ class ChartEditorNoteSprite extends FlxSprite
 
     // Play the appropriate animation for the type, direction, and skin.
     var dirName:String = overrideData != null ? SongNoteData.buildDirectionName(overrideData) : this.noteData.getDirectionName();
-    var noteStyleSuffix:String = this.noteStyle?.toTitleCase() ?? Constants.DEFAULT_NOTE_STYLE.toTitleCase();
     var animationName:String = '${baseAnimationName}${dirName}${this.noteStyle.toTitleCase()}';
 
     this.animation.play(animationName);

--- a/source/funkin/ui/debug/charting/contextmenus/ChartEditorSelectionContextMenu.hx
+++ b/source/funkin/ui/debug/charting/contextmenus/ChartEditorSelectionContextMenu.hx
@@ -27,7 +27,6 @@ class ChartEditorSelectionContextMenu extends ChartEditorBaseContextMenu
   var contextmenuOffsetMove:MenuItem;
   var contextmenuCut:MenuItem;
   var contextmenuCopy:MenuItem;
-  var contextmenuPaste:MenuItem;
   var contextmenuDelete:MenuItem;
   var contextmenuFlip:MenuItem;
   var contextmenuMirrorX:MenuItem;

--- a/source/funkin/ui/debug/charting/dialogs/ChartEditorUploadChartDialog.hx
+++ b/source/funkin/ui/debug/charting/dialogs/ChartEditorUploadChartDialog.hx
@@ -8,7 +8,6 @@ import funkin.util.FileUtil;
 import haxe.io.Path;
 import haxe.ui.containers.dialogs.Dialog.DialogButton;
 import haxe.ui.containers.dialogs.Dialog.DialogEvent;
-import haxe.ui.containers.dialogs.Dialogs.SelectedFileInfo;
 
 // @:nullSafety // TODO: Fix null safety when used with HaxeUI build macros.
 @:build(haxe.ui.ComponentBuilder.build("assets/exclude/data/ui/chart-editor/dialogs/upload-chart.xml"))
@@ -95,7 +94,7 @@ class ChartEditorUploadChartDialog extends ChartEditorBaseDialog
 
     this.lock();
 
-    FileUtil.browseForBinaryFile('Open Chart', [FileUtil.FILE_EXTENSION_INFO_FNFC], onSelectFile, onCancelBrowse);
+    FileUtil.browseForFile('Open Chart', [FileUtil.FILE_FILTER_FNFC], onSelectFile, onCancelBrowse);
   }
 
   /**
@@ -129,7 +128,7 @@ class ChartEditorUploadChartDialog extends ChartEditorBaseDialog
   /**
    * Called when a file is selected by the dialog displayed when clicking the Upload Chart box.
    */
-  function onSelectFile(selectedFile:SelectedFileInfo):Void
+  function onSelectFile(selectedFile:SelectedFileData):Void
   {
     this.unlock();
 

--- a/source/funkin/ui/debug/charting/dialogs/ChartEditorUploadVocalsDialog.hx
+++ b/source/funkin/ui/debug/charting/dialogs/ChartEditorUploadVocalsDialog.hx
@@ -109,7 +109,7 @@ class ChartEditorUploadVocalsDialog extends ChartEditorBaseDialog
 
       vocalsEntry.onClick = function(_event)
       {
-        Dialogs.openBinaryFile('Open $charName Vocals', [{label: 'Audio File (.ogg)', extension: 'ogg'}], function(selectedFile)
+        FileUtil.browseForFile('Open $charName Vocals', [FileUtil.FILE_FILTER_OGG], function(selectedFile)
         {
           if (selectedFile != null && selectedFile.bytes != null)
           {
@@ -211,7 +211,7 @@ class ChartEditorUploadVocalsDialog extends ChartEditorBaseDialog
 
     this.lock();
 
-    FileUtil.browseForBinaryFile('Open Chart', [FileUtil.FILE_EXTENSION_INFO_FNFC], onSelectFile, onCancelBrowse);
+    FileUtil.browseForFile('Open Chart', [FileUtil.FILE_FILTER_FNFC], onSelectFile, onCancelBrowse);
   }
 
   /**
@@ -245,7 +245,7 @@ class ChartEditorUploadVocalsDialog extends ChartEditorBaseDialog
   /**
    * Called when a file is selected by the dialog displayed when clicking the Upload Chart box.
    */
-  function onSelectFile(selectedFile:SelectedFileInfo):Void
+  function onSelectFile(selectedFile:SelectedFileData):Void
   {
     this.unlock();
 

--- a/source/funkin/ui/debug/charting/dialogs/ChartEditorUploadVocalsDialog.hx
+++ b/source/funkin/ui/debug/charting/dialogs/ChartEditorUploadVocalsDialog.hx
@@ -215,34 +215,6 @@ class ChartEditorUploadVocalsDialog extends ChartEditorBaseDialog
   }
 
   /**
-   * Called when a file is selected by dropping a file onto the Upload Chart box.
-   */
-  function onDropFileChartBox(pathStr:String):Void
-  {
-    var path:Path = new Path(pathStr);
-    trace('Dropped file (${path})');
-
-    try
-    {
-      var result:Null<Array<String>> = ChartEditorImportExportHandler.loadFromFNFCPath(chartEditorState, path.toString());
-      if (result != null)
-      {
-        chartEditorState.success('Loaded Chart',
-          result.length == 0 ? 'Loaded chart (${path.toString()})' : 'Loaded chart (${path.toString()})\n${result.join("\n")}');
-        this.hideDialog(DialogButton.APPLY);
-      }
-      else
-      {
-        chartEditorState.failure('Failed to Load Chart', 'Failed to load chart (${path.toString()})');
-      }
-    }
-    catch (err)
-    {
-      chartEditorState.failure('Failed to Load Chart', 'Failed to load chart (${path.toString()}): ${err}');
-    }
-  }
-
-  /**
    * Called when a file is selected by the dialog displayed when clicking the Upload Chart box.
    */
   function onSelectFile(selectedFile:SelectedFileData):Void

--- a/source/funkin/ui/debug/charting/dialogs/ChartEditorUploadVocalsDialog.hx
+++ b/source/funkin/ui/debug/charting/dialogs/ChartEditorUploadVocalsDialog.hx
@@ -109,7 +109,7 @@ class ChartEditorUploadVocalsDialog extends ChartEditorBaseDialog
 
       vocalsEntry.onClick = function(_event)
       {
-        FileUtil.browseForFile('Open $charName Vocals', [FileUtil.FILE_FILTER_OGG], function(selectedFile)
+        FileUtil.browseForFile('Open $charName Vocals', [FileUtil.FILE_FILTER_AUDIO], function(selectedFile)
         {
           if (selectedFile != null && selectedFile.bytes != null)
           {

--- a/source/funkin/ui/debug/charting/handlers/ChartEditorAudioHandler.hx
+++ b/source/funkin/ui/debug/charting/handlers/ChartEditorAudioHandler.hx
@@ -377,7 +377,6 @@ class ChartEditorAudioHandler
   {
     var zipEntries = [];
 
-    var vocalTrackIds = state.audioVocalTrackData.keys().array();
     for (key in state.audioVocalTrackData.keys())
     {
       var data:Null<Bytes> = state.audioVocalTrackData.get(key);

--- a/source/funkin/ui/debug/charting/handlers/ChartEditorAudioHandler.hx
+++ b/source/funkin/ui/debug/charting/handlers/ChartEditorAudioHandler.hx
@@ -10,9 +10,11 @@ import funkin.util.assets.SoundUtil;
 import funkin.audio.waveform.WaveformData;
 import funkin.audio.waveform.WaveformDataParser;
 import funkin.audio.waveform.WaveformSprite;
+import flixel.sound.FlxSoundData;
 import flixel.util.FlxColor;
 import haxe.io.Bytes;
 import haxe.io.Path;
+import lime.media.AudioBuffer;
 
 /**
  * Functions for loading audio for the chart editor.
@@ -69,6 +71,7 @@ class ChartEditorAudioHandler
    */
   public static function loadVocalsFromBytes(state:ChartEditorState, bytes:Bytes, charId:String, instId:String = '', wipeFirst:Bool = false):Bool
   {
+    if (AudioBuffer.getCodec(bytes) == null) return false;
     var trackId:String = '${charId}${instId == '' ? '' : '-${instId}'}';
     if (wipeFirst) wipeVocalData(state);
     state.audioVocalTrackData.set(trackId, bytes);
@@ -119,6 +122,7 @@ class ChartEditorAudioHandler
    */
   public static function loadInstFromBytes(state:ChartEditorState, bytes:Bytes, instId:String = '', wipeFirst:Bool = false):Bool
   {
+    if (AudioBuffer.getCodec(bytes) == null) return false;
     if (instId == '') instId = 'default';
     if (wipeFirst) wipeInstrumentalData(state);
     state.audioInstTrackData.set(instId, bytes);
@@ -159,8 +163,6 @@ class ChartEditorAudioHandler
     var instTrack:Null<FunkinSound> = SoundUtil.buildSoundFromBytes(instTrackData);
     if (instTrack == null) return false;
 
-    instTrack.important = true;
-
     stopExistingInstrumental(state);
     state.audioInstTrack = instTrack;
     state.postLoadInstrumental();
@@ -192,8 +194,6 @@ class ChartEditorAudioHandler
 
     // early return
     if (vocalTrack == null) return false;
-
-    vocalTrack.important = true;
 
     switch (charType)
     {
@@ -272,7 +272,7 @@ class ChartEditorAudioHandler
    */
   public static function playSound(_state:ChartEditorState, path:String, volume:Float = 1.0):Void
   {
-    var asset:Null<FlxSoundAsset> = FlxG.sound.cache(path);
+    var asset:Null<FlxSoundAsset> = FlxSoundData.fromAssetKey(path);
     if (asset == null)
     {
       trace('WARN: Failed to play sound $path, asset not found.');
@@ -299,7 +299,7 @@ class ChartEditorAudioHandler
       if (state.stretchySound1 == null) return;
 
       // Prevent spam playing that could cause issues.
-      if (state.stretchySound1?.isPlaying ?? false || state.stretchySound2?.isPlaying ?? false) return;
+      if (state.stretchySound1?.playing ?? false || state.stretchySound2?.playing ?? false) return;
 
       state.stretchySounds = !state.stretchySounds;
       state.stretchySound1.play(true);
@@ -311,7 +311,7 @@ class ChartEditorAudioHandler
       if (state.stretchySound2 == null) return;
 
       // Prevent spam playing that could cause issues.
-      if (state.stretchySound1?.isPlaying ?? false || state.stretchySound2?.isPlaying ?? false) return;
+      if (state.stretchySound1?.playing ?? false || state.stretchySound2?.playing ?? false) return;
 
       state.stretchySounds = !state.stretchySounds;
       state.stretchySound2.play(true);
@@ -343,26 +343,14 @@ class ChartEditorAudioHandler
     var instTrackIds = state.audioInstTrackData.keys().array();
     for (key in instTrackIds)
     {
-      if (key == 'default')
+      var data:Null<Bytes> = state.audioInstTrackData.get(key);
+      if (data == null)
       {
-        var data:Null<Bytes> = state.audioInstTrackData.get('default');
-        if (data == null)
-        {
-          trace(' WARNING '.warning() + ' Failed to access inst track ($key)');
-          continue;
-        }
-        zipEntries.push(FileUtil.makeZIPEntryFromBytes('Inst.ogg', data));
+        trace(' WARNING '.warning() + ' Failed to access inst track ($key)');
+        continue;
       }
-      else
-      {
-        var data:Null<Bytes> = state.audioInstTrackData.get(key);
-        if (data == null)
-        {
-          trace(' WARNING '.warning() + ' Failed to access inst track ($key)');
-          continue;
-        }
-        zipEntries.push(FileUtil.makeZIPEntryFromBytes('Inst-${key}.ogg', data));
-      }
+      var extension = AudioBuffer.getCodec(data).toFormat();
+      zipEntries.push(FileUtil.makeZIPEntryFromBytes(key == 'default' ? 'Inst.${extension}' : 'Inst-${key}.${extension}', data));
     }
 
     return zipEntries;
@@ -385,7 +373,8 @@ class ChartEditorAudioHandler
         trace(' WARNING '.warning() + ' Failed to access vocal track ($key)');
         continue;
       }
-      zipEntries.push(FileUtil.makeZIPEntryFromBytes('Voices-${key}.ogg', data));
+      var extension = AudioBuffer.getCodec(data).toFormat();
+      zipEntries.push(FileUtil.makeZIPEntryFromBytes('Voices-${key}.${extension}', data));
     }
 
     return zipEntries;

--- a/source/funkin/ui/debug/charting/handlers/ChartEditorDialogHandler.hx
+++ b/source/funkin/ui/debug/charting/handlers/ChartEditorDialogHandler.hx
@@ -23,7 +23,6 @@ import funkin.ui.debug.charting.dialogs.ChartEditorWelcomeDialog;
 import funkin.ui.debug.charting.dialogs.ChartEditorUploadVocalsDialog;
 import funkin.ui.debug.charting.util.ChartEditorDropdowns;
 import funkin.util.Constants;
-import funkin.util.DateUtil;
 import funkin.util.FileUtil;
 import funkin.util.VersionUtil;
 import haxe.io.Path;
@@ -693,6 +692,24 @@ class ChartEditorDialogHandler
     var startingValueNoteStyle = ChartEditorDropdowns.populateDropdownWithNoteStyles(inputNoteStyle, newSongMetadata.playData.noteStyle);
     inputNoteStyle.value = startingValueNoteStyle;
 
+    var inputAlbum:Null<DropDown> = dialog.findComponent('inputAlbum', DropDown);
+    if (inputAlbum == null) throw 'Could not locate inputAlbum DropDown in Song Metadata dialog';
+    inputAlbum.onChange = (event:UIEvent) -> {
+      if (event.data?.id == null) return;
+      newSongMetadata.playData.album = event.data.id;
+    };
+    var startingValueAlbum = ChartEditorDropdowns.populateDropdownWithAlbums(inputAlbum, newSongMetadata.playData.album);
+    inputAlbum.value = startingValueAlbum;
+
+    var inputStickerPack:Null<DropDown> = dialog.findComponent('inputStickerPack', DropDown);
+    if (inputStickerPack == null) throw 'Could not locate inputStickerPack DropDown in Song Metadata dialog';
+    inputStickerPack.onChange = (event:UIEvent) -> {
+      if (event.data?.id == null) return;
+      newSongMetadata.playData.stickerPack = event.data.id;
+    };
+    var startingValueStickerPack = ChartEditorDropdowns.populateDropdownWithStickerPacks(inputStickerPack, newSongMetadata.playData.stickerPack);
+    inputStickerPack.value = startingValueStickerPack;
+
     var inputCharacterPlayer:Null<DropDown> = dialog.findComponent('inputCharacterPlayer', DropDown);
     if (inputCharacterPlayer == null) throw 'ChartEditorToolboxHandler.buildToolboxMetadataLayout() - Could not find inputCharacterPlayer component.';
     inputCharacterPlayer.onChange = function(event:UIEvent)
@@ -1337,6 +1354,16 @@ class ChartEditorDialogHandler
     var startingValueNoteStyle = ChartEditorDropdowns.populateDropdownWithNoteStyles(dialogNoteStyle, state.currentSongMetadata.playData.noteStyle);
     dialogNoteStyle.value = startingValueNoteStyle;
 
+    var dialogAlbum:Null<DropDown> = dialog.findComponent('dialogAlbum', DropDown);
+    if (dialogAlbum == null) throw 'Could not locate dialogAlbum DropDown in Add Variation dialog';
+    var startingValueAlbum = ChartEditorDropdowns.populateDropdownWithAlbums(dialogAlbum, state.currentSongMetadata.playData.album);
+    dialogAlbum.value = startingValueAlbum;
+
+    var dialogStickerPack:Null<DropDown> = dialog.findComponent('dialogStickerPack', DropDown);
+    if (dialogStickerPack == null) throw 'Could not locate dialogStickerPack DropDown in Add Variation dialog';
+    var startingValueStickerPack = ChartEditorDropdowns.populateDropdownWithStickerPacks(dialogStickerPack, state.currentSongMetadata.playData.stickerPack);
+    dialogAlbum.value = startingValueStickerPack;
+
     var dialogCharacterPlayer:Null<DropDown> = dialog.findComponent('dialogCharacterPlayer', DropDown);
     if (dialogCharacterPlayer == null) throw 'Could not locate dialogCharacterPlayer DropDown in Add Variation dialog';
     dialogCharacterPlayer.value = ChartEditorDropdowns.populateDropdownWithCharacters(dialogCharacterPlayer, CharacterType.BF,
@@ -1373,6 +1400,8 @@ class ChartEditorDialogHandler
 
       pendingVariation.playData.stage = dialogStage.value.id;
       pendingVariation.playData.noteStyle = dialogNoteStyle.value.id;
+      pendingVariation.playData.album = dialogAlbum.value.id;
+      pendingVariation.playData.stickerPack = dialogStickerPack.value.id;
       pendingVariation.timeChanges[0].bpm = dialogBPM.value;
 
       state.songMetadata.set(pendingVariation.variation, pendingVariation);

--- a/source/funkin/ui/debug/charting/handlers/ChartEditorDialogHandler.hx
+++ b/source/funkin/ui/debug/charting/handlers/ChartEditorDialogHandler.hx
@@ -532,7 +532,7 @@ class ChartEditorDialogHandler
 
     instrumentalBox.onClick = function(_)
     {
-      Dialogs.openBinaryFile('Open Instrumental', [{label: 'Audio File (.ogg)', extension: 'ogg'}], function(selectedFile:SelectedFileInfo)
+      FileUtil.browseForFile('Open Instrumental', [FileUtil.FILE_FILTER_OGG], function(selectedFile:SelectedFileData)
       {
         if (selectedFile != null && selectedFile.bytes != null)
         {
@@ -944,7 +944,7 @@ class ChartEditorDialogHandler
 
     onClickMetadataVariation = function(variation:String, label:Label, _:UIEvent)
     {
-      Dialogs.openBinaryFile('Open Chart ($variation) Metadata', [{label: 'JSON File (.json)', extension: 'json'}], function(selectedFile)
+      FileUtil.browseForFile('Open Chart ($variation) Metadata', [FileUtil.FILE_FILTER_JSON], function(selectedFile)
       {
         if (selectedFile != null && selectedFile.bytes != null)
         {
@@ -1030,7 +1030,7 @@ class ChartEditorDialogHandler
 
     onClickChartDataVariation = function(variation:String, label:Label, _:UIEvent)
     {
-      Dialogs.openBinaryFile('Open Chart ($variation) Metadata', [{label: 'JSON File (.json)', extension: 'json'}], function(selectedFile)
+      FileUtil.browseForFile('Open Chart ($variation) Metadata', [FileUtil.FILE_FILTER_JSON], function(selectedFile)
       {
         if (selectedFile != null && selectedFile.bytes != null)
         {
@@ -1120,11 +1120,11 @@ class ChartEditorDialogHandler
     var fileFilter = switch (format)
     {
       case 'legacy':
-        [{label: 'JSON Data File (.json)', extension: 'json'}];
+        [FileUtil.FILE_FILTER_JSON];
       case 'stepmania':
-        [{label: 'StepMania File (.sm)', extension: 'sm'}];
+        [FileUtil.FILE_FILTER_SM];
       case 'osumania':
-        [{label: 'OSU! Beatmap File (.osu)', extension: 'osu'}];
+        [FileUtil.FILE_FILTER_OSU];
       default: null;
     }
 
@@ -1136,18 +1136,6 @@ class ChartEditorDialogHandler
         "sm";
       default: "json";
     }
-
-    var fileFilterLabel:String = switch (fileExt)
-    {
-      case 'json':
-        'JSON Data File';
-      case 'sm':
-        'StepMania File';
-      case 'osu':
-        'osu! Beatmap File';
-      default: "Unknown File Type";
-    };
-    fileFilterLabel += ' (.$fileExt)';
 
     dialog.title = 'Import Chart - ${prettyFormat}';
 
@@ -1268,7 +1256,7 @@ class ChartEditorDialogHandler
     importBox.onClick = function(_)
     {
       // TODO / BUG: File filtering not working on mac finder dialog, so we don't use it for now
-      Dialogs.openBinaryFile('Import Chart - ${prettyFormat}', fileFilter ?? [], function(selectedFile:SelectedFileInfo)
+      FileUtil.browseForFile('Import Chart - ${prettyFormat}', fileFilter ?? [], function(selectedFile:SelectedFileData)
       {
         if (selectedFile != null && selectedFile.bytes != null)
         {

--- a/source/funkin/ui/debug/charting/handlers/ChartEditorDialogHandler.hx
+++ b/source/funkin/ui/debug/charting/handlers/ChartEditorDialogHandler.hx
@@ -127,8 +127,6 @@ class ChartEditorDialogHandler
   {
     var charData:SongCharacterData = state.currentSongMetadata.playData.characters;
 
-    var hasClearedVocals:Bool = false;
-
     var charIdsForVocals:Array<String> = [charData.player, charData.opponent];
 
     var dialog = ChartEditorUploadVocalsDialog.build(state, charIdsForVocals, closable);

--- a/source/funkin/ui/debug/charting/handlers/ChartEditorDialogHandler.hx
+++ b/source/funkin/ui/debug/charting/handlers/ChartEditorDialogHandler.hx
@@ -95,7 +95,7 @@ class ChartEditorDialogHandler
     state.isHaxeUIDialogOpen = true;
 
     state.stopAudioPlayback();
-    if (state.welcomeMusic != null && !state.welcomeMusic.isPlaying) state.fadeInWelcomeMusic();
+    if (state.welcomeMusic != null && !state.welcomeMusic.playing) state.fadeInWelcomeMusic();
 
     return dialog;
   }
@@ -529,7 +529,7 @@ class ChartEditorDialogHandler
 
     instrumentalBox.onClick = function(_)
     {
-      FileUtil.browseForFile('Open Instrumental', [FileUtil.FILE_FILTER_OGG], function(selectedFile:SelectedFileData)
+      FileUtil.browseForFile('Open Instrumental', [FileUtil.FILE_FILTER_AUDIO], function(selectedFile:SelectedFileData)
       {
         if (selectedFile != null && selectedFile.bytes != null)
         {
@@ -564,17 +564,8 @@ class ChartEditorDialogHandler
       }
       else
       {
-        var message:String = if (!ChartEditorState.SUPPORTED_MUSIC_FORMATS.contains(path.ext ?? ''))
-        {
-          'File format (${path.ext}) not supported for instrumental track (${path.file}.${path.ext})';
-        }
-        else
-        {
-          'Failed to load instrumental track (${path.file}.${path.ext}) for variation (${state.selectedVariation})';
-        }
-
         // Tell the user the load was successful.
-        state.error('Failed to Load Instrumental', message);
+        state.error('Failed to Load Instrumental', 'Failed to load instrumental track (${path.file}.${path.ext}) for variation (${state.selectedVariation})');
       }
     };
 

--- a/source/funkin/ui/debug/charting/handlers/ChartEditorImportExportHandler.hx
+++ b/source/funkin/ui/debug/charting/handlers/ChartEditorImportExportHandler.hx
@@ -309,8 +309,7 @@ class ChartEditorImportExportHandler
       if (variMetadata == null) continue;
 
       var instId:String = variMetadata?.playData?.characters?.instrumental ?? '';
-
-      var instFileName:String = manifest.getInstFileName(instId);
+      var instFileName:String = manifest.getInstFileName(instId, fileEntries);
       var instFileBytes:Bytes = mappedFileEntries.get(instFileName)?.data ?? throw 'Could not locate instrumental ($instFileName).';
       if (!ChartEditorAudioHandler.loadInstFromBytes(state, instFileBytes, instId)) throw 'Could not load instrumental ($instFileName).';
 
@@ -318,7 +317,7 @@ class ChartEditorImportExportHandler
       var playerVoiceList:Array<String> = variMetadata?.playData.characters?.playerVocals ?? [playerCharId];
       for (voice in playerVoiceList)
       {
-        var playerVocalsFileName:String = manifest.getVocalsFileName(voice, variation);
+        var playerVocalsFileName:String = manifest.getVocalsFileName(voice, variation, fileEntries);
         var playerVocalsFileBytes:Null<Bytes> = mappedFileEntries.get(playerVocalsFileName)?.data;
         if (playerVocalsFileBytes == null)
         {
@@ -336,7 +335,7 @@ class ChartEditorImportExportHandler
       var opponentVoiceList:Array<String> = variMetadata?.playData.characters?.opponentVocals ?? [opponentCharId];
       for (voice in opponentVoiceList)
       {
-        var opponentVocalsFileName:String = manifest.getVocalsFileName(voice, variation);
+        var opponentVocalsFileName:String = manifest.getVocalsFileName(voice, variation, fileEntries);
         var opponentVocalsFileBytes:Null<Bytes> = mappedFileEntries.get(opponentVocalsFileName)?.data;
         if (opponentVocalsFileBytes == null)
         {

--- a/source/funkin/ui/debug/charting/handlers/ChartEditorNotificationHandler.hx
+++ b/source/funkin/ui/debug/charting/handlers/ChartEditorNotificationHandler.hx
@@ -137,8 +137,6 @@ class ChartEditorNotificationHandler
   static function sendNotification(state:ChartEditorState, title:String, body:String, ?type:NotificationType,
       ?actions:Array<NotificationActionData>):Notification
   {
-    var actionNames:Array<String> = actions == null ? [] : actions.map(action -> action.text);
-
     var notif = NotificationManager.instance.addNotification({
       title: title,
       body: body,

--- a/source/funkin/ui/debug/charting/toolboxes/ChartEditorDifficultyToolbox.hx
+++ b/source/funkin/ui/debug/charting/toolboxes/ChartEditorDifficultyToolbox.hx
@@ -243,7 +243,7 @@ class ChartEditorDifficultyToolbox extends ChartEditorBaseToolbox
 
       for (difficulty in difficultyList)
       {
-        var _treeDifficulty:TreeViewNode = treeVariation.addNode({
+        treeVariation.addNode({
           id: 'stv_difficulty_${curVariation}_$difficulty',
           text: 'D: ${difficulty.toTitleCase()}'
         });
@@ -281,7 +281,6 @@ class ChartEditorDifficultyToolbox extends ChartEditorBaseToolbox
   function onTreeChange(event:UIEvent):Void
   {
     // Get the newly selected node.
-    var treeView:TreeView = cast event.target;
     var targetNode:TreeViewNode = difficultyToolboxTree.selectedNode;
 
     if (targetNode == null)

--- a/source/funkin/ui/debug/charting/toolboxes/ChartEditorEventDataToolbox.hx
+++ b/source/funkin/ui/debug/charting/toolboxes/ChartEditorEventDataToolbox.hx
@@ -36,7 +36,6 @@ import flixel.FlxG;
 class ChartEditorEventDataToolbox extends ChartEditorBaseToolbox
 {
   var toolboxEventsEventKind:DropDown;
-  var toolboxEventsDataFrame:Frame;
   var toolboxEventsDataBox:VBox;
 
   var easeGraphImage:Image;

--- a/source/funkin/ui/debug/charting/toolboxes/ChartEditorFreeplayToolbox.hx
+++ b/source/funkin/ui/debug/charting/toolboxes/ChartEditorFreeplayToolbox.hx
@@ -101,31 +101,6 @@ class ChartEditorFreeplayToolbox extends ChartEditorBaseToolbox
     return previewSelectionSprite.width = value - previewBoxStartPosAbsolute;
   }
 
-  var previewBoxStartPosRelative(get, set):Float;
-
-  function get_previewBoxStartPosRelative():Float
-  {
-    return previewSelectionSprite.left - waveformScrollview.hscrollPos;
-  }
-
-  function set_previewBoxStartPosRelative(value:Float):Float
-  {
-    return previewSelectionSprite.left = waveformScrollview.hscrollPos + value;
-  }
-
-  var previewBoxEndPosRelative(get, set):Float;
-
-  function get_previewBoxEndPosRelative():Float
-  {
-    return previewSelectionSprite.left + previewSelectionSprite.width - waveformScrollview.hscrollPos;
-  }
-
-  function set_previewBoxEndPosRelative(value:Float):Float
-  {
-    if (value < previewBoxStartPosRelative) return previewSelectionSprite.left = previewBoxStartPosRelative;
-    return previewSelectionSprite.width = value - previewBoxStartPosRelative;
-  }
-
   /**
    * The amount you need to multiply the zoom by such that, at the base zoom level, one tick is equal to `MAGIC_SCALE_BASE_TIME` seconds.
    */
@@ -362,10 +337,6 @@ class ChartEditorFreeplayToolbox extends ChartEditorBaseToolbox
 
       return '${integerMinutes}:${remainingSecondsPad}${decimalSeconds > 0 ? '.$decimalSeconds' : ''}';
     }
-  }
-
-  function buildTickLabel():Void
-  {
   }
 
   public function onStartDragPlayhead():Void
@@ -635,9 +606,7 @@ class ChartEditorFreeplayToolbox extends ChartEditorBaseToolbox
     {
       var targetScrollPos:Float = waveformMusic.waveform.waveformData.secondsToIndex(audioPreviewTracks.time / Constants.MS_PER_SEC) / (waveformScale / BASE_SCALE * waveformMagicFactor);
       // waveformScrollview.hscrollPos = targetScrollPos;
-      var prevPlayheadAbsolutePos = playheadAbsolutePos;
       playheadAbsolutePos = targetScrollPos;
-      var playheadDiff = playheadAbsolutePos - prevPlayheadAbsolutePos;
 
       // BEHAVIOR C.
       // Copy Audacity!

--- a/source/funkin/ui/debug/charting/toolboxes/ChartEditorFreeplayToolbox.hx
+++ b/source/funkin/ui/debug/charting/toolboxes/ChartEditorFreeplayToolbox.hx
@@ -303,7 +303,7 @@ class ChartEditorFreeplayToolbox extends ChartEditorBaseToolbox
     for (index in 0...numberOfTicks)
     {
       var tickPos = chartEditorState.offsetTickBitmap.width / 2 * index;
-      var tickTime = tickPos * (waveformScale / BASE_SCALE * waveformMagicFactor) / waveformMusic.waveform.waveformData.pointsPerSecond();
+      var tickTime = tickPos * (waveformScale / BASE_SCALE * waveformMagicFactor) / waveformMusic.waveform.waveformData?.pointsPerSecond();
 
       var tickLabel:Label = new Label();
       tickLabel.text = formatTime(tickTime);
@@ -372,7 +372,7 @@ class ChartEditorFreeplayToolbox extends ChartEditorBaseToolbox
 
     // Move the audio preview to the playhead position.
     var currentWaveformIndex:Int = Std.int(playheadAbsolutePos * (waveformScale / BASE_SCALE * waveformMagicFactor));
-    var targetSongTimeSeconds:Float = waveformMusic.waveform.waveformData.indexToSeconds(currentWaveformIndex);
+    var targetSongTimeSeconds:Float = waveformMusic.waveform.waveformData?.indexToSeconds(currentWaveformIndex);
     audioPreviewTracks.time = targetSongTimeSeconds * Constants.MS_PER_SEC;
   }
 
@@ -427,11 +427,11 @@ class ChartEditorFreeplayToolbox extends ChartEditorBaseToolbox
 
     var previewStartPosAbsolute = waveformDragPreviewStartPos + waveformScrollview.hscrollPos;
     var previewStartPosIndex:Int = Std.int(previewStartPosAbsolute * (waveformScale / BASE_SCALE * waveformMagicFactor));
-    var previewStartPosMs:Int = Std.int(waveformMusic.waveform.waveformData.indexToSeconds(previewStartPosIndex) * Constants.MS_PER_SEC);
+    var previewStartPosMs:Int = Std.int(waveformMusic.waveform.waveformData?.indexToSeconds(previewStartPosIndex) * Constants.MS_PER_SEC);
 
     var previewEndPosAbsolute = waveformDragPreviewEndPos + waveformScrollview.hscrollPos;
     var previewEndPosIndex:Int = Std.int(previewEndPosAbsolute * (waveformScale / BASE_SCALE * waveformMagicFactor));
-    var previewEndPosMs:Int = Std.int(waveformMusic.waveform.waveformData.indexToSeconds(previewEndPosIndex) * Constants.MS_PER_SEC);
+    var previewEndPosMs:Int = Std.int(waveformMusic.waveform.waveformData?.indexToSeconds(previewEndPosIndex) * Constants.MS_PER_SEC);
 
     chartEditorState.performCommand(new SetFreeplayPreviewCommand(previewStartPosMs, previewEndPosMs));
 
@@ -604,7 +604,7 @@ class ChartEditorFreeplayToolbox extends ChartEditorBaseToolbox
 
     if (audioPreviewTracks.playing)
     {
-      var targetScrollPos:Float = waveformMusic.waveform.waveformData.secondsToIndex(audioPreviewTracks.time / Constants.MS_PER_SEC) / (waveformScale / BASE_SCALE * waveformMagicFactor);
+      var targetScrollPos:Float = waveformMusic.waveform.waveformData?.secondsToIndex(audioPreviewTracks.time / Constants.MS_PER_SEC) / (waveformScale / BASE_SCALE * waveformMagicFactor);
       // waveformScrollview.hscrollPos = targetScrollPos;
       playheadAbsolutePos = targetScrollPos;
 
@@ -625,11 +625,11 @@ class ChartEditorFreeplayToolbox extends ChartEditorBaseToolbox
     {
       var previewStartPosAbsolute = waveformDragPreviewStartPos + waveformScrollview.hscrollPos;
       var previewStartPosIndex:Int = Std.int(previewStartPosAbsolute * (waveformScale / BASE_SCALE * waveformMagicFactor));
-      var previewStartPosMs:Int = Std.int(waveformMusic.waveform.waveformData.indexToSeconds(previewStartPosIndex) * Constants.MS_PER_SEC);
+      var previewStartPosMs:Int = Std.int(waveformMusic.waveform.waveformData?.indexToSeconds(previewStartPosIndex) * Constants.MS_PER_SEC);
 
       var previewEndPosAbsolute = waveformDragPreviewEndPos + waveformScrollview.hscrollPos;
       var previewEndPosIndex:Int = Std.int(previewEndPosAbsolute * (waveformScale / BASE_SCALE * waveformMagicFactor));
-      var previewEndPosMs:Int = Std.int(waveformMusic.waveform.waveformData.indexToSeconds(previewEndPosIndex) * Constants.MS_PER_SEC);
+      var previewEndPosMs:Int = Std.int(waveformMusic.waveform.waveformData?.indexToSeconds(previewEndPosIndex) * Constants.MS_PER_SEC);
 
       // Set the values in milliseconds.
       freeplayPreviewStart.value = previewStartPosMs;
@@ -640,8 +640,8 @@ class ChartEditorFreeplayToolbox extends ChartEditorBaseToolbox
     }
     else
     {
-      previewBoxStartPosAbsolute = waveformMusic.waveform.waveformData.secondsToIndex(chartEditorState.currentSongFreeplayPreviewStart / Constants.MS_PER_SEC) / (waveformScale / BASE_SCALE * waveformMagicFactor);
-      previewBoxEndPosAbsolute = waveformMusic.waveform.waveformData.secondsToIndex(chartEditorState.currentSongFreeplayPreviewEnd / Constants.MS_PER_SEC) / (waveformScale / BASE_SCALE * waveformMagicFactor);
+      previewBoxStartPosAbsolute = waveformMusic.waveform.waveformData?.secondsToIndex(chartEditorState.currentSongFreeplayPreviewStart / Constants.MS_PER_SEC) / (waveformScale / BASE_SCALE * waveformMagicFactor);
+      previewBoxEndPosAbsolute = waveformMusic.waveform.waveformData?.secondsToIndex(chartEditorState.currentSongFreeplayPreviewEnd / Constants.MS_PER_SEC) / (waveformScale / BASE_SCALE * waveformMagicFactor);
 
       freeplayPreviewStart.value = chartEditorState.currentSongFreeplayPreviewStart;
       freeplayPreviewEnd.value = chartEditorState.currentSongFreeplayPreviewEnd;
@@ -652,7 +652,7 @@ class ChartEditorFreeplayToolbox extends ChartEditorBaseToolbox
   {
     super.refresh();
 
-    waveformMagicFactor = MAGIC_SCALE_BASE_TIME / (chartEditorState.offsetTickBitmap.width / waveformMusic.waveform.waveformData.pointsPerSecond());
+    waveformMagicFactor = MAGIC_SCALE_BASE_TIME / (chartEditorState.offsetTickBitmap.width / waveformMusic.waveform.waveformData?.pointsPerSecond());
 
     var currentZoomFactor = waveformScale / BASE_SCALE * waveformMagicFactor;
 

--- a/source/funkin/ui/debug/charting/toolboxes/ChartEditorMetadataToolbox.hx
+++ b/source/funkin/ui/debug/charting/toolboxes/ChartEditorMetadataToolbox.hx
@@ -3,6 +3,7 @@ package funkin.ui.debug.charting.toolboxes;
 #if FEATURE_CHART_EDITOR
 import funkin.play.character.BaseCharacter.CharacterType;
 import funkin.data.character.CharacterData;
+import funkin.data.freeplay.album.AlbumRegistry;
 import funkin.data.song.importer.ChartManifestData;
 import funkin.data.stage.StageRegistry;
 import funkin.data.notestyle.NoteStyleRegistry;
@@ -11,6 +12,7 @@ import funkin.ui.debug.charting.commands.AddNewTimeChangeCommand;
 import funkin.ui.debug.charting.commands.ModifyTimeChangeCommand;
 import funkin.ui.debug.charting.commands.RemoveTimeChangeCommand;
 import funkin.ui.debug.charting.util.ChartEditorDropdowns;
+import funkin.ui.freeplay.Album;
 import haxe.ui.components.Button;
 import haxe.ui.components.DropDown;
 import haxe.ui.components.Label;
@@ -35,6 +37,8 @@ class ChartEditorMetadataToolbox extends ChartEditorBaseToolbox
   var inputSongCharter:TextField;
   var inputStage:DropDown;
   var inputNoteStyle:DropDown;
+  var inputAlbum:DropDown;
+  var inputStickerPack:DropDown;
   var buttonCharacterPlayer:Button;
   var buttonCharacterGirlfriend:Button;
   var buttonCharacterOpponent:Button;
@@ -153,6 +157,28 @@ class ChartEditorMetadataToolbox extends ChartEditorBaseToolbox
     };
     var startingValueNoteStyle = ChartEditorDropdowns.populateDropdownWithNoteStyles(inputNoteStyle, chartEditorState.currentSongMetadata.playData.noteStyle);
     inputNoteStyle.value = startingValueNoteStyle;
+
+    inputAlbum.onChange = (event:UIEvent) -> {
+      var valid:Bool = event.data != null && event.data.id != null;
+
+      if (valid)
+      {
+        chartEditorState.currentSongAlbum = event.data.id;
+      }
+    }
+    var startingValueAlbum = ChartEditorDropdowns.populateDropdownWithAlbums(inputAlbum, chartEditorState.currentSongMetadata.playData?.album);
+    inputAlbum.value = startingValueAlbum;
+
+    inputStickerPack.onChange = (event:UIEvent) -> {
+      var valid:Bool = event.data != null && event.data.id != null;
+
+      if (valid)
+      {
+        chartEditorState.currentSongStickerPack = event.data.id;
+      }
+    }
+    var startingValueStickerPack = ChartEditorDropdowns.populateDropdownWithStickerPacks(inputStickerPack, chartEditorState.currentSongMetadata.playData?.stickerPack);
+    inputStickerPack.value = startingValueStickerPack;
 
     inputTimeChange.onChange = function(event:UIEvent)
     {
@@ -337,6 +363,7 @@ class ChartEditorMetadataToolbox extends ChartEditorBaseToolbox
     inputSongCharter.value = chartEditorState.currentSongMetadata.charter;
     inputStage.value = chartEditorState.currentSongMetadata.playData.stage;
     inputNoteStyle.value = chartEditorState.currentSongMetadata.playData.noteStyle;
+    inputAlbum.value = chartEditorState.currentSongMetadata.playData.album;
     inputDifficultyRating.value = chartEditorState.currentSongChartDifficultyRating;
     inputScrollSpeed.value = chartEditorState.currentSongChartScrollSpeed;
     labelScrollSpeed.text = 'Scroll Speed: ${chartEditorState.currentSongChartScrollSpeed}x';
@@ -357,6 +384,15 @@ class ChartEditorMetadataToolbox extends ChartEditorBaseToolbox
     if (inputNoteStyle != null)
     {
       inputNoteStyle.value = (noteStyle != null) ? {id: noteStyle.id, text: noteStyle.getName()} : {id: "Funkin", text: "Funkin'"};
+    }
+
+    var albumId:String = chartEditorState.currentSongAlbum;
+    var album:Null<Album> = AlbumRegistry.instance.fetchEntry(albumId);
+    if (inputAlbum != null)
+    {
+      inputAlbum.value = (album != null) ?
+        {id: album.id, text: album.getAlbumName()} :
+          {id: "volume1", text: "Volume 1"};
     }
 
     var LIMIT = 6;

--- a/source/funkin/ui/debug/charting/toolboxes/ChartEditorOffsetsToolbox.hx
+++ b/source/funkin/ui/debug/charting/toolboxes/ChartEditorOffsetsToolbox.hx
@@ -211,7 +211,7 @@ class ChartEditorOffsetsToolbox extends ChartEditorBaseToolbox
         {
           // We have to change the song time to match the playhead position when we move it.
           var currentWaveformIndex:Int = Std.int(playheadAbsolutePos * (waveformScale / BASE_SCALE * waveformMagicFactor));
-          var targetSongTimeSeconds:Float = waveformPlayer.waveform.waveformData.indexToSeconds(currentWaveformIndex);
+          var targetSongTimeSeconds:Float = waveformPlayer.waveform.waveformData?.indexToSeconds(currentWaveformIndex);
           audioPreviewTracks.time = targetSongTimeSeconds * Constants.MS_PER_SEC;
         }
 
@@ -323,7 +323,7 @@ class ChartEditorOffsetsToolbox extends ChartEditorBaseToolbox
     for (index in 0...numberOfTicks)
     {
       var tickPos = chartEditorState.offsetTickBitmap.width / 2 * index;
-      var tickTime = tickPos * (waveformScale / BASE_SCALE * waveformMagicFactor) / waveformInstrumental.waveform.waveformData.pointsPerSecond();
+      var tickTime = tickPos * (waveformScale / BASE_SCALE * waveformMagicFactor) / waveformInstrumental.waveform.waveformData?.pointsPerSecond();
 
       var tickLabel:Label = new Label();
       tickLabel.text = formatTime(tickTime);
@@ -396,7 +396,7 @@ class ChartEditorOffsetsToolbox extends ChartEditorBaseToolbox
 
     // Move the audio preview to the playhead position.
     var currentWaveformIndex:Int = Std.int(playheadAbsolutePos * (waveformScale / BASE_SCALE * waveformMagicFactor));
-    var targetSongTimeSeconds:Float = waveformPlayer.waveform.waveformData.indexToSeconds(currentWaveformIndex);
+    var targetSongTimeSeconds:Float = waveformPlayer.waveform.waveformData?.indexToSeconds(currentWaveformIndex);
     audioPreviewTracks.time = targetSongTimeSeconds * Constants.MS_PER_SEC;
   }
 
@@ -424,11 +424,11 @@ class ChartEditorOffsetsToolbox extends ChartEditorBaseToolbox
     var deltaMilliseconds:Float = switch (dragWaveform)
     {
       case PLAYER:
-        deltaPixels / waveformPlayer.waveform.waveformData.pointsPerSecond() * Constants.MS_PER_SEC;
+        deltaPixels / waveformPlayer.waveform.waveformData?.pointsPerSecond() * Constants.MS_PER_SEC;
       case OPPONENT:
-        deltaPixels / waveformOpponent.waveform.waveformData.pointsPerSecond() * Constants.MS_PER_SEC;
+        deltaPixels / waveformOpponent.waveform.waveformData?.pointsPerSecond() * Constants.MS_PER_SEC;
       case INSTRUMENTAL:
-        deltaPixels / waveformInstrumental.waveform.waveformData.pointsPerSecond() * Constants.MS_PER_SEC;
+        deltaPixels / waveformInstrumental.waveform.waveformData?.pointsPerSecond() * Constants.MS_PER_SEC;
     };
 
     switch (dragWaveform)
@@ -732,7 +732,7 @@ class ChartEditorOffsetsToolbox extends ChartEditorBaseToolbox
     {
       trace('Playback time: ${audioPreviewTracks.time}');
 
-      var targetScrollPos:Float = waveformInstrumental.waveform.waveformData.secondsToIndex(audioPreviewTracks.time / Constants.MS_PER_SEC) / (waveformScale / BASE_SCALE * waveformMagicFactor);
+      var targetScrollPos:Float = waveformInstrumental.waveform.waveformData?.secondsToIndex(audioPreviewTracks.time / Constants.MS_PER_SEC) / (waveformScale / BASE_SCALE * waveformMagicFactor);
       // waveformScrollview.hscrollPos = targetScrollPos;
       var prevPlayheadAbsolutePos = playheadAbsolutePos;
       playheadAbsolutePos = targetScrollPos;
@@ -805,7 +805,7 @@ class ChartEditorOffsetsToolbox extends ChartEditorBaseToolbox
   {
     super.refresh();
 
-    waveformMagicFactor = MAGIC_SCALE_BASE_TIME / (chartEditorState.offsetTickBitmap.width / waveformInstrumental.waveform.waveformData.pointsPerSecond());
+    waveformMagicFactor = MAGIC_SCALE_BASE_TIME / (chartEditorState.offsetTickBitmap.width / waveformInstrumental.waveform.waveformData?.pointsPerSecond());
 
     var currentZoomFactor = waveformScale / BASE_SCALE * waveformMagicFactor;
 

--- a/source/funkin/ui/debug/charting/util/ChartEditorDropdowns.hx
+++ b/source/funkin/ui/debug/charting/util/ChartEditorDropdowns.hx
@@ -1,19 +1,23 @@
 package funkin.ui.debug.charting.util;
 
 #if FEATURE_CHART_EDITOR
-import funkin.data.notestyle.NoteStyleRegistry;
-import funkin.play.notes.notestyle.NoteStyle;
-import funkin.data.song.SongData.SongTimeChange;
-import funkin.play.event.SongEvent;
-import funkin.data.stage.StageRegistry;
 import funkin.data.character.CharacterData;
+import funkin.data.character.CharacterData.CharacterDataParser;
+import funkin.data.event.SongEventRegistry;
+import funkin.data.freeplay.album.AlbumRegistry;
+import funkin.data.notestyle.NoteStyleRegistry;
+import funkin.data.song.SongData.SongTimeChange;
+import funkin.data.stage.StageRegistry;
+import funkin.data.stickers.StickerRegistry;
 import haxe.ui.components.DropDown;
 import funkin.play.stage.Stage;
 import funkin.play.notes.notekind.NoteKind;
 import funkin.play.notes.notekind.NoteKindManager;
 import funkin.play.character.BaseCharacter.CharacterType;
-import funkin.data.event.SongEventRegistry;
-import funkin.data.character.CharacterData.CharacterDataParser;
+import funkin.play.event.SongEvent;
+import funkin.play.notes.notestyle.NoteStyle;
+import funkin.ui.freeplay.Album;
+import funkin.ui.transition.stickers.StickerPack;
 
 /**
  * Functions for populating dropdowns based on game data.
@@ -179,6 +183,68 @@ class ChartEditorDropdowns
 
       var value = {id: noteStyleId, text: noteStyle.getName()};
       if (startingStyleId == noteStyleId) returnValue = value;
+
+      dropDown.dataSource.add(value);
+    }
+
+    dropDown.dataSource.sort('text', ASCENDING);
+
+    return returnValue;
+  }
+
+  /**
+   * Populate a dropdown with a list of albums.
+   */
+  public static function populateDropdownWithAlbums(dropDown:DropDown, startingAlbumId:Null<String>):DropDownEntry
+  {
+    startingAlbumId = startingAlbumId ?? Constants.DEFAULT_ALBUM_ID;
+    dropDown.dataSource.clear();
+
+    var albumIds:Array<String> = AlbumRegistry.instance.listEntryIds();
+
+    var returnValue:DropDownEntry = {id: "volume1", text: "Volume 1"};
+
+    for (albumId in albumIds)
+    {
+      var album:Null<Album> = AlbumRegistry.instance.fetchEntry(albumId);
+      if (album == null) continue;
+
+      // Check if the album has all necessary assets (art and title)
+      if (album._data?.albumArtAsset == null || album._data?.albumTitleAsset == null) continue;
+
+      var value = {id: albumId, text: album.getAlbumName()};
+      if (startingAlbumId == albumId) returnValue = value;
+
+      dropDown.dataSource.add(value);
+    }
+
+    dropDown.dataSource.sort('text', ASCENDING);
+
+    return returnValue;
+  }
+
+  /**
+   * Populate a dropdown with a list of sticker packs.
+   */
+  public static function populateDropdownWithStickerPacks(dropDown:DropDown, startingStickerPackId:Null<String>):DropDownEntry
+  {
+    startingStickerPackId = startingStickerPackId ?? Constants.DEFAULT_STICKER_PACK;
+    dropDown.dataSource.clear();
+
+    var stickerPackIds:Array<String> = StickerRegistry.instance.listEntryIds();
+
+    var returnValue:DropDownEntry = {id: "default", text: "Default"};
+
+    for (stickerPackId in stickerPackIds)
+    {
+      var stickerPack:Null<StickerPack> = StickerRegistry.instance.fetchEntry(stickerPackId);
+      if (stickerPack == null) continue;
+
+      // Check if the sticker has all necessary assets (stickers)
+      if (stickerPack._data?.stickers == null) continue;
+
+      var value = {id: stickerPackId, text: stickerPack.getStickerPackName()};
+      if (startingStickerPackId == stickerPackId) returnValue = value;
 
       dropDown.dataSource.add(value);
     }

--- a/source/funkin/ui/debug/stageeditor/StageEditorState.hx
+++ b/source/funkin/ui/debug/stageeditor/StageEditorState.hx
@@ -496,7 +496,7 @@ class StageEditorState extends UIState
         var filestats:Array<sys.FileStat> = [];
         if (files.length > 0)
         {
-          while (!files[files.length - 1].endsWith(FileUtil.FILE_EXTENSION_INFO_FNFS.extension)
+          while (!files[files.length - 1].endsWith(FileUtil.FILE_FILTER_FNFS.extension)
             || !files[files.length - 1].startsWith("stage-editor-"))
           {
             if (files.length == 0) break;
@@ -1261,11 +1261,11 @@ class StageEditorState extends UIState
           return;
         }
 
-        FileUtil.saveFile(bytes, [FileUtil.FILE_FILTER_FNFS], function(path:String)
+        FileUtil.saveFile('Save stage as FNFS...', bytes, [FileUtil.FILE_FILTER_FNFS], function(path:String)
         {
           saved = true;
           currentFile = path;
-        }, null, stageName + "." + FileUtil.FILE_EXTENSION_INFO_FNFS.extension);
+        }, null, stageName + "." + FileUtil.FILE_FILTER_FNFS.extension);
 
       case "save stage":
         if (currentFile == "")
@@ -1304,7 +1304,7 @@ class StageEditorState extends UIState
           return;
         }
 
-        FileUtil.browseForBinaryFile("Open Stage Data", [FileUtil.FILE_EXTENSION_INFO_FNFS], function(_)
+        FileUtil.browseForFile("Open Stage Data", [FileUtil.FILE_FILTER_FNFS], function(_)
         {
           if (_?.fullPath == null) return;
 
@@ -1552,7 +1552,7 @@ class StageEditorState extends UIState
     FileUtil.createDirIfNotExists(BACKUPS_PATH);
 
     var data = this.packShitToZip();
-    var path = haxe.io.Path.join([BACKUPS_PATH, 'stage-editor-${stageName}-${funkin.util.DateUtil.generateTimestamp()}.${FileUtil.FILE_EXTENSION_INFO_FNFS.extension}']);
+    var path = haxe.io.Path.join([BACKUPS_PATH, 'stage-editor-${stageName}-${funkin.util.DateUtil.generateTimestamp()}.${FileUtil.FILE_FILTER_FNFS.extension}']);
 
     FileUtil.writeBytesToPath(path, data);
 

--- a/source/funkin/ui/debug/stageeditor/components/WelcomeDialog.hx
+++ b/source/funkin/ui/debug/stageeditor/components/WelcomeDialog.hx
@@ -58,7 +58,7 @@ class WelcomeDialog extends Dialog
       contentRecent.addComponent(fileText);
     }
 
-    boxDrag.onClick = function(_) FileUtil.browseForBinaryFile("Open Stage Data", [FileUtil.FILE_EXTENSION_INFO_FNFS],
+    boxDrag.onClick = function(_) FileUtil.browseForFile("Open Stage Data", [FileUtil.FILE_FILTER_FNFS],
       (fileInfo) -> loadFromFilePath(fileInfo.fullPath, null, 0, 0));
 
     var defaultStages:Array<String> = StageRegistry.instance.listEntryIds();

--- a/source/funkin/ui/debug/stageeditor/toolboxes/StageEditorObjectGraphicToolbox.hx
+++ b/source/funkin/ui/debug/stageeditor/toolboxes/StageEditorObjectGraphicToolbox.hx
@@ -3,6 +3,7 @@ package funkin.ui.debug.stageeditor.toolboxes;
 #if FEATURE_STAGE_EDITOR
 import flixel.graphics.frames.FlxAtlasFrames;
 import funkin.ui.debug.stageeditor.handlers.AssetDataHandler;
+import funkin.util.FileUtil;
 import haxe.ui.components.Button;
 import haxe.ui.components.Image;
 import haxe.ui.components.NumberStepper;
@@ -43,7 +44,7 @@ class StageEditorObjectGraphicToolbox extends StageEditorDefaultToolbox
     {
       if (linkedObj == null) return;
 
-      Dialogs.openBinaryFile("Open Image File", FileDialogTypes.IMAGES, function(selectedFile)
+      FileUtil.browseForFile("Open Image File", [FileUtil.FILE_FILTER_PNG], function(selectedFile)
       {
         if (selectedFile == null) return;
         objImage.resource = null;
@@ -122,13 +123,14 @@ class StageEditorObjectGraphicToolbox extends StageEditorDefaultToolbox
     // Callback for loading the text for the Frame Data.
     objLoadFrames.onClick = function(_)
     {
-      Dialogs.openTextFile("Open Text File", FileDialogTypes.TEXTS, function(selectedFile)
+      FileUtil.browseForFile("Open Text File", [FileUtil.FILE_FILTER_XML, FileUtil.FILE_FILTER_TXT], function(selectedFile)
       {
-        if (selectedFile.text == null || (!selectedFile.name.endsWith(".xml") && !selectedFile.name.endsWith(".txt"))) return;
+        if (selectedFile != null && selectedFile.bytes != null)
+        {
+          objFrameTxt.text = selectedFile.bytes.toString();
 
-        objFrameTxt.text = selectedFile.text;
-
-        state.notifyChange("Frame Text Loaded", "The Text File " + selectedFile.name + " has been loaded.");
+          state.notifyChange("Frame Text Loaded", "The Text File " + selectedFile.name + " has been loaded.");
+        }
       });
     }
 

--- a/source/funkin/ui/freeplay/AlbumRoll.hx
+++ b/source/funkin/ui/freeplay/AlbumRoll.hx
@@ -149,8 +149,6 @@ class AlbumRoll extends FlxSpriteGroup
     });
   }
 
-  var titleTimer:Null<FlxTimer> = null;
-
   /**
    * Play the intro animation on the album art.
    */

--- a/source/funkin/ui/freeplay/AlbumRoll.hx
+++ b/source/funkin/ui/freeplay/AlbumRoll.hx
@@ -23,7 +23,7 @@ class AlbumRoll extends FlxSpriteGroup
 
   function set_albumId(value:Null<String>):Null<String>
   {
-    if (this.albumId != value || value == null)
+    if (this.albumId != value)
     {
       this.albumId = value;
       updateAlbum();
@@ -77,7 +77,7 @@ class AlbumRoll extends FlxSpriteGroup
    */
   function updateAlbum():Void
   {
-    if (albumId == null)
+    if (albumId == null || albumId == "random")
     {
       this.visible = false;
       albumData = null;

--- a/source/funkin/ui/freeplay/CapsuleText.hx
+++ b/source/funkin/ui/freeplay/CapsuleText.hx
@@ -4,7 +4,6 @@ import openfl.filters.BitmapFilterQuality;
 import flixel.text.FlxText;
 import flixel.group.FlxSpriteGroup;
 import funkin.graphics.shaders.GaussianBlurShader;
-import funkin.graphics.shaders.LeftMaskShader;
 import flixel.math.FlxRect;
 import flixel.tweens.FlxEase;
 import flixel.util.FlxTimer;
@@ -20,8 +19,6 @@ class CapsuleText extends FlxSpriteGroup
   var whiteText:FlxText;
 
   public var text(default, set):Null<String>;
-
-  var maskShaderSongName:LeftMaskShader = new LeftMaskShader();
 
   public var clipWidth(default, set):Int = 255;
 

--- a/source/funkin/ui/freeplay/FreeplayState.hx
+++ b/source/funkin/ui/freeplay/FreeplayState.hx
@@ -3391,11 +3391,6 @@ class FreeplaySongData
     return isFav;
   }
 
-  function updateValues(variations:Array<String>):Void
-  {
-    // this.isNew = song.isSongNew(suffixedDifficulty);
-  }
-
   function get_idAndVariation()
   {
     return '${data.id}:${curVariation}';

--- a/source/funkin/ui/freeplay/FreeplayState.hx
+++ b/source/funkin/ui/freeplay/FreeplayState.hx
@@ -14,6 +14,7 @@ import flixel.util.FlxColor;
 import openfl.filters.ShaderFilter;
 import flixel.util.FlxTimer;
 import funkin.audio.FunkinSound;
+import funkin.audio.PreviewMusicData;
 import funkin.data.freeplay.player.PlayerRegistry;
 import funkin.ui.freeplay.dj.BaseFreeplayDJ;
 import funkin.ui.freeplay.dj.AnimateAtlasFreeplayDJ;
@@ -44,7 +45,7 @@ import funkin.ui.AtlasText;
 import funkin.ui.FullScreenScaleMode;
 import funkin.ui.MusicBeatSubState;
 import funkin.ui.freeplay.backcards.*;
-import funkin.ui.freeplay.components.DifficultySprite;
+import funkin.ui.freeplay.components.*;
 import funkin.ui.freeplay.charselect.PlayableCharacter;
 import funkin.ui.mainmenu.MainMenuState;
 import funkin.ui.story.Level;
@@ -170,9 +171,9 @@ class FreeplayState extends MusicBeatSubState
   var difficultyDots:FlxTypedSpriteGroup<DifficultyDot>;
 
   /**
-   *  An array of preview timers, so that we can prevent the timers from overlapping.
+   * A timer for to load the current selected capsule, to prevent playing the wrong song to preview.
    */
-  var previewTimers:Array<FlxTimer> = [];
+  var previewSongTimer:Null<FlxTimer>;
 
   /**
    * Bit of a utility var to get the currently displayed DifficultySprite
@@ -271,6 +272,8 @@ class FreeplayState extends MusicBeatSubState
   var forceSkipIntro:Bool = false;
 
   public var freeplayArrow:Null<FlxText>;
+
+  var previewMusicData:Null<PreviewMusicData> = null;
 
   public function new(?params:FreeplayStateParams, ?stickers:StickerSubState)
   {
@@ -774,7 +777,6 @@ class FreeplayState extends MusicBeatSubState
         {
           sillyStroke.width = 0;
           sillyStroke.height = 0;
-          changeSelection();
         });
       });
 
@@ -796,6 +798,8 @@ class FreeplayState extends MusicBeatSubState
 
       refreshDots(5, allDifficulties.indexOf(currentDifficulty), allDifficulties.indexOf(currentDifficulty));
       fadeDots(true);
+
+      changeSelection();
 
       #if FEATURE_TOUCH_CONTROLS
       FlxG.touches.swipeThreshold.x = 60;
@@ -2231,8 +2235,10 @@ class FreeplayState extends MusicBeatSubState
     super.destroy();
     // remove and destroy freeplay camera
     FlxG.cameras.remove(funnyCam);
-    // Cancel all song preview timers just in case a preview loads after we exit.
-    clearPreviews();
+    // Cancel the song preview timer just in case a preview loads after we exit.
+    previewSongTimer?.cancel();
+    // Destroy the preview music data.
+    previewMusicData?.destroy();
   }
 
   function goBack():Void
@@ -2531,12 +2537,17 @@ class FreeplayState extends MusicBeatSubState
       }
 
       // Reset the song preview in case we changed variations (normal->erect etc)
-      if (currentVariation != previousVariation) playCurSongPreview();
+      if (currentVariation != previousVariation)
+      {
+        previewSongTimer?.cancel();
+        if (FlxG.sound.music != null) FlxG.sound.music.fadeOut(FADE_IN_DELAY);
+        previewSongTimer = new FlxTimer().start(FADE_IN_DELAY, (_) -> playCurSongPreview(currentCapsule));
+      }
     }
 
     // Set the album graphic and play the animation if relevant.
     var newAlbumId:Null<String> = daSong?.data.getAlbumId(currentDifficulty, currentVariation);
-    if (albumRoll.albumId != newAlbumId && (currentVariation != previousVariation || uiStateMachine.canInteract()) && !fromCharSelect)
+    if (newAlbumId != null && albumRoll.albumId != newAlbumId && (currentVariation != previousVariation || uiStateMachine.canInteract()) && !fromCharSelect)
     {
       albumRoll.albumId = newAlbumId;
       albumRoll.skipIntro();
@@ -2812,6 +2823,7 @@ class FreeplayState extends MusicBeatSubState
     new FlxTimer().start(styleData?.getStartDelay(), function(tmr:FlxTimer)
     {
       FunkinSound.emptyPartialQueue();
+      FlxG.sound.music?.fadeOut(0.2, FlxEase.quadIn);
 
       #if FEATURE_TOUCH_CONTROLS
       if (backButton != null)
@@ -2822,6 +2834,7 @@ class FreeplayState extends MusicBeatSubState
       #end
       funnyCam.fade(FlxColor.BLACK, 0.2, false, function()
       {
+        FlxG.sound.music?.stop();
         Paths.setCurrentLevel(cap?.freeplayData?.levelId);
         LoadingState.loadPlayState({
           targetSong: targetSong,
@@ -2937,7 +2950,8 @@ class FreeplayState extends MusicBeatSubState
     intendedCompletion = Scoring.tallyCompletion(songScore?.tallies);
     rememberedSongId = currentCapsule.freeplayData?.data.id;
 
-    if (currentCapsule.freeplayData == null) albumRoll.albumId = null;
+    if (curSelected == 0) albumRoll.albumId = "random";
+    else if (currentCapsule.freeplayData == null) albumRoll.albumId = null;
 
     changeDiff();
     currentCapsule.refreshDisplay(currentCapsule.freeplayData == null);
@@ -2965,9 +2979,11 @@ class FreeplayState extends MusicBeatSubState
 
     if (grpCapsules.countLiving() > 0 && !prepForNewRank && uiStateMachine.canInteract())
     {
-      FlxG.sound.music?.pause();
-      FlxTimer.wait(FADE_IN_DELAY, playCurSongPreview.bind(currentCapsule));
       currentCapsule.selected = true;
+
+      previewSongTimer?.cancel();
+      if (FlxG.sound.music != null) FlxG.sound.music.fadeOut(FADE_IN_DELAY);
+      previewSongTimer = new FlxTimer().start(FADE_IN_DELAY, (_) -> playCurSongPreview(currentCapsule));
 
       // switchBackingImage(currentCapsule.freeplayData);
     }
@@ -2985,24 +3001,27 @@ class FreeplayState extends MusicBeatSubState
     var previewVolume:Float = 0.7;
     if (dj != null) previewVolume *= dj.getMusicPreviewMult();
 
-    clearPreviews();
-
     if (FlxG.sound.music != null) FlxG.sound.music.stop();
 
     if (curSelected == 0)
     {
-      FunkinSound.playMusic('freeplayRandom', {
+      FunkinSound.playMusic(dj?.getRandomCapsuleMusicPath() ?? Constants.DEFAULT_RANDOM_CAPSULE_MUSIC, {
         startingVolume: 0.0,
         overrideExisting: true,
-        restartTrack: false
+        restartTrack: false,
+        pathsFunction: dj == null ? MUSIC : NONE
       });
-      if (FlxG.sound.music != null) FlxG.sound.music.fadeIn(2, 0, previewVolume);
+      FlxG.sound.music.fadeIn(PreviewMusicData.FADE_IN_DURATION, 0, previewVolume, PreviewMusicData.FADE_IN_EASE_FUNCTION);
     }
-    else
+    else if (daSongCapsule != null)
     {
+      var previewFreeplayData:Null<FreeplaySongData> = daSongCapsule.freeplayData;
+      if (previewFreeplayData == null) return;
+
       // Make sure the player is still hovering over the song we want to load preview for
-      if (!daSongCapsule.selected) return;
-      var previewSong:Null<Song> = daSongCapsule?.freeplayData?.data;
+      if (!daSongCapsule.selected && currentCapsule?.freeplayData != null && previewFreeplayData != currentCapsule.freeplayData) return;
+
+      var previewSong:Null<Song> = previewFreeplayData.data;
       if (previewSong == null) return;
 
       // Check if character-specific difficulty exists
@@ -3021,50 +3040,32 @@ class FreeplayState extends MusicBeatSubState
       instSuffix = (instSuffix != '') ? '-$instSuffix' : '';
       // trace('Attempting to play partial preview: ${previewSong.id}:${instSuffix}');
 
-      FunkinSound.playMusic(previewSong.id, {
-        startingVolume: 0.0,
-        overrideExisting: true,
-        restartTrack: false,
-        mapTimeChanges: false, // The music metadata is not alongside the audio file so this won't work.
-        pathsFunction: INST,
-        suffix: instSuffix,
-        partialParams: {
-          loadPartial: true,
-          start: daSongCapsule?.freeplayData?.previewStartTime,
-          end: daSongCapsule?.freeplayData?.previewEndTime
-        },
-        onLoad: function()
-        {
-          FlxG.sound.music.fadeIn(2, 0, previewVolume);
+      if (FlxG.sound.music == null)
+      {
+        // Initialize the FlxG.sound.music if it haven't been created.
+        FunkinSound.setMusic(FunkinSound.load(null));
+      }
 
-          var fadeStart:Float = (FlxG.sound.music.length / 1000) - 2;
+      if (previewMusicData == null) previewMusicData = new PreviewMusicData();
+      previewMusicData.setAssetPath(Paths.inst(previewSong.id, instSuffix),
+        previewFreeplayData.previewStartTime, previewFreeplayData.previewEndTime, null, function(musicData:PreviewMusicData)
+      {
+        // Check again if it's still selected.
+        if (!daSongCapsule.selected) return;
 
-          previewTimers.push(new FlxTimer().start(fadeStart, function(_)
-          {
-            FlxG.sound.music.fadeOut(2, 0);
-          }));
-
-          previewTimers.push(new FlxTimer().start(FlxG.sound.music.length / 1000, function(_)
-          {
-            playCurSongPreview();
-          }));
-        },
+        FlxG.sound.music.fadeTween?.cancel();
+        FlxG.sound.music.unload();
+        FlxG.sound.music.loadEmbedded(musicData);
+        FlxG.sound.music.volume = previewVolume;
+        FlxG.sound.music.looped = true;
+        FlxG.sound.music.play(true, 0);
       });
+
       if (songDifficulty != null)
       {
         Conductor.instance.mapTimeChanges(songDifficulty.timeChanges);
       }
     }
-  }
-
-  public function clearPreviews()
-  {
-    for (timer in previewTimers)
-    {
-      if (timer != null) timer.cancel();
-    }
-
-    previewTimers = [];
   }
 
   public function switchBackingImage(?freeplaySongData:FreeplaySongData):Void

--- a/source/funkin/ui/freeplay/FreeplayState.hx
+++ b/source/funkin/ui/freeplay/FreeplayState.hx
@@ -771,7 +771,6 @@ class FreeplayState extends MusicBeatSubState
 
         clearBoxSprite.visible = true;
         txtCompletion.visible = true;
-        intendedCompletion = 0;
 
         new FlxTimer().start(1.5 / 24, function(bold)
         {

--- a/source/funkin/ui/freeplay/SongMenuItem.hx
+++ b/source/funkin/ui/freeplay/SongMenuItem.hx
@@ -473,7 +473,7 @@ class SongMenuItem extends FlxSpriteGroup
 
   function updateDifficultyRating(newRating:Int):Void
   {
-    var ratingPadded:String = newRating < 10 ? '0$newRating' : '$newRating';
+    //var ratingPadded:String = newRating < 10 ? '0$newRating' : '$newRating';
 
     for (i in 0...difficultyNumbers.length)
     {

--- a/source/funkin/ui/freeplay/backcards/NewCharacterCard.hx
+++ b/source/funkin/ui/freeplay/backcards/NewCharacterCard.hx
@@ -21,8 +21,6 @@ class NewCharacterCard extends BackingCard
   var yellow:FlxSprite;
   var multiplyBar:FlxSprite;
 
-  var bruh:FlxSprite;
-
   public var friendFoe:BGScrollingText;
   public var newUnlock1:BGScrollingText;
   public var waiting:BGScrollingText;

--- a/source/funkin/ui/freeplay/dj/BaseFreeplayDJ.hx
+++ b/source/funkin/ui/freeplay/dj/BaseFreeplayDJ.hx
@@ -90,7 +90,6 @@ class BaseFreeplayDJ extends FunkinSprite implements IFreeplayScriptedClass
   final playableCharData:Null<PlayerFreeplayDJData>;
 
   var timeIdling:Float = 0;
-  var lowPumpLoopPoint:Int = 4;
 
   public function new(x:Float, y:Float, characterId:String)
   {

--- a/source/funkin/ui/freeplay/dj/BaseFreeplayDJ.hx
+++ b/source/funkin/ui/freeplay/dj/BaseFreeplayDJ.hx
@@ -132,6 +132,11 @@ class BaseFreeplayDJ extends FunkinSprite implements IFreeplayScriptedClass
     return 1;
   }
 
+  public function getRandomCapsuleMusicPath():String
+  {
+    return Paths.music(playableCharData?.randomCapsuleMusic ?? Constants.DEFAULT_RANDOM_CAPSULE_MUSIC);
+  }
+
   public function onConfirm():Void
   {
     // We really don't want to play anything but the new character animation here.

--- a/source/funkin/ui/options/ControlsMenu.hx
+++ b/source/funkin/ui/options/ControlsMenu.hx
@@ -260,7 +260,6 @@ class ControlsMenu extends Page<OptionsState.OptionsMenuPageName>
     for (item in controlGrid.members)
       item.updateDevice(currentDevice);
 
-    var inputName = device == Keys ? "key" : "button";
     var cancel = device == Keys ? "Escape" : "Back";
     // todo: alignment
     if (device == Keys)

--- a/source/funkin/ui/options/OffsetMenu.hx
+++ b/source/funkin/ui/options/OffsetMenu.hx
@@ -28,6 +28,7 @@ import flixel.util.FlxColor;
 import flixel.math.FlxMath;
 import flixel.tweens.FlxEase;
 import flixel.group.FlxSpriteGroup.FlxTypedSpriteGroup;
+import flixel.sound.FlxSound;
 
 /**
  * Data structure for an arrow in the offset calibration/testing screen.
@@ -274,10 +275,6 @@ class OffsetMenu extends Page<OptionsState.OptionsMenuPageName>
 
       calibrating = true;
       MenuTypedList.pauseInput = true;
-      OptionsState.instance.drumsBG.pause();
-      OptionsState.instance.drumsBG.time = FlxG.sound.music.time;
-      OptionsState.instance.drumsBG.resume();
-      OptionsState.instance.drumsBG.fadeIn(1, 0, 1);
       canExit = false;
       differences = [];
       offsetLerp = 0;
@@ -291,6 +288,12 @@ class OffsetMenu extends Page<OptionsState.OptionsMenuPageName>
       receptor.angle = 0;
 
       _gotMad = false;
+
+      FlxG.sound.music.prepare(FlxG.sound.music.time);
+      OptionsState.instance.drumsBG.prepare(FlxG.sound.music.time);
+
+      OptionsState.instance.drumsBG.fadeIn(1, 0, 1);
+      FlxSound.playSounds([FlxG.sound.music, OptionsState.instance.drumsBG]);
     });
     createButtonItem('Test', function()
     {
@@ -304,9 +307,6 @@ class OffsetMenu extends Page<OptionsState.OptionsMenuPageName>
       testStrumline.noteData = [];
       testStrumline.nextNoteIndex = 0;
 
-      OptionsState.instance.drumsBG.pause();
-      OptionsState.instance.drumsBG.time = FlxG.sound.music.time;
-      OptionsState.instance.drumsBG.resume();
       localConductor.update(FlxG.sound.music.time, true);
 
       var floored = Math.floor(localConductor.currentBeatTime);
@@ -358,7 +358,13 @@ class OffsetMenu extends Page<OptionsState.OptionsMenuPageName>
       }
       #end
       MenuTypedList.pauseInput = true;
+
+      FlxG.sound.music.prepare(FlxG.sound.music.time);
+      OptionsState.instance.drumsBG.prepare(FlxG.sound.music.time);
+
       OptionsState.instance.drumsBG.fadeIn(1, 0, 1);
+      FlxSound.playSounds([FlxG.sound.music, OptionsState.instance.drumsBG]);
+
       canExit = false;
       differences = [];
 
@@ -426,6 +432,7 @@ class OffsetMenu extends Page<OptionsState.OptionsMenuPageName>
     }
     else
       FunkinSound.playOnce(Paths.sound('confirmMenu'));
+
     offsetItem.currentValue = Preferences.globalOffset;
     OptionsState.instance.drumsBG.fadeOut(1, 0);
   }
@@ -500,16 +507,13 @@ class OffsetMenu extends Page<OptionsState.OptionsMenuPageName>
   override function update(elapsed:Float):Void
   {
     super.update(elapsed);
-    localConductor.update(localConductor.songPosition + elapsed * 1000, false);
+    localConductor.update(FlxG.sound.music.time, false);
 
     var b:Float = localConductor.currentBeatTime;
 
     // Restart logic
     if (FlxG.sound.music.time < _lastTime)
     {
-      localConductor.update(FlxG.sound.music.time, !calibrating);
-      b = localConductor.currentBeatTime;
-
       // Update arrows to be the correct distance away from the receptor.
       var lastArrowBeat:Float = 0;
       for (i in 0...arrows.length)
@@ -538,20 +542,18 @@ class OffsetMenu extends Page<OptionsState.OptionsMenuPageName>
 
     _lastBeat = b;
 
-    // Resync logic
-    var diff:Float = Math.abs((FlxG.sound.music.time + localConductor.combinedOffset) - localConductor.songPosition);
-    var diffBg:Float = Math.abs(FlxG.sound.music.time - OptionsState.instance.drumsBG.time);
-    if (diff > 50 || diffBg > 50)
+    // Resync music
+    if (FlxG.sound.music.playing && OptionsState.instance.drumsBG.playing)
     {
-      trace('Resyncing conductor: ' + (diff > diffBg ? diff : diffBg) + 'ms difference');
+      var diffBg:Float = Math.abs(FlxG.sound.music.getActualTime() - OptionsState.instance.drumsBG.getActualTime());
+      if (diffBg > 50)
+      {
+        trace('Resyncing music: ' + diffBg + 'ms difference');
 
-      // If the difference is greater than 50ms, we resync the conductor.
-      localConductor.update(FlxG.sound.music.time, true);
-      OptionsState.instance.drumsBG.pause();
-      OptionsState.instance.drumsBG.time = FlxG.sound.music.time;
-      OptionsState.instance.drumsBG.resume();
-      b = localConductor.currentBeatTime;
-      _lastBeat = b;
+        FlxG.sound.music.prepare(FlxG.sound.music.time);
+        OptionsState.instance.drumsBG.prepare(FlxG.sound.music.time);
+        FlxSound.playSounds([FlxG.sound.music, OptionsState.instance.drumsBG]);
+      }
     }
 
     _lastTime = FlxG.sound.music.time;

--- a/source/funkin/ui/options/PreferencesMenu.hx
+++ b/source/funkin/ui/options/PreferencesMenu.hx
@@ -39,6 +39,10 @@ class PreferencesMenu extends Page<OptionsState.OptionsMenuPageName>
   var hudCamera:FlxCamera;
   var camFollow:FlxObject;
 
+  #if desktop
+  var audioDeviceItem:EnumPreferenceItem<String>;
+  #end
+
   public function new()
   {
     super();
@@ -177,6 +181,25 @@ class PreferencesMenu extends Page<OptionsState.OptionsMenuPageName>
     }, Preferences.autoFullscreen);
     #end
 
+    #if desktop
+    audioDeviceItem = createPrefItemEnum('Audio Device', 'What audio device should the game playbacks sounds to.', generateAudioDeviceEnums(),
+      (key:String, value:String) ->
+    {
+      Preferences.audioDevice = value;
+    }, Preferences.audioDevice);
+    FlxG.sound.onDefaultDeviceChanged.add(refreshAudioDeviceItem);
+    FlxG.sound.onDeviceAdded.add(refreshAudioDeviceItem);
+    FlxG.sound.onDeviceRemoved.add(refreshAudioDeviceItem);
+    #end
+
+    #if native
+    createPrefItemCheckbox('Music Streaming', 'Turn this off if your hardware can\'t handle it and freezes the song every few seconds.',
+      function(value:Bool):Void
+    {
+      Preferences.streamedMusic = value;
+    }, Preferences.streamedMusic);
+    #end
+
     // disable on mobile and web since it barely has any effect
     #if !(mobile || web)
     createPrefItemEnum('VSync', "When enabled, the game attempts to match the framerate with your monitor's refresh rate.",
@@ -267,7 +290,7 @@ class PreferencesMenu extends Page<OptionsState.OptionsMenuPageName>
    * @param onChange Gets called every time the player changes the value; use this to apply the value
    * @param defaultValue The value that is loaded in when the pref item is created (usually your Preferences.settingVariable)
    */
-  function createPrefItemCheckbox(prefName:String, prefDesc:String, onChange:Bool->Void, defaultValue:Bool, available:Bool = true):Void
+  function createPrefItemCheckbox(prefName:String, prefDesc:String, onChange:Bool->Void, defaultValue:Bool, available:Bool = true):CheckboxPreferenceItem
   {
     var checkbox:CheckboxPreferenceItem = new CheckboxPreferenceItem(funkin.ui.FullScreenScaleMode.gameNotchSize.x, 120 * (items.length - 1 + 1),
       defaultValue, available);
@@ -281,6 +304,8 @@ class PreferencesMenu extends Page<OptionsState.OptionsMenuPageName>
 
     preferenceItems.add(checkbox);
     preferenceDesc.push(prefDesc);
+
+    return checkbox;
   }
 
   /**
@@ -294,13 +319,16 @@ class PreferencesMenu extends Page<OptionsState.OptionsMenuPageName>
    * @param precision Rounds decimals up to a `precision` amount of digits (ex: 4 -> 0.1234, 2 -> 0.12)
    */
   function createPrefItemNumber(prefName:String, prefDesc:String, onChange:Float->Void, ?valueFormatter:Float->String, defaultValue:Float, min:Float,
-      max:Float, step:Float = 0.1, precision:Int):Void
+      max:Float, step:Float = 0.1, precision:Int):NumberPreferenceItem
   {
     var item = new NumberPreferenceItem(funkin.ui.FullScreenScaleMode.gameNotchSize.x, (120 * items.length) + 30, prefName, defaultValue, min, max, step,
       precision, onChange, valueFormatter);
+
     items.addItem(prefName, item);
     preferenceItems.add(item.lefthandText);
     preferenceDesc.push(prefDesc);
+
+    return item;
   }
 
   /**
@@ -310,7 +338,7 @@ class PreferencesMenu extends Page<OptionsState.OptionsMenuPageName>
    * @param min Minimum value (default = 0)
    * @param max Maximum value (default = 100)
    */
-  function createPrefItemPercentage(prefName:String, prefDesc:String, onChange:Int->Void, defaultValue:Int, min:Int = 0, max:Int = 100):Void
+  function createPrefItemPercentage(prefName:String, prefDesc:String, onChange:Int->Void, defaultValue:Int, min:Int = 0, max:Int = 100):NumberPreferenceItem
   {
     var newCallback = function(value:Float)
     {
@@ -320,11 +348,15 @@ class PreferencesMenu extends Page<OptionsState.OptionsMenuPageName>
     {
       return '${value}%';
     };
+
     var item = new NumberPreferenceItem(funkin.ui.FullScreenScaleMode.gameNotchSize.x, (120 * items.length) + 30, prefName, defaultValue, min, max, 10, 0,
       newCallback, formatter);
+
     items.addItem(prefName, item);
     preferenceItems.add(item.lefthandText);
     preferenceDesc.push(prefDesc);
+
+    return item;
   }
 
   /**
@@ -333,18 +365,46 @@ class PreferencesMenu extends Page<OptionsState.OptionsMenuPageName>
    * @param onChange Gets called every time the player changes the value; use this to apply the value
    * @param defaultValue The value that is loaded in when the pref item is created (usually your Preferences.settingVariable)
    */
-  function createPrefItemEnum<T>(prefName:String, prefDesc:String, values:Map<String, T>, onChange:String->T->Void, defaultKey:String):Void
+  function createPrefItemEnum<T>(prefName:String, prefDesc:String, values:Map<String, T>, onChange:String->T->Void, defaultKey:String):EnumPreferenceItem<T>
   {
     var item = new EnumPreferenceItem<T>(funkin.ui.FullScreenScaleMode.gameNotchSize.x, (120 * items.length) + 30, prefName, values, defaultKey, onChange);
+
     items.addItem(prefName, item);
     preferenceItems.add(item.lefthandText);
     preferenceDesc.push(prefDesc);
+
+    return item;
   }
+
+  #if desktop
+  function generateAudioDeviceEnums():Map<String, String>
+  {
+    var enums = ['Default' => 'Default'];
+    var devices = lime.media.AudioManager.getPlaybackDeviceNames();
+
+    for (device in devices)
+    {
+      enums.set(device, device);
+    }
+
+    return enums;
+  }
+
+  function refreshAudioDeviceItem(deviceName:String):Void
+  {
+    audioDeviceItem.changeEnums(generateAudioDeviceEnums(), Preferences.audioDevice);
+  }
+  #end
 
   override function exit():Void
   {
     camFollow.setPosition(640, 30);
     menuCamera.snapToTarget();
+    #if desktop
+    FlxG.sound.onDefaultDeviceChanged.remove(refreshAudioDeviceItem);
+    FlxG.sound.onDeviceAdded.remove(refreshAudioDeviceItem);
+    FlxG.sound.onDeviceRemoved.remove(refreshAudioDeviceItem);
+    #end
     super.exit();
   }
 }

--- a/source/funkin/ui/options/items/EnumPreferenceItem.hx
+++ b/source/funkin/ui/options/items/EnumPreferenceItem.hx
@@ -43,8 +43,6 @@ class EnumPreferenceItem<T> extends TextMenuItem
     var i:Int = 0;
     for (key in map.keys())
     {
-      var value:T = map[key];
-
       this.keys.push(key);
       if (this.currentKey == key) index = i;
       i += 1;

--- a/source/funkin/ui/options/items/EnumPreferenceItem.hx
+++ b/source/funkin/ui/options/items/EnumPreferenceItem.hx
@@ -31,14 +31,23 @@ class EnumPreferenceItem<T> extends TextMenuItem
     super(x, y, name, function()
     {
       var value = map.get(this.currentKey);
-      callback(this.currentKey, value);
+      this.onChangeCallback(this.currentKey, value);
     });
 
     updateHitbox();
 
-    this.map = map;
-    this.currentKey = defaultKey;
     this.onChangeCallback = callback;
+    changeEnums(map, defaultKey);
+
+    lefthandText = new AtlasText(x + 15, y, formatted(defaultKey), AtlasFont.DEFAULT);
+
+    this.fireInstantly = true;
+  }
+
+  public function changeEnums(map:Map<String, T>, ?defaultKey:String):Void
+  {
+    this.map = map;
+    if (defaultKey != null) this.currentKey = defaultKey;
 
     var i:Int = 0;
     for (key in map.keys())
@@ -47,10 +56,6 @@ class EnumPreferenceItem<T> extends TextMenuItem
       if (this.currentKey == key) index = i;
       i += 1;
     }
-
-    lefthandText = new AtlasText(x + 15, y, formatted(defaultKey), AtlasFont.DEFAULT);
-
-    this.fireInstantly = true;
   }
 
   override function update(elapsed:Float):Void

--- a/source/funkin/ui/story/StoryMenuState.hx
+++ b/source/funkin/ui/story/StoryMenuState.hx
@@ -65,11 +65,6 @@ class StoryMenuState extends MusicBeatState
   var scoreText:FlxText;
 
   /**
-   * The mode text at the top-middle.
-   */
-  var modeText:FlxText;
-
-  /**
    * The list of songs on the left.
    */
   var tracklistText:FlxText;

--- a/source/funkin/ui/title/TitleState.hx
+++ b/source/funkin/ui/title/TitleState.hx
@@ -10,7 +10,6 @@ import flixel.util.FlxDirectionFlags;
 import flixel.util.FlxTimer;
 import funkin.util.HapticUtil;
 import funkin.graphics.shaders.ColorSwap;
-import funkin.graphics.shaders.LeftMaskShader;
 import funkin.graphics.FunkinSprite;
 import funkin.ui.MusicBeatState;
 import funkin.audio.FunkinSound;
@@ -63,7 +62,6 @@ class TitleState extends MusicBeatState
   var gfDance:FunkinSprite;
   var danceLeft:Bool = false;
   var titleText:FunkinSprite;
-  var maskShader = new LeftMaskShader();
 
   #if FEATURE_VIDEO_PLAYBACK
   var attractTimer:FlxTimer;

--- a/source/funkin/ui/transition/LoadingState.hx
+++ b/source/funkin/ui/transition/LoadingState.hx
@@ -209,11 +209,6 @@ class LoadingState extends MusicBeatSubState
     }
   }
 
-  static function getSongPath():String
-  {
-    return Paths.inst(PlayState.instance?.currentSong.id ?? throw 'Cannot retrieve song path');
-  }
-
   static var stageDirectory:String = "shared";
 
   /**

--- a/source/funkin/ui/transition/LoadingState.hx
+++ b/source/funkin/ui/transition/LoadingState.hx
@@ -62,11 +62,11 @@ class LoadingState extends MusicBeatSubState
 
     add(loadBar);
 
+    callbacks = new MultiCallback(onLoad);
+    var introComplete = callbacks.add('introComplete');
+
     initSongsManifest().onComplete(function(lib)
     {
-      callbacks = new MultiCallback(onLoad);
-      var introComplete = callbacks.add('introComplete');
-
       if (playParams != null)
       {
         // Load and cache the song's charts.
@@ -97,17 +97,20 @@ class LoadingState extends MusicBeatSubState
 
       checkLibrary('shared');
       checkLibrary('videos');
-      checkLibrary(stageDirectory);
       checkLibrary('tutorial');
-
-      var fadeTime:Float = 0.5;
-      FlxG.camera.fade(FlxG.camera.bgColor, fadeTime, true);
-      new FlxTimer().start(fadeTime + MIN_TIME, function(_) introComplete());
+      checkLibrary(stageDirectory);
     });
+
+    var fadeTime:Float = 0.5;
+    FlxG.camera.fade(fadeTime, true, true);
+    FlxTimer.wait(fadeTime + MIN_TIME, function() introComplete());
   }
 
   function checkLoadSong(path:String):Void
   {
+    trace(path, OpenFLAssets.cache.hasSound(path));
+    var callback = callbacks?.add('song:' + path);
+
     if (!OpenFLAssets.cache.hasSound(path))
     {
       var library = Assets.getLibrary('songs');
@@ -116,27 +119,35 @@ class LoadingState extends MusicBeatSubState
       // library.types.set(symbolPath, SOUND);
       // @:privateAccess
       // library.pathGroups.set(symbolPath, [library.__cacheBreak(symbolPath)]);
-      var callback = callbacks?.add('song:' + path);
       Assets.loadSound(path).onComplete(function(_)
       {
         if (callback != null) callback();
       });
     }
+    else if (callback != null)
+    {
+      callback();
+    }
   }
 
   function checkLibrary(library:String):Void
   {
-    trace(Assets.hasLibrary(library));
+    trace(library, Assets.hasLibrary(library), Assets.getLibrary(library) != null);
+    var callback = callbacks?.add('library:' + library);
+
     if (Assets.getLibrary(library) == null)
     {
       @:privateAccess
       if (!LimeAssets.libraryPaths.exists(library)) throw 'Missing library: ' + library;
 
-      var callback = callbacks?.add('library:' + library);
       Assets.loadLibrary(library).onComplete(function(_)
       {
         if (callback != null) callback();
       });
+    }
+    else if (callback != null)
+    {
+      callback();
     }
   }
 
@@ -189,24 +200,28 @@ class LoadingState extends MusicBeatSubState
 
   function onLoad():Void
   {
-    // Stop the instrumental.
-    @:nullSafety(Off)
-    if (stopMusic && FlxG.sound.music != null)
+    FlxG.camera.fade(0.25, false, true);
+    FlxTimer.wait(0.25, function()
     {
-      FlxG.sound.music.destroy();
-      FlxG.sound.music = null;
-    }
+      // Stop the instrumental.
+      @:nullSafety(Off)
+      if (stopMusic && FlxG.sound.music != null)
+      {
+        FlxG.sound.music.destroy();
+        FlxG.sound.music = null;
+      }
 
-    if (asSubState)
-    {
-      this.close();
-      // We will assume the target is a valid substate.
-      FlxG.state.openSubState(cast target);
-    }
-    else
-    {
-      FlxG.switchState(target);
-    }
+      if (asSubState)
+      {
+        this.close();
+        // We will assume the target is a valid substate.
+        FlxG.state.openSubState(cast target);
+      }
+      else
+      {
+        FlxG.switchState(target);
+      }
+    });
   }
 
   static var stageDirectory:String = "shared";

--- a/source/funkin/ui/transition/preload/FunkinPreloader.hx
+++ b/source/funkin/ui/transition/preload/FunkinPreloader.hx
@@ -92,8 +92,6 @@ class FunkinPreloader extends FlxBasePreloader
 
   private var initializingScriptsPercent:Float = -1;
 
-  private var cachingCoreAssetsPercent:Float = -1;
-
   /**
    * The timestamp when the other steps completed and the `Finishing up` step started.
    */
@@ -445,9 +443,8 @@ class FunkinPreloader extends FlxBasePreloader
           cachingAudioPercent = 0.0;
           cachingAudioStartTime = elapsed;
 
-          var assetsToCache:Array<String> = []; // Assets.listSound('core');
-
           /*
+          var assetsToCache:Array<String> = []; // Assets.listSound('core');
             var future:Future<Array<String>> = []; // Assets.cacheAssets(assetsToCache);
 
             future.onProgress((loaded:Int, total:Int) -> {

--- a/source/funkin/util/Constants.hx
+++ b/source/funkin/util/Constants.hx
@@ -292,6 +292,11 @@ class Constants
   public static final DEFAULT_OST_NAME:String = 'OFFICIAL OST';
 
   /**
+   * The default random capsule music to play in freeplay.
+   */
+  public static final DEFAULT_RANDOM_CAPSULE_MUSIC:String = 'freeplayRandom';
+
+  /**
    * The default preview start time for the songs in Freeplay.
    */
   public static final DEFAULT_PREVIEW_START_TIME:Float = 0;
@@ -578,6 +583,11 @@ class Constants
    * The file extension used when loading data files.
    */
   public static final EXT_DATA = "json";
+
+  /**
+   * The file extensions supported for loading audio files.
+   */
+  public static final EXT_SOUNDS = ["ogg", "mp3", "wav", "opus", "flac"];
 
   /**
    * OTHER

--- a/source/funkin/util/FileUtil.hx
+++ b/source/funkin/util/FileUtil.hx
@@ -9,12 +9,6 @@ import haxe.io.Path;
 import openfl.net.FileReference;
 import openfl.events.Event;
 import openfl.events.IOErrorEvent;
-#if FEATURE_HAXEUI
-import haxe.ui.containers.dialogs.Dialog.DialogButton;
-import haxe.ui.containers.dialogs.Dialogs;
-import haxe.ui.containers.dialogs.Dialogs.SelectedFileInfo;
-import haxe.ui.containers.dialogs.Dialogs.FileDialogExtensionInfo;
-#end
 
 using StringTools;
 
@@ -24,31 +18,55 @@ using StringTools;
 @:nullSafety
 class FileUtil
 {
-  public static final FILE_FILTER_FNFC:FileFilter = new FileFilter("Friday Night Funkin' Chart (.fnfc)", "*.fnfc");
-  public static final FILE_FILTER_JSON:FileFilter = new FileFilter("JSON Data File (.json)", "*.json");
-  public static final FILE_FILTER_ZIP:FileFilter = new FileFilter("ZIP Archive (.zip)", "*.zip");
-  public static final FILE_FILTER_PNG:FileFilter = new FileFilter("PNG Image (.png)", "*.png");
-  public static final FILE_FILTER_FNFS:FileFilter = new FileFilter("Friday Night Funkin' Stage (.fnfs)", "*.fnfs");
+  /**
+   * File filter for Friday Night Funkin' chart files.
+   */
+  public static final FILE_FILTER_FNFC:FileFilter = new FileFilter('Friday Night Funkin\' Chart', '*.fnfc');
 
-  #if FEATURE_HAXEUI
-  public static final FILE_EXTENSION_INFO_FNFC:FileDialogExtensionInfo = {
-    extension: 'fnfc',
-    label: 'Friday Night Funkin\' Chart',
-  };
-  public static final FILE_EXTENSION_INFO_ZIP:FileDialogExtensionInfo = {
-    extension: 'zip',
-    label: 'ZIP Archive',
-  };
-  public static final FILE_EXTENSION_INFO_PNG:FileDialogExtensionInfo = {
-    extension: 'png',
-    label: 'PNG Image',
-  };
+  /**
+   * File filter for Friday Night Funkin' stage files.
+   */
+  public static final FILE_FILTER_FNFS:FileFilter = new FileFilter('Friday Night Funkin\' Stage', '*.fnfs');
 
-  public static final FILE_EXTENSION_INFO_FNFS:FileDialogExtensionInfo = {
-    extension: 'fnfs',
-    label: 'Friday Night Funkin\' Stage',
-  };
-  #end
+  /**
+   * File filter for JSON data files.
+   */
+  public static final FILE_FILTER_JSON:FileFilter = new FileFilter('JSON Data File', '*.json');
+
+  /**
+   * File filter for plain text files.
+   */
+  public static final FILE_FILTER_TXT:FileFilter = new FileFilter('Text File', '*.txt');
+
+  /**
+   * File filter for XML data files.
+   */
+  public static final FILE_FILTER_XML:FileFilter = new FileFilter('XML Data File', '*.xml');
+
+  /**
+   * File filter for ZIP archive files.
+   */
+  public static final FILE_FILTER_ZIP:FileFilter = new FileFilter('ZIP Archive', '*.zip');
+
+  /**
+   * File filter for OGG audio files.
+   */
+  public static final FILE_FILTER_OGG:FileFilter = new FileFilter('OGG Audio File', '*.ogg');
+
+  /**
+   * File filter for PNG image files.
+   */
+  public static final FILE_FILTER_PNG:FileFilter = new FileFilter('PNG Image File', '*.png');
+
+  /**
+   * File filter for StepMania chart files.
+   */
+  public static final FILE_FILTER_SM:FileFilter = new FileFilter('StepMania File', '*.sm');
+
+  /**
+   * File filter for OSU! beatmap files.
+   */
+  public static final FILE_FILTER_OSU:FileFilter = new FileFilter('OSU! Beatmap File', '*.osu');
 
   /**
    * Paths which should not be deleted or modified by scripts.
@@ -90,82 +108,12 @@ class FileUtil
   }
   #end
 
-  #if FEATURE_HAXEUI
   /**
-   * Browses for a single file, then calls `onSelect(fileInfo)` when a file is selected.
-   * Powered by HaxeUI, so it works on all platforms.
-   * File contents will be binary, not String.
+   * Browses for a directory.
    *
-   * @param typeFilter
-   * @param onSelect A callback that provides a `SelectedFileInfo` object when a file is selected.
-   * @param onCancel A callback that is called when the user closes the dialog without selecting a file.
+   * Note that on HTML5 this will immediately fail.
    */
-  public static function browseForBinaryFile(dialogTitle:String, ?typeFilter:Array<FileDialogExtensionInfo>, onSelect:(SelectedFileInfo) -> Void,
-      ?onCancel:() -> Void)
-  {
-    var onComplete = function(button, selectedFiles)
-    {
-      if (button == DialogButton.OK && selectedFiles.length > 0)
-      {
-        onSelect(selectedFiles[0]);
-      }
-      else if (onCancel != null)
-      {
-        onCancel();
-      }
-    };
-
-    Dialogs.openFile(onComplete, {
-      readContents: true,
-      readAsBinary: true, // Binary
-      multiple: false,
-      extensions: typeFilter ?? new Array<FileDialogExtensionInfo>(),
-      title: dialogTitle,
-    });
-  }
-
-  /**
-   * Browses for a single file, then calls `onSelect(fileInfo)` when a file is selected.
-   * Powered by HaxeUI, so it works on all platforms.
-   * File contents will be a String, not binary.
-   *
-   * @param typeFilter
-   * @param onSelect A callback that provides a `SelectedFileInfo` object when a file is selected.
-   * @param onCancel A callback that is called when the user closes the dialog without selecting a file.
-   */
-  public static function browseForTextFile(dialogTitle:String, ?typeFilter:Array<FileDialogExtensionInfo>, onSelect:(SelectedFileInfo) -> Void,
-      ?onCancel:() -> Void):Void
-  {
-    var onComplete = function(button, selectedFiles)
-    {
-      if (button == DialogButton.OK && selectedFiles.length > 0)
-      {
-        onSelect(selectedFiles[0]);
-      }
-      else if (onCancel != null)
-      {
-        onCancel();
-      }
-    };
-
-    Dialogs.openFile(onComplete, {
-      readContents: true,
-      readAsBinary: false, // Text
-      multiple: false,
-      extensions: typeFilter ?? new Array<FileDialogExtensionInfo>(),
-      title: dialogTitle,
-    });
-  }
-  #end
-
-  /**
-   * Browses for a directory, then calls `onSelect(path)` when a path chosen.
-   *
-   * @param typeFilter TODO What does this do?
-   * @return Whether the file dialog was opened successfully.
-   */
-  public static function browseForDirectory(?typeFilter:Array<FileFilter>, onSelect:(String) -> Void, ?onCancel:() -> Void, ?defaultPath:String,
-      ?dialogTitle:String):Bool
+  public static function browseForDirectory(dialogTitle:String, onSelect:(String) -> Void, ?onCancel:() -> Void, ?defaultPath:String):Void
   {
     #if html5
     trace('WARNING: browseForDirectory not implemented for this platform');
@@ -174,10 +122,8 @@ class FileUtil
     {
       onCancel();
     }
-
-    return false;
     #else
-    FileDialog.openDirectory(Lib.current.stage.window, function(filepaths:Array<String>):Void
+    FileDialog.openDirectory(Lib.current.stage.window, dialogTitle, function(filepaths:Array<String>):Void
     {
       if (filepaths.length > 0)
       {
@@ -194,19 +140,53 @@ class FileUtil
         }
       }
     }, defaultPath, false);
-
-    return true;
     #end
   }
 
   /**
-   * Browses for multiple file, then calls `onSelect(paths)` when a path chosen.
-   * Note that on HTML5 this will immediately fail.
+   * Browses for a file.
    *
-   * @return Whether the file dialog was opened successfully.
+   * Note that on HTML5 this will immediately fail.
    */
-  public static function browseForMultipleFiles(?typeFilter:Array<FileFilter>, onSelect:(Array<String>) -> Void, ?onCancel:() -> Void, ?defaultPath:String,
-      ?dialogTitle:String):Bool
+  public static function browseForFile(dialogTitle:String, ?typeFilter:Array<FileFilter>, onSelect:(SelectedFileData) -> Void, ?onCancel:() -> Void,
+      ?defaultPath:String):Void
+  {
+    #if html5
+    trace('WARNING: browseForFile not implemented for this platform');
+
+    if (onCancel != null)
+    {
+      onCancel();
+    }
+    #else
+    FileDialog.openFile(Lib.current.stage.window, dialogTitle, function(filepaths:Array<String>, filter):Void
+    {
+      if (filepaths.length > 0)
+      {
+        if (onSelect != null)
+        {
+          onSelect(SelectedFileData.fromPath(filepaths[0]));
+        }
+      }
+      else
+      {
+        if (onCancel != null)
+        {
+          onCancel();
+        }
+      }
+    }, @:privateAccess openfl.filesystem.File.__getFilterTypes(typeFilter ?? []),
+      defaultPath, false);
+    #end
+  }
+
+  /**
+   * Browses for a multiple files.
+   *
+   * Note that on HTML5 this will immediately fail.
+   */
+  public static function browseForMultipleFiles(dialogTitle:String, ?typeFilter:Array<FileFilter>, onSelect:(Array<String>) -> Void, ?onCancel:() -> Void,
+      ?defaultPath:String):Void
   {
     #if html5
     trace('WARNING: browseForMultipleFiles not implemented for this platform');
@@ -215,10 +195,8 @@ class FileUtil
     {
       onCancel();
     }
-
-    return false;
     #else
-    FileDialog.openFile(Lib.current.stage.window, function(filepaths:Array<String>, filter):Void
+    FileDialog.openFile(Lib.current.stage.window, dialogTitle, function(filepaths:Array<String>, filter):Void
     {
       if (filepaths.length > 0)
       {
@@ -236,19 +214,16 @@ class FileUtil
       }
     }, @:privateAccess openfl.filesystem.File.__getFilterTypes(typeFilter ?? []),
       defaultPath, true);
-
-    return true;
     #end
   }
 
   /**
-   * Browses for a file location to save to, then calls `onSave(path)` when a path chosen.
+   * Browses for a file location to save to.
    *
-   * @param typeFilter TODO What does this do?
-   * @return Whether the file dialog was opened successfully.
+   * Note that on HTML5 this will immediately fail.
    */
-  public static function browseForSaveFile(?typeFilter:Array<FileFilter>, onSelect:(String) -> Void, ?onCancel:() -> Void, ?defaultPath:String,
-      ?dialogTitle:String):Bool
+  public static function browseForSaveFile(dialogTitle:String, ?typeFilter:Array<FileFilter>, onSelect:(String) -> Void, ?onCancel:() -> Void,
+      ?defaultPath:String):Void
   {
     #if html5
     trace('WARNING: browseForSaveFile not implemented for this platform');
@@ -257,10 +232,8 @@ class FileUtil
     {
       onCancel();
     }
-
-    return false;
     #else
-    FileDialog.saveFile(Lib.current.stage.window, function(filepath:String, filter):Void
+    FileDialog.saveFile(Lib.current.stage.window, dialogTitle, function(filepath:String, filter):Void
     {
       if (filepath != null)
       {
@@ -277,18 +250,16 @@ class FileUtil
         }
       }
     }, @:privateAccess openfl.filesystem.File.__getFilterTypes(typeFilter ?? []), defaultPath);
-    return true;
     #end
   }
 
   /**
    * Browses for a single file location, then writes the provided `haxe.io.Bytes` data and calls `onSave(path)` when done.
-   * Works great on desktop and HTML5.
    *
-   * @return Whether the file dialog was opened successfully.
+   * Note that on HTML5 this will immediately fail.
    */
-  public static function saveFile(data:Bytes, ?typeFilter:Array<FileFilter>, ?onSave:(String) -> Void, ?onCancel:() -> Void, ?defaultFileName:String,
-      ?dialogTitle:String):Bool
+  public static function saveFile(dialogTitle:String, data:Bytes, ?typeFilter:Array<FileFilter>, ?onSave:(String) -> Void, ?onCancel:() -> Void,
+      ?defaultPath:String):Void
   {
     #if html5
     trace('WARNING: saveFile not implemented for this platform');
@@ -297,10 +268,8 @@ class FileUtil
     {
       onCancel();
     }
-
-    return false;
     #else
-    FileDialog.saveFile(Lib.current.stage.window, function(filepath:String, filter):Void
+    FileDialog.saveFile(Lib.current.stage.window, dialogTitle, function(filepath:String, filter):Void
     {
       if (filepath != null)
       {
@@ -321,10 +290,7 @@ class FileUtil
           onCancel();
         }
       }
-    }, @:privateAccess openfl.filesystem.File.__getFilterTypes(typeFilter ?? []),
-      defaultFileName);
-
-    return true;
+    }, @:privateAccess openfl.filesystem.File.__getFilterTypes(typeFilter ?? []), defaultPath);
     #end
   }
 
@@ -337,34 +303,24 @@ class FileUtil
    * @return Whether the file dialog was opened successfully.
    */
   public static function saveMultipleFiles(resources:Array<Entry>, ?onSaveAll:(Array<String>) -> Void, ?onCancel:() -> Void, ?defaultPath:String,
-      force:Bool = false):Bool
+      force:Bool = false):Void
   {
-    #if desktop
-    // Prompt the user for a directory, then write all of the files to there.
-    var onSelectDir:(String) -> Void = function(targetPath:String):Void
+    #if html5
+    trace('WARNING: saveMultipleFiles not implemented for this platform');
+
+    if (onCancel != null)
+    {
+      onCancel();
+    }
+    #elseif desktop
+    trace('Browsing for directory to save individual files to...');
+
+    browseForDirectory('Choose directory to save all files to...', function(targetPath:String):Void
     {
       var paths:Array<String> = new Array<String>();
+
       for (resource in resources)
       {
-        /*
-          var filePath:String = Path.join([targetPath, resource.fileName]);
-          try
-          {
-            if (resource.data == null)
-            {
-              trace('WARNING: File $filePath has no data or content. Skipping.');
-              continue;
-            }
-            else
-            {
-              writeBytesToPath(filePath, resource.data, force ? Force : Skip);
-            }
-          }
-          catch (e:Dynamic)
-          {
-            throw 'Failed to write file (probably already exists): $filePath';
-          }
-         */
         if (resource.data == null)
         {
           trace('WARNING: File ${resource.fileName} has no data or content. Skipping.');
@@ -380,30 +336,9 @@ class FileUtil
       {
         onSaveAll(paths);
       }
-    }
-
-    trace('Browsing for directory to save individual files to...');
-
-    #if mac
-    defaultPath = null;
-    #end
-
-    browseForDirectory(null, onSelectDir, onCancel, defaultPath, 'Choose directory to save all files to...');
-
-    return true;
-    #elseif html5
-    saveFilesAsZIP(resources, onSaveAll, onCancel, defaultPath, force);
-
-    return true;
+    }, onCancel, defaultPath);
     #else
-    trace('WARNING: saveMultipleFiles not implemented for this platform');
-
-    if (onCancel != null)
-    {
-      onCancel();
-    }
-
-    return false;
+    saveFilesAsZIP(resources, onSaveAll, onCancel, defaultPath, force);
     #end
   }
 
@@ -411,11 +346,9 @@ class FileUtil
    * Takes an array of file entries and prompts the user to save them as a ZIP file.
    */
   public static function saveFilesAsZIP(resources:Array<Entry>, ?onSave:(Array<String>) -> Void, ?onCancel:() -> Void, ?defaultPath:String,
-      force:Bool = false):Bool
+      force:Bool = false):Void
   {
-    // Create a ZIP file.
-    var zipBytes:Bytes = createZIPFromEntries(resources);
-    var onSave:(String) -> Void = function(path:String)
+    saveFile('Save files as ZIP...', createZIPFromEntries(resources), [FILE_FILTER_ZIP], function(path:String)
     {
       trace('Saved ${resources.length} files to ZIP at "$path"');
 
@@ -423,22 +356,16 @@ class FileUtil
       {
         onSave([path]);
       }
-    };
-
-    // Prompt the user to save the ZIP file.
-    saveFile(zipBytes, [FILE_FILTER_ZIP], onSave, onCancel, defaultPath, 'Save files as ZIP...');
-    return true;
+    }, onCancel, defaultPath);
   }
 
   /**
    * Takes an array of file entries and prompts the user to save them as a FNFC file.
    */
   public static function saveChartAsFNFC(resources:Array<Entry>, ?onSave:(Array<String>) -> Void, ?onCancel:() -> Void, ?defaultPath:String,
-      force:Bool = false):Bool
+      force:Bool = false):Void
   {
-    // Create a ZIP file.
-    var zipBytes:Bytes = createZIPFromEntries(resources);
-    var onSave:(String) -> Void = function(path:String)
+    saveFile('Save chart as FNFC...', createZIPFromEntries(resources), [FILE_FILTER_FNFC], function(path:String)
     {
       trace('Saved FNFC file to "$path"');
 
@@ -446,28 +373,20 @@ class FileUtil
       {
         onSave([path]);
       }
-    };
-    // Prompt the user to save the ZIP file.
-    saveFile(zipBytes, [FILE_FILTER_FNFC], onSave, onCancel, defaultPath, 'Save chart as FNFC...');
-    return true;
+    }, onCancel, defaultPath);
   }
 
   /**
    * Takes an array of file entries and forcibly writes a ZIP to the given path.
-   * Only works on native, because HTML5 doesn't allow you to write files to arbitrary paths.
-   * Use `saveFilesAsZIP` instead.
+   *
+   * Only works on native.
+   *
    * @param force Whether to force overwrite an existing file.
    */
-  public static function saveFilesAsZIPToPath(resources:Array<Entry>, path:String, mode:FileWriteMode = Skip):Bool
+  public static function saveFilesAsZIPToPath(resources:Array<Entry>, path:String, mode:FileWriteMode = Skip):Void
   {
     #if sys
-    // Create a ZIP file.
-    var zipBytes:Bytes = createZIPFromEntries(resources);
-    // Write the ZIP.
-    writeBytesToPath(path, zipBytes, mode);
-    return true;
-    #else
-    return false;
+    writeBytesToPath(path, createZIPFromEntries(resources), mode);
     #end
   }
 
@@ -1231,23 +1150,6 @@ class FileUtil
     throw 'External file selection is not supported on this platform.';
     #end
   }
-
-  private static function convertTypeFilter(?typeFilter:Array<FileFilter>):Null<String>
-  {
-    var filter:Null<String> = null;
-    if (typeFilter != null)
-    {
-      var filters:Array<String> = new Array<String>();
-      for (type in typeFilter)
-      {
-        filters.push(type.extension.replace('*.', '').replace(';', ','));
-      }
-
-      filter = filters.join(';');
-    }
-
-    return filter;
-  }
 }
 
 /**
@@ -1361,74 +1263,67 @@ class FileUtilSandboxed
   }
 
   public static final FILE_FILTER_FNFC:FileFilter = FileUtil.FILE_FILTER_FNFC;
+  public static final FILE_FILTER_FNFS:FileFilter = FileUtil.FILE_FILTER_FNFS;
   public static final FILE_FILTER_JSON:FileFilter = FileUtil.FILE_FILTER_JSON;
+  public static final FILE_FILTER_TXT:FileFilter = FileUtil.FILE_FILTER_TXT;
+  public static final FILE_FILTER_XML:FileFilter = FileUtil.FILE_FILTER_XML;
   public static final FILE_FILTER_ZIP:FileFilter = FileUtil.FILE_FILTER_ZIP;
+  public static final FILE_FILTER_OGG:FileFilter = FileUtil.FILE_FILTER_OGG;
   public static final FILE_FILTER_PNG:FileFilter = FileUtil.FILE_FILTER_PNG;
+  public static final FILE_FILTER_SM:FileFilter = FileUtil.FILE_FILTER_SM;
+  public static final FILE_FILTER_OSU:FileFilter = FileUtil.FILE_FILTER_OSU;
 
-  #if FEATURE_HAXEUI
-  public static final FILE_EXTENSION_INFO_FNFC:FileDialogExtensionInfo = FileUtil.FILE_EXTENSION_INFO_FNFC;
-  public static final FILE_EXTENSION_INFO_ZIP:FileDialogExtensionInfo = FileUtil.FILE_EXTENSION_INFO_ZIP;
-  public static final FILE_EXTENSION_INFO_PNG:FileDialogExtensionInfo = FileUtil.FILE_EXTENSION_INFO_PNG;
-
-  public static function browseForBinaryFile(dialogTitle:String, ?typeFilter:Array<FileDialogExtensionInfo>, onSelect:(SelectedFileInfo) -> Void,
-      ?onCancel:() -> Void)
+  public static function browseForDirectory(dialogTitle:String, onSelect:(String) -> Void, ?onCancel:() -> Void, ?defaultPath:String):Void
   {
-    FileUtil.browseForBinaryFile(dialogTitle, typeFilter, onSelect, onCancel);
+    FileUtil.browseForDirectory(dialogTitle, onSelect, onCancel, defaultPath);
   }
 
-  public static function browseForTextFile(dialogTitle:String, ?typeFilter:Array<FileDialogExtensionInfo>, onSelect:(SelectedFileInfo) -> Void,
-      ?onCancel:() -> Void):Void
+  public static function browseForFile(dialogTitle:String, ?typeFilter:Array<FileFilter>, onSelect:(SelectedFileData) -> Void, ?onCancel:() -> Void,
+      ?defaultPath:String):Void
   {
-    FileUtil.browseForTextFile(dialogTitle, typeFilter, onSelect, onCancel);
-  }
-  #end
-
-  public static function browseForDirectory(?typeFilter:Array<FileFilter>, onSelect:(String) -> Void, ?onCancel:() -> Void, ?defaultPath:String,
-      ?dialogTitle:String):Bool
-  {
-    return FileUtil.browseForDirectory(typeFilter, onSelect, onCancel, defaultPath, dialogTitle);
+    FileUtil.browseForFile(dialogTitle, typeFilter, onSelect, onCancel, defaultPath);
   }
 
-  public static function browseForMultipleFiles(?typeFilter:Array<FileFilter>, onSelect:(Array<String>) -> Void, ?onCancel:() -> Void, ?defaultPath:String,
-      ?dialogTitle:String):Bool
+  public static function browseForMultipleFiles(dialogTitle:String, ?typeFilter:Array<FileFilter>, onSelect:(Array<String>) -> Void, ?onCancel:() -> Void,
+      ?defaultPath:String):Void
   {
-    return FileUtil.browseForMultipleFiles(typeFilter, onSelect, onCancel, defaultPath, dialogTitle);
+    FileUtil.browseForMultipleFiles(dialogTitle, typeFilter, onSelect, onCancel, defaultPath);
   }
 
-  public static function browseForSaveFile(?typeFilter:Array<FileFilter>, onSelect:(String) -> Void, ?onCancel:() -> Void, ?defaultPath:String,
-      ?dialogTitle:String):Bool
+  public static function browseForSaveFile(dialogTitle:String, ?typeFilter:Array<FileFilter>, onSelect:(String) -> Void, ?onCancel:() -> Void,
+      ?defaultPath:String):Void
   {
-    return FileUtil.browseForSaveFile(typeFilter, onSelect, onCancel, defaultPath, dialogTitle);
+    FileUtil.browseForSaveFile(dialogTitle, typeFilter, onSelect, onCancel, defaultPath);
   }
 
-  public static function saveFile(data:Bytes, ?typeFilter:Array<FileFilter>, ?onSave:(String) -> Void, ?onCancel:() -> Void, ?defaultFileName:String,
-      ?dialogTitle:String):Bool
+  public static function saveFile(dialogTitle:String, data:Bytes, ?typeFilter:Array<FileFilter>, ?onSave:(String) -> Void, ?onCancel:() -> Void,
+      ?defaultPath:String):Void
   {
-    return FileUtil.saveFile(data, typeFilter, onSave, onCancel, defaultFileName, dialogTitle);
+    FileUtil.saveFile(dialogTitle, data, typeFilter, onSave, onCancel, defaultPath);
   }
 
   public static function saveMultipleFiles(resources:Array<Entry>, ?onSaveAll:(Array<String>) -> Void, ?onCancel:() -> Void, ?defaultPath:String,
-      force:Bool = false):Bool
+      force:Bool = false):Void
   {
-    return FileUtil.saveMultipleFiles(resources, onSaveAll, onCancel, defaultPath, force);
+    FileUtil.saveMultipleFiles(resources, onSaveAll, onCancel, defaultPath, force);
   }
 
   public static function saveFilesAsZIP(resources:Array<Entry>, ?onSave:(Array<String>) -> Void, ?onCancel:() -> Void, ?defaultPath:String,
-      force:Bool = false):Bool
+      force:Bool = false):Void
   {
-    return FileUtil.saveFilesAsZIP(resources, onSave, onCancel, defaultPath, force);
+    FileUtil.saveFilesAsZIP(resources, onSave, onCancel, defaultPath, force);
   }
 
   public static function saveChartAsFNFC(resources:Array<Entry>, ?onSave:(Array<String>) -> Void, ?onCancel:() -> Void, ?defaultPath:String,
-      force:Bool = false):Bool
+      force:Bool = false):Void
   {
-    return FileUtil.saveChartAsFNFC(resources, onSave, onCancel, defaultPath, force);
+    FileUtil.saveChartAsFNFC(resources, onSave, onCancel, defaultPath, force);
   }
 
-  public static function saveFilesAsZIPToPath(resources:Array<Entry>, path:String, mode:FileWriteMode = Skip):Bool
+  public static function saveFilesAsZIPToPath(resources:Array<Entry>, path:String, mode:FileWriteMode = Skip):Void
   {
     if (isProtected(path = sanitizePath(path), false)) throw 'Cannot write to protected path: $path';
-    return FileUtil.saveFilesAsZIPToPath(resources, path, mode);
+    FileUtil.saveFilesAsZIPToPath(resources, path, mode);
   }
 
   public static function readStringFromPath(path:String):String
@@ -1598,4 +1493,21 @@ enum FileWriteMode
    * Skip the file if it already exists.
    */
   Skip;
+}
+
+@:structInit
+class SelectedFileData
+{
+  public static function fromPath(path:String):SelectedFileData
+  {
+    return {
+      name: new Path(path).file,
+      bytes: Bytes.fromFile(path),
+      fullPath: path
+    };
+  }
+
+  public var name:String;
+  public var bytes:Bytes;
+  public var fullPath:String;
 }

--- a/source/funkin/util/FileUtil.hx
+++ b/source/funkin/util/FileUtil.hx
@@ -49,9 +49,9 @@ class FileUtil
   public static final FILE_FILTER_ZIP:FileFilter = new FileFilter('ZIP Archive', '*.zip');
 
   /**
-   * File filter for OGG audio files.
+   * File filter for all supported audio files.
    */
-  public static final FILE_FILTER_OGG:FileFilter = new FileFilter('OGG Audio File', '*.ogg');
+  public static final FILE_FILTER_AUDIO:FileFilter = new FileFilter('Audio File', '*.ogg; *.mp3; *.wav; *.opus; *.flac');
 
   /**
    * File filter for PNG image files.
@@ -1268,7 +1268,7 @@ class FileUtilSandboxed
   public static final FILE_FILTER_TXT:FileFilter = FileUtil.FILE_FILTER_TXT;
   public static final FILE_FILTER_XML:FileFilter = FileUtil.FILE_FILTER_XML;
   public static final FILE_FILTER_ZIP:FileFilter = FileUtil.FILE_FILTER_ZIP;
-  public static final FILE_FILTER_OGG:FileFilter = FileUtil.FILE_FILTER_OGG;
+  public static final FILE_FILTER_AUDIO:FileFilter = FileUtil.FILE_FILTER_AUDIO;
   public static final FILE_FILTER_PNG:FileFilter = FileUtil.FILE_FILTER_PNG;
   public static final FILE_FILTER_SM:FileFilter = FileUtil.FILE_FILTER_SM;
   public static final FILE_FILTER_OSU:FileFilter = FileUtil.FILE_FILTER_OSU;

--- a/source/funkin/util/ReflectUtil.hx
+++ b/source/funkin/util/ReflectUtil.hx
@@ -1,6 +1,7 @@
 package funkin.util;
 
 import Type.ValueType;
+import polymod.hscript._internal.PolymodScriptClass;
 
 /**
  * Provides sanitized and blacklisted access to haxe's Reflection functions.
@@ -11,19 +12,21 @@ import Type.ValueType;
 class ReflectUtil
 {
   /**
-   * A list of field names which cannot be retrieved with `getAnonymousField()`
-   */
-  @:unreflective
-  static var FIELD_NAME_BLACKLIST:Array<String> = ['_interp'];
-
-  /**
-   * This function is not allowed to be used by scripts.
-   * @throws error When called by a script.
+   * Calls a method value of a specific field on an object.
+   * Accounts for property blacklist for security.
+   * @param obj The object to modify.
+   * @param name The field to modify.
+   * @param value The new value to apply.
+   * @throws error When trying to call a blacklisted method.
    */
   @SuppressWarnings("checkstyle:FieldDocComment")
   public static function callMethod(obj:Any, name:String, args:Array<Any>):Any
   {
-    throw "Function Reflect.callMethod is blacklisted.";
+    if (!isAccessAllowed(obj, name))
+    {
+      throw 'Attempted to call blacklisted method "${name}"';
+    }
+    return Reflect.callMethod(getReflectionParent(obj), Reflect.field(getReflectionParent(obj), name), args);
   }
 
   /**
@@ -107,6 +110,10 @@ class ReflectUtil
    */
   public static function deleteAnonymousField(obj:Any, name:String):Bool
   {
+    if (!isAccessAllowed(obj, name))
+    {
+      throw 'Attempted to delete blacklisted field "${name}"';
+    };
     return Reflect.deleteField(obj, name);
   }
 
@@ -143,12 +150,12 @@ class ReflectUtil
    */
   public static function getAnonymousField(obj:Any, name:String):Any
   {
-    if (FIELD_NAME_BLACKLIST.contains(name))
+    if (!isAccessAllowed(obj, name))
     {
       throw 'Attempted to retrieve blacklisted field "${name}"';
     };
 
-    return Reflect.field(obj, name);
+    return Reflect.field(getReflectionParent(obj), name);
   }
 
   /**
@@ -194,12 +201,12 @@ class ReflectUtil
    */
   public static function getProperty(obj:Any, name:String):Any
   {
-    if (FIELD_NAME_BLACKLIST.contains(name))
+    if (!isAccessAllowed(obj, name))
     {
       throw 'Attempted to retrieve blacklisted field "${name}"';
     };
 
-    return Reflect.getProperty(obj, name);
+    return Reflect.getProperty(getReflectionParent(obj), name);
   }
 
   /**
@@ -218,16 +225,16 @@ class ReflectUtil
    * Determine whether the given anonymous structure has the given field.
    * @param obj The structure to query.
    * @param name The field name to query.
-   * @return Whether the field exists.
+   * @return Whether the field exists and isnt blacklisted.
    */
   public static function hasAnonymousField(obj:Any, name:String):Bool
   {
-    if (FIELD_NAME_BLACKLIST.contains(name))
+    if (!isAccessAllowed(obj, name))
     {
       return false;
     }
 
-    return Reflect.hasField(obj, name);
+    return Reflect.hasField(getReflectionParent(obj), name);
   }
 
   /**
@@ -277,10 +284,15 @@ class ReflectUtil
    * @param obj The object to modify.
    * @param name The field to modify.
    * @param value The new value to apply.
+   * @throws error When trying to set a blacklisted field.
    */
   public static function setAnonymousField(obj:Any, name:String, value:Any):Void
   {
-    return Reflect.setField(obj, name, value);
+    if (!isAccessAllowed(obj, name))
+    {
+      throw 'Attempted to set blacklisted field "${name}"';
+    };
+    return Reflect.setField(getReflectionParent(obj), name, value);
   }
 
   /**
@@ -288,31 +300,48 @@ class ReflectUtil
    * Accounts for property fields with getters and setters.
    * @param obj The object to modify.
    * @param name The field to modify.
-   * @param value The new value to apply.
+   * @throws error When trying to set a blacklisted field.
    */
   public static function setProperty(obj:Any, name:String, value:Any):Void
   {
-    return Reflect.setProperty(obj, name, value);
+    if (!isAccessAllowed(obj, name))
+    {
+      throw 'Attempted to set blacklisted field "${name}"';
+    };
+    return Reflect.setProperty(getReflectionParent(obj), name, value);
   }
 
   /**
-   * This function is not allowed to be used by scripts.
-   * @throws error When called by a script.
+   * Creats a empty instance of specified class
+   * Accounts for property blacklist for security.
+   * @param cls The class to create.
+   * @throws error When trying to create a blacklisted class.
    */
   @SuppressWarnings("checkstyle:FieldDocComment")
   public static function createEmptyInstance(cls:Class<Any>):Any
   {
-    throw "Function Type.createEmptyInstance is blacklisted.";
+    if (!isAccessAllowed(cls))
+    {
+      throw 'Attempted to call createInstance onto a blacklisted class "${getClassNameOf(cls)}"';
+    }
+    return Type.createEmptyInstance(getReflectionParent(cls));
   }
 
   /**
-   * This function is not allowed to be used by scripts.
-   * @throws error When called by a script.
+   * Creats a instance of specified class
+   * Accounts for property blacklist for security.
+   * @param cls The class to create.
+   * @param args Parameters to give to the constructor
+   * @throws error When trying to create a blacklisted class.
    */
   @SuppressWarnings("checkstyle:FieldDocComment")
   public static function createInstance(cls:Class<Any>, args:Array<Any>):Any
   {
-    throw "Function Type.createInstance is blacklisted.";
+    if (!isAccessAllowed(cls))
+    {
+      throw 'Attempted to call createInstance onto a blacklisted class "${getClassNameOf(cls)}"';
+    }
+    return Type.createInstance(getReflectionParent(cls), args);
   }
 
   /**
@@ -320,9 +349,16 @@ class ReflectUtil
    * @throws error When called by a script.
    */
   @SuppressWarnings("checkstyle:FieldDocComment")
-  public static function resolveClass(name:String):Class<Any>
+  public static function resolveClass(name:String):Null<Class<Any>>
   {
-    throw "Function Type.resolveClass is blacklisted.";
+    var resolved = getReflectionParent(getClassOrEnumFromName(name));
+    if (resolved == null) return null;
+    if (!Std.isOfType(resolved, Class)) return null;
+    if (!isAccessAllowed(resolved))
+    {
+      throw 'Attempted to resolve a blacklisted class "${getClassNameOf(getClassOrEnumFromName(name))}"';
+    }
+    return resolved;
   }
 
   /**
@@ -330,9 +366,16 @@ class ReflectUtil
    * @throws error When called by a script.
    */
   @SuppressWarnings("checkstyle:FieldDocComment")
-  public static function resolveEnum(name:String):Enum<Any>
+  public static function resolveEnum(name:String):Null<Enum<Any>>
   {
-    throw "Function Type.resolveEnum is blacklisted.";
+    var resolved = getReflectionParent(getClassOrEnumFromName(name));
+    if (resolved == null) return null;
+    if (!Std.isOfType(resolved, Enum)) return null;
+    if (!isAccessAllowed(resolved))
+    {
+      throw 'Attempted to resolve a blacklisted enum "${getClassNameOf(getClassOrEnumFromName(name))}"';
+    }
+    return resolved;
   }
 
   /**
@@ -376,6 +419,7 @@ class ReflectUtil
    */
   public static function getInstanceFields(cls:Class<Any>):Array<String>
   {
+    if (cls == null) return [];
     return Type.getInstanceFields(cls);
   }
 
@@ -411,6 +455,7 @@ class ReflectUtil
   public static function getClassNameOf(obj:Any):String
   {
     if (obj == null) return "Unknown";
+    if (obj is String && Type.resolveClass(obj) != null) return obj;
     @:nullSafety(Off)
     var cls = Type.getClass(obj);
     if (cls == null) return "Unknown";
@@ -424,5 +469,74 @@ class ReflectUtil
   public static function makeVarArgs(f:Array<Dynamic>->Dynamic):Dynamic
   {
     return Reflect.makeVarArgs(f);
+  }
+
+  @:unreflective
+  static final pathResolveCache:Map<String, Any> = new Map();
+
+  @:unreflective
+  static final blacklistedFieldsCache:Map<String, Any> = new Map();
+
+  @:unreflective
+  @:nullSafety(Off)
+  static function getClassOrEnumFromName(path:String):Any
+  {
+    if (pathResolveCache.exists(path)) return pathResolveCache.get(path);
+    var resultCls:Class<Dynamic> = Type.resolveClass(path);
+    if (resultCls != null)
+    {
+      pathResolveCache.set(path, resultCls);
+      return resultCls;
+    }
+    else
+    {
+      var resultEnm:Enum<Dynamic> = Type.resolveEnum(path);
+      if (resultEnm != null) pathResolveCache.set(path, resultEnm);
+      return resultEnm;
+    }
+  }
+
+  @:unreflective
+  @:nullSafety(Off)
+  static function getReflectionParent(obj:Dynamic):Dynamic
+  {
+    var clsName = getClassNameOf(obj);
+    if (clsName == "Unknown") clsName = null;
+    var objName = obj is String ? obj : (clsName ?? obj);
+    return PolymodScriptClass.importOverrides.exists(objName) ? PolymodScriptClass.importOverrides.get(objName) : obj;
+  }
+
+  @:unreflective
+  @:nullSafety(Off)
+  static function isAccessAllowed(obj:Dynamic, ?varName:String):Bool
+  {
+    var reflectedObj = getReflectionParent(obj);
+    var isClassReflect = Std.isOfType(reflectedObj, Class);
+
+    var key:String;
+    if (isClassReflect) key = Type.getClassName(cast reflectedObj);
+    else
+      key = getClassNameOf(reflectedObj);
+
+    if (varName != null)
+    {
+      var cacheKey = '${isClassReflect ? "C_" : "I_"}$key';
+      var blacklistedFields:Array<String> = blacklistedFieldsCache.get(cacheKey);
+      if (blacklistedFields == null)
+      {
+        if (isClassReflect) blacklistedFields = PolymodScriptClass.blacklistedStaticFields.get(cast reflectedObj);
+        else
+          blacklistedFields = PolymodScriptClass.blacklistedInstanceFields.get(key);
+
+        if (blacklistedFields == null) blacklistedFields = [];
+        blacklistedFieldsCache.set(cacheKey, blacklistedFields);
+      }
+
+      if (blacklistedFields.contains(varName)) return false;
+    }
+
+    if (PolymodScriptClass.importOverrides.exists(key) && PolymodScriptClass.importOverrides.get(key) == null) return false;
+
+    return true;
   }
 }

--- a/source/funkin/util/VersionUtil.hx
+++ b/source/funkin/util/VersionUtil.hx
@@ -23,7 +23,6 @@ class VersionUtil
   {
     try
     {
-      var versionRaw:thx.semver.Version.SemVer = version;
       return version.satisfies(versionRule);
     }
     catch (e)

--- a/source/funkin/util/file/FNFCUtil.hx
+++ b/source/funkin/util/file/FNFCUtil.hx
@@ -56,7 +56,7 @@ class FNFCUtil
     var audioVocalTrackGroup = new VoicesGroup();
 
     var instId:String = targetDifficulty.characters.instrumental ?? '';
-    var audioInstTrackName:String = manifest.getInstFileName(instId);
+    var audioInstTrackName:String = manifest.getInstFileName(instId, fileEntries);
     try
     {
       audioInstTrack = loadSoundFromFNFCZipEntries(mappedFileEntries, audioInstTrackName);
@@ -72,7 +72,7 @@ class FNFCUtil
     var playerVocalList:Array<String> = targetDifficulty.characters.playerVocals ?? [];
     for (playerVocalId in playerVocalList)
     {
-      var audioVocalTrackName:String = manifest.getVocalsFileName(playerVocalId, variation);
+      var audioVocalTrackName:String = manifest.getVocalsFileName(playerVocalId, variation, fileEntries);
       var audioVocalTrack = loadSoundFromFNFCZipEntries(mappedFileEntries, audioVocalTrackName);
       try
       {
@@ -88,7 +88,7 @@ class FNFCUtil
     var opponentVocalList:Array<String> = targetDifficulty.characters.opponentVocals ?? [];
     for (opponentVocalId in opponentVocalList)
     {
-      var audioVocalTrackName:String = manifest.getVocalsFileName(opponentVocalId, variation);
+      var audioVocalTrackName:String = manifest.getVocalsFileName(opponentVocalId, variation, fileEntries);
       var audioVocalTrack = loadSoundFromFNFCZipEntries(mappedFileEntries, audioVocalTrackName);
       try
       {

--- a/source/funkin/util/plugins/ScreenshotPlugin.hx
+++ b/source/funkin/util/plugins/ScreenshotPlugin.hx
@@ -466,6 +466,7 @@ class ScreenshotPlugin extends FlxBasic
     return state;
   }
 
+  #if !web
   static function getScreenshotPath():String
   {
     return '$SCREENSHOT_FOLDER/';
@@ -475,6 +476,7 @@ class ScreenshotPlugin extends FlxBasic
   {
     FileUtil.createDirIfNotExists(SCREENSHOT_FOLDER);
   }
+  #end
 
   /**
    * Convert a Bitmap to a PNG ByteArray to save to a file.
@@ -497,12 +499,19 @@ class ScreenshotPlugin extends FlxBasic
    */
   function saveScreenshot(bitmap:Bitmap, targetPath = "image", screenShotNum:Int = 0, delaySave:Bool = true):Void
   {
+    #if !web
     makeScreenshotPath();
+    #end
+
     // Check that we're not overriding a previous image, and keep making a unique path until we can
     if (previousScreenshotName != targetPath && previousScreenshotName != (targetPath + ' (${previousScreenshotCopyNum})'))
     {
       previousScreenshotName = targetPath;
+      #if !web
       targetPath = getScreenshotPath() + targetPath + '.png';
+      #else
+      targetPath = targetPath + '.png';
+      #end
       previousScreenshotCopyNum = 2;
     }
     else
@@ -514,56 +523,81 @@ class ScreenshotPlugin extends FlxBasic
         newTargetPath = targetPath + ' (${previousScreenshotCopyNum})';
       }
       previousScreenshotName = newTargetPath;
+      #if !web
       targetPath = getScreenshotPath() + newTargetPath + '.png';
+      #else
+      targetPath = newTargetPath + '.png';
+      #end
     }
-
-    // TODO: Make screenshot saving work on browser.
-    // Maybe save the images into a buffer that you can download as a zip or something? That'd work
-    // Shouldn't be too hard to do something similar to the chart editor saving
 
     if (delaySave)
-    { // Save the images with a delay (a timer)
+    {
+      // Save the images with a delay (a timer)
       new FlxTimer().start(screenShotNum, function(_)
       {
-        var pngData:ByteArray = encode(bitmap);
-
-        if (pngData == null)
-        {
-          trace(' WARNING '.warning() + ' Failed to encode PNG data');
-          previousScreenshotName = null;
-          // Just in case
-          unsavedScreenshotBuffer.shift();
-          unsavedScreenshotNameBuffer.shift();
-          return;
-        }
-        else
-        {
-          trace('Saving screenshot to: ' + targetPath);
-          FileUtil.writeBytesToPath(targetPath, pngData);
-          // Remove the screenshot from the unsaved buffer because we literally just saved it
-          unsavedScreenshotBuffer.shift();
-          unsavedScreenshotNameBuffer.shift();
-          if (Preferences.previewOnSave) showFancyPreview(bitmap); // Only show the preview after a screenshot is saved
-        }
+        writeScreenshotFromBitmap(targetPath, bitmap, true);
       });
     }
-    else // Save the screenshot immediately
+    else
     {
-      var pngData:ByteArray = encode(bitmap);
-
-      if (pngData == null)
-      {
-        trace(' WARNING '.warning() + ' Failed to encode PNG data');
-        previousScreenshotName = null;
-        return;
-      }
-      else
-      {
-        trace('Saving screenshot to: ' + targetPath);
-        FileUtil.writeBytesToPath(targetPath, pngData);
-        if (Preferences.previewOnSave) showFancyPreview(bitmap); // Only show the preview after a screenshot is saved
-      }
+      // Save the screenshot immediately
+      writeScreenshotFromBitmap(targetPath, bitmap, false);
     }
+  }
+
+  function writeScreenshotFromBitmap(targetPath:String, bitmap:Bitmap, dequeue:Bool):Void
+  {
+    #if web
+    trace('Saving screenshot as: ' + targetPath);
+
+    var a:js.html.AnchorElement = cast js.Browser.document.createElement('a');
+    js.Browser.document.body.appendChild(a);
+    a.style.display = 'none';
+    a.href = bitmap.bitmapData.image.src.toDataURL("image/png");
+    a.download = targetPath;
+    a.click();
+
+    if (dequeue)
+    {
+      // Remove the screenshot from the unsaved buffer because we literally just saved it
+      unsavedScreenshotBuffer.shift();
+      unsavedScreenshotNameBuffer.shift();
+    }
+
+    if (Preferences.previewOnSave) showFancyPreview(bitmap); // Only show the preview after a screenshot is saved
+    #else
+    var pngData:ByteArray = encode(bitmap);
+
+    if (pngData == null)
+    {
+      trace(' WARNING '.warning() + ' Failed to encode PNG data');
+      previousScreenshotName = null;
+
+      if (dequeue)
+      {
+        // Just in case
+        unsavedScreenshotBuffer.shift();
+        unsavedScreenshotNameBuffer.shift();
+      }
+
+      return;
+    }
+    else
+    {
+      trace('Saving screenshot to: ' + targetPath);
+
+      FileUtil.writeBytesToPath(targetPath, pngData);
+
+      if (dequeue)
+      {
+        // Remove the screenshot from the unsaved buffer because we literally just saved it
+        unsavedScreenshotBuffer.shift();
+        unsavedScreenshotNameBuffer.shift();
+      }
+
+      if (Preferences.previewOnSave) showFancyPreview(bitmap); // Only show the preview after a screenshot is saved
+    }
+    #end
   }
 
   // I' m very happy with this code, all of it just works

--- a/templates/haxe/ApplicationMain.hx
+++ b/templates/haxe/ApplicationMain.hx
@@ -115,6 +115,9 @@ class ApplicationMain
       colorDepth: ::colorDepth::,
       depth: ::depthBuffer::,
       hardware: ::hardware::,
+      #if (html5 && FEATURE_SCREENSHOTS)
+      preserveDrawingBuffer: true,
+      #end
       stencil: ::stencilBuffer::,
       type: null,
       vsync: ::vsync::


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
- https://github.com/FunkinCrew/Funkin/issues/4366
- https://github.com/FunkinCrew/Funkin/issues/5449
- https://github.com/FunkinCrew/Funkin/issues/4657
- https://github.com/FunkinCrew/Funkin/issues/2432

<!-- Briefly describe the issue(s) fixed. -->
## Description
This pull request requires below of these another pull requests to work:
- https://github.com/FunkinCrew/Funkin/pull/6725 (For standardized percentage format in freeplay preview to make web 1 to 1 with native)
- https://github.com/FunkinCrew/Funkin/pull/7230 (Fix a bug in freeplay preview music)
- https://github.com/FunkinCrew/lime/pull/57 (Core/Main changes)
- https://github.com/FunkinCrew/openfl/pull/17 (Not important, not too unimportant)
- https://github.com/FunkinCrew/flixel/pull/11 (FlxSound rework)
- https://github.com/FunkinCrew/FlxPartialSound/pull/10 (Support with more formats in native)
- https://github.com/FunkinCrew/funkVis/pull/17 (Compatible with audio streaming)

Others pull request that requires this.
- https://github.com/FunkinCrew/funkin.assets/pull/381

A Whole rework/recode of Audio to work with more audio formats (flac, mp3, opus, made possible with dr_libs, opusfile), and hopefully to fix almost every audio related issues such as restarting, not ending correctly, etc.

List of what it changes:
- Adds an option that lets users to switch audio device without having to go to their operating system to change the default audio device just for the game (In native only)
- Implement Audio Streaming for Music and Songs. (In native only)
- Change every time related variables from Int to Float for more accuracy
- Seamless Loop for both static and streaming sound assets
- Support more formats such as flac, mp3, opus, compressed wav (In native only, web depends on what browsers the player is using)
- Makes FlxSound.amplitude work
- Better sound caching (in Flixel Pull Request)
- Real-time Sound Playback Effects (lime.media.AudioEffect, lime.media.effects.*)
- Implement previewStart, and previewEnd for freeplay preview songs
- Smooth fading freeplay preview musics when changing/going in/going out of freeplay
- Conductor.songPositionDelta isn't needed anymore as FlxSound.time is now interpolated to be 1 to 1 with HTML5 (Howler. Use FlxSound.getActualTime() to get the internal time instead of interpolated time)
- Add `randomCapsuleMusic` to PlayerFreeplayDJData `assets/data/players/` for customizable freeplay random capsule music
- More internal changes list at https://github.com/FunkinCrew/lime/pull/57, https://github.com/FunkinCrew/flixel/pull/11


<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos


https://github.com/user-attachments/assets/a82f3112-e947-40f9-9477-29a38b86a741


https://github.com/user-attachments/assets/75497518-2cbb-49fa-a4a7-36ba5a49d460


https://github.com/user-attachments/assets/1858b4b4-0c43-4850-8e1a-ead90d80855c


https://github.com/user-attachments/assets/54e7fec1-ca41-4224-8a8a-3b06db48dc0e

(Note: My recorder doesn't capture the other playback devices, only my earphones device)



Todo list:
- ~~Get more audio formats in chart editor working~~
- ~~[**High Priority**] Make `FlxPartialSound`, any waveform/ffts related stuffs work with this..~~
- ~~Implement Audio Streaming to almost possible scenarios except for Chart Editor where it requires full loaded audio data to parse into.~~
- ~~Try to fix previewStart and previewEnd in web target too. (Need https://github.com/FunkinCrew/Funkin/pull/6725 to fix this)~~
- ~~[**Low Priority**] Normalize every songs to -8 db with metadatas (?)~~ (Not too important, too unrelated for this pull request.)

DONE!!
