### PR TITLE
[OPTIMIZATION] Massively optimize Spaghetti on `develop`

### DIFF
--- a/source/funkin/data/event/SongEventRegistry.hx
+++ b/source/funkin/data/event/SongEventRegistry.hx
@@ -204,10 +204,6 @@ class SongEventRegistry
     {
       ScriptEventDispatcher.callEvent(eventHandler, scriptEvent);
     }
-    else
-    {
-      trace('WARNING: No event handler for event with kind: ${eventKind}');
-    }
   }
 
   public static inline function callEvent(events:Array<SongEventData>, scriptEvent:ScriptEvent):Void


### PR DESCRIPTION
## Linked Issues
None

## Description
This was a fumble on my end, since back when making the PR for adding Script Event support for Song Events, I didn't account for there being events that weren't a part of the registry like the Spaghetti-specific events, as there weren't any back then. This is why a big chunk of text was traced every tick whenever playing Spaghetti on `develop`.