### PR TITLE
[BUGFIX] Fix controls menu crash when unplugging a gamepad

### DIFF
--- a/source/funkin/ui/options/ControlsMenu.hx
+++ b/source/funkin/ui/options/ControlsMenu.hx
@@ -304,7 +304,8 @@ class ControlsMenu extends Page<OptionsState.OptionsMenuPageName>
 
             // keyUsedToEnterPrompt is my weird workaround.
 
-            var key = FlxG.keys.firstJustReleased();
+            var key = FlxG.keys?.firstJustReleased();
+            if (key == null) return;
             if (key != NONE && key != keyUsedToEnterPrompt)
             {
               if (key == ESCAPE)
@@ -325,7 +326,8 @@ class ControlsMenu extends Page<OptionsState.OptionsMenuPageName>
           }
         case Gamepad(id):
           {
-            var button = FlxG.gamepads.getByID(id).firstJustReleasedID();
+            var button = FlxG.gamepads?.getByID(id)?.firstJustReleasedID();
+            if (button == null) return;
             if (button != NONE && button != buttonUsedToEnterPrompt)
             {
               if (button != BACK) onInputSelect(button);
@@ -357,12 +359,12 @@ class ControlsMenu extends Page<OptionsState.OptionsMenuPageName>
       {
         case Keys:
           {
-            var key = FlxG.keys.firstJustReleased();
+            var key = FlxG.keys?.firstJustReleased();
             if (key == ESCAPE) closePopup();
           }
         case Gamepad(id):
           {
-            var button = FlxG.gamepads.getByID(id).firstJustReleasedID();
+            var button = FlxG.gamepads?.getByID(id)?.firstJustReleasedID();
             if (button == BACK) closePopup();
 
             var key = FlxG.keys.firstJustReleased();
@@ -375,7 +377,8 @@ class ControlsMenu extends Page<OptionsState.OptionsMenuPageName>
     {
       case Keys:
         {
-          var keyJustReleased:Int = FlxG.keys.firstJustReleased();
+          var keyJustReleased:Null<Int> = FlxG.keys?.firstJustReleased();
+          if (keyJustReleased == null) return;
           if (keyJustReleased != NONE && keyJustReleased == keyUsedToEnterPrompt)
           {
             keyUsedToEnterPrompt = null;
@@ -384,7 +387,8 @@ class ControlsMenu extends Page<OptionsState.OptionsMenuPageName>
         }
       case Gamepad(id):
         {
-          var buttonJustReleased:Int = FlxG.gamepads.getByID(id).firstJustReleasedID();
+          var buttonJustReleased:Null<Int> = FlxG.gamepads?.getByID(id)?.firstJustReleasedID();
+          if (buttonJustReleased == null) return;
           if (buttonJustReleased != NONE && buttonJustReleased == buttonUsedToEnterPrompt)
           {
             buttonUsedToEnterPrompt = null;


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
#7159 
<!-- Briefly describe the issue(s) fixed. -->
## Description
This PR basically fixes a bug where unplugging a gamepad made the game crash. Also fixes the same crash when the prompt is open.

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos

https://github.com/user-attachments/assets/e954cf56-02c1-49df-ab8c-65d56efb129a

