### PR TITLE
[BUGFIX] Re-enable autoPause when using the sticker transition if the Preference is enabled

### DIFF
--- a/source/funkin/ui/transition/stickers/StickerSubState.hx
+++ b/source/funkin/ui/transition/stickers/StickerSubState.hx
@@ -17,6 +17,7 @@ import funkin.ui.MusicBeatSubState;
 import funkin.ui.transition.stickers.StickerPack;
 import funkin.FunkinMemory;
 import funkin.util.DeviceUtil;
+import funkin.Preferences;
 
 using Lambda;
 using StringTools;
@@ -115,6 +116,10 @@ class StickerSubState extends MusicBeatSubState
     }
     else
     {
+      #if !mobile
+      // Re-enable autoPause if it was disabled
+      FlxG.autoPause = Preferences.autoPause;
+      #end  
       regenStickers();
     }
   }


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
https://github.com/FunkinCrew/Funkin/issues/7127

<!-- Briefly describe the issue(s) fixed. -->
## Description
This PR re-enables `FlxG.autoPause` in the sticker substate if `Preferences.autoPause` is enabled, which should prevent the stickers from still playing while tabbed out of the game.

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos
Video by NotHyper-474:

https://github.com/user-attachments/assets/caf670e1-08d5-49f7-b582-008dd2a95673

