### PR TITLE
[BUGFIX] Fallback for Freeplay previews being muted with bad metadata

### DIFF
--- a/source/funkin/data/song/SongData.hx
+++ b/source/funkin/data/song/SongData.hx
@@ -498,7 +498,7 @@ class SongPlayData implements ICloneable<SongPlayData>
    * @since `2.2.2`
    */
   @:optional
-  @:default(0)
+  @:default(funkin.util.Constants.DEFAULT_PREVIEW_START_TIME)
   public var previewStart:Float;
 
   /**
@@ -507,7 +507,7 @@ class SongPlayData implements ICloneable<SongPlayData>
    * @since `2.2.2`
    */
   @:optional
-  @:default(0.2)
+  @:default(funkin.util.Constants.DEFAULT_PREVIEW_END_TIME)
   public var previewEnd:Float;
 
   public function new()

--- a/source/funkin/play/song/Song.hx
+++ b/source/funkin/play/song/Song.hx
@@ -91,26 +91,6 @@ class Song implements IPlayStateScriptedClass implements IRegistryEntry<SongMeta
   }
 
   /**
-   * The start time of this song's preview in Freeplay (in range 0 - 1)
-   */
-  public var previewStartTime(get, never):Float;
-
-  function get_previewStartTime():Float
-  {
-    return _data?.playData?.previewStart ?? 0;
-  }
-
-  /**
-   * The end time of this song's preview in Freeplay (in range 0 - 1)
-   */
-  public var previewEndTime(get, never):Float;
-
-  function get_previewEndTime():Float
-  {
-    return _data?.playData?.previewEnd ?? 0.2;
-  }
-
-  /**
    * Set to false if the song was edited in the charter and should not be saved as a high score.
    */
   public var validScore:Bool = true;

--- a/source/funkin/ui/debug/charting/ChartEditorState.hx
+++ b/source/funkin/ui/debug/charting/ChartEditorState.hx
@@ -294,6 +294,7 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
   {
     this.songLengthInMs = value;
 
+    resetPreviewTimes();
     updateGridHeight();
 
     return this.songLengthInMs;
@@ -1435,8 +1436,7 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
   {
     songMetadata.set(selectedVariation, value);
 
-    if (value.playData.previewStart <= 1) value.playData.previewStart *= songLengthInMs;
-    if (value.playData.previewEnd <= 1) value.playData.previewEnd *= songLengthInMs;
+    resetPreviewTimes();
 
     return value;
   }
@@ -1592,7 +1592,7 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
 
   function set_currentSongFreeplayPreviewStart(value:Float):Float
   {
-    return currentSongMetadata.playData.previewStart = value;
+    return currentSongMetadata.playData.previewStart = value * (value < 1 ? songLengthInMs : 1);
   }
 
   var currentSongFreeplayPreviewEnd(get, set):Float;
@@ -1604,7 +1604,7 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
 
   function set_currentSongFreeplayPreviewEnd(value:Float):Float
   {
-    return currentSongMetadata.playData.previewEnd = value;
+    return currentSongMetadata.playData.previewEnd = value * (value < 1 ? songLengthInMs : 1);
   }
 
   var currentSongStage(get, set):String;
@@ -2548,6 +2548,11 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
     this.welcomeMusic.loadEmbedded(Paths.music('chartEditorLoop/chartEditorLoop'));
     FlxG.sound.list.add(this.welcomeMusic);
     this.welcomeMusic.looped = true;
+  }
+
+  public function resetPreviewTimes() {
+    currentSongFreeplayPreviewStart = (currentSongMetadata?.playData?.previewStart ?? Constants.DEFAULT_PREVIEW_START_TIME);
+    currentSongFreeplayPreviewEnd = (currentSongMetadata?.playData?.previewEnd ?? Constants.DEFAULT_PREVIEW_END_TIME);
   }
 
   public function loadPreferences():Void

--- a/source/funkin/ui/debug/charting/toolboxes/ChartEditorFreeplayToolbox.hx
+++ b/source/funkin/ui/debug/charting/toolboxes/ChartEditorFreeplayToolbox.hx
@@ -245,6 +245,10 @@ class ChartEditorFreeplayToolbox extends ChartEditorBaseToolbox
 
     initializeTicks();
 
