### PR TITLE
[FIX/ENHANCEMENT/Modding] Fix health icon angle lerping too quickly and use a Constant for the half life to allow customizability by modders.

### DIFF
--- a/source/funkin/play/components/HealthIcon.hx
+++ b/source/funkin/play/components/HealthIcon.hx
@@ -226,9 +226,7 @@ class HealthIcon extends FunkinSprite
 
     if (bopEvery != 0)
     {
-      var dt:Float = elapsed * 60;
-
-      this.angle = MathUtil.smoothLerpPrecision(this.angle, 0, dt, 0.512);
+      this.angle = MathUtil.smoothLerpPrecision(this.angle, 0, elapsed, Constants.HEALTH_ICON_ANGLE_HALF_LIFE);
     }
 
     this.updatePosition();

--- a/source/funkin/util/Constants.hx
+++ b/source/funkin/util/Constants.hx
@@ -673,6 +673,11 @@ class Constants
   public inline static final DEFAULT_VIBRATION_SHARPNESS:Float = 1;
 
   /**
+   * The smoothness of the health icon angle rotation on bop.
+   */
+  public static final HEALTH_ICON_ANGLE_HALF_LIFE:Float = 0.512;
+
+  /**
    * The path where our save data will be stored.
    */
   public inline static final SAVE_PATH:String = 'FunkinCrew';


### PR DESCRIPTION
## Linked Issues
- Closes #7153

## Description
This PR removes the forced multiplier applied to the health icon angle that made it update too quickly.
Also add a new Constant for the half life of the angle lerp.

## Screenshots/Videos

### Before

https://github.com/user-attachments/assets/bda69810-a7cd-4ef0-a60d-12ec1e493052

### After PR

https://github.com/user-attachments/assets/4517c789-c557-49ab-aa09-6a3761f57f68
