### PR TITLE
[ENHANCEMENT] Relabel Backup window button from 'Take Me There' to 'Open In Folder'

### DIFF
--- a/source/funkin/ui/debug/stageeditor/components/BackupAvailableDialog.hx
+++ b/source/funkin/ui/debug/stageeditor/components/BackupAvailableDialog.hx
@@ -19,7 +19,7 @@ using StringTools;
 		<hbox width="100%">
 			<button text="No Thanks" id="dialogCancel" />
 			<spacer width="100%" />
-			<button text="Take Me There" id="buttonGoToFolder" />
+			<button text="Open In Folder" id="buttonGoToFolder" />
 			<spacer width="100%" />
 			<button text="Open It" id="buttonOpenBackup" />
 		</hbox>


### PR DESCRIPTION


<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues

none

<!-- Briefly describe the issue(s) fixed. -->
## Description

i didn't understand the difference between "take me there" and "open it" very much, so this pr makes it more clear on what it does

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos
