### PR TITLE
[BUGFIX] 3-Digit Freeplay Percentages Now Fully Exit Out

### DIFF
--- a/source/funkin/ui/freeplay/FreeplayState.hx
+++ b/source/funkin/ui/freeplay/FreeplayState.hx
@@ -664,9 +664,14 @@ class FreeplayState extends MusicBeatSubState
       }
     };
 
-    exitMovers.set([fpScoreDisplay, txtCompletion, fnfHighscoreSpr, clearBoxSprite], {
+    exitMovers.set([fpScoreDisplay, fnfHighscoreSpr, clearBoxSprite], {
       x: FlxG.width,
       speed: 0.3
+    });
+
+    exitMovers.set([txtCompletion], {
+      x: FlxG.width * 1.05,
+      speed: 0.315
     });
 
     exitMoversCharSel.set([fpScoreDisplay, txtCompletion, fnfHighscoreSpr, clearBoxSprite], {


### PR DESCRIPTION
## Linked Issues
Haven't found any ¯\_(ツ)_/¯

## Description
Literally unplayable.

This PR fixes Freeplay's 'CLEARED' percentage not fully exiting out if the value is more than 2 digits, probably due to the `x` hardcoded to being offset if the length is 3....

I guess giving it some extra room helps!

## Videos
https://github.com/user-attachments/assets/a22c98fe-8f98-40fe-9dd8-3272bd715157

https://github.com/user-attachments/assets/5effb13a-a2c6-41d3-8e38-d6153d3c1f88