### PR TITLE
[FIX] Improve Preloader time on HashLink

### DIFF
--- a/source/funkin/ui/transition/preload/FunkinPreloader.hx
+++ b/source/funkin/ui/transition/preload/FunkinPreloader.hx
@@ -281,7 +281,7 @@ class FunkinPreloader extends FlxBasePreloader
 
   override function update(percent:Float):Void
   {
-    var elapsed:Float = (Date.now().getTime() - this._startTime) / 1000.0;
+    var elapsed:Float = (#if hl Sys.time() * 1000.0 #else Date.now().getTime() #end - this._startTime) / 1000.0;
 
     vfdShader.update(elapsed * 100);
 
@@ -767,7 +767,7 @@ class FunkinPreloader extends FlxBasePreloader
           }
         }
       case FunkinPreloaderState.Complete:
-        if (completeTime < 0)
+        if (completeTime <= 0)
         {
           completeTime = elapsed;
         }


### PR DESCRIPTION

<!-- Briefly describe the issue(s) fixed. -->
## Description
For some reason, on C++ `Date.getTime` gives out a more precise resolution of a second, whereas in HashLink it is a whole number instead. For instance an `elapsed` that would be 1.50 in C++ would become just 1 in HashLink, and this would mean the Preloader graphics and state would only update every second.

## Screenshots/Videos

https://github.com/user-attachments/assets/466a577e-bb55-44b0-9ff5-e537cc576246

