### PR TITLE
[VULNERABILITY] Blacklist `readObject()` functions

### DIFF
--- a/source/funkin/modding/PolymodHandler.hx
+++ b/source/funkin/modding/PolymodHandler.hx
@@ -425,6 +425,12 @@ class PolymodHandler
       'clearData', // No score manipulation please
       'setLevelScore', 'setSongScore', 'applySongRank']);
 
+    // `openfl.filesystem.FileStream`, `openfl.net.Socket`, `openfl.utils.ByteArray.ByteArrayData`
+    // Returns `Unseralizer.run` if encoded in HXSF format, though it does have to be seralized correctly for the exploit to work.
+    Polymod.blacklistInstanceFields(openfl.filesystem.FileStream, ['readObject']);
+    Polymod.blacklistInstanceFields(openfl.net.Socket, ['readObject']);
+    Polymod.blacklistInstanceFields(openfl.utils.ByteArray.ByteArrayData, ['readObject']);
+
     // `funkin.api.*`
     // Contains functions which may allow for cheating and such.
     for (cls in ClassMacro.listClassesInPackage('funkin.api'))


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Briefly describe the issue(s) fixed. -->
## Description
blacklists the `readObject()` function in `ByteArrayData`, `FileStream`, and `Socket` since they all return `Unserializer.run` if encoded in [HXSF](https://haxe.org/manual/std-serialization-format.html) format. 
btw do note that for the exploit to work, they have to be serialized properly

if i see Unserializer one more time im gonna shit myself

_(yes ik `FileStream` and `Socket` aren't compiled in even without DCE but still, this prevents scripts from using it even when #7115 gets merged)_

