### PR TITLE
[FIX] Fix improper ANSI call for exit trace

### DIFF
--- a/source/Main.hx
+++ b/source/Main.hx
@@ -91,7 +91,7 @@ class Main extends Sprite
     // Force-kill the game to prevent background processing.
     Lib.current.stage.window.onClose.add(function()
     {
-      trace(' EXITING '.bold().bg_red + ' Game is exiting, cleaning up resources...');
+      trace(' EXITING '.bold().bg_red() + ' Game is exiting, cleaning up resources...');
 
       #if hxvlc
       // Clean up VLC threads to prevent memory leaks.


### PR DESCRIPTION
<!-- Briefly describe the issue(s) fixed. -->
## Description
This fixes a string concatenation for a trace incorrectly concatenating a function instance instead of the result of that function.
<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos
| Before |
|--------|
| <img width="558" height="17" alt="image" src="https://github.com/user-attachments/assets/8ff75999-ff11-41a5-954a-f268d5681a30" /> |

| After |
|--------|
| <img width="558" height="17" alt="image" src="https://github.com/user-attachments/assets/8b4aa8e0-c2ff-466a-95db-4f813cd35f45" /> | 

