### PR TITLE
[BUGFIX] Actually fix the Freeplay crash this time

### DIFF
--- a/source/funkin/ui/freeplay/FreeplayState.hx
+++ b/source/funkin/ui/freeplay/FreeplayState.hx
@@ -2961,7 +2961,7 @@ class FreeplayState extends MusicBeatSubState
         overrideExisting: true,
         restartTrack: false
       });
-      FlxG.sound.music.fadeIn(2, 0, previewVolume);
+      if (FlxG.sound.music != null) FlxG.sound.music.fadeIn(2, 0, previewVolume);
     }
     else
     {


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
https://github.com/FunkinCrew/Funkin/issues/6956

<!-- Briefly describe the issue(s) fixed. -->
## Description
This potentially fixes a freeplay crash caused by the game trying to fade in the song previews while `FlxG.sound.music` is null

> [!NOTE]  
> Requires thorough testing by someone with a mouse that supports infinite scrolling