### PR TITLE
[BUGFIX] Prevent Chart Editor playbar head from dragging during playtest

### DIFF
--- a/source/funkin/ui/debug/charting/ChartEditorState.hx
+++ b/source/funkin/ui/debug/charting/ChartEditorState.hx
@@ -6479,6 +6479,7 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
 
     LoadingState.loadPlayState(targetStateParams, false, true, function(targetState)
     {
+      if (playbarHeadDragging) playbarHeadDragging = false;
       // Apply volume settings.
       if (playtestAudioSettings)
       {


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
https://github.com/FunkinCrew/Funkin/issues/6983

<!-- Briefly describe the issue(s) fixed. -->
## Description
This PR prevents the player from being able to still drag the playbar at the bottom of the Chart Editor while playtesting the song.

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos

BEFORE:

https://github.com/user-attachments/assets/1d95830e-3b5e-48a5-b8f4-eda08531c78a


AFTER:

https://github.com/user-attachments/assets/9e3e6bbf-cb7b-4ee9-9de6-6897c0b8a4c7

