### PR TITLE
[BUGFIX] Fix song favoriting breaking capsule song text cycling

### DIFF
--- a/source/funkin/ui/freeplay/FreeplayState.hx
+++ b/source/funkin/ui/freeplay/FreeplayState.hx
@@ -3092,6 +3092,7 @@ class FreeplayState extends MusicBeatSubState
         FunkinSound.playOnce(Paths.sound('fav'), 1);
         selectedCapsule.checkClip();
         selectedCapsule.selected = true; // set selected again, so it can run its getter function to initialize movement
+        selectedCapsule.updateSelected();
         uiStateMachine.transition(Interacting);
 
         selectedCapsule.doLerp = false;
@@ -3118,6 +3119,7 @@ class FreeplayState extends MusicBeatSubState
           selectedCapsule.favIconBlurred.visible = false;
           selectedCapsule.checkClip();
           selectedCapsule.selected = true; // set selected again, so it can run its getter function to initialize movement
+          selectedCapsule.updateSelected();
         });
 
         uiStateMachine.transition(Interacting);

--- a/source/funkin/ui/freeplay/SongMenuItem.hx
+++ b/source/funkin/ui/freeplay/SongMenuItem.hx
@@ -758,7 +758,7 @@ class SongMenuItem extends FlxSpriteGroup
     return forceHighlight;
   }
 
-  function updateSelected():Void
+  public function updateSelected():Void
   {
     final isSelected:Bool = (this.selected || this.forceHighlight);
 


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues

Nuh uh I don't think so

<!-- Briefly describe the issue(s) fixed. -->
## Description

This PR fixes a bug where favoriting a song stops the capsule's text from moving left and right.

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos

https://github.com/user-attachments/assets/66f9b915-8a5b-4d99-b253-e3ba1d082df1