### PR TITLE
[BUGFIX] Fix Sustain Trails Changing Height When Hit Too Early

### DIFF
--- a/source/funkin/play/notes/Strumline.hx
+++ b/source/funkin/play/notes/Strumline.hx
@@ -972,7 +972,8 @@ class Strumline extends FlxSpriteGroup
       note.holdNoteSprite.hitNote = true;
       note.holdNoteSprite.missedNote = false;
 
-      note.holdNoteSprite.sustainLength = (note.holdNoteSprite.strumTime + note.holdNoteSprite.fullSustainLength) - conductorInUse.songPosition;
+      note.holdNoteSprite.sustainLength = Math.min(note.holdNoteSprite.fullSustainLength,
+        (note.holdNoteSprite.strumTime + note.holdNoteSprite.fullSustainLength) - conductorInUse.songPosition);
     }
 
     #if FEATURE_GHOST_TAPPING

--- a/source/funkin/play/notes/SustainTrail.hx
+++ b/source/funkin/play/notes/SustainTrail.hx
@@ -120,13 +120,13 @@ class SustainTrail extends FlxSprite
   {
     super(0, 0);
 
+    setupHoldNoteGraphic(noteStyle);
+    noteStyleOffsets = noteStyle.getHoldNoteOffsets();
+
     // BASIC SETUP
     this.sustainLength = sustainLength;
     this.fullSustainLength = sustainLength;
     this.noteDirection = noteDirection;
-
-    setupHoldNoteGraphic(noteStyle);
-    noteStyleOffsets = noteStyle.getHoldNoteOffsets();
 
     setIndices(TRIANGLE_VERTEX_INDICES);
 
@@ -262,7 +262,6 @@ class SustainTrail extends FlxSprite
   {
     if (s < 0.0) s = 0.0;
 
-    if (sustainLength == s) return s;
     this.sustainLength = s;
     triggerRedraw();
     return this.sustainLength;


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues

Fixes #4999

<!-- Briefly describe the issue(s) fixed. -->
## Description

This PR fixes a bug where sustain trails change height when hitting the note early.

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos

Before:

https://github.com/user-attachments/assets/ded01195-3660-4dec-81f9-638ac0546ac3

After:

https://github.com/user-attachments/assets/1b23706d-3835-4254-aca8-b6f79e9bf097