### PR TITLE
[BUGFIX] Stop the Playtest Results Screen from appearing with Botplay Mode enabled

### DIFF
--- a/source/funkin/play/PlayState.hx
+++ b/source/funkin/play/PlayState.hx
@@ -3634,7 +3634,7 @@ class PlayState extends MusicBeatSubState
     {
       if (isSubState)
       {
-        if (isPlaytestResults)
+        if (isPlaytestResults && !isBotPlayMode)
         {
           moveToResultsScreen(false, prevScoreData);
         }


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
Mentioned by Hundrec

<!-- Briefly describe the issue(s) fixed. -->
## Description
This PR prevents the results screen from appearing in the chart editor when botplay is enabled.

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos
BEFORE:

https://github.com/user-attachments/assets/e37f9546-ba86-4634-8601-e1dbe46670e1

AFTER:


https://github.com/user-attachments/assets/18a46f1f-fc69-42bc-bc62-3b9ae68a086a

