### PR TITLE
[BUGFIX] Fix character stuck in miss pose during no-anim notes

### DIFF
--- a/source/funkin/play/character/BaseCharacter.hx
+++ b/source/funkin/play/character/BaseCharacter.hx
@@ -371,7 +371,11 @@ class BaseCharacter extends Bopper
     // Reset hold timer for each note pressed.
     if (justPressedNote() && this.characterType == BF)
     {
-      holdTimer = 0;
+      // If the note kind has `noanim` do not reset holdTimer.
+      if (curNoteKind != null && !curNoteKind.noanim)
+      {
+        holdTimer = 0;
+      }
     }
 
     if (isDead)
@@ -530,39 +534,21 @@ class BaseCharacter extends Bopper
     super.onNoteHit(event);
     // If another script cancelled the event, don't do anything.
     if (event.eventCanceled) return;
+
     curNoteKind = NoteKindManager.getNoteKind(event.note.noteData.kind);
+
+    // Let the character naturally transition back to their idle/dance animation.
+    if (curNoteKind != null && curNoteKind.noanim) return;
 
     if (event.note.noteData.getMustHitNote() && characterType == BF)
     {
-      if (curNoteKind != null)
-      {
-        if (!curNoteKind.noanim)
-        {
-          this.playSingAnimation(event.note.noteData.getDirection(), false, curNoteKind?.suffix);
-          holdTimer = 0;
-        }
-      }
-      else
-      {
-        this.playSingAnimation(event.note.noteData.getDirection(), false);
-        holdTimer = 0;
-      }
+      this.playSingAnimation(event.note.noteData.getDirection(), false);
+      holdTimer = 0;
     }
     else if (!event.note.noteData.getMustHitNote() && characterType == DAD)
     {
-      if (curNoteKind != null)
-      {
-        if (!curNoteKind.noanim)
-        {
-          this.playSingAnimation(event.note.noteData.getDirection(), false, curNoteKind?.suffix);
-          holdTimer = 0;
-        }
-      }
-      else
-      {
-        this.playSingAnimation(event.note.noteData.getDirection(), false);
-        holdTimer = 0;
-      }
+      this.playSingAnimation(event.note.noteData.getDirection(), false);
+      holdTimer = 0;
     }
     else if (characterType == GF && event.note.noteData.getMustHitNote())
     {
@@ -591,6 +577,7 @@ class BaseCharacter extends Bopper
     {
       // If the note is from the same strumline, play the miss animation.
       this.playSingAnimation(event.note.noteData.getDirection(), true);
+      this.holdTimer = 0;
     }
     else if (!event.note.noteData.getMustHitNote() && characterType == DAD)
     {


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
#7044 - Character doesn't return to idle when continually hitting No Animation notes

<!-- Briefly describe the issue(s) fixed. -->
## Description
This PR should fix characters being stuck in their miss-animations instead going back to their dance / idle poses.

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos
### BEFORE:
https://github.com/user-attachments/assets/6e6a473e-d613-4d3d-9716-05630922e843
### AFTER:
https://github.com/user-attachments/assets/a43ace24-7c06-446b-b9c2-991d2c348a9c