### PR TITLE
[ENHANCEMENT] Strumline background no longer overlaps other UI elements.

### DIFF
--- a/source/funkin/play/PlayState.hx
+++ b/source/funkin/play/PlayState.hx
@@ -2254,6 +2254,9 @@ class PlayState extends MusicBeatSubState
     opponentStrumline.zIndex = 1000;
     opponentStrumline.cameras = [camHUD];
 
+    playerStrumline.initBackground(this);
+    opponentStrumline.initBackground(this);
+
     #if mobile
     if (Preferences.controlsScheme == FunkinHitboxControlSchemes.Arrows && !ControlsHandler.hasExternalInputDevice)
     {

--- a/source/funkin/play/notes/Strumline.hx
+++ b/source/funkin/play/notes/Strumline.hx
@@ -4,6 +4,7 @@ import flixel.util.FlxSignal.FlxTypedSignal;
 import flixel.FlxG;
 import funkin.play.notes.NoteVibrationsHandler.NoteStatus;
 import funkin.play.notes.notestyle.NoteStyle;
+import flixel.group.FlxGroup;
 import flixel.group.FlxSpriteGroup;
 import flixel.group.FlxSpriteGroup.FlxTypedSpriteGroup;
 import flixel.tweens.FlxEase;
@@ -15,7 +16,10 @@ import funkin.util.SortUtil;
 import funkin.util.GRhythmUtil;
 import funkin.play.notes.notekind.NoteKind;
 import funkin.play.notes.notekind.NoteKindManager;
+import flixel.FlxCamera;
 import flixel.math.FlxPoint;
+import flixel.util.FlxDestroyUtil;
+import openfl.display.BlendMode;
 #if mobile
 import funkin.mobile.input.ControlsHandler;
 import funkin.mobile.ui.FunkinHitbox.FunkinHitboxControlSchemes;
@@ -240,23 +244,6 @@ class Strumline extends FlxSpriteGroup
     this.noteSplashes.zIndex = 50;
     this.add(this.noteSplashes);
 
-    var backgroundWidth:Float = KEY_COUNT * Strumline.NOTE_SPACING + BACKGROUND_PAD * 2;
-    #if mobile
-    if (inArrowControlSchemeMode && isPlayer)
-    {
-      backgroundWidth = backgroundWidth * 1.84;
-    }
-    #end
-    this.background = new FunkinSprite(0, 0).makeSolidColor(Std.int(backgroundWidth), FlxG.height, 0xFF000000);
-    // Convert the percent to a number between 0 and 1.
-    this.background.alpha = Preferences.strumlineBackgroundOpacity / 100.0;
-    this.background.scrollFactor.set(0, 0);
-    this.background.x = -BACKGROUND_PAD;
-    #if mobile
-    if (inArrowControlSchemeMode && isPlayer) this.background.x -= 100;
-    #end
-    this.add(this.background);
-
     strumlineScale = new FlxCallbackPoint(strumlineScaleCallback);
 
     this.refresh();
@@ -286,6 +273,45 @@ class Strumline extends FlxSpriteGroup
     this.active = true;
   }
 
+  public function initBackground(state:FlxGroup):Void
+  {
+    #if mobile
+    // We do not want to initialize the background for the opponent if no external devices are used
+    if (inArrowControlSchemeMode && !isPlayer) return;
+    #end
+    var backgroundWidth:Float = KEY_COUNT * Strumline.NOTE_SPACING + BACKGROUND_PAD * 2;
+    #if mobile
+    if (inArrowControlSchemeMode && isPlayer)
+    {
+      backgroundWidth = backgroundWidth * 1.84;
+    }
+    #end
+    this.background = new FunkinSprite(this.x - BACKGROUND_PAD, this.y).makeSolidColor(Std.int(backgroundWidth), FlxG.height, 0xFF000000);
+    // Convert the percent to a number between 0 and 1.
+    this.background.alpha = Preferences.strumlineBackgroundOpacity / 100.0;
+    this.background.scrollFactor.set(0, 0);
+    this.background.camera = this.camera;
+    this.background.x += noteStyle.getStrumlineOffsets()[0];
+    #if mobile
+    if (inArrowControlSchemeMode && isPlayer) this.background.x -= 100;
+    #end
+    state.add(this.background);
+  }
+
+  override function set_x(value:Float):Float
+  {
+    super.set_x(value);
+
+    if (this.background != null)  {
+      this.background.x = this.x - BACKGROUND_PAD;
+      #if mobile
+      if (inArrowControlSchemeMode && isPlayer) this.background.x -= 100;
+      #end
+      this.background.x += noteStyle.getStrumlineOffsets()[0];
+    }
+    return value;
+  }
+
   override function set_y(value:Float):Float
   {
     super.set_y(value);
@@ -296,11 +322,47 @@ class Strumline extends FlxSpriteGroup
     return value;
   }
 
