### PR TITLE
[ENHANCEMENT] Add `isBlank` to `StringTools` for easier empty string checking.

### DIFF
--- a/source/funkin/util/tools/StringTools.hx
+++ b/source/funkin/util/tools/StringTools.hx
@@ -6,6 +6,18 @@ package funkin.util.tools;
 @:nullSafety
 class StringTools
 {
+
+  /**
+   * Checks if a string is `null` or blank (contains only whitespaces).
+   *
+   * @param value The string to check.
+   * @return True... or False...
+   */
+  public static function isBlank(value:String):Bool
+  {
+    return value == null || value.trim().length == 0;
+  }
+
   /**
    * Converts a string to title case. For example, "hello world" becomes "Hello World".
      *


### PR DESCRIPTION
## Description
This PR adds a new utility method in `StringTools` called `isBlank`, which makes it easier to check if a string is blank or not.

This will return for the following cases true:
|String | Result |
| -------- | --------- |
| `null` | `true` |
| `''` |  `true` |
| `' '` | `true` |
| `'       '` | `true` |
| `'\n'` | `true` |
| `'\t'` | `true` |
| `'\r'` | `true` |
| `' test '` | `false` |
| anything else | `false` |