### PR TITLE
[FIX] Fix duplicate asset paths in note styles crashing when exiting PlayState in Chart Editor.

### DIFF
--- a/source/funkin/play/components/PopUpStuff.hx
+++ b/source/funkin/play/components/PopUpStuff.hx
@@ -52,6 +52,8 @@ class PopUpStuff extends FlxTypedGroup<FunkinSprite>
     rating.velocity.y -= FlxG.random.int(140, 175);
     rating.velocity.x -= FlxG.random.int(0, 10);
 
+    rating.graphic.destroyOnNoUse = false;
+
     add(rating);
 
     var fadeEase = noteStyle.isJudgementSpritePixel(daRating) ? EaseUtil.stepped(2) : null;
@@ -100,6 +102,8 @@ class PopUpStuff extends FlxTypedGroup<FunkinSprite>
       numScore.acceleration.y = FlxG.random.int(250, 300);
       numScore.velocity.y -= FlxG.random.int(130, 150);
       numScore.velocity.x = FlxG.random.float(-5, 5);
+
+      numScore.graphic.destroyOnNoUse = false;
 
       add(numScore);
 

--- a/source/funkin/play/notes/Strumline.hx
+++ b/source/funkin/play/notes/Strumline.hx
@@ -1095,6 +1095,8 @@ class Strumline extends FlxSpriteGroup
       splash.y = this.y;
       splash.y -= INITIAL_OFFSET;
       splash.y += noteStyle.getSplashOffsets()[1] * splash.scale.y;
+
+      splash.graphic.destroyOnNoUse = false;
     }
   }
 
@@ -1172,6 +1174,8 @@ class Strumline extends FlxSpriteGroup
       noteSprite.x -= NUDGE;
       noteSprite.y = -9999;
 
+      noteSprite.graphic.destroyOnNoUse = false;
+
       if (noteKind != null) noteSprite.scoreable = noteKind.scoreable;
     }
 
@@ -1212,6 +1216,8 @@ class Strumline extends FlxSpriteGroup
       holdNoteSprite.x += STRUMLINE_SIZE / 2;
       holdNoteSprite.x -= holdNoteSprite.width / 2;
       holdNoteSprite.y = -9999;
+
+      holdNoteSprite.graphic.destroyOnNoUse = false;
 
       if (noteKind != null) holdNoteSprite.scoreable = noteKind.scoreable;
     }


### PR DESCRIPTION
## Linked Issues
- Closes #6524

## Description
This PR fixes an odd crash that happens after exiting a PlayState test in minimal mode inside the Chart Editor.
The reason why this happened only with `pixel` notestyle is that the assetPath is duplicated for `note` and `noteStrumline` thus destroying an already destroyed graphic. This prevents that by adding `destroyOnNoUse` for the Strumline/PopUp sprites.
This seems to happen only when the first PlayState entered is the minimal playtest.

## Screenshots/Videos

### Before

https://github.com/user-attachments/assets/c791db06-af12-4f20-9736-48441ada79b4

### After

https://github.com/user-attachments/assets/243038c4-1121-49ba-b278-9ae484765b20
