### PR TITLE
[ENHANCEMENT] Make hold note script events more accessible to scripts

### DIFF
--- a/source/funkin/modding/IScriptedClass.hx
+++ b/source/funkin/modding/IScriptedClass.hx
@@ -73,6 +73,11 @@ interface INoteScriptedClass extends IScriptedClass
   public function onNoteMiss(event:NoteScriptEvent):Void;
 
   /**
+   * Called when either player holds a note.
+   */
+  public function onNoteHoldHit(event:HoldNoteScriptEvent):Void;
+
+  /**
    * Called when EITHER player (usually the player) drops a hold note.
    */
   public function onNoteHoldDrop(event:HoldNoteScriptEvent):Void;

--- a/source/funkin/modding/events/ScriptEventDispatcher.hx
+++ b/source/funkin/modding/events/ScriptEventDispatcher.hx
@@ -115,6 +115,9 @@ class ScriptEventDispatcher
         case NOTE_MISS:
           t.onNoteMiss(cast event);
           return;
+        case NOTE_HOLD_HIT:
+          t.onNoteHoldHit(cast event);
+          return;
         case NOTE_HOLD_DROP:
           t.onNoteHoldDrop(cast event);
           return;

--- a/source/funkin/modding/events/ScriptEventType.hx
+++ b/source/funkin/modding/events/ScriptEventType.hx
@@ -98,6 +98,15 @@ enum abstract ScriptEventType(String) from String to String
   public var NOTE_MISS = 'NOTE_MISS';
 
   /**
+   * Called when a character holds a hold note.
+   * Important information such as note data, player/opponent, etc. are all provided.
+   *
+   * This event IS cancelable! Canceling this event prevents the hold note from being held,
+   *   and will likely result in a miss later.
+   */
+  var NOTE_HOLD_HIT = 'NOTE_HOLD_HIT';
+
+  /**
    * Called when a character lets go of a hold note.
    * Important information such as note data, player/opponent, etc. are all provided.
    *

--- a/source/funkin/modding/module/Module.hx
+++ b/source/funkin/modding/module/Module.hx
@@ -173,6 +173,10 @@ class Module implements IPlayStateScriptedClass implements IStateChangingScripte
   {
   }
 
+  public function onNoteHoldHit(event:HoldNoteScriptEvent)
+  {
+  }
+
   public function onNoteHoldDrop(event:HoldNoteScriptEvent)
   {
   }

--- a/source/funkin/play/PlayState.hx
+++ b/source/funkin/play/PlayState.hx
@@ -2840,11 +2840,12 @@ class PlayState extends MusicBeatSubState
       // While the hold note is being hit, and there is length on the hold note...
       if (holdNote.hitNote && !holdNote.missedNote && holdNote.sustainLength > 0)
       {
-        // Make sure the opponent keeps singing while the note is held.
-        if (currentStage != null && currentStage.getDad() != null && currentStage.getDad().isSinging())
-        {
-          currentStage.getDad().holdTimer = 0;
-        }
+        // Dispatch the event, which should make the opponent keep singing while the note is held.
+        var event:HoldNoteScriptEvent = new HoldNoteScriptEvent(NOTE_HOLD_HIT, holdNote, 0, 0, false, 0);
+        dispatchEvent(event);
+
+        // Drop the held note if the event is cancelled.
+        if (event.eventCanceled) holdNote.missedNote = true;
       }
 
       if (holdNote.missedNote && !holdNote.handledMiss)
@@ -2856,7 +2857,8 @@ class PlayState extends MusicBeatSubState
         {
           // We dropped a hold note.
           // Play miss animation, but don't penalize.
-          if (currentStage != null) currentStage.getOpponent().playSingAnimation(holdNote.noteData.getDirection(), true);
+          var event:HoldNoteScriptEvent = new HoldNoteScriptEvent(NOTE_HOLD_DROP, holdNote, 0, 0, true, 0);
+          dispatchEvent(event);
         }
       }
     }
@@ -2924,18 +2926,21 @@ class PlayState extends MusicBeatSubState
       // While the hold note is being hit, and there is length on the hold note...
       if (holdNote.hitNote && !holdNote.missedNote && holdNote.sustainLength > 0)
       {
+        var healthChange:Float = Constants.HEALTH_HOLD_BONUS_PER_SECOND * elapsed;
+        var scoreChange:Int = Constants.SCORE_HOLD_BONUS_PER_SECOND * elapsed;
+
+        var event:HoldNoteScriptEvent = new HoldNoteScriptEvent(NOTE_HOLD_HIT, holdNote, healthChange, scoreChange, false, Highscore.tallies.combo);
+        dispatchEvent(event);
+
         // Grant the player health.
         if (!isBotPlayMode && holdNote.scoreable)
         {
-          health += Constants.HEALTH_HOLD_BONUS_PER_SECOND * elapsed;
-          songScore += Constants.SCORE_HOLD_BONUS_PER_SECOND * elapsed;
+          health += event.healthChange;
+          songScore += event.score;
         }
 
-        // Make sure the player keeps singing while the note is held by the bot.
-        if (isBotPlayMode && currentStage != null && currentStage.getBoyfriend() != null && currentStage.getBoyfriend().isSinging())
-        {
-          currentStage.getBoyfriend().holdTimer = 0;
-        }
+        // Drop the held note if the event is cancelled.
+        if (event.eventCanceled) holdNote.missedNote = true;
       }
 
       if (holdNote.missedNote && !holdNote.handledMiss)

--- a/source/funkin/play/character/BaseCharacter.hx
+++ b/source/funkin/play/character/BaseCharacter.hx
@@ -596,6 +596,26 @@ class BaseCharacter extends Bopper
   }
 
   /**
+   * Every time a hold note is held, check if it is of the same strumline before updating the hold timer.
+   */
+  public override function onNoteHoldHit(event:HoldNoteScriptEvent)
+  {
+    super.onNoteHoldHit(event);
+
+    // If another script cancelled the event, don't do anything.
+    if (event.eventCanceled) return;
+
+    if (event.holdNote.noteData.getMustHitNote() && characterType == BF)
+    {
+      holdTimer = 0;
+    }
+    else if (!event.holdNote.noteData.getMustHitNote() && characterType == DAD)
+    {
+      holdTimer = 0;
+    }
+  }
+
+  /**
    * Every time a note is missed, check if the note is from the same strumline.
    * If it is, then play the sing animation.
    */

