### PR TITLE
Big Batch of Checkstyle Rule Changes

### DIFF
--- a/checkstyle.json
+++ b/checkstyle.json
@@ -270,7 +270,6 @@
           "SWITCH",
           "TRY",
           "CATCH",
-          "REIFICATION",
           "ARRAY_COMPREHENSION"
         ],
         "severity": "INFO"

--- a/checkstyle.json
+++ b/checkstyle.json
@@ -51,6 +51,14 @@
       "type": "AvoidStarImport"
     },
     {
+      "comment": "If enabled, prevents ternary operators from being nested.",
+      "props": {
+        "severity": "INFO",
+        "maxDepth": 1
+      },
+      "type": "AvoidTernaryOperator"
+    },
+    {
       "comment": "If enabled, prevents conditional compilation from crossing blocks. This prevents the case where conditional compilation could potentially create invalid syntax.",
       "props": { "severity": "INFO" },
       "type": "BlockBreakingConditional"

--- a/checkstyle.json
+++ b/checkstyle.json
@@ -99,7 +99,17 @@
       "props": {
         "ignoreExtern": true,
         "format": "^?:_[a-zA-Z0-9]+(?:_[a-zA-Z0-9]+)*$",
-        "tokens": ["INLINE", "NOTINLINE"],
+        "tokens": ["INLINE", "NOTINLINE", "NOTFINAL"],
+        "severity": "INFO"
+      },
+      "type": "ConstantName"
+    },
+    {
+      "comment": "Specifies a specific naming format for static final identifiers.",
+      "props": {
+        "ignoreExtern": true,
+        "format": "^[A-Z]([_A-Z0-9]+)*$",
+        "tokens": ["INLINE", "NOTINLINE", "FINAL"],
         "severity": "INFO"
       },
       "type": "ConstantName"

--- a/checkstyle.json
+++ b/checkstyle.json
@@ -693,6 +693,16 @@
     },
     {
       "comment": "If enabled, complains about trailing whitespaces at the end of lines.",
+      "props": {
+        "severity": "INFO",
+        "enforceArrayComprehension": false,
+        "enforceArrayLiterals": false,
+        "enforceObjectLiterals": false
+      },
+      "type": "TrailingComma"
+    },
+    {
+      "comment": "If enabled, complains about trailing whitespaces at the end of lines.",
       "props": { "severity": "INFO" },
       "type": "TrailingWhitespace"
     },

