### PR TITLE
[BUGFIX] Fix Rank Slamming Animation

### DIFF
--- a/source/funkin/play/ResultState.hx
+++ b/source/funkin/play/ResultState.hx
@@ -941,7 +941,7 @@ class ResultState extends MusicBeatSubState
         var isScoreValid = !(params?.isPracticeMode ?? false) && !(params?.isBotPlayMode ?? false);
         var isPersonalBest = rank > Scoring.calculateRank(params?.prevScoreData);
 
-        if (isScoreValid && isPersonalBest)
+        if ((isScoreValid && isPersonalBest) || params.forceRankSlam)
         {
           trace('THE RANK IS Higher.....');
 
@@ -1158,4 +1158,9 @@ typedef ResultsStateParams =
    * The previous score data, used for rank comparision.
    */
   var ?prevScoreData:SaveScoreData;
+
+  /**
+   * Forces to do the rank slamming animation in freeplay for debug purposes
+   */
+  var ?forceRankSlam:Bool;
 };

--- a/source/funkin/play/scoring/Scoring.hx
+++ b/source/funkin/play/scoring/Scoring.hx
@@ -529,7 +529,7 @@ enum abstract ScoringRank(String)
       case SHIT:
         return 2 / 24;
       default:
-        return 3.5;
+        return 2 / 24;
     }
   }
 
@@ -549,7 +549,7 @@ enum abstract ScoringRank(String)
       case SHIT:
         return 95 / 24;
       default:
-        return 3.5;
+        return 95 / 24;
     }
   }
 
@@ -569,7 +569,7 @@ enum abstract ScoringRank(String)
       case SHIT:
         return 186 / 24;
       default:
-        return 3.5;
+        return 186 / 24;
     }
   }
 
@@ -589,7 +589,7 @@ enum abstract ScoringRank(String)
       case SHIT:
         return 207 / 24;
       default:
-        return 3.5;
+        return 207 / 24;
     }
   }
 
@@ -631,7 +631,7 @@ enum abstract ScoringRank(String)
       case SHIT:
         return 'resultScreen/rankText/rankScrollLOSS';
       default:
-        return 'resultScreen/rankText/rankScrollGOOD';
+        return 'resultScreen/rankText/rankScrollLOSS';
     }
   }
 
@@ -652,7 +652,7 @@ enum abstract ScoringRank(String)
       case SHIT:
         return 'resultScreen/rankText/rankTextLOSS';
       default:
-        return 'resultScreen/rankText/rankTextGOOD';
+        return 'resultScreen/rankText/rankTextLOSS';
     }
   }
 
@@ -672,6 +672,8 @@ enum abstract ScoringRank(String)
         0xFFFF58B4;
       case PERFECT_GOLD:
         0xFFFFB619;
+      default:
+        0xFF6044FF;
     }
   }
 

--- a/source/funkin/ui/debug/results/ResultsDebugSubState.hx
+++ b/source/funkin/ui/debug/results/ResultsDebugSubState.hx
@@ -72,6 +72,10 @@ class ResultsDebugSubState extends MusicBeatSubState
     {
       resultsParams.scoreData.tallies = DebugTallies.getTallyForRank(result);
     });
+    createToggleListItem("Force Rank Slam (Freeplay Only)", ["No", "Yes"], function(result:String)
+    {
+      resultsParams.forceRankSlam = result == "Yes";
+    });
   }
 
   function createTextItem(name:String, ?onChange:Void->Void):MenuTypedItem<FlxText>

--- a/source/funkin/ui/freeplay/FreeplayState.hx
+++ b/source/funkin/ui/freeplay/FreeplayState.hx
@@ -1196,10 +1196,10 @@ class FreeplayState extends MusicBeatSubState
 
       FlxTween.tween(funnyCam, {"zoom": 1.05}, 0.3, {ease: FlxEase.elasticOut});
 
-      capsuleToRank.capsule.angle = -3;
-      FlxTween.tween(capsuleToRank.capsule, {angle: 0}, 0.5, {ease: FlxEase.backOut});
+      capsuleToRank.angle = -3;
+      FlxTween.tween(capsuleToRank, {angle: 0}, 0.5, {ease: FlxEase.backOut});
 
