### PR TITLE
[ENHANCEMENT+BUGFIX] Reusable and stutter-proof Timer Sequences

### DIFF
--- a/source/funkin/util/TimerUtil.hx
+++ b/source/funkin/util/TimerUtil.hx
@@ -32,51 +32,87 @@ class Sequence
    * @param events A list of `SequenceEvent`s.
    * @param mult Optional multiplier for callback times. Useful for frame-based or music-based timing.
    * @param start Whether to immediately start the sequence.
+   * @param autoDestroy Whether to destroy this sequence after its completion.
    */
-  public function new(events:Array<SequenceEvent>, mult:Float = 1, start:Bool = true)
+  public function new(events:Array<SequenceEvent>, mult:Float = 1, start:Bool = true, autoDestroy:Bool = true)
   {
-    if (events.length == 0) return;
+    this.events = events.copy();
 
-    mult = Math.max(0, mult);
+    if (this.events.length == 0) return;
 
-    for (event in events)
+    this.multiplier = Math.max(0, mult);
+    this.autoDestroy = autoDestroy;
+
+    this.events.sort((a, b) ->
     {
-      timers.push(new FlxTimer().start(event.time * mult, function(timer:FlxTimer)
+      // Providing a negative time should make it positive to mimic how FlxTimers work.
+      a.time = Math.abs(a.time);
+      b.time = Math.abs(b.time);
+      return Reflect.compare(a.time, b.time);
+    });
+
+    timer.start(currentEvent.time * multiplier, _ ->
+    {
+      currentEvent.callback();
+      eventCount++;
+
+      if (!completed)
       {
-        event.callback();
-        timers.remove(timer);
-      }));
-    }
+        timer.reset((currentEvent.time - events[eventCount - 1].time) * multiplier);
+      }
+      else if (this.autoDestroy)
+      {
+        destroy();
+      }
+    });
 
     running = start;
   }
 
   /**
-   * The list of uncompleted timers for their respective events.
+   * The internal timer used by this sequence.
    */
-  final timers:Array<FlxTimer> = [];
+  final timer:FlxTimer = new FlxTimer();
+
+  /**
+   * A multiplier for callback times. Useful for frame-based or music-based timing.
+   */
+  public var multiplier:Float;
+
+  /**
+   * The current event being executed. Will be null if this sequence has finished.
+   */
+  public var currentEvent(get, never):Null<SequenceEvent>;
+
+  inline function get_currentEvent():Null<SequenceEvent>
+  {
+    return events[eventCount];
+  }
+
+  /**
+   * The events for this sequence.
+   */
+  var events:Array<SequenceEvent>;
+
+  /**
+   * The amount of currently finished events.
+   */
+  var eventCount:Int = 0;
 
   /**
    * Controls whether this sequence is running or not.
    */
   public var running(get, set):Bool;
 
-  var _running:Bool = false;
-
   function get_running():Bool
   {
-    return completed ? false : _running;
+    return completed ? false : (timer.active && !timer.finished);
   }
 
   function set_running(v:Bool):Bool
   {
     if (completed) return false;
-    for (timer in timers)
-    {
-      timer.active = v;
-    }
-    _running = v;
-    return _running;
+    return timer.active = v;
   }
 
   /**
@@ -86,20 +122,47 @@ class Sequence
 
   function get_completed():Bool
   {
-    return timers.length == 0;
+    return eventCount >= events.length;
+  }
+
+  /**
+   * Whether this sequence should be destroyed after completing.
+   */
+  public var autoDestroy:Bool;
+
+  /**
+   * Starts the sequence from the beginning.
+   */
+  public function start():Void
+  {
+    if (events.length == 0)
+    {
+      trace(' WARNING '.bg_yellow().bold() + ' There was an attempt to start a sequence with no events. Was it destroyed?');
+      return;
+    }
+    eventCount = 0;
+    timer.reset(currentEvent.time * multiplier);
+  }
+
+  /**
+   * Cancels out all the events in the sequence.
+   */
+  public function stop():Void
+  {
+    eventCount = events.length;
+    timer.cancel();
   }
 
   /**
    * Clean up and destroy this sequence.
+   * Note that this will render the sequence unusable.
    */
   public function destroy():Void
   {
-    while (!completed)
-    {
-      var timer:Null<FlxTimer> = timers.pop();
-      timer?.cancel();
-      timer?.destroy();
-    }
+    timer.cancel();
+    timer.destroy();
+    events.clear();
+    eventCount = 0;
   }
 }
 


### PR DESCRIPTION
## Description
Reworks the `funkin.util.TimerUtil.Sequence` class to allow it to be reusable, allowing the improval of memory usage.

More detailedly:
- New `autoDestroy` constructor parameter, defaults to `true` to keep the original behavior.
- The time multiplier can now also be changed through the `multiplier` variable.
- New `start` and `stop` functions. The first will restart the sequence from the beginning and the latter will cancel it. Pausing is still handled by the `running` property.
- One single `FlxTimer` instance is used instead of one for each event, this was done to fix issues with timers that'd usually occur during a lag spike.

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos
The video demonstrates this PR successfully fixing the Nametag bug (presented in the second game window that was opened). I've added a functionality to the code that creates an artificial 300 ms lag-spike whenever I press a key, that I've used to successfully reproduce the bug.

https://github.com/user-attachments/assets/59875078-0cd4-47fa-9e05-19781cd50e23

