### PR TITLE
[OPTIMIZATION] Cache `DataAssets` to slightly improve load times

### DIFF
--- a/source/funkin/modding/PolymodHandler.hx
+++ b/source/funkin/modding/PolymodHandler.hx
@@ -18,6 +18,7 @@ import funkin.modding.module.ModuleHandler;
 import funkin.data.character.CharacterData.CharacterDataParser;
 import funkin.save.Save;
 import funkin.util.FileUtil;
+import funkin.util.assets.DataAssets;
 import funkin.util.macro.ClassMacro;
 import polymod.backends.PolymodAssets.PolymodAssetType;
 import polymod.format.ParseRules.TextFileFormat;
@@ -617,6 +618,7 @@ class PolymodHandler
     // to ensure build macros work properly.
     SongEventRegistry.loadEventCache();
 
+    DataAssets.clearTextAssetsCache();
     SongRegistry.instance.loadEntries();
     LevelRegistry.instance.loadEntries();
     NoteStyleRegistry.instance.loadEntries();

--- a/source/funkin/util/assets/DataAssets.hx
+++ b/source/funkin/util/assets/DataAssets.hx
@@ -8,14 +8,21 @@ class DataAssets
     return 'assets/data/${path}';
   }
 
+  static var textAssetsCache:Null<Array<String>>;
+
+  public inline static function clearTextAssetsCache():Void
+  {
+    textAssetsCache = null;
+  }
+
   public static function listDataFilesInPath(path:String, suffix:String = '.json'):Array<String>
   {
-    var textAssets = openfl.utils.Assets.list(TEXT);
+    textAssetsCache ??= openfl.utils.Assets.list(TEXT);
 
     var queryPath = buildDataPath(path);
 
     var results:Array<String> = [];
-    for (textPath in textAssets)
+    for (textPath in textAssetsCache)
     {
       if (textPath.startsWith(queryPath) && textPath.endsWith(suffix))
       {


### PR DESCRIPTION
## Linked Issues
None
<!-- Briefly describe the issue(s) fixed. -->
## Description
We add a cache for the text asset names so that they don't have to be repeatedly retrieved for each registry while the game is first loading or during a hot-reload.

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos

Testing on a HashLink build with `REDIRECT_ASSETS_FOLDER` and using the time it takes for the Debug Display to appear as reference, we can see an improvement of about 3 seconds, which honestly isn't a lot but is still something I guess.

## Before

[before.webm](https://github.com/user-attachments/assets/43e0a50f-6ac0-458b-adf7-3db17bc75000)

## After

[after.webm](https://github.com/user-attachments/assets/025ebeb1-89f6-43a8-b78d-b68a429a7f88)

