### PR TITLE
[BUGFIX] Fix Random capsule not updating OST text

### DIFF
--- a/source/funkin/ui/freeplay/AlbumRoll.hx
+++ b/source/funkin/ui/freeplay/AlbumRoll.hx
@@ -80,6 +80,7 @@ class AlbumRoll extends FlxSpriteGroup
     if (albumId == null)
     {
       this.visible = false;
+      albumData = null;
       return;
     }
     else


### PR DESCRIPTION
## Linked Issues
None
<!-- Briefly describe the issue(s) fixed. -->
## Description
This was a fumble on my part, because I HAD this change in my PR before, but I unstaged it thinking it had to do with another change.

It is important that we set `albumData` to null when `albumId` is set to null, lest `getOSTNameOverride` is able to get the name properly.

## Screenshots/Videos

Note: The "LE SSERAFIM" text is not actually in-game and is just there for sake of demonstration.

https://github.com/user-attachments/assets/0b7302ec-3f3e-4677-9990-ef43e03ad781

