### PR TITLE
[BUGFIX] Fix Freeplay song preview not updating after rank animation finishes

### DIFF
--- a/source/funkin/ui/freeplay/FreeplayState.hx
+++ b/source/funkin/ui/freeplay/FreeplayState.hx
@@ -2912,6 +2912,9 @@ class FreeplayState extends MusicBeatSubState
       #end
     }
 
+    // Reset `prepForNewRank` flag on change to prevent song previews from not updating.
+    if (change != 0 && prepForNewRank) prepForNewRank = false;
+
     if (!prepForNewRank && curSelected != prevSelected) FunkinSound.playOnce(Paths.sound('scrollMenu'), 0.4);
 
     var songScore:Null<SaveScoreData> = Save.instance.getSongScore(currentCapsule.freeplayData?.data.id ?? '', currentDifficulty, currentVariation);


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
- FunkinCrew/Funkin#6432

<!-- Briefly describe the issue(s) fixed. -->
## Description
Recently I've noticed song previews don't update if you scroll fast right after the rank animation plays, This PR fixes that, by letting the animation play first, and letting you scroll after.

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos
### BEFORE:
https://github.com/user-attachments/assets/b4eb7bda-ed56-4d55-bf2b-f0bf59e5e156
### AFTER:
https://github.com/user-attachments/assets/1da7b429-0462-487a-b37f-d62cd4778ed7
