### PR TITLE
[ENHANCEMENT] Go back to the random capsule instead of the selected song

### DIFF
--- a/source/funkin/ui/freeplay/FreeplayState.hx
+++ b/source/funkin/ui/freeplay/FreeplayState.hx
@@ -2618,6 +2618,8 @@ class FreeplayState extends MusicBeatSubState
     curSelected = grpCapsules.members.indexOf(targetSongCap);
     changeSelection(); // Trigger an update. This will also fix the target variation.
 
+    rememberedSongId = null; // Go back to the random capsule when you reopen the menu.
+
     var targetSongId:String = targetSongCap?.freeplayData?.data.id ?? 'unknown';
     var targetSongNullable:Null<Song> = SongRegistry.instance.fetchEntry(targetSongId);
     if (targetSongNullable == null)

--- a/source/funkin/ui/freeplay/FreeplayState.hx
+++ b/source/funkin/ui/freeplay/FreeplayState.hx
@@ -366,6 +366,12 @@ class FreeplayState extends MusicBeatSubState
 
     if (fromResultsParams != null)
     {
+      if (prepForNewRank && rememberedSongId == null)
+      {
+        // Set rememberedSongId to last played song if accessed from the RANDOM option
+        rememberedSongId = fromResultsParams.songId;
+      }
+    
       @:privateAccess
       this._parentState._constructor = () ->
       {

--- a/source/funkin/ui/freeplay/FreeplayState.hx
+++ b/source/funkin/ui/freeplay/FreeplayState.hx
@@ -2885,6 +2885,8 @@ class FreeplayState extends MusicBeatSubState
     curSelected = grpCapsules.members.indexOf(targetSongCap);
     changeSelection(); // Trigger an update. This will also fix the target variation.
 
+    rememberedSongId = null; // Go back to the random capsule when you reopen the menu.
+
     var targetSongId:String = targetSongCap?.freeplayData?.data.id ?? 'unknown';
     var targetSongNullable:Null<Song> = SongRegistry.instance.fetchEntry(targetSongId);
     if (targetSongNullable == null)

--- a/source/funkin/ui/freeplay/FreeplayState.hx
+++ b/source/funkin/ui/freeplay/FreeplayState.hx
@@ -396,6 +396,12 @@ class FreeplayState extends MusicBeatSubState
 
     if (fromResultsParams != null)
     {
+      if (prepForNewRank && rememberedSongId == null)
+      {
+        // Set rememberedSongId to last played song if accessed from the RANDOM option
+        rememberedSongId = fromResultsParams.songId;
+      }
+    
       @:privateAccess
       this._parentState._constructor = () ->
       {


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
https://github.com/FunkinCrew/Funkin/issues/7110

<!-- Briefly describe the issue(s) fixed. -->
## Description
This PR now auto selects the random capsule instead of the capsule for the song that was randomly chosen, letting players instantly go for another random song instead of scrolling back to the capsule.

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos

https://github.com/user-attachments/assets/3624a08e-f9f4-4c25-9562-3e3668cc22ed