--- a/source/funkin/play/notes/notekind/NoteKind.hx
+++ b/source/funkin/play/notes/notekind/NoteKind.hx
@@ -116,6 +116,10 @@ class NoteKind implements INoteScriptedClass
   {
   }
 
+  public function onNoteHoldHit(event:HoldNoteScriptEvent)
+  {
+  }
+
   public function onNoteHoldDrop(event:HoldNoteScriptEvent)
   {
   }

--- a/source/funkin/play/song/Song.hx
+++ b/source/funkin/play/song/Song.hx
@@ -667,6 +667,10 @@ class Song implements IPlayStateScriptedClass implements IRegistryEntry<SongMeta
   {
   };
 
+  public function onNoteHoldHit(event:HoldNoteScriptEvent)
+  {
+  }
+
   public function onNoteMiss(event:NoteScriptEvent):Void
   {
   };

--- a/source/funkin/play/stage/Bopper.hx
+++ b/source/funkin/play/stage/Bopper.hx
@@ -368,6 +368,10 @@ class Bopper extends StageProp implements IPlayStateScriptedClass
   {
   }
 
+  public function onNoteHoldHit(event:HoldNoteScriptEvent)
+  {
+  }
+
   public function onNoteHoldDrop(event:HoldNoteScriptEvent)
   {
   }

--- a/source/funkin/play/stage/Stage.hx
+++ b/source/funkin/play/stage/Stage.hx
@@ -918,6 +918,10 @@ class Stage extends FlxSpriteGroup implements IPlayStateScriptedClass implements
   {
   }
 
+  public function onNoteHoldHit(event:HoldNoteScriptEvent)
+  {
+  }
+
   public function onNoteHoldDrop(event:HoldNoteScriptEvent)
   {
   }


### PR DESCRIPTION
## Linked Issues
None.

## Description
This PR adjusts the hold note script events in a couple of ways:
* Makes it so that a HoldNoteScriptEvent gets dispatched when a hold note is held, both by the player and by the opponent
* Moves the holdTimer setting to the HoldNoteScriptEvent that gets dispatched when a note is held. This is useful for charts with multiple opponents, because this allows for the main opponent to not hold the sing pose for a long period when a secondary opponent holds a note.
* Makes the HoldNoteScriptEvent for holding a note cancellable. It behaves similarly to cancelling the event of `onNoteHit`.
* Dispatches the event to the `onNoteHoldDrop` function when the opponent drops a note since a comment implies that this should be possible.

## Screenshots/Videos

https://github.com/user-attachments/assets/026d3cd8-05be-4183-9954-c72d58172723
