### PR TITLE
[BUGFIX] Fix `TextureSwap` not finding ASTC textures

### DIFF
--- a/source/funkin/graphics/shaders/TextureSwap.hx
+++ b/source/funkin/graphics/shaders/TextureSwap.hx
@@ -8,16 +8,9 @@ class TextureSwap extends FlxShader
   public var swappedImage(default, set):BitmapData;
   public var amount(default, set):Float;
 
-  public function loadSwapImage(path:String)
+  public function loadSwapImage(path:String):Void
   {
-    #if html5
-    BitmapData.loadFromFile(path).onComplete(function(bmp:BitmapData)
-    {
-      swappedImage = bmp;
-    });
-    #else
-    swappedImage = BitmapData.fromFile(path);
-    #end
+    swappedImage = Assets.getBitmapData(path, false);
   }
 
   function set_swappedImage(_bitmapData:BitmapData):BitmapData


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
Only reported on Discord.
<!-- Briefly describe the issue(s) fixed. -->
## Description

> [!NOTE]
> Requires https://github.com/FunkinCrew/funkin.assets/pull/393

Fixes a `develop` issue where ASTC textures are unable to be found by `TextureSwap`. This is what `DropShadowShader` already does so...

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos
Compression did me dirty here :obese_cat:

<img width="2400" height="1080" alt="image" src="https://github.com/user-attachments/assets/067230a8-f6c6-4922-989b-dc07b5a0bd0d" />