+    chartEditorState.resetPreviewTimes();
+    freeplayPreviewStart.value = chartEditorState.currentSongFreeplayPreviewStart;
+    freeplayPreviewEnd.value = chartEditorState.currentSongFreeplayPreviewEnd;
+
     refreshAudioPreview();
     refresh();
     refreshTicks();

--- a/source/funkin/ui/freeplay/FreeplayState.hx
+++ b/source/funkin/ui/freeplay/FreeplayState.hx
@@ -3025,8 +3025,8 @@ class FreeplayState extends MusicBeatSubState
         suffix: instSuffix,
         partialParams: {
           loadPartial: true,
-          start: daSongCapsule?.freeplayData?.previewStartTime ?? 0,
-          end: daSongCapsule?.freeplayData?.previewEndTime ?? 0.2
+          start: daSongCapsule?.freeplayData?.previewStartTime,
+          end: daSongCapsule?.freeplayData?.previewEndTime
         },
         onLoad: function()
         {
@@ -3410,16 +3410,32 @@ class FreeplaySongData
 
   function get_previewStartTime():Float
   {
-    var prevStartTime = @:privateAccess data._metadata.get(curVariation)?.playData?.previewStart ?? 0.0;
+    @:privateAccess final _metadata = data._metadata;
 
-    return prevStartTime > 1 ? 0 : prevStartTime;
+    var prevStart:Float = _metadata.get(curVariation)?.playData?.previewStart ?? Constants.DEFAULT_PREVIEW_START_TIME;
+    final prevEnd:Float = _metadata.get(curVariation)?.playData?.previewEnd ?? Constants.DEFAULT_PREVIEW_END_TIME;
+
+    if (prevStart >= prevEnd || prevStart > 1)
+    {
+      prevStart = Constants.DEFAULT_PREVIEW_START_TIME;
+    }
+
+    return prevStart;
   }
 
   function get_previewEndTime():Float
   {
-    var prevEndTime = @:privateAccess data._metadata.get(curVariation)?.playData?.previewEnd ?? 0.2;
+    @:privateAccess final _metadata = data._metadata;
 
-    return prevEndTime > 1 ? 0.2 : prevEndTime;
+    final prevStart:Float = _metadata.get(curVariation)?.playData?.previewStart ?? Constants.DEFAULT_PREVIEW_START_TIME;
+    var prevEnd:Float = _metadata.get(curVariation)?.playData?.previewEnd ?? Constants.DEFAULT_PREVIEW_END_TIME;
+
+    if (prevStart >= prevEnd || prevEnd > 1)
+    {
+      prevEnd = Constants.DEFAULT_PREVIEW_END_TIME;
+    }
+
+    return prevEnd;
   }
 
   function get_isNew():Bool

--- a/source/funkin/util/Constants.hx
+++ b/source/funkin/util/Constants.hx
@@ -292,6 +292,16 @@ class Constants
   public static final DEFAULT_OST_NAME:String = 'OFFICIAL OST';
 
   /**
+   * The default preview start time for the songs in Freeplay.
+   */
+  public static final DEFAULT_PREVIEW_START_TIME:Float = 0;
+
+  /**
+   * The default preview end time for the songs in Freeplay.
+   */
+  public static final DEFAULT_PREVIEW_END_TIME:Float = 0.2;
+
+  /**
    * The default timing format for songs.
    */
   public static final DEFAULT_TIMEFORMAT:SongTimeFormat = SongTimeFormat.MILLISECONDS;


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
I do not know of any issues relating to this PR that have been reported.
Please mention them in the replies if you find any, it'd be a big help!

<!-- Briefly describe the issue(s) fixed. -->
## Description
In some metadata files, `previewStart` is either less than `previewEnd` or both of them are equal to 0.
And in others, both of them are too big to fit in the range of 0-1 due to the old system using milliseconds.

These caused an issue where the song preview went completely mute, which this pull request fixes.

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos
Me explaining what I changed
https://youtu.be/vPMXfpuF57g

A showcase of the changed sounds, with the changes from this PR:

https://github.com/user-attachments/assets/a2b0b040-2c16-4212-83e4-9fca7180143e