### PR TITLE
[ENHANCEMENT/Modding] Add `shouldBop` in `HealthIconData` to allow any type of icon to bop.

### DIFF
--- a/source/funkin/data/character/CharacterData.hx
+++ b/source/funkin/data/character/CharacterData.hx
@@ -460,6 +460,7 @@ class CharacterDataParser
   public static final DEFAULT_NAME:String = 'Untitled Character';
   public static final DEFAULT_OFFSETS:Array<Float> = [0, 0];
   public static final DEFAULT_HEALTHICON_OFFSETS:Array<Int> = [0, 25];
+  public static final DEFAULT_SHOULDBOP:Bool = true;
   public static final DEFAULT_RENDERTYPE:CharacterRenderType = CharacterRenderType.Sparrow;
   public static final DEFAULT_SCALE:Float = 1;
   public static final DEFAULT_SCROLL:Array<Float> = [0, 0];
@@ -532,6 +533,7 @@ class CharacterDataParser
     {
       input.healthIcon = {
         id: null,
+        shouldBop: null,
         scale: null,
         flipX: null,
         isPixel: null,
@@ -542,6 +544,11 @@ class CharacterDataParser
     if (input.healthIcon.id == null)
     {
       input.healthIcon.id = id;
+    }
+
+    if (input.healthIcon.shouldBop == null)
+    {
+      input.healthIcon.shouldBop = DEFAULT_SHOULDBOP;
     }
 
     if (input.healthIcon.scale == null)
@@ -832,6 +839,12 @@ typedef HealthIconData =
    * @default The character's ID
    */
   var id:Null<String>;
+
+  /**
+   * Whether the health icon should bop or not.
+   * @default true
+   */
+  var shouldBop:Null<Bool>;
 
   /**
    * The scale of the health icon.

--- a/source/funkin/play/components/HealthIcon.hx
+++ b/source/funkin/play/components/HealthIcon.hx
@@ -81,6 +81,11 @@ class HealthIcon extends FunkinSprite
   var isLegacyStyle:Bool = false;
 
   /**
+   * Whether this icon should bop or not.
+   */
+  var shouldBop:Bool = true;
+
+  /**
    * At this amount of health, play the Winning animation instead of the idle.
    */
   static final WINNING_THRESHOLD:Float = 0.8 * 2;
@@ -199,6 +204,7 @@ class HealthIcon extends FunkinSprite
     {
       this.characterId = data.id;
       this.isPixel = data.isPixel ?? false;
+      this.shouldBop = data.shouldBop ?? true;
 
       loadCharacter(characterId);
 
@@ -294,7 +300,7 @@ class HealthIcon extends FunkinSprite
   public function onStepHit(curStep:Int):Void
   {
     // Make the icons bop.
-    if (bopEvery != 0 && curStep % bopEvery == 0 && isLegacyStyle)
+    if (bopEvery != 0 && curStep % bopEvery == 0 && shouldBop)
     {
       bopTween?.cancel();
       setGraphicSize(Std.int(this.width + (HEALTH_ICON_SIZE * this.size.x * BOP_SCALE)), 0);

--- a/source/funkin/play/event/SetHealthIconSongEvent.hx
+++ b/source/funkin/play/event/SetHealthIconSongEvent.hx
@@ -38,6 +38,7 @@ class SetHealthIconSongEvent extends SongEvent
   static final DEFAULT_SCALE:Float = 1.0;
   static final DEFAULT_FLIPX:Bool = false;
   static final DEFAULT_ISPIXEL:Bool = false;
+  static final DEFAULT_SHOULDBOP:Bool = true;
 
   static final DEFAULT_X_OFFSET:Float = 0.0;
   static final DEFAULT_Y_OFFSET:Float = 0.0;
@@ -54,6 +55,7 @@ class SetHealthIconSongEvent extends SongEvent
 
     var healthIconData:HealthIconData = {
       id: data.value.id ?? Constants.DEFAULT_HEALTH_ICON,
+      shouldBop: data.value.shouldBop ?? DEFAULT_SHOULDBOP,
       scale: data.value.scale ?? DEFAULT_SCALE,
       flipX: data.value.flipX ?? DEFAULT_FLIPX,
       isPixel: data.value.isPixel ?? DEFAULT_ISPIXEL,
@@ -97,6 +99,11 @@ class SetHealthIconSongEvent extends SongEvent
       title: 'Health Icon ID',
       defaultValue: Constants.DEFAULT_HEALTH_ICON,
       type: SongEventFieldType.STRING,
+    }, {
+      name: 'shouldBop',
+      title: 'Should Bop?',
+      defaultValue: DEFAULT_SHOULDBOP,
+      type: SongEventFieldType.BOOL,
     }, {
       name: 'scale',
       title: 'Scale',


### PR DESCRIPTION
## Linked Issues
- Closes #3725

## Description
This PR adds a new field called `shouldBop` in the `HealthIconData` to allow any type of icon to bop and make it more softcodeable, instead of being forced to legacyMode or scripts.

This defaults to true as the original behavior, but the animated icons will now bop, so if someone doesn't want that, they can set the field in characters data to false:
```json
{
  "healthIcon": {
    "shouldBop": false
  }
}
``` 

## Screenshots/Videos

https://github.com/user-attachments/assets/4dc84b22-5102-4a53-b610-983049cf72ed
