### PR TITLE
[ENHANCEMENT] Add "Edit Note" option to Chart Editor note context menu

### DIFF
--- a/source/funkin/ui/debug/charting/contextmenus/ChartEditorHoldNoteContextMenu.hx
+++ b/source/funkin/ui/debug/charting/contextmenus/ChartEditorHoldNoteContextMenu.hx
@@ -11,6 +11,7 @@ import funkin.ui.debug.charting.commands.ExtendNoteLengthCommand;
 @:build(haxe.ui.ComponentBuilder.build("assets/exclude/data/ui/chart-editor/context-menus/hold-note.xml"))
 class ChartEditorHoldNoteContextMenu extends ChartEditorBaseContextMenu
 {
+  var contextmenuEdit:MenuItem;
   var contextmenuFlip:MenuItem;
   var contextmenuDelete:MenuItem;
 
@@ -27,6 +28,11 @@ class ChartEditorHoldNoteContextMenu extends ChartEditorBaseContextMenu
   public function initialize():Void
   {
     // NOTE: Remember to use commands here to ensure undo/redo works properly
+    contextmenuEdit.onClick = function(_)
+    {
+      chartEditorState.showToolbox(ChartEditorState.CHART_EDITOR_TOOLBOX_NOTE_DATA_LAYOUT);
+    }
+
     contextmenuFlip.onClick = function(_)
     {
       chartEditorState.performCommand(new FlipNotesCommand([data]));

--- a/source/funkin/ui/debug/charting/contextmenus/ChartEditorNoteContextMenu.hx
+++ b/source/funkin/ui/debug/charting/contextmenus/ChartEditorNoteContextMenu.hx
@@ -12,6 +12,7 @@ import funkin.ui.debug.charting.commands.ExtendNoteLengthCommand;
 @:build(haxe.ui.ComponentBuilder.build("assets/exclude/data/ui/chart-editor/context-menus/note.xml"))
 class ChartEditorNoteContextMenu extends ChartEditorBaseContextMenu
 {
+  var contextmenuEdit:MenuItem;
   var contextmenuFlip:MenuItem;
   var contextmenuMirrorX:MenuItem;
   var contextmenuDelete:MenuItem;
@@ -29,6 +30,11 @@ class ChartEditorNoteContextMenu extends ChartEditorBaseContextMenu
   public function initialize():Void
   {
     // NOTE: Remember to use commands here to ensure undo/redo works properly
+    contextmenuEdit.onClick = function(_)
+    {
+      chartEditorState.showToolbox(ChartEditorState.CHART_EDITOR_TOOLBOX_NOTE_DATA_LAYOUT);
+    }
+
     contextmenuFlip.onClick = function(_)
     {
       chartEditorState.performCommand(new FlipNotesCommand([data]));


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Briefly describe the issue(s) fixed. -->
## Description
This PR implements a new option to the Chart Editor note context menu called ``Edit Note``.
If you click it, the ``Notes`` tab will show up.

In short, it serves as a shortcut to the ``Notes`` tab.

> [!IMPORTANT]
> Requires https://github.com/FunkinCrew/funkin.assets/pull/371

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos


https://github.com/user-attachments/assets/d5285455-bb6d-4c11-9493-89c17bb7089f



https://github.com/user-attachments/assets/5976ab00-837b-442d-8775-488c878aa8f5


