### PR TITLE
[BUGFIX] Prevent `goBack()` from running if `mustNotExit` is true

### DIFF
--- a/source/funkin/play/GameOverSubState.hx
+++ b/source/funkin/play/GameOverSubState.hx
@@ -531,7 +531,7 @@ class GameOverSubState extends MusicBeatSubState
    */
   public function goBack():Void
   {
-    if (blueballed == false) return;
+    if (!blueballed || mustNotExit) return;
     isEnding = true;
     blueballed = false;
     if (parentPlayState != null) parentPlayState.deathCounter = 0;


### PR DESCRIPTION
## Description
When mustNotExit in GameOverSubState is set to true, the game prevents you from leaving/restarting the song until it's set to false. However on mobile, this is ignored as the back button calls the goBack function directly. We fix this by making that function also check against the variable. This prevents mobile from being able to skip Boyfriend's fakeout death, or mods that enable it for their own purposes.

## Screenshots/Videos
NOTE: I am using a mod to force the `fakeoutDeath` animation to play: [BFFakeOut.zip](https://github.com/user-attachments/files/25251650/BFFakeOut.zip)

Before:

https://github.com/user-attachments/assets/dcfa75c3-6520-4197-b66e-6dd28aea563e

After:

https://github.com/user-attachments/assets/115e97b8-5a18-4039-aebd-60e2b923c531
