### PR TITLE
[BUGFIX] Disable page navigation while Save Data prompts are open in Options.

### DIFF
--- a/source/funkin/ui/options/SaveDataMenu.hx
+++ b/source/funkin/ui/options/SaveDataMenu.hx
@@ -84,25 +84,24 @@ class SaveDataMenu extends Page<OptionsState.OptionsMenuPageName>
     prompt.createBgFromMargin(100, 0xFFFAFD6D);
     prompt.back.scrollFactor.set(0, 0);
     FlxG.state.add(prompt);
+    // Disable page navigation while the prompt is open
+    codex.currentPage.enabled = false;
+
+    final closePrompt:()->Void = () -> {
+      codex.currentPage.enabled = true;
+      prompt.close();
+      prompt.destroy();
+      prompt = null;
+    };
 
     prompt.onYes = function()
     {
       onYes();
 
-      if (prompt != null)
-      {
-        prompt.close();
-        prompt.destroy();
-        prompt = null;
-      }
+      closePrompt();
     };
 
-    prompt.onNo = function()
-    {
-      prompt.close();
-      prompt.destroy();
-      prompt = null;
-    }
+    prompt.onNo = closePrompt;
   }
 
   public function openSaveDataPrompt()


### PR DESCRIPTION
## Linked Issues
- Closes #7190

## Description
This PR fixes the Save Data prompts allowing page navigation while open, it also prevents users from select the page item and the prompt option at once (which could happen before).

## Screenshots/Videos

### Before

[broke](https://github.com/user-attachments/assets/eac4531a-4364-4343-978f-08639b021a71)

### After
I know this looks like I don't try to navigate the page entries but I did try during the whole prompt.

[fix prompts](https://github.com/user-attachments/assets/b59c7af4-a605-478d-af93-a783de9a347f)
