### PR TITLE
[FEATURE/Modding] Add support for the new Polymod mod ID system.

### DIFF
--- a/source/funkin/modding/PolymodErrorHandler.hx
+++ b/source/funkin/modding/PolymodErrorHandler.hx
@@ -15,6 +15,12 @@ class PolymodErrorHandler
       //
 
       case MOD_MISSING_DIRECTORY:
+        // A mod directory was included in the list of mods to load, but it isn't installed.
+        trace(' WARNING '.warning() + 'Tried to load a mod that was not installed: ${error.message}');
+        // Notify the user via popup.
+        funkin.util.WindowUtil.showError('Mod Load Error', error.message);
+
+      case MOD_MISSING_ID:
         // A mod ID was included in the list of mods to load, but it isn't installed.
         trace(' WARNING '.warning() + ' Tried to load a mod that was not installed: ${error.message}');
         // Notify the user via popup.

--- a/source/funkin/modding/PolymodHandler.hx
+++ b/source/funkin/modding/PolymodHandler.hx
@@ -70,6 +70,11 @@ class PolymodHandler
     #end;
 
   /**
+   * Populated with the directories of mods once they're successfully loaded.
+   */
+  public static var loadedModDirs:Array<String> = [];
+
+  /**
    * Populated with the IDs of mods once they're successfully loaded.
    */
   public static var loadedModIds:Array<String> = [];
@@ -95,7 +100,7 @@ class PolymodHandler
     createModRoot();
     #end
     trace('Initializing Polymod (using all mods)...');
-    loadModsById(getAllModIds());
+    loadModsByDir(getAllModDirs());
   }
 
   /**
@@ -108,7 +113,7 @@ class PolymodHandler
     createModRoot();
     #end
     trace('Initializing Polymod (using configured mods)...');
-    loadModsById(Save.instance.enabledModIds.value);
+    loadModsByDir(Save.instance.enabledModDirs.value);
   }
 
   /**
@@ -122,22 +127,22 @@ class PolymodHandler
     #end
     // We still need to configure the debug print calls etc.
     trace('Initializing Polymod (using no mods)...');
-    loadModsById([]);
+    loadModsByDir([]);
   }
 
   /**
-   * Load all the mods with the given ids.
-   * @param ids The ORDERED list of mod ids to load.
+   * Load all the mods with the directories they're in.
+   * @param dirs The ORDERED list of mod ids to load.
    */
-  public static function loadModsById(ids:Array<String>):Void
+  public static function loadModsByDir(dirs:Array<String>):Void
   {
-    if (ids.length == 0)
+    if (dirs.length == 0)
     {
       trace('You attempted to load zero mods.');
     }
     else
     {
-      trace('Attempting to load ${ids.length} mods...');
+      trace('Attempting to load ${dirs.length} mods...');
     }
 
     buildImports();
@@ -148,7 +153,7 @@ class PolymodHandler
       // Root directory for all mods.
       modRoot: MOD_FOLDER,
       // The directories for one or more mods to load.
-      dirs: ids,
+      dirs: dirs,
       // Framework being used to load assets.
       framework: OPENFL,
       // The current version of our API.
@@ -185,18 +190,20 @@ class PolymodHandler
     {
       if (loadedModList.length == 0)
       {
-        trace('Mod loading complete. We loaded no mods / ${ids.length} mods.');
+        trace('Mod loading complete. We loaded no mods / ${dirs.length} mods.');
       }
       else
       {
-        trace('Mod loading complete. We loaded ${loadedModList.length} / ${ids.length} mods.');
+        trace('Mod loading complete. We loaded ${loadedModList.length} / ${dirs.length} mods.');
       }
     }
 
     loadedModIds = [];
+    loadedModDirs = [];
     for (mod in loadedModList)
     {
       trace(' * ${mod.title} v${mod.modVersion} [${mod.id}]');
+      loadedModDirs.push(mod.dirName);
       loadedModIds.push(mod.id);
     }
 
@@ -558,17 +565,27 @@ class PolymodHandler
   }
 
   /**
+   * Retrieve a list of ALL mod directory names, including disabled mods.
+   * @return An array of mod direcotry names
+   */
+  public static function getAllModDirs():Array<String>
+  {
+    var modDirs:Array<String> = [for (i in getAllMods()) i.dirName];
+    return modDirs;
+  }
+
+  /**
    * Retrieve a list of metadata for all enabled mods.
    * @return An array of mod metadata
    */
   public static function getEnabledMods():Array<ModMetadata>
   {
-    var modIds:Array<String> = Save.instance.enabledModIds.value;
+    var modDirs:Array<String> = Save.instance.enabledModDirs.value;
     var modMetadata:Array<ModMetadata> = getAllMods();
     var enabledMods:Array<ModMetadata> = [];
     for (item in modMetadata)
     {
-      if (modIds.indexOf(item.id) != -1)
+      if (modDirs.indexOf(item.dirName) != -1)
       {
         enabledMods.push(item);
       }

--- a/source/funkin/save/Save.hx
+++ b/source/funkin/save/Save.hx
@@ -245,7 +245,7 @@ class Save implements ConsoleClass
   /// MODS
   ///
   @:saveProperty(data.mods.enabledMods)
-  public var enabledModIds:SaveProperty<Array<String>>;
+  public var enabledModDirs:SaveProperty<Array<String>>;
 
   ///
   /// CHART EDITOR OPTIONS


### PR DESCRIPTION
## Linked Issues
- Closes #3991
- Honorable Mentione #5988

> [!IMPORTANT]
> - Requires the following PR to be merged: https://github.com/FunkinCrew/polymod/pull/330

## Description
This PR updates the `PolymodHandler` to use the new `dirName` instead of `id` for loading mods.

**Note:** This is a breaking change for mods such as the Funkin' Mod Menu if they dont switch to using Dirs and `dirName` instead of Ids !

So let's take this file Tree as example:
```
.
└── mods/
    ├── Test
    └── TestTwo
```

The mod "Test" will be the dependency mod for "TestTwo". And its metadata doesn't contain an `id`, that means the dependency must be tied to the directory name:
```json
// TestTwo/_polymod_meta.json
  "dependencies": {
    "Test": "<VERSION>"
  }
```
But if a user modifies the directory name it will no longer work (check the polymod PR for reasons why).

That's why mods can add a "static" mod ID, which the dependencies could use and work even if the directory name changes:
```json
// Test/_polymod_meta.json
  "id": "Test"
```

> [!NOTE]
> This doesn't change the old behavior and mods don't need to update to this system immediately !

## Screenshots/Videos

https://github.com/user-attachments/assets/59ec6bd7-2494-4ff1-9405-9eeb35f2633f

