### PR TITLE
[BUGFIX] Fix alignment for Pixel icons in Editor character selectors

### DIFF
--- a/source/funkin/data/character/CharacterData.hx
+++ b/source/funkin/data/character/CharacterData.hx
@@ -366,6 +366,10 @@ class CharacterDataParser
         return null;
       }
 
+      // Remove frameX/Y from the frame offsets, as they align the Chart and Stage Editor character selectors icons off-centered
+      idleFrame.offset.set(0, 0);
+      idleFrame.sourceSize.set(idleFrame.frame.width, idleFrame.frame.height);
+
       // so, haxe.ui.backend.AssetsImpl uses the parent width and height, which makes the image go crazy when rendered
       // so this is a work around so that it uses the actual width and height
       var imageGraphic = flixel.graphics.FlxGraphic.fromFrame(idleFrame);


### PR DESCRIPTION
## Linked Issues
- Closes #7173

## Description
This PR removes the idleFrame offsets from the pixel icons in the Chart and Stage Editor character selector lists.

## Screenshots/Videos
Didn't make videos of Stage Editor but I checked and it's the same fix there aswell.

### 0.8.3 (develop)

[Old Chart Editor.webm](https://github.com/user-attachments/assets/5fa679d4-cd4a-4261-b57b-a4e098962e4e)

### This PR

[Fixed Chart Editor.webm](https://github.com/user-attachments/assets/88a74f5b-7d97-4d4f-9c87-030e6e1f3c15)
