### PR TITLE
[BUGFIX] Hide the Chart Editor Event/Note tooltips when killing said objects

### DIFF
--- a/source/funkin/ui/debug/charting/components/ChartEditorEventSprite.hx
+++ b/source/funkin/ui/debug/charting/components/ChartEditorEventSprite.hx
@@ -213,6 +213,14 @@ class ChartEditorEventSprite extends FlxSprite
     }
   }
 
+  override public function kill()
+  {
+    super.kill();
+
+    // Remove the tooltip to prevent recently deleted events from showing a tooltip.
+    ToolTipManager.instance.unregisterTooltipRegion(this.tooltip);
+  }
+
   /**
    * Return whether this event is currently visible.
    */

--- a/source/funkin/ui/debug/charting/components/ChartEditorNoteSprite.hx
+++ b/source/funkin/ui/debug/charting/components/ChartEditorNoteSprite.hx
@@ -259,6 +259,14 @@ class ChartEditorNoteSprite extends FlxSprite
     kindIndicator.draw();
   }
 
+  override public function kill()
+  {
+    super.kill();
+
+    // Remove the tooltip to prevent recently deleted notes from showing a tooltip.
+    ToolTipManager.instance.unregisterTooltipRegion(this.tooltip);
+  }
+
   function get_noteStyle():Null<String>
   {
     if (this.noteStyle == null)


### PR DESCRIPTION
## Linked Issues
None.

## Description
When removing notes/events in the chart editor, the tooltip region instance is still left in the region map, which causes the tooltips to show even when their parent object is killed for recycling. This PR fixes that by removing the tooltip region whenever `kill()` is called on the parent object. Tooltips get re-registered whenever the positions update anyways.

## Screenshots/Videos

https://github.com/user-attachments/assets/2c847790-32c1-46ac-869d-45f5f83137b5
