### PR TITLE
Fix assets not being cleared on HashLink in general

### DIFF
--- a/project.hxp
+++ b/project.hxp
@@ -1522,7 +1522,7 @@ class Project extends HXProject
     var exportPath:Null<String> = app.path ?? "";
 
     // mac target uses `macos` for the export folder instead of `mac`
-    var platform:String = (!isMac() ? Std.string(this.target) : (isHashLink() ? 'hl' : 'macos'));
+    var platform:String = (isHashLink() ? 'hl' : !isMac() ? Std.string(this.target) : 'macos');
     var basePath:String = Path.join([exportPath, platform, "bin"]);
     var assetsPath:String = "";
 


### PR DESCRIPTION
<!-- Briefly describe the issue(s) fixed. -->
## Description
Fixes what 56d576700407b78000c6f88f8792140e7ea954ed thought was only an issue on MacOS
