### PR TITLE
[BUGFIX] Save Kevin and Michael

### DIFF
--- a/source/Main.hx
+++ b/source/Main.hx
@@ -158,6 +158,10 @@ class Main extends Sprite
 
     WindowUtil.setVSyncMode(funkin.Preferences.vsyncMode);
 
+    // Force a `FunkinCamera` to be the default camera.
+    // This allows the blend mode shader to work everywhere.
+    untyped FlxG.cameras = new funkin.graphics.FunkinCameraFrontEnd();
+
     var game:FlxGame = new FlxGame(gameWidth, gameHeight, initialState, Preferences.framerate, Preferences.framerate, skipSplash,
       (FlxG.stage.window.fullscreen || Preferences.autoFullscreen));
 
@@ -173,10 +177,6 @@ class Main extends Sprite
     game.debugger.interaction.addTool(new funkin.util.TrackerToolButtonUtil());
     funkin.util.macro.ConsoleMacro.init();
     #end
-
-    // Force a `FunkinCamera` to be the default camera.
-    // This allows the blend mode shader to work everywhere.
-    untyped FlxG.cameras = new funkin.graphics.FunkinCameraFrontEnd();
 
     #if !html5
     FlxG.scaleMode = new FullScreenScaleMode();


### PR DESCRIPTION
<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
The internal Linear issue made for this bug.
<!-- Briefly describe the issue(s) fixed. -->
## Description
With the introduction of blend modes came the addition of the `FunkinCameraFrontEnd`, this, however, broke `TouchPointerPlugin`, because it is now adding the cameras that render our touch buddies to the old frontend.
This PR fixes the issue by moving where the frontend is changed to be before any plugins are initialized, which is when `FlxGame` is created.

Turns out Kevin and Michael were just hiding this whole time and were in no danger :D
<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos
https://github.com/user-attachments/assets/b2558da8-fd23-478e-af25-1d5c88535af9

