### PR TITLE
Use CSS files for HaxeUI styling instead of a workaround Box component.

### DIFF
--- a/source/Main.hx
+++ b/source/Main.hx
@@ -213,7 +213,7 @@ class Main extends Sprite
     // - It initializes the theme styles.
     // - It scans the class path and registers any HaxeUI components.
     haxe.ui.Toolkit.init();
-    haxe.ui.Toolkit.theme = 'dark'; // don't be cringe
+    haxe.ui.Toolkit.theme = 'funkin-dark'; // don't be cringe
     // haxe.ui.Toolkit.theme = 'light'; // embrace cringe
     haxe.ui.Toolkit.autoScale = false;
     // Don't focus on UI elements when they first appear.

--- a/source/module.xml
+++ b/source/module.xml
@@ -17,4 +17,24 @@
 		<!-- Custom components. -->
 		<class package="funkin.ui.haxeui.components" loadAll="true" />
 	</components>
+
+	<resources>
+        <resource path="assets/exclude/data/ui/chart-editor/style" prefix="style" />
+  </resources>
+
+	<themes>
+		<funkin-dark parent="dark">
+			<!-- Be careful when editing these priorities! It can mess up how the style looks. -->
+			<style resource="style/buttons.css" priority="10" />
+			<style resource="style/compact.css" priority="10" />
+			<style resource="style/dialogs.css" priority="10" />
+			<style resource="style/notifs.css" priority="10" />
+			<style resource="style/text.css" priority="10" />
+			<style resource="style/general.css" priority="15" />
+
+			<!-- These take a higher priorities due to being chart editor specific. -->
+			<style resource="style/playbar.css" priority="20" />
+			<style resource="style/toolbox.css" priority="20" />
+		</funkin-dark>
+	</themes>
 </module>


### PR DESCRIPTION
(Requires [this pr](https://github.com/FunkinCrew/funkin.assets/pull/380) to be merged)

This PR re-factors how styling for HaxeUI works by using the built-in HaxeUI css style system using module.xml

Right now the game uses .xml files with an empty box component that has styling to the game's HaxeUI styling. While this works, this workaround can cause a lot of issues relating to both z-index and more issues I've personally noticed when testing this out.
This system HaxeUI uses is a lot more controllable, cleaner organization, and allows for being able to make custom themes if that were to be done in the future.

Feel free to comment if this PR causes any issues to how things look.