### PR TITLE
[BUGFIX] Chart Editor - Ctrl click on hold note NOR fix (again) 

### DIFF
--- a/source/funkin/ui/debug/charting/ChartEditorState.hx
+++ b/source/funkin/ui/debug/charting/ChartEditorState.hx
@@ -4923,8 +4923,9 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
             }
             else if (highlightedHoldNote != null && highlightedHoldNote.noteData != null)
             {
-              // Control click to select/deselect an individual note.
-              if (isNoteSelected(highlightedNote.noteData))
+              // Control click to select/deselect an individual hold note.
+              // This will NOR if the highlighted note var is passed instead. Please do not change it back!
+              if (isNoteSelected(highlightedHoldNote.noteData))
               {
                 performCommand(new DeselectItemsCommand([highlightedHoldNote.noteData], []));
               }
@@ -5216,7 +5217,8 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
             }
             else if (highlightedHoldNote != null && highlightedHoldNote.noteData != null)
             {
-              if (isNoteSelected(highlightedNote.noteData))
+              // This will NOR if the highlighted note var is passed instead. Please do not change it back!
+              if (isNoteSelected(highlightedHoldNote.noteData))
               {
                 performCommand(new DeselectItemsCommand([highlightedHoldNote.noteData], []));
               }


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
None (and hopefully this issue continues to stay that way).
<!-- Briefly describe the issue(s) fixed. -->
## Description
Ctrl clicking on a hold note causes a null reference error because it tries to check if a regular note is selected, rather than a hold note.

This simply changes it to check for a hold note instead.

Now also includes a comment specifying the issue this fixes so that the change doesn't get reverted again in the future.