+  override function set_blend(value:BlendMode):BlendMode
+  {
+    super.set_blend(value);
+
+    if (this.background != null) this.background.blend = value;
+
+    return value;
+  }
+
+  override function set_cameras(value:Array<FlxCamera>):Array<FlxCamera>
+  {
+    super.set_cameras(value);
+
+    if (this.background != null) this.background.cameras = value;
+
+    return value;
+  }
+
+  override function set_visible(value:Bool):Bool
+  {
+    super.set_visible(value);
+
+    if (this.background != null) this.background.visible = value;
+
+    return value;
+  }
+
+  override function set_camera(value:FlxCamera):FlxCamera
+  {
+    super.set_camera(value);
+
+    if (this.background != null) this.background.camera = value;
+
+    return value;
+  }
+
   override function set_alpha(value:Float):Float
   {
     super.set_alpha(value);
 
-    this.background.alpha = Preferences.strumlineBackgroundOpacity / 100.0 * alpha;
+    if (this.background != null) this.background.alpha = Preferences.strumlineBackgroundOpacity / 100.0 * alpha;
 
     return value;
   }
@@ -1507,5 +1569,11 @@ class Strumline extends FlxSpriteGroup
       if (maxY > value) value = maxY;
     }
     return value;
+  }
+
+  override public function destroy():Void
+  {
+    if (this.background != null) FlxDestroyUtil.destroy(this.background);
+    super.destroy();
   }
 }

--- a/source/funkin/ui/options/OffsetMenu.hx
+++ b/source/funkin/ui/options/OffsetMenu.hx
@@ -196,9 +196,9 @@ class OffsetMenu extends Page<OptionsState.OptionsMenuPageName>
     testStrumline.setPosition(FlxG.width / 2, FlxG.height / 2);
     testStrumline.x -= testStrumline.width / 2;
     testStrumline.scrollFactor.set(0, 0);
-    add(testStrumline);
-
     testStrumline.cameras = [menuCamera];
+    testStrumline.initBackground(this);
+    add(testStrumline);
 
     testStrumline.conductorInUse = localConductor;
     testStrumline.zIndex = 1001;


### PR DESCRIPTION
## Linked Issues
- Closes #4541

## Description
This PR changes the strumline background to allow UI elements to show above it and no longer layer over them.

> [!IMPORTANT]
> Requires PR to fix the strumline hiding in assets: https://github.com/FunkinCrew/funkin.assets/pull/398

## Screenshots/Videos

### Desktop

<img width="1920" height="1008" alt="screenshot-2026-03-25-22-04-08" src="https://github.com/user-attachments/assets/a1f4ebd7-ef26-42b9-8305-76078ebe4ef2" />

<img width="1920" height="1008" alt="screenshot-2026-03-25-22-15-31" src="https://github.com/user-attachments/assets/1c340977-973e-4160-a433-0499037f302d" />

<img width="1920" height="1008" alt="screenshot-2026-03-25-22-16-33" src="https://github.com/user-attachments/assets/8cd42368-329a-468b-a145-160333cbd7db" />

<img width="1280" height="720" alt="screenshot-2026-03-28-11-27-56" src="https://github.com/user-attachments/assets/87d87a7c-0879-495a-b190-b51007352f8d" />

<img width="1280" height="720" alt="screenshot-2026-03-27-23-15-53" src="https://github.com/user-attachments/assets/802a848f-1e68-400b-89bf-d15b23e9a993" />

### Mobile

![Screenshot_20260327_230743.png](https://github.com/user-attachments/assets/2066ca73-fcc6-4d06-94c5-c8d98bce8a56)


#### About offsets/lag adjustement substate, not sure if the background should show as before or not, same goes for minimal playstate