### PR TITLE
[BUGFIX] Fix Camera Moving While Paused

### DIFF
--- a/source/funkin/play/PlayState.hx
+++ b/source/funkin/play/PlayState.hx
@@ -1502,7 +1502,7 @@ class PlayState extends MusicBeatSubState
           dispatchEvent(eventEvent);
 
           // Calling event.cancelEvent() skips the event. Neat!
-          if (!eventEvent.eventCanceled)
+          if (!eventEvent.eventCanceled && !shouldSubstatePause)
           {
             SongEventRegistry.handleEvent(event);
           }


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues

Fixes #3096

<!-- Briefly describe the issue(s) fixed. -->
## Description

This PR fixes an issue where pausing the game at the right time doesn't pause camera movements.

Below is a mod that pauses the game every time a focus camera event triggers. Please test the mod with and without this PR.

[pause on camera event.zip](https://github.com/user-attachments/files/25974739/pause.on.camera.event.zip)