### PR TITLE
[BUGFIX] Change FlxTrail time from frames to seconds to remove FPS-dependency

### DIFF
--- a/source/funkin/effects/FunkTrail.hx
+++ b/source/funkin/effects/FunkTrail.hx
@@ -23,7 +23,7 @@ class FunkTrail extends FlxTrail
    * @param	alpha		The alpha value for the very first trailsprite.
    * @param	diff		How much lower the alpha of the next trailsprite is.
    */
-  public function new(target:FlxSprite, ?graphic:FlxGraphicAsset, length:Int = 10, delay:Int = 3, alpha:Float = 0.4, diff:Float = 0.05)
+  public function new(target:FlxSprite, ?graphic:FlxGraphicAsset, length:Int = 10, delay:Float = 0.1, alpha:Float = 0.4, diff:Float = 0.05)
   {
     super(target, graphic, length, delay, alpha, diff);
   }

--- a/source/funkin/ui/freeplay/SongMenuItem.hx
+++ b/source/funkin/ui/freeplay/SongMenuItem.hx
@@ -423,7 +423,7 @@ class SongMenuItem extends FlxSpriteGroup
     FlxTween.tween(impactThing.scale, {x: 2.5, y: 2.5}, 0.5);
     // FlxTween.tween(impactThing, {alpha: 0}, 0.5);
 
-    evilTrail = new FlxTrail(impactThing, null, 15, 2, 0.01, 0.069);
+    evilTrail = new FlxTrail(impactThing, null, 15, 0.03, 0.01, 0.069);
     evilTrail.blend = BlendMode.ADD;
     evilTrail.zIndex = capsule.zIndex - 5;
     FlxTween.tween(evilTrail, {alpha: 0}, 0.6, {


### PR DESCRIPTION
## Description
Fixes FlxTrail being FPS-dependent to fix Spirit's trail.

Needs PR:
https://github.com/FunkinCrew/flixel-addons/pull/3

Assets PR:
https://github.com/FunkinCrew/funkin.assets/pull/389