### PR TITLE
[BUGFIX] Fix CharSelect nametag getting stuck mid-transition

### DIFF
--- a/source/funkin/ui/charSelect/Nametag.hx
+++ b/source/funkin/ui/charSelect/Nametag.hx
@@ -41,29 +41,36 @@ class Nametag extends FlxSprite
 
   public function switchChar(str:String, playMosaicSequence:Bool = true):Void
   {
-    if (playMosaicSequence) shaderEffect();
+    var path:String = (str == "bf") ? "boyfriend" : "bf";
+    if (str != "bf") path = str;
 
-    new FlxTimer().start(4 / 30, _ ->
+    loadGraphic(Paths.image("charSelect/" + path + "Nametag"));
+    updateHitbox();
+    scale.set(0.77, 0.77);
+    updatePosition();
+
+    // Reset shader to ensure the nametag doesn't get stuck
+    if (playMosaicSequence)
     {
-      var path:String = str;
-      switch str
-      {
-        case "bf":
-          path = "boyfriend";
-      }
+      mosaicShader.setBlockSize(1, 1);
+      shaderEffect();
 
-      loadGraphic(Paths.image('charSelect/' + path + "Nametag"));
-      updateHitbox();
-      scale.x = scale.y = 0.77;
-
-      updatePosition();
-
-      if (playMosaicSequence) shaderEffect(true);
-    });
+      // Delay the shader effect by a bit to prevent lag.
+      new FlxTimer().start(2 / 30, _ -> {
+        shaderEffect(true);
+      });
+    }
+    else
+    {
+      mosaicShader.setBlockSize(1, 1);
+    }
   }
 
   function shaderEffect(fadeOut:Bool = false):Void
   {
+    // Skip the shader effect if the width is too small.
+    if (width <= 1) return;
+
     if (currentMosaicSequence != null)
     {
       // Forcibly reset the shader to prevent overlapping blur sequences


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
Closes FunkinCrew/Funkin#6943 - Character select nametags get stuck mid-transition with lag

<!-- Briefly describe the issue(s) fixed. -->
## Description
This PR fixes the character select name-tags getting blurred / pixelized on selection. 

### Changes:
- `selectChar()` rewrite:
    - Moved `loadGraphic` and `scale` logic before `FlxTimer` to make sure the nametag loads instantly.
    - Added `setBlockSize(1,1)` to clear the mosaic effect before and after transitions.
- Implemented a safety check where `shaderEffect()` wont initialize if the sprites size are less than or equal to 1.


<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos
### Before:
https://github.com/user-attachments/assets/00fde514-8b52-47b0-b881-23fa59cd722e
### After:
https://github.com/user-attachments/assets/a582831b-4063-499e-9ce0-ee9d95cc8536