### PR TITLE
[ENHANCEMENT] Open Chart Editor Character previews with Ctrl-click on icons

### DIFF
--- a/source/funkin/ui/debug/charting/ChartEditorState.hx
+++ b/source/funkin/ui/debug/charting/ChartEditorState.hx
@@ -3036,7 +3036,14 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
     {
       if (!isCursorOverHaxeUI && !isPlaytesting)
       {
-        this.openCharacterDropdown(CharacterType.DAD, true);
+        if (pressingControl())
+        {
+          this.setToolboxState(CHART_EDITOR_TOOLBOX_OPPONENT_PREVIEW_LAYOUT, true);
+        }
+        else
+        {
+          this.openCharacterDropdown(CharacterType.DAD, true);
+        }
       }
     });
 
@@ -3044,7 +3051,14 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
     {
       if (!isCursorOverHaxeUI && !isPlaytesting)
       {
-        this.openCharacterDropdown(CharacterType.BF, true);
+        if (pressingControl())
+        {
+          this.setToolboxState(CHART_EDITOR_TOOLBOX_PLAYER_PREVIEW_LAYOUT, true);
+        }
+        else
+        {
+          this.openCharacterDropdown(CharacterType.BF, true);
+        }
       }
     });
 


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
None
<!-- Briefly describe the issue(s) fixed. -->
## Description
Pressing Ctrl while clicking the player/opponent character icon in the Chart Editor
now opens the player/opponent preview.
<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos

https://github.com/user-attachments/assets/721443e9-a29b-4cfb-90f2-78f739d15432

