### PR TITLE
[BUGFIX] Account for offset when adding the fake cutouts

### DIFF
--- a/source/funkin/ui/FullScreenScaleMode.hx
+++ b/source/funkin/ui/FullScreenScaleMode.hx
@@ -228,8 +228,8 @@ class FullScreenScaleMode extends flixel.system.scaleModes.BaseScaleMode
       {
         final game = FlxG.game;
 
-        cutoutBitmaps[i] = bitmap = new Bitmap(new BitmapData(ratioAxis == X ? Math.ceil(cutoutSize.x / 2) : Math.ceil(FlxG.scaleMode.gameSize.x),
-          ratioAxis == Y ? Math.ceil(cutoutSize.y / 2) : Math.ceil(FlxG.scaleMode.gameSize.y), true, 0xFF000000));
+        cutoutBitmaps[i] = bitmap = new Bitmap(new BitmapData((ratioAxis == X ? Math.ceil(cutoutSize.x / 2) : Math.ceil(FlxG.scaleMode.gameSize.x)) + 1,
+          (ratioAxis == Y ? Math.ceil(cutoutSize.y / 2) : Math.ceil(FlxG.scaleMode.gameSize.y)) + 1, true, 0xFF000000));
         game.parent.addChildAt(bitmap, game.parent.getChildIndex(game) + 1);
       }
 
@@ -238,8 +238,8 @@ class FullScreenScaleMode extends flixel.system.scaleModes.BaseScaleMode
 
       if (ratioAxis == X)
       {
-        bitmap.x = instance.offset.x + ((i == 0) ? -bitmap.width : FlxG.scaleMode.gameSize.x);
-        targetX = instance.offset.x + ((i == 0) ? 0 : FlxG.scaleMode.gameSize.x - bitmap.width);
+        bitmap.x = instance.offset.x + ((i == 0) ? -bitmap.width - 1 : FlxG.scaleMode.gameSize.x + 1);
+        targetX = instance.offset.x + ((i == 0) ? -1 : FlxG.scaleMode.gameSize.x - bitmap.width + 1);
         bitmap.y = 0;
         targetY = 0;
       }
@@ -247,8 +247,8 @@ class FullScreenScaleMode extends flixel.system.scaleModes.BaseScaleMode
       {
         bitmap.x = 0;
         targetX = 0;
-        bitmap.y = instance.offset.y + ((i == 0) ? -bitmap.height : FlxG.scaleMode.gameSize.y);
-        targetY = instance.offset.y + ((i == 0) ? 0 : FlxG.scaleMode.gameSize.y - bitmap.height);
+        bitmap.y = instance.offset.y + ((i == 0) ? -bitmap.height - 1 : FlxG.scaleMode.gameSize.y + 1);
+        targetY = instance.offset.y + ((i == 0) ? -1 : FlxG.scaleMode.gameSize.y - bitmap.height + 1);
       }
 
       bitmap.alpha = 0;
@@ -283,8 +283,8 @@ class FullScreenScaleMode extends flixel.system.scaleModes.BaseScaleMode
         continue;
       }
 
-      final targetX:Float = (ratioAxis == Y) ? 0 : instance.offset.x + ((i == 0) ? -bitmap.width : FlxG.scaleMode.gameSize.x);
-      final targetY:Float = (ratioAxis == X) ? 0 : instance.offset.y + ((i == 0) ? -bitmap.height : FlxG.scaleMode.gameSize.y);
+      final targetX:Float = (ratioAxis == Y) ? -1 : instance.offset.x + ((i == 0) ? -bitmap.width - 1 : FlxG.scaleMode.gameSize.x + 1);
+      final targetY:Float = (ratioAxis == X) ? -1 : instance.offset.y + ((i == 0) ? -bitmap.height - 1 : FlxG.scaleMode.gameSize.y + 1);
 
       if (tweenDuration > 0.0)
       {


### PR DESCRIPTION
## Linked Issues
Fixes #5356 

## Description
The fake cutouts that come into view in 2hot's ending cutscene do not account for the offset of the game screen. This PR fixes that.

## Screenshots/Videos
Before:
<img width="3440" height="1440" alt="2026-02-13_16-04-33_Funkin" src="https://github.com/user-attachments/assets/274821d7-c261-4794-8030-d2915475f09d" />


After:
<img width="3440" height="1440" alt="2026-02-13_20-45-26_Funkin" src="https://github.com/user-attachments/assets/4fccd7fc-301c-496b-a746-4faabfe8b894" />
