### PR TITLE
[FIX] Ignore health icon offsets in Chart Editor to prevent out-of-bounds rendering.

### DIFF
--- a/source/funkin/ui/debug/charting/ChartEditorState.hx
+++ b/source/funkin/ui/debug/charting/ChartEditorState.hx
@@ -5960,6 +5960,7 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
       if (healthIconBF != null)
       {
         healthIconBF.configure(_charIconData?.healthIcon);
+        healthIconBF.iconOffset.set();
         healthIconBF.size *= 0.5; // Make the icon smaller in Chart Editor.
         healthIconBF.flipX = !healthIconBF.flipX; // BF faces the other way.
       }
@@ -5974,6 +5975,7 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
       if (healthIconDad != null)
       {
         healthIconDad.configure(_charIconData?.healthIcon);
+        healthIconDad.iconOffset.set();
         healthIconDad.size *= 0.5; // Make the icon smaller in Chart Editor.
       }
       if (buttonSelectOpponent != null)


### PR DESCRIPTION
## Linked Issues
- Closes #6708

## Description
This PR removes the health icon offsets in Chart Editor to prevent out-of-bounds rendering.

This was mostly met when choosing a character with health icon offsets in their data such as Kazuha. As seen in the linked issue or below.

## Screenshots/Videos

| Before | After |
| :---: | :---: |
|  <img width="559" height="642" alt="image" src="https://github.com/user-attachments/assets/5e07ab7f-6a9a-450f-9428-e9209d0e9eb7" />| <img width="577" height="692" alt="image" src="https://github.com/user-attachments/assets/11149fe5-5756-4249-8a74-f3220113d4fd" /> |

