### PR TITLE
[BUGFIX] Fix characters with global offsets not getting properly moved in the Stage Editor

### DIFF
--- a/source/funkin/ui/debug/stageeditor/StageEditorState.hx
+++ b/source/funkin/ui/debug/stageeditor/StageEditorState.hx
@@ -797,13 +797,13 @@ class StageEditorState extends UIState
         {
           this.createAndPushAction(CHARACTER_MOVED);
 
-          moveOffset = [FlxG.mouse.getWorldPosition().x - selectedChar.cornerPosition.x, FlxG.mouse.getWorldPosition().y - selectedChar.cornerPosition.y];
+          moveOffset = [FlxG.mouse.getWorldPosition().x - selectedChar.x, FlxG.mouse.getWorldPosition().y - selectedChar.y];
         }
 
-        var posBros = new FlxPoint(FlxG.mouse.getWorldPosition().x - moveOffset[0], FlxG.mouse.getWorldPosition().y - moveOffset[1]);
+        var posBros:FlxPoint = FlxPoint.get(FlxG.mouse.getWorldPosition().x - moveOffset[0], FlxG.mouse.getWorldPosition().y - moveOffset[1]);
 
-        selectedChar.cornerPosition = new FlxPoint(Math.floor(posBros.x) - Math.floor(posBros.x) % moveStep,
-          Math.floor(posBros.y) - Math.floor(posBros.y) % moveStep);
+        selectedChar.x = Math.floor(posBros.x) - Math.floor(posBros.x) % moveStep;
+        selectedChar.y = Math.floor(posBros.y) - Math.floor(posBros.y) % moveStep;
       }
 
       arrowMovement(selectedChar);
@@ -1714,6 +1714,7 @@ typedef StageEditorParams =
    * If non-null, load this stage immediately instead of the welcome screen.
    */
   var ?targetStageId:String;
+
   /**
    * If non-null, load this character as Boyfriend.
    */

--- a/source/funkin/ui/debug/stageeditor/handlers/StageDataHandler.hx
+++ b/source/funkin/ui/debug/stageeditor/handlers/StageDataHandler.hx
@@ -243,8 +243,8 @@ class StageDataHandler
 
       if (charData == null) continue;
 
-      char.x = charData.position[0] - char.characterOrigin.x + char.globalOffsets[0];
-      char.y = charData.position[1] - char.characterOrigin.y + char.globalOffsets[1];
+      char.x = charData.position[0] - char.characterOrigin.x;
+      char.y = charData.position[1] - char.characterOrigin.y;
       state.charGroups[char.characterType].zIndex = charData.zIndex;
 
       char.setScale(char.getBaseScale() * charData.scale);

--- a/source/funkin/ui/debug/stageeditor/toolboxes/StageEditorCharacterToolbox.hx
+++ b/source/funkin/ui/debug/stageeditor/toolboxes/StageEditorCharacterToolbox.hx
@@ -139,8 +139,8 @@ class StageEditorCharacterToolbox extends StageEditorDefaultToolbox
   public function repositionCharacter()
   {
     if (stageEditorState.selectedChar == null) return;
-    stageEditorState.selectedChar.x = charPosX.pos - stageEditorState.selectedChar.characterOrigin.x + stageEditorState.selectedChar.globalOffsets[0];
-    stageEditorState.selectedChar.y = charPosY.pos - stageEditorState.selectedChar.characterOrigin.y + stageEditorState.selectedChar.globalOffsets[1];
+    stageEditorState.selectedChar.x = charPosX.pos - stageEditorState.selectedChar.characterOrigin.x;
+    stageEditorState.selectedChar.y = charPosY.pos - stageEditorState.selectedChar.characterOrigin.y;
 
     stageEditorState.selectedChar.setScale(stageEditorState.selectedChar.getBaseScale() * charScale.pos);
     stageEditorState.updateMarkerPos();


### PR DESCRIPTION
## Linked Issues
Closes https://github.com/FunkinCrew/Funkin/issues/6995

## Description
The issue was basically that, because offsets get applied in `getScreenPosition()`, the calculation gets messed up every time a character with offsets was getting moved with the mouse in the Stage Editor.

## Screenshots/Videos

https://github.com/user-attachments/assets/6123dae2-d238-45e3-9d5f-7d8dc99527cd
