### PR TITLE
[FIX/REFACTOR] Remove `discord_rpc` from background process 

### DIFF
--- a/source/Main.hx
+++ b/source/Main.hx
@@ -98,11 +98,6 @@ class Main extends Sprite
       hxvlc.util.Handle.dispose();
       #end
 
-      #if discord_rpc
-      // Just incase you have `discord_rpc` enabled, dispose of the RPC manager.
-      funkin.util.discord.RichPresenceManager.dispose();
-      #end
-
       Sys.exit(0);
     });
     #end


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
Funkin' Contributors Discord Server.

<!-- Briefly describe the issue(s) fixed. -->
## Description
DiscordRPC is being handled somewhere else. having these managers running twice, both for the same reasons its kind of pointless. This PR stops `discord_rpc` from doing that by removing it from background processing.
