### PR TITLE
[BUGFIX] Fix character stuck in miss pose during no-anim notes (pt.2)

### DIFF
--- a/source/funkin/play/character/BaseCharacter.hx
+++ b/source/funkin/play/character/BaseCharacter.hx
@@ -407,7 +407,12 @@ class BaseCharacter extends Bopper
     // Reset hold timer for each note pressed.
     if (justPressedNote() && this.characterType == BF)
     {
-      holdTimer = 0;
+      // If the `noanim` noteKind is active, don't reset the holdTimer.
+      if (curNoteKind != null && curNoteKind.noanim) return;
+      else
+      {
+        holdTimer = 0;
+      }
     }
 
     if (isDead)
@@ -573,39 +578,20 @@ class BaseCharacter extends Bopper
    */
   public function playNoteSingAnimation(noteData:SongNoteData, judgement:Null<String> = null, comboCount:Int = 0):Void
   {
-    curNoteKind = NoteKindManager.getNoteKind(noteData.kind);
+     curNoteKind = NoteKindManager.getNoteKind(noteData.kind);
+    // Let the character naturally transition back to their idle/dance animation
+    // if the notekind is set to noanim.
+    if (curNoteKind != null && curNoteKind.noanim) return;
 
     if (noteData.getMustHitNote() && characterType == BF)
     {
-      if (curNoteKind != null)
-      {
-        if (!curNoteKind.noanim)
-        {
-          this.playSingAnimation(noteData.getDirection(), false, curNoteKind?.suffix);
-          holdTimer = 0;
-        }
-      }
-      else
-      {
-        this.playSingAnimation(noteData.getDirection(), false);
-        holdTimer = 0;
-      }
+      this.playSingAnimation(noteData.getDirection(), false, curNoteKind?.suffix ?? '');
+      holdTimer = 0;
     }
     else if (!noteData.getMustHitNote() && characterType == DAD)
     {
-      if (curNoteKind != null)
-      {
-        if (!curNoteKind.noanim)
-        {
-          this.playSingAnimation(noteData.getDirection(), false, curNoteKind?.suffix);
-          holdTimer = 0;
-        }
-      }
-      else
-      {
-        this.playSingAnimation(noteData.getDirection(), false);
-        holdTimer = 0;
-      }
+      this.playSingAnimation(noteData.getDirection(), false, curNoteKind?.suffix ?? '');
+      holdTimer = 0;
     }
     else if (characterType == GF && noteData.getMustHitNote() && judgement != null)
     {
@@ -647,11 +633,13 @@ class BaseCharacter extends Bopper
     {
       // If the note is from the same strumline, play the miss animation.
       this.playSingAnimation(event.note.noteData.getDirection(), true);
+      holdTimer = 0;
     }
     else if (!event.note.noteData.getMustHitNote() && characterType == DAD)
     {
       // If the note is from the same strumline, play the miss animation.
       this.playSingAnimation(event.note.noteData.getDirection(), true);
+      holdTimer = 0;
     }
     else if (event.note.noteData.getMustHitNote() && characterType == GF)
     {
@@ -670,11 +658,13 @@ class BaseCharacter extends Bopper
     {
       // If the note is from the same strumline, play the miss animation.
       this.playSingAnimation(event.holdNote.noteData.getDirection(), true);
+      holdTimer = 0;
     }
     else if (!event.holdNote.noteData.getMustHitNote() && characterType == DAD)
     {
       // If the note is from the same strumline, play the miss animation.
       this.playSingAnimation(event.holdNote.noteData.getDirection(), true);
+      holdTimer = 0;
     }
     else if (event.holdNote.noteData.getMustHitNote() && event.isComboBreak && characterType == GF)
     {
@@ -750,6 +740,7 @@ class BaseCharacter extends Bopper
     var anim:String = 'sing${dir.nameUpper}${miss ? 'miss' : ''}${suffix != '' ? '-${suffix}' : ''}';
 
     // restart even if already playing, because the character might sing the same note twice.
+    holdTimer = 0;
 
     playAnimation(anim, true);
   }


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
- FunkinCrew/Funkin#7044 - Character doesn't return to idle when continually hitting No Animation notes
- FunkinCrew/Funkin#7182 - Missing multiple times snaps back to idle too soon

<!-- Briefly describe the issue(s) fixed. -->
## Description
> [!NOTE]
> This PR was in fact merged (#7078) but was reverted due to multiple bugs that came after.

This PR should fix characters being stuck in their miss-animations instead going back to their dance / idle poses; As well as snapping back to idle after missing multiple times.

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos
### BEFORE (Second video was taken by @Hundrec):
https://github.com/user-attachments/assets/9a7e143f-6b81-43a3-92c4-8a1855986257

https://github.com/user-attachments/assets/cd67a44c-0509-4aed-b050-216b8f013680
### AFTER:
https://github.com/user-attachments/assets/d005f987-1fb4-4fa6-88a1-884b71413ce3

https://github.com/user-attachments/assets/6bd5ebe1-44f5-48d3-9a89-9dee722b2897