### PR TITLE
[BUGFIX] Fix a crash when loading a song with only the instrumental

### DIFF
--- a/source/funkin/ui/debug/charting/handlers/ChartEditorImportExportHandler.hx
+++ b/source/funkin/ui/debug/charting/handlers/ChartEditorImportExportHandler.hx
@@ -95,9 +95,13 @@ class ChartEditorImportExportHandler
         if (playerVoiceList.length == 0 && opponentVoiceList.length == 0) // Legacy support...
         {
           var suffix:String = (instId != null && instId != '' && instId != 'default') ? '-$instId' : '';
-          state.loadVocalsFromAsset(Paths.voices(diff.song.id, suffix), diff.characters.player, instId);
-          state.audioVocalTrackGroup.legacyVoiceSystem = true;
-          state.audioVocalTrackGroup.legacyVoiceUsesPlayer = true;
+          var voiceFile = Paths.voices(diff.song.id, suffix);
+          if (Assets.exists(voiceFile))
+          {
+            state.loadVocalsFromAsset(voiceFile, diff.characters.player, instId);
+            state.audioVocalTrackGroup.legacyVoiceSystem = true;
+            state.audioVocalTrackGroup.legacyVoiceUsesPlayer = true;  
+          }
         }
 
         // Set the difficulty of the song if one was passed in the params, and it isn't the default


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
Fixes https://github.com/FunkinCrew/Funkin/issues/7106

<!-- Briefly describe the issue(s) fixed. -->
## Description
This PR adds a check to see if there's a legacy voice file to load to prevent a crash for songs with only the instrumental

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos

https://github.com/user-attachments/assets/13237d57-e9ba-4c19-b6c0-9043ddb1459a

