### PR TITLE
[BUGFIX] Fix Rimlight Alt Masks Not Working On Web

### DIFF
--- a/source/funkin/graphics/shaders/DropShadowShader.hx
+++ b/source/funkin/graphics/shaders/DropShadowShader.hx
@@ -216,14 +216,7 @@ class DropShadowShader extends FlxShader
    */
   public function loadAltMask(path:String):Void
   {
-    #if html5
-    BitmapData.loadFromFile(path).onComplete(function(bmp:BitmapData)
-    {
-      altMaskImage = bmp;
-    });
-    #else
     altMaskImage = Assets.getBitmapData(path, false);
-    #end
   }
 
   /**


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Briefly describe the issue(s) fixed. -->
## Description

This PR fixes an issue on web where rimlight alt masks fail to load on web.

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos

Before (Ew yucky I hate Pico because of this)

<img width="422" height="369" alt="Screenshot 2026-02-07 150342" src="https://github.com/user-attachments/assets/8b9316a9-a0ae-46c5-bcdc-ee7f512c442a" />

After (Yes not yucky I love Pico because of this)

<img width="422" height="347" alt="Screenshot 2026-02-07 150844" src="https://github.com/user-attachments/assets/fb067a79-688b-4c82-a309-cbbca99273a9" />

Of course, you can see the difference with other characters.