### PR TITLE
[ENHANCEMENT] Added an option called "Cutscenes on Freeplay" to the preference menu

### DIFF
--- a/source/funkin/Preferences.hx
+++ b/source/funkin/Preferences.hx
@@ -540,6 +540,25 @@ class Preferences
     return value;
   }
 
+  /**
+   * If enabled, cutscenes and dialogue sequences will be played on freeplay.
+   * @default `true`
+   */
+  public static var freeplayCutscenes(get, set):Bool;
+
+  static function get_freeplayCutscenes():Bool
+  {
+    return Save?.instance?.options?.freeplayCutscenes ?? true;
+  }
+
+  static function set_freeplayCutscenes(value:Bool):Bool
+  {
+    var save:Save = Save.instance;
+    save.options.freeplayCutscenes = value;
+    Save.system.flush();
+    return value;
+  }
+
   #if mobile
   /**
    * If enabled, device will be able to sleep on its own.

--- a/source/funkin/save/Save.hx
+++ b/source/funkin/save/Save.hx
@@ -107,6 +107,7 @@ class Save implements ConsoleClass
         debugDisplay: 'Off',
         debugDisplayBGOpacity: 50,
         subtitles: true,
+        freeplayCutscenes: true,
         hapticsMode: 'All',
         hapticsIntensityMultiplier: 1,
         autoPause: true,
@@ -1171,6 +1172,12 @@ typedef SaveDataOptions =
    * @default `true`
    */
   var subtitles:Bool;
+
+  /**
+   * If enabled, cutscenes and dialogue sequences will be played on freeplay.
+   * @default `true`
+   */
+  var freeplayCutscenes:Bool;
 
   /**
    * If enabled, haptic feedback will be enabled.

--- a/source/funkin/ui/options/PreferencesMenu.hx
+++ b/source/funkin/ui/options/PreferencesMenu.hx
@@ -154,6 +154,11 @@ class PreferencesMenu extends Page<OptionsState.OptionsMenuPageName>
     {
       Preferences.subtitles = value;
     }, Preferences.subtitles);
+    createPrefItemCheckbox('Cutscenes on Freeplay', 'When enabled, cutscenes on start and dialogue sequences will be played on freeplay.',
+      function(value:Bool):Void
+      {
+        Preferences.freeplayCutscenes = value;
+      }, Preferences.freeplayCutscenes);
     #if FEATURE_DEBUG_DISPLAY
     // note: technically we can do DebugDisplayMode.Advanced => DebugDisplayMode.Advanced, etc. here, but that's a bit headache inducing.
     createPrefItemEnum('Debug Display', 'When enabled, FPS and other debug stats are displayed.',


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->
# This change depends on my funkin.assets repo PR here:
**[PR #377](https://github.com/FunkinCrew/funkin.assets/pull/377)**

<!-- Briefly describe the issue(s) fixed. -->
## Description
This PR is adding an option that disables start cutscenes on freeplay song, like: Pico, Philly, Blammed pico mixes, Spaghetti, Stress Pico Mix, Senpai and Roses pico mixes.

<!-- Include any relevant screenshots or videos. -->
## Screenshot
<img width="1592" height="880" alt="fenasal funkin" src="https://github.com/user-attachments/assets/e5670b66-8a37-4e54-90fd-105715c6385e" />


