### PR TITLE
[BUGFIX / REFACTOR] Re-Implement `curNoteKind.suffix` 

### DIFF
--- a/source/funkin/play/character/BaseCharacter.hx
+++ b/source/funkin/play/character/BaseCharacter.hx
@@ -542,12 +542,12 @@ class BaseCharacter extends Bopper
 
     if (event.note.noteData.getMustHitNote() && characterType == BF)
     {
-      this.playSingAnimation(event.note.noteData.getDirection(), false);
+      this.playSingAnimation(event.note.noteData.getDirection(), false, curNoteKind?.suffix ?? '');
       holdTimer = 0;
     }
     else if (!event.note.noteData.getMustHitNote() && characterType == DAD)
     {
-      this.playSingAnimation(event.note.noteData.getDirection(), false);
+      this.playSingAnimation(event.note.noteData.getDirection(), false, curNoteKind?.suffix ?? '');
       holdTimer = 0;
     }
     else if (characterType == GF && event.note.noteData.getMustHitNote())


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
Funkin' Contributors Discord Server **(IM SO SORRY :whatthesad:)**


<!-- Briefly describe the issue(s) fixed. -->
## Description
Turns out when fixing the no-animation event bug (#7078) I accidentally may have removed `curNoteKind.suffix` and it completely broke custom note kinds for mods (whoopsies!!) This PR basically re-adds this ability back but also keeping the no-animation event in tact :)

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos
### BEFORE: (Video by @ComedyLost)
https://github.com/user-attachments/assets/29c1fb84-9404-4b55-b558-01b74199d432
### AFTER:
https://github.com/user-attachments/assets/a647a54b-9cdf-42d2-9f65-abdc88b43cd1