### PR TITLE
[BUGFIX] Fix invalid Freeplay Pixel Icons showing previous song's icon

### DIFF
--- a/source/funkin/ui/PixelatedIcon.hx
+++ b/source/funkin/ui/PixelatedIcon.hx
@@ -4,7 +4,7 @@ import funkin.graphics.FlxFilteredSprite;
 
 /**
  * The icon that gets used for Freeplay capsules and char select
- * NOT to be confused with the CharIcon class, which is for the in-game icons
+ * NOT to be confused with the HealthIcon class, which is for the in-game icons
  */
 @:nullSafety
 class PixelatedIcon extends FlxFilteredSprite
@@ -25,7 +25,6 @@ class PixelatedIcon extends FlxFilteredSprite
   public function setCharacter(char:String):Void
   {
     if (this.char == char) return;
-    this.char = char;
 
     var charPath:String = "freeplay/icons/";
 
@@ -52,10 +51,9 @@ class PixelatedIcon extends FlxFilteredSprite
       this.visible = false;
       return;
     }
-    else
-    {
-      this.visible = true;
-    }
+
+    this.visible = true;
+    this.char = char; // if we went past this its safe to assume the icon exists so we can assign it
 
     var isAnimated = Assets.exists(Paths.file('images/$charPath.xml'));
 

--- a/source/funkin/ui/freeplay/SongMenuItem.hx
+++ b/source/funkin/ui/freeplay/SongMenuItem.hx
@@ -431,7 +431,7 @@ class SongMenuItem extends FlxSpriteGroup
     {
       songText.text = freeplayData.fullSongName;
       if (freeplayData.songCharacter != null) pixelIcon.setCharacter(freeplayData.songCharacter);
-      pixelIcon.visible = true;
+      if (pixelIcon.char != freeplayData.songCharacter) pixelIcon.visible = false;
       updateBPM(Std.int(freeplayData.songStartingBpm) ?? 0);
       updateDifficultyRating(freeplayData.difficultyRating ?? 0);
       if (updateRank) updateScoringRank(freeplayData.scoringRank);


### PR DESCRIPTION
## Linked Issues
https://github.com/FunkinCrew/Funkin/issues/2460

## Description
Fixes a issue where freeplay icons that werent valid were using their last valid character

## Screenshots/Videos
<img width="1282" height="752" alt="image" src="https://github.com/user-attachments/assets/d348747f-a57c-4f32-8ff8-f3d3a530db27" />