### PR TITLE
[ENHANCEMENT/Modding] Optional dependencies no longer throw window errors and improve log output messages.

### DIFF
--- a/source/funkin/modding/PolymodErrorHandler.hx
+++ b/source/funkin/modding/PolymodErrorHandler.hx
@@ -16,37 +16,37 @@ class PolymodErrorHandler
 
       case MOD_MISSING_DIRECTORY:
         // A mod ID was included in the list of mods to load, but it isn't installed.
-        trace(' WARNING '.warning() + 'Tried to load a mod that was not installed: ${error.message}');
+        trace(' WARNING '.warning() + ' Tried to load a mod that was not installed: ${error.message}');
         // Notify the user via popup.
         funkin.util.WindowUtil.showError('Mod Load Error', error.message);
 
       case MOD_MISSING_METADATA:
         // A mod ID was included in the list of mods to load, but the mod folder doesn't have metadata.
-        trace(' ERROR '.error() + 'Tried to load a mod with no metadata: ${error.message}');
+        trace(' ERROR '.error() + ' Tried to load a mod with no metadata: ${error.message}');
         // Notify the user via popup.
         funkin.util.WindowUtil.showError('Mod Load Error', error.message);
 
       case MOD_METADATA_PARSE_FAILED:
         // Polymod tries to load the mod's metadata, but it could not be parsed.
-        trace(' ERROR '.error() + 'Failed to parse mod metadata: ${error.message}');
+        trace(' ERROR '.error() + ' Failed to parse mod metadata: ${error.message}');
         // Notify the user via popup.
         funkin.util.WindowUtil.showError('Mod Metadata Parse Error', error.message);
 
       case MOD_VERSION_PARSE_FAILED:
         // Polymod tries to load the mod's version, but it could not be parsed.
-        trace(' ERROR '.error() + 'Failed to parse mod version: ${error.message}');
+        trace(' ERROR '.error() + ' Failed to parse mod version: ${error.message}');
         // Notify the user via popup.
         funkin.util.WindowUtil.showError('Mod Version Parse Error', error.message);
 
       case MOD_API_VERSION_PARSE_FAILED:
         // Polymod tries to load the mod's API version, but it could not be parsed.
-        trace(' ERROR '.error() + 'Failed to parse mod API version: ${error.message}');
+        trace(' ERROR '.error() + ' Failed to parse mod API version: ${error.message}');
         // Notify the user via popup.
         funkin.util.WindowUtil.showError('Mod API Version Parse Error', error.message);
 
       case MOD_MISSING_ICON:
         // A mod is missing an icon.
-        trace(' WARNING '.warning() + 'A mod is missing an icon: ${error.message}');
+        trace(' WARNING '.warning() + ' A mod is missing an icon: ${error.message}');
 
       //
       // Mod Loading Errors
@@ -55,7 +55,7 @@ class PolymodErrorHandler
       case MOD_API_VERSION_MISMATCH:
         // Polymod tried to load a mod but failed because it has the wrong API version.
         // This is an important issue that requires user attention so it can be resolved by the mod developer.
-        trace(' WARNING '.warning() + 'Failed to load mod - ${error.message}');
+        trace(' WARNING '.warning() + ' Failed to load mod - ${error.message}');
 
         var regex:EReg = ~/Mod "([-_a-zA-Z0-9]+)" is not compatible with API version "(.*?)", got "(.*?)"/;
         if (regex.match(error.message))
@@ -65,7 +65,7 @@ class PolymodErrorHandler
           // var apiVersion:String = regex.matched(2);
           var modVersion:String = regex.matched(3);
 
-          var message:String = 'Installed mod "$modId" was built for "$modVersion". It does not support ${Constants.GENERATED_BY}, and must be skipped.'
+          var message:String = 'Installed mod "$modId" uses an older API version $modVersion which is not supported by the current API version ${Constants.VERSION.substr(1)}, and must be skipped.'
             + '\n\nPlease inform the mod developer that "$modId" must be updated for compatibility.';
 
           funkin.util.WindowUtil.showError('Mod Outdated', message);
