### PR TITLE
[BUGFIX] Remove Duplicate Blacklisting of the `funkin.api.newgrounds` Package

### DIFF
--- a/source/funkin/modding/PolymodHandler.hx
+++ b/source/funkin/modding/PolymodHandler.hx
@@ -452,15 +452,6 @@ class PolymodHandler
       Polymod.blacklistImport(className);
     }
 
-    // `funkin.api.newgrounds.*`
-    // Contains functions which allow for cheating medals and leaderboards.
-    for (cls in ClassMacro.listClassesInPackage('funkin.api.newgrounds'))
-    {
-      if (cls == null) continue;
-      var className:String = Type.getClassName(cls);
-      Polymod.blacklistImport(className);
-    }
-
     // `io.newgrounds.*`
     // Contains functions which allow for cheating medals and leaderboards.
     for (cls in ClassMacro.listClassesInPackage('io.newgrounds'))


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
#5995

<!-- Briefly describe the issue(s) fixed. -->
## Description
The `funkin.api.newgrounds` package is blacklisted right after the `funkin.api` package is blacklisted?? So we remove the extra blacklisting. The `funkin.api` blacklist also accounts for import aliases so this PR also fixes mod access to the sandboxed classes.