### PR TITLE
[ENHANCEMENT + BUGFIX] Improve Freeplay song preview & audio handling

### DIFF
--- a/hmm.json
+++ b/hmm.json
@@ -209,7 +209,7 @@
       "name": "polymod",
       "type": "git",
       "dir": null,
-      "ref": "d42902d49a31e66fdeabbc8bb885a4bc99cd08d8",
+      "ref": "b0df16616aea536a73ce061eb264bf264e19c4a3",
       "url": "https://github.com/FunkinCrew/polymod"
     },
     {

--- a/source/funkin/data/BaseRegistry.hx
+++ b/source/funkin/data/BaseRegistry.hx
@@ -278,7 +278,8 @@ abstract class BaseRegistry<T:(IRegistryEntry<J> & Constructible<EntryConstructo
    * @param version The entry's version (use `fetchEntryVersion(id)`).
    * @return The created entry.
    */
-  public function parseEntryDataWithMigration(id:String, version:Null<thx.semver.Version>):Null<J>
+  public function parseEntryDataWithMigration(id:String,
+    version:Null<thx.semver.Version>):Null<J>
   {
     if (version == null)
     {
@@ -330,7 +331,8 @@ abstract class BaseRegistry<T:(IRegistryEntry<J> & Constructible<EntryConstructo
    */
   abstract function createScriptedEntry(clsName:String):Null<T>;
 
-  function printErrors(errors:Array<json2object.Error>, id:String = ''):Void
+  function printErrors(errors:Array<json2object.Error>,
+    id:String = ''):Void
   {
     trace(' $registryId '.bold().bg_note_down() + ' ERROR '.error() + 'Failed to parse entry data: ${id}');
 

--- a/source/funkin/data/character/CharacterData.hx
+++ b/source/funkin/data/character/CharacterData.hx
@@ -93,9 +93,17 @@ class CharacterDataParser
       {
         try
         {
-          var character:SparrowCharacter = ScriptedSparrowCharacter.scriptInit(charCls, DEFAULT_CHAR_ID);
-          log('Loaded character ${character.characterName} (scripted: $charCls)');
-          characterScriptedClass.set(character.characterId, charCls);
+          var character:Null<SparrowCharacter> = ScriptedSparrowCharacter.scriptInit(charCls, DEFAULT_CHAR_ID);
+          if (character == null)
+          {
+            log(' ERROR '.error() + 'Failed to initialize scripted character: $charCls');
+            continue;
+          }
+          else
+          {
+            log('Loaded character ${character.characterName} (scripted: $charCls)');
+            characterScriptedClass.set(character.characterId, charCls);
+          }
         }
         catch (e)
         {
@@ -113,9 +121,17 @@ class CharacterDataParser
       {
         try
         {
-          var character:PackerCharacter = ScriptedPackerCharacter.scriptInit(charCls, DEFAULT_CHAR_ID);
-          log('Loaded character ${character.characterName} (scripted: $charCls)');
-          characterScriptedClass.set(character.characterId, charCls);
+          var character:Null<PackerCharacter> = ScriptedPackerCharacter.scriptInit(charCls, DEFAULT_CHAR_ID);
+          if (character == null)
+          {
+            log(' ERROR '.error() + 'Failed to initialize scripted character: $charCls');
+            continue;
+          }
+          else
+          {
+            log('Loaded character ${character.characterName} (scripted: $charCls)');
+            characterScriptedClass.set(character.characterId, charCls);
+          }
         }
         catch (e)
         {
@@ -133,9 +149,17 @@ class CharacterDataParser
       {
         try
         {
-          var character:MultiSparrowCharacter = ScriptedMultiSparrowCharacter.scriptInit(charCls, DEFAULT_CHAR_ID);
-          log('Loaded character ${character.characterName} (scripted: $charCls)');
-          characterScriptedClass.set(character.characterId, charCls);
+          var character:Null<MultiSparrowCharacter> = ScriptedMultiSparrowCharacter.scriptInit(charCls, DEFAULT_CHAR_ID);
+          if (character == null)
+          {
+            log(' ERROR '.error() + 'Failed to initialize scripted character: $charCls');
+            continue;
+          }
+          else
+          {
+            log('Loaded character ${character.characterName} (scripted: $charCls)');
+            characterScriptedClass.set(character.characterId, charCls);
+          }
         }
         catch (e)
         {
@@ -153,9 +177,17 @@ class CharacterDataParser
       {
         try
         {
-          var character:AnimateAtlasCharacter = ScriptedAnimateAtlasCharacter.scriptInit(charCls, DEFAULT_CHAR_ID);
-          log('Loaded character ${character.characterName} (scripted: $charCls)');
-          characterScriptedClass.set(character.characterId, charCls);
+          var character:Null<AnimateAtlasCharacter> = ScriptedAnimateAtlasCharacter.scriptInit(charCls, DEFAULT_CHAR_ID);
+          if (character == null)
+          {
+            log(' ERROR '.error() + 'Failed to initialize scripted character: $charCls');
+            continue;
+          }
+          else
+          {
+            log('Loaded character ${character.characterName} (scripted: $charCls)');
+            characterScriptedClass.set(character.characterId, charCls);
+          }
         }
         catch (e)
         {
@@ -173,9 +205,17 @@ class CharacterDataParser
       {
         try
         {
-          var character:MultiAnimateAtlasCharacter = ScriptedMultiAnimateAtlasCharacter.scriptInit(charCls, DEFAULT_CHAR_ID);
-          log('Loaded character ${character.characterName} (scripted: $charCls)');
-          characterScriptedClass.set(character.characterId, charCls);
+          var character:Null<MultiAnimateAtlasCharacter> = ScriptedMultiAnimateAtlasCharacter.scriptInit(charCls, DEFAULT_CHAR_ID);
+          if (character == null)
+          {
+            log(' ERROR '.error() + 'Failed to initialize scripted character: $charCls');
+            continue;
+          }
+          else
+          {
+            log('Loaded character ${character.characterName} (scripted: $charCls)');
+            characterScriptedClass.set(character.characterId, charCls);
+          }
         }
         catch (e)
         {
@@ -202,7 +242,7 @@ class CharacterDataParser
       log('Instantiating ${scriptedCharClassNames.length} (Base) scripted characters...');
       for (charCls in scriptedCharClassNames)
       {
-        var character:BaseCharacter = ScriptedBaseCharacter.scriptInit(charCls, DEFAULT_CHAR_ID, Custom);
+        var character:Null<BaseCharacter> = ScriptedBaseCharacter.scriptInit(charCls, DEFAULT_CHAR_ID, Custom);
         if (character == null)
         {
           log(' ERROR '.error() + 'Failed to initialize scripted character: $charCls');

--- a/source/funkin/data/event/SongEventRegistry.hx
+++ b/source/funkin/data/event/SongEventRegistry.hx
@@ -68,7 +68,7 @@ class SongEventRegistry
 
     for (eventCls in scriptedEventClassNames)
     {
-      var event:SongEvent = ScriptedSongEvent.scriptInit(eventCls, 'UKNOWN');
+      var event:Null<SongEvent> = ScriptedSongEvent.scriptInit(eventCls, 'UKNOWN');
 
       if (event != null)
       {

--- a/source/funkin/data/song/SongRegistry.hx
+++ b/source/funkin/data/song/SongRegistry.hx
@@ -56,7 +56,7 @@ class SongRegistry extends BaseRegistry<Song, SongMetadata, SongEntryParams> imp
 
     for (entryCls in scriptedEntryClassNames)
     {
-      var entry:Song = createScriptedEntry(entryCls);
+      var entry:Null<Song> = createScriptedEntry(entryCls);
 
       if (entry != null)
       {

--- a/source/funkin/data/stickers/StickerRegistry.hx
+++ b/source/funkin/data/stickers/StickerRegistry.hx
@@ -79,7 +79,7 @@ class StickerRegistry extends BaseRegistry<StickerPack, StickerData, StickerEntr
     return parser.value;
   }
 
-  function createScriptedEntry(clsName:String):StickerPack
+  override function createScriptedEntry(clsName:String):Null<StickerPack>
   {
     return ScriptedStickerPack.scriptInit(clsName, 'unknown');
   }

--- a/source/funkin/modding/module/ModuleHandler.hx
+++ b/source/funkin/modding/module/ModuleHandler.hx
@@ -32,7 +32,7 @@ class ModuleHandler
     trace(' Instantiating ${scriptedModuleClassNames.length} modules...');
     for (moduleCls in scriptedModuleClassNames)
     {
-      var module:Module = ScriptedModule.scriptInit(moduleCls, moduleCls);
+      var module:Null<Module> = ScriptedModule.scriptInit(moduleCls, moduleCls);
       if (module != null)
       {
         trace('   Loaded module: ${moduleCls}');

--- a/source/funkin/ui/freeplay/FreeplayState.hx
+++ b/source/funkin/ui/freeplay/FreeplayState.hx
@@ -306,7 +306,8 @@ class FreeplayState extends MusicBeatSubState
       var allScriptedCards:Array<String> = ScriptedBackingCard.listScriptClasses();
       for (cardClass in allScriptedCards)
       {
-        var card:BackingCard = ScriptedBackingCard.scriptInit(cardClass, 'unknown');
+        var card:Null<BackingCard> = ScriptedBackingCard.scriptInit(cardClass, 'unknown');
+        if (card == null) continue;
         if (card.currentCharacter == currentCharacterId)
         {
           backingCardPrep = card;

--- a/source/funkin/ui/freeplay/FreeplayState.hx
+++ b/source/funkin/ui/freeplay/FreeplayState.hx
@@ -2816,7 +2816,8 @@ class FreeplayState extends MusicBeatSubState
           minimalMode: false,
 
           #if FEATURE_DEBUG_FUNCTIONS
-          botPlayMode: FlxG.keys.pressed.SHIFT, mirrored: FlxG.keys.pressed.CONTROL,
+          botPlayMode: FlxG.keys.pressed.SHIFT,
+          mirrored: FlxG.keys.pressed.CONTROL,
           #else
           botPlayMode: false,
           #end
@@ -2889,6 +2890,9 @@ class FreeplayState extends MusicBeatSubState
 
   function changeSelection(change:Int = 0):Void
   {
+    // Reset new rank prep flag if we're changing selection to prevent the song preview from not updating to a new one.
+    if (change != 0 && prepForNewRank) prepForNewRank = false;
+
     var prevSelected:Int = curSelected;
 
     curSelected += change;
@@ -2952,11 +2956,15 @@ class FreeplayState extends MusicBeatSubState
 
     if (grpCapsules.countLiving() > 0 && !prepForNewRank && uiStateMachine.canInteract())
     {
-      FlxG.sound.music?.pause();
-      FlxTimer.wait(FADE_IN_DELAY, playCurSongPreview.bind(currentCapsule));
-      currentCapsule.selected = true;
+      clearPreviews();
 
-      // switchBackingImage(currentCapsule.freeplayData);
+      // Create a timer to delay the song preview to prevent overlapping or cutting out.
+      var timer = new FlxTimer().start(FADE_IN_DELAY, function(tmr:FlxTimer) {
+        if (FlxG.sound.music != null) FlxG.sound.music.stop();
+        playCurSongPreview(currentCapsule);
+      });
+
+      previewTimers.push(timer);
     }
 
     // Small vibrations every selection change.
@@ -3022,18 +3030,33 @@ class FreeplayState extends MusicBeatSubState
         },
         onLoad: function()
         {
+          #if html5
+          // > Hardcode fade-in and fade-out times due to HTML5 not processing `partialParams` correctly.
+          // > 12 - 15 seconds is the average length of a preview, so fading out around the 10 second mark feels appropriate.
+          // > NOTE: Due to `partialParams` being finicky on web builds, the preview may take about 2 - 3 seconds to fade back in after the fade-out.
+          var fadeStart:Float = 10;
+          var loopEnd:Float = (FlxG.sound.music.length > 0) ? 14 : 15;  // Default the preview to 15 seconds if the length is 0.
+          var fadeDuration:Float = Math.min(3, loopEnd - fadeStart);
+          #else
+          var fadeDuration:Float = 5;
+          var loopEnd:Float = FlxG.sound.music.length / 1000;
+          var fadeStart:Float = loopEnd - fadeDuration;
+          #end
+
+          FlxG.sound.music.volume = 0;
           FlxG.sound.music.fadeIn(2, 0, previewVolume);
 
           var fadeStart:Float = (FlxG.sound.music.length / Constants.MS_PER_SEC) - 2;
+          clearPreviews();
 
           previewTimers.push(new FlxTimer().start(fadeStart, function(_)
           {
-            FlxG.sound.music.fadeOut(2, 0);
+            if (FlxG.sound.music != null) FlxG.sound.music.fadeOut(fadeDuration, 0);
           }));
 
-          previewTimers.push(new FlxTimer().start(FlxG.sound.music.length / Constants.MS_PER_SEC, function(_)
+          previewTimers.push(new FlxTimer().start(loopEnd, function(_)
           {
-            playCurSongPreview();
+            if (daSongCapsule.selected) playCurSongPreview(daSongCapsule);
           }));
         },
       });

--- a/source/funkin/util/macro/RegistryMacro.hx
+++ b/source/funkin/util/macro/RegistryMacro.hx
@@ -140,7 +140,7 @@ class RegistryMacro
    * @param dataType The type of the data for entries in the registry.
    * @return The modified list of fields for the target class.
    */
-  static function buildRegistryMethods(cls:ClassType, fields:Array<Field>, entryType:ClassType, dataType:Dynamic):Array<Field>
+  static function buildRegistryMethods(cls:ClassType, fields:Array<Field>, entryType:ClassType, dataType:DefType):Array<Field>
   {
     var scriptedEntryClsName:String = entryType.pack.join('.') + '.Scripted' + entryType.name;
 
@@ -174,17 +174,19 @@ class RegistryMacro
           });
         }
 
-        function getScriptedClassNames()
+        function getScriptedClassNames():Array<String>
         {
           return ${Context.parse(getScriptedClassName, Context.currentPos())}.listScriptClasses();
         }
 
-        function createScriptedEntry(clsName:String)
+        override function createScriptedEntry(clsName:String)
+
         {
           return ${Context.parse(createScriptedEntry, Context.currentPos())};
         }
 
         public function parseEntryData(id:String)
+
         {
           var parser = ${Context.parse(newJsonParser, Context.currentPos())};
           parser.ignoreUnknownVariables = false;
@@ -208,6 +210,7 @@ class RegistryMacro
         }
 
         public function parseEntryDataRaw(contents:String, ?fileName:String)
+
         {
           var parser = ${Context.parse(newJsonParser, Context.currentPos())};
           parser.ignoreUnknownVariables = false;


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
- FunkinCrew/Funkin#6932
- FunkinCrew/Funkin#7039
- FunkinCrew/Funkin#6432
- FunkinCrew/Funkin#7157

<!-- Briefly describe the issue(s) fixed. -->
## Description
> [!IMPORTANT] 
> **THIS PR NEEDS TO BE PROPERLY MAINTAINED!!!** 

This PR fixes, and improves how the song previews are handled.

## Changes:
- Added a timer to the song preview to prevent audio overlapping
     - Added `clearPreviews()` inside the timer function so old song requests get cached.
     - [HTML5] Implemented a specific 11 - 13 second fade-out and a 14 second window to prevent audio buffering and overlap.
     - [HTML5] Added a 15 second fall back for the loop timer if the web build fails to get the correct song preview length.
- Made sure the menu music stops right when the song preview is ready to play.
- Fixed issue where the song previews don't update after rank animation plays