@@ -78,14 +78,18 @@ class PolymodErrorHandler
 
       case MOD_LOAD_FAILED:
         // Polymod failed to load a mod. A different error would have already been logged.
-        trace(' WARNING '.warning() + 'Failed to load mod - ${error.message}');
+        trace(' WARNING '.warning() + ' Failed to load mod - ${error.message}');
 
       case MOD_LOAD_DONE:
-        trace(' INFO '.info() + 'Loaded mod - ${error.message}');
+        trace(' INFO '.info() + ' Loaded mod - ${error.message}');
 
       //
       // Mod Dependency Errors
       //
+
+      case MOD_OPTIONAL_DEPENDENCY_UNMET:
+        // Polymod looked at the list of available mods, and one of them was missing an optional dependency.
+        trace(' INFO '.info() + ' Installed mod is missing an optional dependency: ${error.message}');
 
       case MOD_DEPENDENCY_UNMET:
         switch (error.origin)
@@ -93,13 +97,13 @@ class PolymodErrorHandler
           case SCAN:
             // Polymod looked at the list of available mods, and one of them was missing a dependency.
             // This is an important warning that should be shown to the user.
-            trace(' WARNING '.warning() + 'Installed mod is missing a dependency: ${error.message}');
+            trace(' WARNING '.warning() + ' Installed mod is missing a dependency: ${error.message}');
             // Notify the user via popup.
             funkin.util.WindowUtil.showError('Mod Dependency Error', error.message);
           default:
             // Polymod tried to load a mod, but failed because it has a dependency that wasn't met.
             // This is a major error that should be shown to the user.
-            trace(' ERROR '.error() + 'Failed to load mod due to missing dependency: ${error.message}');
+            trace(' ERROR '.error() + ' Failed to load mod due to missing dependency: ${error.message}');
             // Notify the user via popup.
             funkin.util.WindowUtil.showError('Mod Dependency Error', error.message);
         }
@@ -111,13 +115,13 @@ class PolymodErrorHandler
             // Polymod looked at the list of available mods, and one of them has a dependency on a different mod,
             // but the mod has the wrong version.
             // This is an important warning that should be shown to the user.
-            trace(' WARNING '.warning() + 'Installed mod has a mismatched dependency: ${error.message}');
+            trace(' WARNING '.warning() + ' Installed mod has a mismatched dependency: ${error.message}');
             // Notify the user via popup.
             funkin.util.WindowUtil.showError('Mod Dependency Error', error.message);
           default:
             // Polymod tried to load a mod, but failed because one of its dependencies was the wrong version.
             // This is a major error that should be shown to the user.
-            trace(' ERROR '.error() + 'Failed to load mod due to mismatched dependency: ${error.message}');
+            trace(' ERROR '.error() + ' Failed to load mod due to mismatched dependency: ${error.message}');
             // Notify the user via popup.
             funkin.util.WindowUtil.showError('Mod Dependency Error', error.message);
         }
@@ -125,7 +129,7 @@ class PolymodErrorHandler
       case MOD_DEPENDENCY_CYCLICAL:
         // Polymod tried to load a mod, but failed because one of its dependencies depends on that mod.
         // This is a major error that should be shown to the user.
-        trace(' ERROR '.error() + 'Failed to load mod due to cyclical dependency: ${error.message}');
+        trace(' ERROR '.error() + ' Failed to load mod due to cyclical dependency: ${error.message}');
         // Notify the user via popup.
         funkin.util.WindowUtil.showError('Mod Dependency Error', error.message);
 
@@ -135,47 +139,47 @@ class PolymodErrorHandler
 
       case SCRIPT_PARSE_FAILED:
         // A syntax error when parsing a script.
