### PR TITLE
[BUGFIX] Fix Pause Menu global offset adjustment being FPS-dependent

### DIFF
--- a/source/funkin/play/PauseSubState.hx
+++ b/source/funkin/play/PauseSubState.hx
@@ -605,6 +605,9 @@ class PauseSubState extends MusicBeatSubState
   // ===============
   var fastOffset:Bool = false;
   var lastOffsetPress:Float = 0;
+  #if !mobile
+  var offset:Float = Preferences.globalOffset ?? 0;
+  #end
 
   /**
    * Process user inputs every frame.
@@ -680,7 +683,6 @@ class PauseSubState extends MusicBeatSubState
   function handleModifyingOffsets():Bool
   {
     #if !mobile
-    var offset:Int = Preferences.globalOffset ?? 0;
     if (FlxG.keys.pressed.SHIFT && (controls.UI_UP || controls.UI_DOWN))
     {
       lastOffsetPress += FlxG.elapsed;
@@ -697,20 +699,20 @@ class PauseSubState extends MusicBeatSubState
         {
           offset += (controls.UI_UP_P || controls.UI_UP) ? 1 : -1;
 
-          offsetText.text = 'Global Offset: ${offset}ms';
+          offsetText.text = 'Global Offset: ${Std.int(offset)}ms';
         }
       }
       else
       {
-        offset += (controls.UI_UP_P || controls.UI_UP) ? 1 : -1;
+        offset += ((controls.UI_UP_P || controls.UI_UP) ? 1 : -1) * (FlxG.elapsed * 30);
 
-        offsetText.text = 'Global Offset: ${offset}ms';
+        offsetText.text = 'Global Offset: ${Std.int(offset)}ms';
       }
 
       if (offset > 1500) offset = 1500;
       if (offset < -1500) offset = -1500;
 
-      Preferences.globalOffset = offset;
+      Preferences.globalOffset = Std.int(offset);
 
       return true;
     }


### PR DESCRIPTION
## Description
Fixes the global offset changing being extremly fast when on high fps. Really noticable when playing on unlocked fps.
