### PR TITLE
[BUGFIX] Filter out unavailable difficulties from Story Mode levels.

### DIFF
--- a/source/funkin/ui/story/StoryMenuState.hx
+++ b/source/funkin/ui/story/StoryMenuState.hx
@@ -507,7 +507,7 @@ class StoryMenuState extends MusicBeatState
   {
     // "For now, NO erect in story mode" -Dave
 
-    var difficultyList:Array<String> = Constants.DEFAULT_DIFFICULTY_LIST;
+    var difficultyList:Array<String> = currentLevel.getDifficulties().filter(e -> Constants.DEFAULT_DIFFICULTY_LIST.contains(e));
     // Use this line to displays all difficulties
     // var difficultyList:Array<String> = currentLevel.getDifficulties();
     var currentIndex:Int = difficultyList.indexOf(currentDifficultyId);


### PR DESCRIPTION
## Linked Issues

- Closes #2800

## Description

This PR fixes an issue where Story Mode displayed all difficulties regardless of the available difficulties in a level.
Instead of using a constant array for all levels, the Story Mode now filters the current level's available difficulties with the default list to be sure that only the level difficulties are displayed.

## Screenshots/Videos

https://github.com/user-attachments/assets/1ac6aa3d-4786-480e-887f-2dab59b8728e

