### PR TITLE
[BUGFIX] Results State: Fix song name showing up in top right

### DIFF
--- a/source/funkin/play/ResultState.hx
+++ b/source/funkin/play/ResultState.hx
@@ -139,6 +139,7 @@ class ResultState extends MusicBeatSubState
     songName.letterSpacing = -15;
     songName.angle = -4.4;
     songName.zIndex = 1000;
+    songName.visible = false;
 
     difficulty = new FlxSprite(555 + FullScreenScaleMode.gameNotchSize.x);
     difficulty.zIndex = 1000;
@@ -343,7 +344,7 @@ class ResultState extends MusicBeatSubState
 
     blackTopBar.loadGraphic(funkin.util.BitmapUtil.createResultsBar());
     blackTopBar.y = -blackTopBar.height;
-    FlxTween.tween(blackTopBar, {y: 0}, 7 / 24, {ease: FlxEase.quartOut, startDelay: 3 / 24});
+    FlxTween.tween(blackTopBar, {y: 0}, 7 / 24, {ease: FlxEase.quartOut, startDelay: 3 / 24, onComplete: _ -> songName.visible = true});
     blackTopBar.zIndex = 1010;
     add(blackTopBar);
 


### PR DESCRIPTION
<!-- Perhaps the last thing I do before my goodbye. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
Fixes #6918
<!-- Briefly describe the issue(s) fixed. -->
## Description
Fixes the issue by hiding the song name until the top bar finishes its tween.
Co-authored by the True...fellow since he's the one who came up with the ingenious idea for the fix.

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos

https://github.com/user-attachments/assets/c7e8ea64-db3a-4a2d-965c-393b8df740d1

