### PR TITLE
[BUGFIX] Stop Results theme when hot-reloading in Chart Editor Results Screen

### DIFF
--- a/source/funkin/play/ResultState.hx
+++ b/source/funkin/play/ResultState.hx
@@ -561,6 +561,16 @@ class ResultState extends MusicBeatSubState
     super.create();
   }
 
+  override public function destroy():Void
+  {
+    // Kill all music types to prevent audio overlap into new states.
+    if (resultsMusic != null) resultsMusic.stop();
+    if (introMusicAudio != null) introMusicAudio.stop();
+    if (FlxG.sound.music != null) FlxG.sound.music.stop();
+
+    super.destroy();
+  }
+
   function getMusicPath(playerCharacter:Null<PlayableCharacter>, rank:ScoringRank):String
   {
     return playerCharacter?.getResultsMusicPath(rank) ?? 'resultsNORMAL';


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
- #7123

<!-- Briefly describe the issue(s) fixed. -->
## Description

> [!NOTE]
> **THIS BUG CAN *ONLY* BE PRODUCED IN THE CHART EDITOR**

This PR fixes results music bleeding / overlapping into playstate when hot reloading. (F5)

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos
### BEFORE: (Video by @SuperEric1)
https://github.com/user-attachments/assets/25f73a93-ba1a-4764-b7e3-7ab12bf84116

### AFTER:
https://github.com/user-attachments/assets/22ddf23d-5f68-4c48-924d-7a93f6dea3ff