--- a/checkstyle.json
+++ b/checkstyle.json
@@ -95,7 +95,7 @@
       "type": "ConditionalCompilation"
     },
     {
-      "comment": "Specifies a specific naming format for constant (static) identifiers.",
+      "comment": "Specifies a specific naming format for static var identifiers.",
       "props": {
         "ignoreExtern": true,
         "format": "^?:_[a-zA-Z0-9]+(?:_[a-zA-Z0-9]+)*$",
@@ -326,11 +326,21 @@
       "type": "ListenerName"
     },
     {
-      "comment": "Specifies a specific naming format for local variables.",
+      "comment": "Specifies a specific naming format for local var variables.",
       "props": {
         "ignoreExtern": true,
-        "format": "^[a-zA-Z][_a-zA-Z0-9]*$",
-        "tokens": [],
+        "format": "^[a-z][a-zA-Z0-9]*$",
+        "tokens": ["NOTFINAL"],
+        "severity": "INFO"
+      },
+      "type": "LocalVariableName"
+    },
+    {
+      "comment": "Specifies a specific naming format for local final variables.",
+      "props": {
+        "ignoreExtern": true,
+        "format": "^[A-Z][_A-Z0-9]*$",
+        "tokens": ["FINAL"],
         "severity": "INFO"
       },
       "type": "LocalVariableName"

--- a/checkstyle.json
+++ b/checkstyle.json
@@ -666,6 +666,14 @@
       "type": "StringLiteral"
     },
     {
+      "comment": "If enabled, requires that switch conditions be wrapped in parenthesis.",
+      "props": {
+        "policy": "require",
+        "severity": "INFO"
+      },
+      "type": "SwitchParentheses"
+    },
+    {
       "comment": "Puts a warning on unresolved TODO/FIXME comments.",
       "props": {
         "format": "^\\s*(TODO|FIXME|HACK|XXX|BUG)",

--- a/checkstyle.json
+++ b/checkstyle.json
@@ -346,6 +346,18 @@
       "type": "LocalVariableName"
     },
     {
+      "comment": "Puts a warning on long numbers without separators. 1000000 is invalid and 1_000_000 is valid.",
+      "props": {
+        "severity": "INFO",
+
+        "ignoreNumbers": [],
+
+        "checkBinary": false,
+        "checkHexadecimal": false
+      },
+      "type": "LongNumber"
+    },
+    {
       "comment": "If enabled, warns when unlabelled numeric values get used. Use named constants instead to improve code clarity.",
       "props": { "ignoreNumbers": [-1, 0, 1, 2], "severity": "INFO" },
       "type": "MagicNumber"

--- a/checkstyle.json
+++ b/checkstyle.json
@@ -446,12 +446,13 @@
       "comment": "Specifies a specific order for modifiers on fields.",
       "props": {
         "modifiers": [
+          "OVERRIDE",
+          "OVERLOAD",
+
           "PUBLIC_PRIVATE",
           "STATIC",
           "ABSTRACT",
 
-          "OVERRIDE",
-          "OVERLOAD",
           "EXTERN",
           "INLINE",
 

--- a/checkstyle.json
+++ b/checkstyle.json
@@ -634,7 +634,11 @@
     },
     {
       "comment": "If enabled, complains about overly complicated boolean expressions.",
-      "props": { "severity": "WARNING" },
+      "props": {
+        "severity": "WARNING",
+
+        "allowEqualsFalse": false
+      },
       "type": "SimplifyBooleanExpression"
     },
     {

--- a/checkstyle.json
+++ b/checkstyle.json
@@ -692,7 +692,7 @@
       "type": "Trace"
     },
     {
-      "comment": "If enabled, complains about trailing whitespaces at the end of lines.",
+      "comment": "If enabled, complains about trailing commas at the end of array and object literals.",
       "props": {
         "severity": "INFO",
         "enforceArrayComprehension": false,

--- a/checkstyle.json
+++ b/checkstyle.json
@@ -356,10 +356,10 @@
       "props": {
         "severity": "INFO",
 
-        "ignoreNumbers": [],
-
-        "checkBinary": false,
-        "checkHexadecimal": false
+        "decimalGroupSize": 3,
+        "fractionalGroupSize": -1,
+        "binaryGroupSize": 8,
+        "hexadecimalGroupSize": 8
       },
       "type": "LongNumber"
     },

--- a/checkstyle.json
+++ b/checkstyle.json
@@ -132,7 +132,13 @@
     },
     {
       "comment": "Specifies the format for doc-style comments ().",
-      "props": { "lineStyle": "onestar", "startStyle": "ignore" },
+      "props": {
+        "startStyle": "twostars",
+        "endStyle": "onestar",
+        "lineStyle": "onestar",
+
+        "severity": "INFO"
+      },
       "type": "DocCommentStyle"
     },
     {

--- a/checkstyle.json
+++ b/checkstyle.json
@@ -476,15 +476,16 @@
       "comment": "If enabled, mandates the use of braces on specific block types, unless they fit on a single line.",
       "props": {
         "allowSingleLineStatement": true,
-        "tokens": [
-          "FUNCTION",
-          "FOR",
-          "IF",
-          "ELSE_IF",
-          "WHILE",
-          "DO_WHILE",
-          "CATCH"
-        ],
+        "tokens": ["FUNCTION", "FOR", "IF", "IF_WITH_ELSE", "ELSE"],
+        "severity": "INFO"
+      },
+      "type": "NeedBraces"
+    },
+    {
+      "comment": "If enabled, mandates the use of braces on specific block types, and prevent them from being placed on a single line.",
+      "props": {
+        "allowSingleLineStatement": false,
+        "tokens": ["IF_WITH_ELSE", "CATCH", "WHILE", "DO_WHILE", "ELSE_IF"],
         "severity": "INFO"
       },
       "type": "NeedBraces"

--- a/checkstyle.json
+++ b/checkstyle.json
@@ -33,6 +33,9 @@
         "allowReturn": true,
         "allowFunction": true,
         "allowCurlyBody": true,
+
+        "enforceArrowForNonMemberFunctions": true,
+
         "severity": "INFO"
       },
       "type": "ArrowFunction"

--- a/checkstyle.json
+++ b/checkstyle.json
@@ -399,13 +399,18 @@
         "modifiers": [
           "PUBLIC_PRIVATE",
           "STATIC",
-          "MACRO",
+          "ABSTRACT",
+
           "OVERRIDE",
+          "OVERLOAD",
+          "EXTERN",
           "INLINE",
+
           "DYNAMIC",
+          "MACRO",
           "FINAL"
         ],
-        "severity": "IGNORE"
+        "severity": "INFO"
       },
       "type": "ModifierOrder"
     },

--- a/checkstyle.json
+++ b/checkstyle.json
@@ -692,7 +692,13 @@
     {
       "comment": "If enabled, mandates documentation comments on classes and interfaces.",
       "props": {
-        "tokens": ["CLASS_DEF", "ENUM_DEF", "INTERFACE_DEF", "TYPEDEF_DEF"],
+        "tokens": [
+          "CLASS_DEF",
+          "INTERFACE_DEF",
+          "TYPEDEF_DEF",
+          "ABSTRACT_DEF",
+          "ENUM_DEF"
+        ],
         "severity": "INFO"
       },
       "type": "TypeDocComment"

--- a/checkstyle.json
+++ b/checkstyle.json
@@ -309,7 +309,7 @@
       "comment": "Specifies a specific naming format for local variables.",
       "props": {
         "ignoreExtern": true,
-        "format": "^[a-z][a-zA-Z0-9]*$",
+        "format": "^[a-zA-Z][_a-zA-Z0-9]*$",
         "tokens": [],
         "severity": "INFO"
       },
@@ -323,7 +323,7 @@
     {
       "comment": "Specifies a specific naming format for public abstract member fields.",
       "props": {
-        "format": "^[_a-zA-Z][a-z][a-zA-Z0-9]*$",
+        "format": "^[a-zA-Z][_a-zA-Z0-9]*$",
         "tokens": ["PUBLIC", "ABSTRACT"]
       },
       "type": "MemberName"
@@ -340,7 +340,7 @@
     {
       "comment": "Specifies a specific naming format for public class member fields.",
       "props": {
-        "format": "^[_a-zA-Z][a-z][a-zA-Z0-9]*$",
+        "format": "^[a-zA-Z][a-z][a-zA-Z0-9]*$",
         "tokens": ["PUBLIC", "CLASS"]
       },
       "type": "MemberName"
@@ -348,7 +348,7 @@
     {
       "comment": "Specifies a specific naming format for private class member fields.",
       "props": {
-        "format": "^[_a-zA-Z][a-z][a-zA-Z0-9]*$",
+        "format": "^[_a-zA-Z][_a-zA-Z0-9]*$",
         "tokens": ["PRIVATE", "CLASS"]
       },
       "type": "MemberName"
@@ -356,8 +356,8 @@
     {
       "comment": "Specifies a specific naming format for enum member fields.",
       "props": {
-        "format": "^[_a-zA-Z][a-z][a-zA-Z0-9]*$",
-        "tokens": ["ENUM"]
+        "format": "^[a-zA-Z][_a-zA-Z0-9]*$",
+        "tokens": ["PUBLIC", "ENUM"]
       },
       "type": "MemberName"
     },
@@ -388,9 +388,9 @@
       "comment": "Specifies a specific naming format for method names.",
       "props": {
         "ignoreExtern": true,
-        "format": "^[a-z][a-zA-Z0-9]*$",
+        "format": "^[a-z][_a-zA-Z0-9]*$",
         "tokens": [],
-        "severity": "IGNORE"
+        "severity": "INFO"
       },
       "type": "MethodName"
     },

--- a/hxformat.json
+++ b/hxformat.json
@@ -18,8 +18,8 @@
 
     "betweenTypes": 1,
 
-    "lineCommentsBetweenTypes": "keep",
-    "lineCommentsBetweenFunctions": "keep",
+    "lineCommentsBetweenTypes": "one",
+    "lineCommentsBetweenFunctions": "one",
 
     "betweenSingleLineTypes": 0,
 
@@ -37,7 +37,7 @@
       "betweenVars": 0,
       "afterVars": 1,
       "betweenFunctions": 1,
-      "existingBetweenFields": "keep"
+      "existingBetweenFields": "remove"
     },
 
     "classEmptyLines": {
@@ -54,7 +54,7 @@
       "afterPrivateFunctions": 1,
       "betweenFunctions": 1,
 
-      "existingBetweenFields": "keep"
+      "existingBetweenFields": "remove"
     },
 
     "macroClassEmptyLines": {
@@ -71,7 +71,7 @@
       "afterPrivateFunctions": 1,
       "betweenFunctions": 1,
 
-      "existingBetweenFields": "keep"
+      "existingBetweenFields": "remove"
     },
 
     "externClassEmptyLines": {
@@ -81,7 +81,7 @@
       "betweenVars": 0,
       "afterVars": 0,
       "betweenFunctions": 0,
-      "existingBetweenFields": "keep"
+      "existingBetweenFields": "remove"
     },
 
     "abstractEmptyLines": {
@@ -98,7 +98,7 @@
       "afterPrivateFunctions": 1,
       "betweenFunctions": 1,
 
-      "existingBetweenFields": "keep"
+      "existingBetweenFields": "remove"
     },
 
     "interfaceEmptyLines": {
@@ -108,7 +108,7 @@
       "betweenVars": 0,
       "afterVars": 0,
       "betweenFunctions": 0,
-      "existingBetweenFields": "keep"
+      "existingBetweenFields": "remove"
     },
 
     "enumEmptyLines": {
@@ -116,7 +116,7 @@
       "endType": 0,
 
       "betweenFields": 0,
-      "existingBetweenFields": "keep"
+      "existingBetweenFields": "remove"
     },
 
     "typedefEmptyLines": {
@@ -124,7 +124,7 @@
       "endType": 0,
 
       "betweenFields": 0,
-      "existingBetweenFields": "keep"
+      "existingBetweenFields": "remove"
     },
 
     "conditionalsEmptyLines": {

--- a/hxformat.json
+++ b/hxformat.json
@@ -159,9 +159,9 @@
   "lineEnds": {
     "lineEndCharacter": "auto",
 
-    "metadataType": "none",
-    "metadataVar": "none",
-    "metadataFunction": "none",
+    "metadataType": "forceAfterLast",
+    "metadataVar": "forceAfterLast",
+    "metadataFunction": "forceAfterLast",
     "metadataOther": "none",
 
     "caseColon": "after",
@@ -229,7 +229,7 @@
     "tryCatch": "next",
 
     "caseBody": "next",
-    "expressionCase": "keep",
+    "expressionCase": "next",
     "expressionTry": "same",
 
     "functionBody": "same",
@@ -241,7 +241,14 @@
   },
 
   "whitespace": {
-    "parenConfig": {},
+    "parenConfig": {
+      "metadataParens": {
+        "openingPolicy": "none",
+        "closingPolicy": "none",
+        "removeInnerWhenEmpty": true
+      }
+    },
+
     "bracesConfig": {},
     "bracketConfig": {},
 

--- a/hxformat.json
+++ b/hxformat.json
@@ -327,7 +327,45 @@
     "mapWrap": {
       "defaultWrap": "noWrap",
       "defaultLocation": "afterLast",
-      "defaultAdditionalIndent": 0
+      "defaultAdditionalIndent": 0,
+      "rules": [
+        {
+          "type": "onePerLine",
+          "conditions": [
+            {
+              "cond": "anyItemLength >= n",
+              "value": 32
+            }
+          ]
+        },
+        {
+          "type": "onePerLine",
+          "conditions": [
+            {
+              "cond": "itemCount >= n",
+              "value": 5
+            }
+          ]
+        },
+        {
+          "type": "onePerLine",
+          "conditions": [
+            {
+              "cond": "hasMultilineItems",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "type": "onePerLine",
+          "conditions": [
+            {
+              "cond": "totalItemLength >= n",
+              "value": 160
+            }
+          ]
+        }
+      ]
     },
 
     "typeParameter": {

--- a/hxformat.json
+++ b/hxformat.json
@@ -283,7 +283,45 @@
     "arrayWrap": {
       "defaultWrap": "noWrap",
       "defaultLocation": "afterLast",
-      "defaultAdditionalIndent": 0
+      "defaultAdditionalIndent": 0,
+      "rules": [
+        {
+          "type": "onePerLine",
+          "conditions": [
+            {
+              "cond": "anyItemLength >= n",
+              "value": 32
+            }
+          ]
+        },
+        {
+          "type": "onePerLine",
+          "conditions": [
+            {
+              "cond": "itemCount >= n",
+              "value": 5
+            }
+          ]
+        },
+        {
+          "type": "onePerLine",
+          "conditions": [
+            {
+              "cond": "hasMultilineItems",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "type": "onePerLine",
+          "conditions": [
+            {
+              "cond": "totalItemLength >= n",
+              "value": 160
+            }
+          ]
+        }
+      ]
     },
 
     "mapWrap": {


### PR DESCRIPTION
I've wanted to make a bunch more changes to the repository's `haxe-formatter` and `haxe-checkstyle` rules, and I decided the best way to get some feedback was to make a public branch for people to review since I think one or two of the current rules might be a bit inconvenient right now.

## Code Style Rule Changes

- Add rules for line wrapping on arrays and maps.
  - If any one entry is >32 chars long, if there are at least 5 items, if there are any items that span multiple lines, or the total length of all wrappable items spans 160 characters, force each array element to its own line.
  - We can evaluate different arrays in the codebase and choose to add more specific rules for this if we want.
- Fix an issue where if you had an `enum abstract`, it would sometimes display a warning that the type wasn't documented even though it clearly is.
- Disable a style rule where it would request newlines for macro reification (like `macro $v{value}`)
- Enforce a newline after the type metadata. I wanted to enforce a newline for each metadata on a class type but couldn't find a rule for that.
- Enable a rule where modifiers (`public`, `static`, `inline`, `final`, etc.) must be in a specific pre-determined order. Please stop putting `override public` in your code it implicitly sounds wrong, like saying "green big house"
- Modify the naming regexes for local variables and member variables/functions, since I made a PR to support splitting rules up based on whether the variable is `final` or not.
- Require parenthesis around the switch condition (I didn't know they were optional but someone made a PR to add a rule for it).
- Disable enforcement of trailing commas on arrays and object literals (we could force them to be included, thoughts? there's no way to force them to be excluded right now).
- Inline functions are now required to be formatted as arrow functions.
- Disable the use of nested ternary operators (like `foo ? bar ? true : false : false)`.
- Add a rule requiring large decimal numbers to use separators (`1235678` must now be formatted as `1_235_678`, yes you can use underscores in the middle of numbers in Haxe)
- I made a PR just so I could implement a rule requiring the use of curly braces on any `if` block that has a corresponding `else` block.
- Doc comments now require `/**` on open, `*` on each line, and `*/` on close, matching the syntax used by both Java and HaxeFlixel.

# NOTE

To properly view and use these rules in your copy of VSCode, you'll need to use a fork of the Haxe Checkstyle extension that supports some of the new rules that are included: https://github.com/EliteMasterEric/vscode-checkstyle/releases

The PR is like 20 commits long but each commit only changes one rule so you can see exactly what each rule change is. Note that this PR will itself require a follow-up PR to apply the style changes to all the Haxe files in the project, and that will deliberately be a separate chore PR.