-      IntervalShake.shake(capsuleToRank.capsule, 0.3, 1 / 30, 0.1, 0, FlxEase.quadOut);
+      IntervalShake.shake(capsuleToRank, 0.3, 1 / 30, 0.1, 0, FlxEase.quadOut);
     });
 
     new FlxTimer().start(0.4, _ ->
@@ -1265,7 +1265,7 @@ class FreeplayState extends MusicBeatSubState
           {
             FlxTween.cancelTweensOf(capsule);
             // capsule.targetPos.x += 50;
-            capsule.fadeAnim();
+            capsule.fadeAnim(fromResultsParams?.newRank);
 
             rankVignette.color = capsule.getTrailColor();
             rankVignette.alpha = 1;
@@ -1300,8 +1300,8 @@ class FreeplayState extends MusicBeatSubState
             {
               capsule.doLerp = false;
 
-              capsule.capsule.angle = FlxG.random.float(-10 + (distFromSelected * 2), 10 - (distFromSelected * 2));
-              FlxTween.tween(capsule.capsule, {angle: 0}, 0.5, {ease: FlxEase.backOut});
+              capsule.angle = FlxG.random.float(-10 + (distFromSelected * 2), 10 - (distFromSelected * 2));
+              FlxTween.tween(capsule, {angle: 0}, 0.5, {ease: FlxEase.backOut});
 
               IntervalShake.shake(capsule, 0.6, 1 / 24, 0.12 / (distFromSelected + 1), 0, FlxEase.quadOut, function(_)
               {
@@ -1317,8 +1317,8 @@ class FreeplayState extends MusicBeatSubState
             {
               capsule.doLerp = false;
 
-              capsule.capsule.angle = FlxG.random.float(-10 + (distFromSelected * 2), 10 - (distFromSelected * 2));
-              FlxTween.tween(capsule.capsule, {angle: 0}, 0.5, {ease: FlxEase.backOut});
+              capsule.angle = FlxG.random.float(-10 + (distFromSelected * 2), 10 - (distFromSelected * 2));
+              FlxTween.tween(capsule, {angle: 0}, 0.5, {ease: FlxEase.backOut});
 
               IntervalShake.shake(capsule, 0.6, 1 / 24, 0.12 / (distFromSelected + 1), 0, FlxEase.quadOut, function(_)
               {
@@ -1643,6 +1643,7 @@ class FreeplayState extends MusicBeatSubState
     {
       rankAnimStart(fromResultsParams ?? {
         playRankAnim: true,
+        oldRank: currentCapsule.ranking.rank,
         newRank: PERFECT_GOLD,
         songId: "tutorial",
         difficultyId: "hard"

--- a/source/funkin/ui/freeplay/SongItemGroup.hx
+++ b/source/funkin/ui/freeplay/SongItemGroup.hx
@@ -38,14 +38,21 @@ class SongItemGroup extends FlxTypedGroup<SongMenuItem>
 
     final capsulesToRender:Array<SongMenuItem> = [];
 
+    var hasTrail = false;
     for (capsule in this.members)
     {
-      if (capsule != null && capsule.exists && capsule.visible) capsulesToRender.push(capsule);
+      if (capsule != null && capsule.exists && capsule.visible)
+      {
+        if (capsule.hasTrail) hasTrail = true;
+        capsulesToRender.push(capsule);
+      }
     }
 
     if (capsulesToRender.length == 0) return;
 
-    final memberCount:Int = capsulesToRender[0].length; // Capsules always have a constant number of members to render.
+    var firstCapsule = capsulesToRender[0];
+    var memberCount:Int = firstCapsule.length;
+    if (hasTrail && !firstCapsule.hasTrail) memberCount += 2;
     for (i in 0...memberCount)
     {
       for (capsule in capsulesToRender)

--- a/source/funkin/ui/freeplay/SongMenuItem.hx
+++ b/source/funkin/ui/freeplay/SongMenuItem.hx
@@ -381,8 +381,30 @@ class SongMenuItem extends FlxSpriteGroup
 
   var evilTrail:FlxTrail;
 
-  public function fadeAnim():Void
+  public var hasTrail:Bool = false;
+
+  function clearUpTrail()
   {
+    if (impactThing != null)
+    {
+      FlxTween.cancelTweensOf(impactThing);
+      remove(impactThing);
+      impactThing.destroy();
+      impactThing = null;
+    }
+    if (evilTrail != null)
+    {
+      FlxTween.cancelTweensOf(evilTrail);
+      remove(evilTrail);
+      evilTrail.destroy();
+      evilTrail = null;
+    }
+  }
+
+  public function fadeAnim(?newRank:ScoringRank):Void
+  {
+    if (hasTrail) clearUpTrail();
+    hasTrail = true;
     impactThing = new FunkinSprite(0, 0);
     impactThing.frames = capsule.frames;
     impactThing.frame = capsule.frame;
@@ -403,12 +425,13 @@ class SongMenuItem extends FlxSpriteGroup
       ease: FlxEase.quadOut,
       onComplete: function(_)
       {
-        remove(evilTrail);
+        clearUpTrail();
+        hasTrail = false;
       }
     });
     add(evilTrail);
 
-    evilTrail.color = ranking.rank.getRankingFreeplayColor();
+    evilTrail.color = (newRank ?? ranking.rank).getRankingFreeplayColor();
   }
 
   public function getTrailColor():FlxColor


### PR DESCRIPTION
## Description
This PR fixes the rank slamming animation that was mising the glow of the capsule and it also polishes it by applying transformations into the group itself instead of the capsule display sprite so it looks cleaner also added a option into the results debug to test the rank slamming from results

## Screenshots/Videos

https://github.com/user-attachments/assets/8685c11d-2c98-4ea3-872b-31a5cd9fe6e5