### PR TITLE
[CRASHFIX] Fix crash with events on HashLink

### DIFF
--- a/source/funkin/data/song/SongData.hx
+++ b/source/funkin/data/song/SongData.hx
@@ -863,7 +863,7 @@ class SongEventDataRaw implements ICloneable<SongEventDataRaw>
   public function getInt(key:String):Null<Int>
   {
     if (this.value == null) return null;
-    var result = Reflect.field(this.value, key);
+    var result:Any = Reflect.field(this.value, key);
     if (result == null) return null;
     if (Std.isOfType(result, Int)) return result;
     if (Std.isOfType(result, String)) return Std.parseInt(cast result);
@@ -878,7 +878,7 @@ class SongEventDataRaw implements ICloneable<SongEventDataRaw>
   public function getFloat(key:String):Null<Float>
   {
     if (this.value == null) return null;
-    var result = Reflect.field(this.value, key);
+    var result:Any = Reflect.field(this.value, key);
     if (result == null) return null;
     if (Std.isOfType(result, Float)) return result;
     if (Std.isOfType(result, String)) return Std.parseFloat(cast result);


### PR DESCRIPTION
<!-- Briefly describe the issue(s) fixed. -->
## Description
This was a fix that I had already included in #6135, but that for some odd reason magically disappeared after being merged.
It makes the type of certain local variables explicit, since the code generator for HashLink will infer that the type for `result` should be the same as the return type, when it should be a `Dynamic` or `Any` instead.