### PR TITLE
[BUGFIX?] Fix Compile Errors With Both `FLX_NO_DEBUG` and `FEATURE_DEBUG_FUNCTIONS` Enabled

### DIFF
--- a/source/Main.hx
+++ b/source/Main.hx
@@ -184,7 +184,7 @@ class Main extends Sprite
     addChild(game);
 
     #if FEATURE_DEBUG_FUNCTIONS
-    game.debugger.interaction.addTool(new funkin.util.TrackerToolButtonUtil());
+    #if !FLX_NO_DEBUG game.debugger.interaction.addTool(new funkin.util.TrackerToolButtonUtil()); #end
     funkin.util.macro.ConsoleMacro.init();
     #end
 

--- a/source/funkin/InitState.hx
+++ b/source/funkin/InitState.hx
@@ -588,7 +588,7 @@ class InitState extends FlxState
     //
     // FLIXEL DEBUG SETUP
     //
-    #if FEATURE_DEBUG_FUNCTIONS
+    #if (FEATURE_DEBUG_FUNCTIONS && !FLX_NO_DEBUG)
     trace('Initializing Flixel debugger...');
 
     #if !debug


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Briefly describe the issue(s) fixed. -->
## Description
The current flixel debugger eats memory and not everyone will have a use for it at the time and some people may want to disable it. The `FLX_NO_DEBUG` flag wasn't accounted for in the code, though, so now this PR exists.