### PR TITLE
[OPTIMIZATION] Avoid immediately destroying graphics on no use

### DIFF
--- a/source/funkin/InitState.hx
+++ b/source/funkin/InitState.hx
@@ -145,6 +145,9 @@ class InitState extends FlxState
       // This ain't a pixel art game! (most of the time)
       FlxSprite.defaultAntialiasing = true;
 
+      // Avoid immediately destroying graphics that will be re-used later most of the time
+      FlxGraphic.defaultDestroyOnNoUse = false;
+
       // Disable default keybinds for volume (we manually control volume in MusicBeatState with custom binds)
       FlxG.sound.volumeUpKeys = [];
       FlxG.sound.volumeDownKeys = [];


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
None Issues, but from what i gathered, the game constantly destroys and creates freeplayCapsule graphic in freeplay menu.
This fixes that.

<!-- Briefly describe the issue(s) fixed. -->
## Description
Avoids immediately destroying graphics that may be re-used later for most of the time.

Require this pull request at flixel to work:
- https://github.com/FunkinCrew/flixel/pull/16

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos
None