-        trace(' ERROR '.error() + error.message);
+        trace(' ERROR '.error() + ' ' + error.message);
         // Notify the user via popup.
         funkin.util.WindowUtil.showError('Script Parsing Error', error.message);
 
       case SCRIPT_RUNTIME_EXCEPTION:
         // A runtime error when running a script.
-        trace(' ERROR '.error() + error.message);
+        trace(' ERROR '.error() + ' ' + error.message);
         // Notify the user via popup.
         funkin.util.WindowUtil.showError('Script Exception', error.message);
 
       case SCRIPTED_CLASS_NOT_REGISTERED:
         // Polymod attempted to initialize a scripted class, but it wasn't registered.
-        trace(' ERROR '.error() + error.message);
+        trace(' ERROR '.error() + ' ' + error.message);
         // Notify the user via popup.
         funkin.util.WindowUtil.showError('Script Parsing Error', error.message);
 
       case SCRIPTED_CLASS_ALREADY_REGISTERED:
         // Polymod attempted to register a scripted class, but one with the same name and package already exists.
-        trace(' ERROR '.error() + error.message);
+        trace(' ERROR '.error() + ' ' + error.message);
         // Notify the user via popup.
         funkin.util.WindowUtil.showError('Script Parsing Error', error.message);
 
       case SCRIPTED_CLASS_REDUNDANT_IMPORT:
         // A scripted class imported a module that's already imported.
-        trace(' WARNING '.warning() + error.message);
+        trace(' WARNING '.warning() + ' ' + error.message);
 
       case SCRIPTED_CLASS_UNRESOLVED_IMPORT:
         // A scripted class tried to import a module that doesn't exist.
-        trace(' ERROR '.error() + error.message);
+        trace(' ERROR '.error() + ' ' + error.message);
         // Notify the user via popup.
         funkin.util.WindowUtil.showError('Script Import Error', error.message);
 
       case SCRIPTED_CLASS_BLACKLISTED_MODULE:
         // A scripted class tried to import a module that's blacklisted.
-        trace(' ERROR '.error() + error.message);
+        trace(' ERROR '.error() + ' ' + error.message);
         // Notify the user via popup.
         funkin.util.WindowUtil.showError('Script Blacklist Violation', error.message);
 
       case SCRIPTED_CLASS_BLACKLISTED_FIELD:
         // A scripted class tried to access a field that's blacklisted.
-        trace(' ERROR '.error() + error.message);
+        trace(' ERROR '.error() + ' ' + error.message);
         // Notify the user via popup.
         funkin.util.WindowUtil.showError('Script Blacklist Violation', error.message);
 
@@ -192,11 +196,11 @@ class PolymodErrorHandler
         switch (error.severity)
         {
           case ERROR:
-            trace(' ERROR '.error() + error.message);
+            trace(' ERROR '.error() + ' ' + error.message);
           case WARNING:
-            trace(' WARNING '.warning() + error.message);
+            trace(' WARNING '.warning() + ' ' + error.message);
           case INFO:
-            trace(' INFO '.info() + error.message);
+            trace(' INFO '.info() + ' ' + error.message);
           case DEBUG:
             // trace(' DEBUG '.debug() + error.message);
         }


### PR DESCRIPTION
## Linked Issues

- Closes #7054
- Closes #7055 

> [!IMPORTANT]
> - Requires https://github.com/FunkinCrew/polymod/pull/363

## Description

This PR makes the optionals dependency no longer window error and only write a log in the console.
And improves the error message when an unsupported API version is used by mods.

## Screenshots/Videos

### Before

<img width="810" height="216" alt="image" src="https://github.com/user-attachments/assets/4d63710b-904e-4b6c-a2eb-34985fbe0cab" />

### After

<img width="907" height="216" alt="image" src="https://github.com/user-attachments/assets/a2b3f14c-c1aa-496c-8596-dd38dcc98741" />
