### PR TITLE
[OPTIMIZATION] Recycle script events

### DIFF
--- a/source/funkin/data/character/CharacterData.hx
+++ b/source/funkin/data/character/CharacterData.hx
@@ -676,7 +676,9 @@ class CharacterDataParser
     char.debug = debug;
 
     // Call onCreate only in the fetchCharacter() function, not at application initialization.
-    ScriptEventDispatcher.callEvent(char, new ScriptEvent(CREATE));
+    var event:ScriptEvent = ScriptEvent.get(CREATE);
+    ScriptEventDispatcher.callEvent(char, event);
+    event.put();
 
     return char;
   }

--- a/source/funkin/modding/events/ScriptEvent.hx
+++ b/source/funkin/modding/events/ScriptEvent.hx
@@ -17,6 +17,8 @@ import openfl.events.KeyboardEvent;
  * It can be used to identify the type of event called, store data, and cancel event propagation.
  */
 @:nullSafety
+@:build(funkin.util.macro.ScriptEventPoolMacro.buildPool())
+@:autoBuild(funkin.util.macro.ScriptEventPoolMacro.buildPool())
 class ScriptEvent
 {
   /**
@@ -40,6 +42,13 @@ class ScriptEvent
    * Whether the event has been canceled by one of the scripts that received it.
    */
   public var eventCanceled(default, null):Bool;
+
+  /**
+   * Whether the event has been used in the pool.
+   * In certain cases, such as when switching states in `onStateChangeBegin`, multiple of the same events would be needed,
+   * and this variable signified whether another event instance should be created.
+   */
+  public var hasBeenUsed(default, null):Bool = false;
 
   public function new(type:ScriptEventType, cancelable:Bool = false):Void
   {
@@ -76,6 +85,14 @@ class ScriptEvent
   public function stopPropagation():Void
   {
     shouldPropagate = false;
+  }
+
+  /**
+   * Make this event reusable in the pool.
+   */
+  public function put()
+  {
+    hasBeenUsed = false;
   }
 
   public function toString():String
@@ -412,17 +429,17 @@ class KeyboardInputScriptEvent extends ScriptEvent
   /**
    * The associated keyboard event.
    */
-  public var event(default, null):KeyboardEvent;
+  public var keyEvent(default, null):KeyboardEvent;
 
-  public function new(type:ScriptEventType, event:KeyboardEvent):Void
+  public function new(type:ScriptEventType, keyEvent:KeyboardEvent):Void
   {
     super(type, false);
-    this.event = event;
+    this.keyEvent = keyEvent;
   }
 
   override public function toString():String
   {
-    return 'KeyboardInputScriptEvent(type=' + type + ', event=' + event + ')';
+    return 'KeyboardInputScriptEvent(type=' + type + ', event=' + keyEvent + ')';
   }
 }
 

--- a/source/funkin/modding/module/ModuleHandler.hx
+++ b/source/funkin/modding/module/ModuleHandler.hx
@@ -183,7 +183,9 @@ class ModuleHandler
 
   static function onStateSwitchComplete():Void
   {
-    callEvent(new StateChangeScriptEvent(STATE_CHANGE_END, FlxG.state, true));
+    var event:StateChangeScriptEvent = StateChangeScriptEvent.get(STATE_CHANGE_END, FlxG.state, true);
+    callEvent(event);
+    event.put();
   }
 
   static function addToModuleCache(module:Module):Void
@@ -251,7 +253,7 @@ class ModuleHandler
   {
     if (moduleCache != null)
     {
-      var event = new ScriptEvent(DESTROY, false);
+      var event = ScriptEvent.get(DESTROY);
 
       // Note: Ignore stopPropagation()
       for (key => value in moduleCache)
@@ -261,6 +263,7 @@ class ModuleHandler
 
       moduleCache.clear();
       modulePriorityOrder = [];
+      event.put();
     }
   }
 
@@ -287,6 +290,8 @@ class ModuleHandler
 
   public static inline function callOnCreate():Void
   {
-    callEvent(new ScriptEvent(CREATE, false));
+    var event:ScriptEvent = ScriptEvent.get(CREATE);
+    callEvent(event);
+    event.put();
   }
 }

--- a/source/funkin/play/Countdown.hx
+++ b/source/funkin/play/Countdown.hx
@@ -3,6 +3,7 @@ package funkin.play;
 import flixel.tweens.FlxEase;
 import flixel.tweens.FlxTween;
 import funkin.modding.events.ScriptEvent;
+import funkin.modding.events.ScriptEventType;
 import funkin.modding.events.ScriptEvent.CountdownScriptEvent;
 import flixel.util.FlxTimer;
 import funkin.util.EaseUtil;
@@ -107,23 +108,22 @@ class Countdown
    */
   static function propagateCountdownEvent(index:CountdownStep):Bool
   {
-    var event:ScriptEvent;
-
-    switch (index)
+    var type:ScriptEventType = switch (index)
     {
       case BEFORE:
-        event = new CountdownScriptEvent(COUNTDOWN_START, index);
-      case THREE | TWO | ONE | GO: // I didn't know you could use `|` in a switch/case block!
-        event = new CountdownScriptEvent(COUNTDOWN_STEP, index);
+        ScriptEventType.COUNTDOWN_START;
       case AFTER:
-        event = new CountdownScriptEvent(COUNTDOWN_END, index, false);
+        ScriptEventType.COUNTDOWN_END;
       default:
-        return true;
+        ScriptEventType.COUNTDOWN_STEP;
     }
+
+    var event:CountdownScriptEvent = CountdownScriptEvent.get(type, index, (index != AFTER));
 
     // Modules, stages, characters.
     @:privateAccess
     PlayState.instance.dispatchEvent(event);
+    event.put();
 
     return event.eventCanceled;
   }

--- a/source/funkin/play/PlayState.hx
+++ b/source/funkin/play/PlayState.hx
@@ -548,7 +548,6 @@ class PlayState extends MusicBeatSubState
   var discordRPCAlbum:String = '';
   var discordRPCIcon:String = '';
   #end
-
   /**
    * RENDER OBJECTS
    */
@@ -1058,13 +1057,14 @@ class PlayState extends MusicBeatSubState
 
       prevScrollTargets = [];
 
-      var retryEvent = new SongRetryEvent(currentDifficulty);
+      var retryEvent = SongRetryEvent.get(currentDifficulty);
 
       previousDifficulty = currentDifficulty;
 
       currentStage?.resetStage();
 
       dispatchEvent(retryEvent);
+      retryEvent.put();
 
       resetCamera();
 
@@ -1280,8 +1280,9 @@ class PlayState extends MusicBeatSubState
         Events.logFailSong(currentSong.id, currentVariation);
         #end
 
-        var event:ScriptEvent = new ScriptEvent(GAME_OVER, true);
+        var event:ScriptEvent = ScriptEvent.get(GAME_OVER, true);
         dispatchEvent(event);
+        event.put();
 
         if (event.eventCanceled) return;
 
@@ -1372,16 +1373,18 @@ class PlayState extends MusicBeatSubState
       case Conversation:
         preparePauseUI();
 
-        final event = new PauseScriptEvent(false);
+        final event = PauseScriptEvent.get(false);
         dispatchEvent(event);
+        event.put();
 
         if (!event.eventCanceled) openPauseSubState(Conversation, camPause, lostFocus, () -> currentConversation?.pauseMusic());
 
       case Cutscene:
         preparePauseUI();
 
-        final event = new PauseScriptEvent(false);
+        final event = PauseScriptEvent.get(false);
         dispatchEvent(event);
+        event.put();
 
         if (!event.eventCanceled) openPauseSubState(Cutscene, camPause, lostFocus, () -> VideoCutscene.pauseVideo());
 
@@ -1391,8 +1394,9 @@ class PlayState extends MusicBeatSubState
         Countdown.pauseCountdown();
         preparePauseUI();
 
-        final event = new PauseScriptEvent(FlxG.random.bool(1 / 1000 * 100));
+        final event = PauseScriptEvent.get(FlxG.random.bool(1 / 1000 * 100));
         dispatchEvent(event);
+        event.put();
 
         if (!event.eventCanceled)
         {
@@ -1516,8 +1520,9 @@ class PlayState extends MusicBeatSubState
             }
           };
 
-          var eventEvent:SongEventScriptEvent = new SongEventScriptEvent(event);
+          var eventEvent:SongEventScriptEvent = SongEventScriptEvent.get(event);
           dispatchEvent(eventEvent);
+          eventEvent.put();
 
           // Calling event.cancelEvent() skips the event. Neat!
           if (!eventEvent.eventCanceled)
@@ -1645,9 +1650,10 @@ class PlayState extends MusicBeatSubState
     if (shouldSubstatePause)
     {
       shouldSubstatePause = false;
-      var event:ScriptEvent = new ScriptEvent(RESUME, true);
+      var event:ScriptEvent = ScriptEvent.get(RESUME, true);
 
       dispatchEvent(event);
+      event.put();
 
       if (event.eventCanceled) return;
 
@@ -2075,8 +2081,9 @@ class PlayState extends MusicBeatSubState
       currentStage.revive(); // Stages are killed and props destroyed when the PlayState is destroyed to save memory.
 
       // Actually create and position the sprites.
-      var event:ScriptEvent = new ScriptEvent(CREATE, false);
+      var event:ScriptEvent = ScriptEvent.get(CREATE);
       ScriptEventDispatcher.callEvent(currentStage, event);
+      event.put();
 
       resetCameraZoom();
 
@@ -2499,8 +2506,9 @@ class PlayState extends MusicBeatSubState
 
     regenNoteData(startTimestamp);
 
-    var event:ScriptEvent = new ScriptEvent(CREATE, false);
+    var event:ScriptEvent = ScriptEvent.get(CREATE);
     ScriptEventDispatcher.callEvent(currentSong, event);
+    event.put();
 
     generatedMusic = true;
   }
@@ -2520,7 +2528,7 @@ class PlayState extends MusicBeatSubState
     Highscore.tallies = new Tallies();
 
     @:nullSafety(Off)
-    var event:SongLoadScriptEvent = new SongLoadScriptEvent(
+    var event:SongLoadScriptEvent = SongLoadScriptEvent.get(
       currentChart.song.id,
       currentChart.difficulty,
       currentChart.notes.copy(),
@@ -2528,6 +2536,7 @@ class PlayState extends MusicBeatSubState
     );
 
     dispatchEvent(event);
+    event.put();
 
     var builtNoteData = event.notes;
     var builtEventData = event.events;
@@ -2573,9 +2582,10 @@ class PlayState extends MusicBeatSubState
 
   function onStrumlineNoteIncoming(noteSprite:NoteSprite):Void
   {
-    var event:NoteScriptEvent = new NoteScriptEvent(NOTE_INCOMING, noteSprite, 0, false);
+    var event:NoteScriptEvent = NoteScriptEvent.get(NOTE_INCOMING, noteSprite, 0, false);
 
     dispatchEvent(event);
+    event.put();
   }
 
   /**
@@ -2613,8 +2623,9 @@ class PlayState extends MusicBeatSubState
     add(currentConversation);
     refresh();
 
-    var event:ScriptEvent = new ScriptEvent(CREATE, false);
+    var event:ScriptEvent = ScriptEvent.get(CREATE);
     ScriptEventDispatcher.callEvent(currentConversation, event);
+    event.put();
   }
 
   /**
@@ -2715,7 +2726,9 @@ class PlayState extends MusicBeatSubState
       handleSkippedNotes();
     }
 
-    dispatchEvent(new ScriptEvent(SONG_START));
+    var event:ScriptEvent = ScriptEvent.get(SONG_START);
+    dispatchEvent(event);
+    event.put();
 
     #if FEATURE_NEWGROUNDS
     Events.logStartSong(currentSong.id, currentVariation);
@@ -2817,8 +2830,9 @@ class PlayState extends MusicBeatSubState
       var r = GRhythmUtil.processWindow(note, false);
       if (r.botplayHit)
       {
-        var event:NoteScriptEvent = new HitNoteScriptEvent(note, 0.0, 0, 'perfect', false, 0);
+        var event:NoteScriptEvent = HitNoteScriptEvent.get(note, 0.0, 0, 'perfect', false, 0);
         dispatchEvent(event);
+        event.put();
 
         // Calling event.cancelEvent() skips all the other logic! Neat!
         if (event.eventCanceled) continue;
@@ -2885,8 +2899,9 @@ class PlayState extends MusicBeatSubState
 
         // Call an event to allow canceling the note hit.
         // NOTE: This is what handles the character animations!
-        var event:NoteScriptEvent = new HitNoteScriptEvent(note, 0.0, 0, 'perfect', false, 0);
+        var event:NoteScriptEvent = HitNoteScriptEvent.get(note, 0.0, 0, 'perfect', false, 0);
         dispatchEvent(event);
+        event.put();
 
         // Calling event.cancelEvent() skips all the other logic! Neat!
         if (event.eventCanceled) continue;
@@ -2908,8 +2923,9 @@ class PlayState extends MusicBeatSubState
       {
         // Call an event to allow canceling the note miss.
         // NOTE: This is what handles the character animations!
-        var event:NoteScriptEvent = new NoteScriptEvent(NOTE_MISS, note, Constants.HEALTH_MISS_PENALTY, Highscore.tallies.combo, true);
+        var event:NoteScriptEvent = NoteScriptEvent.get(NOTE_MISS, note, Constants.HEALTH_MISS_PENALTY, Highscore.tallies.combo, true);
         dispatchEvent(event);
+        event.put();
 
         // Calling event.cancelEvent() skips all the other logic! Neat!
         if (event.eventCanceled) continue;
@@ -2975,8 +2991,9 @@ class PlayState extends MusicBeatSubState
             var healthChange = healthChangeUncapped.clamp(healthChangeMax, 0);
             var scoreChange:Float = Constants.SCORE_HOLD_DROP_PENALTY_PER_SECOND * remainingLengthSec;
 
-            var event:HoldNoteScriptEvent = new HoldNoteScriptEvent(NOTE_HOLD_DROP, holdNote, healthChange, scoreChange, true, Highscore.tallies.combo);
+            var event:HoldNoteScriptEvent = HoldNoteScriptEvent.get(NOTE_HOLD_DROP, holdNote, healthChange, scoreChange, true, Highscore.tallies.combo);
             dispatchEvent(event);
+            event.put();
 
             // Calling event.cancelEvent() skips all the other logic! Neat!
             if (event.eventCanceled) continue;
@@ -3147,7 +3164,7 @@ class PlayState extends MusicBeatSubState
     }
 
     // Send the note hit event.
-    var event:HitNoteScriptEvent = new HitNoteScriptEvent(
+    var event:HitNoteScriptEvent = HitNoteScriptEvent.get(
       note,
       healthChange,
       score,
@@ -3158,6 +3175,7 @@ class PlayState extends MusicBeatSubState
       daRating == 'sick'
     );
     dispatchEvent(event);
+    event.put();
 
     // Calling event.cancelEvent() skips all the other logic! Neat!
     if (event.eventCanceled) return;
@@ -3220,12 +3238,13 @@ class PlayState extends MusicBeatSubState
    */
   function ghostNoteMiss(direction:NoteDirection, hasPossibleNotes:Bool = true):Void
   {
-    var event:GhostMissNoteScriptEvent = new GhostMissNoteScriptEvent(direction, // Direction missed in.
+    var event:GhostMissNoteScriptEvent = GhostMissNoteScriptEvent.get(direction, // Direction missed in.
       hasPossibleNotes, // Whether there was a note you could have hit.
       Constants.HEALTH_GHOST_MISS_PENALTY, // How much health to add (negative).
       Constants.SCORE_GHOST_MISS_PENALTY // Amount of score to add (negative).
     );
     dispatchEvent(event);
+    event.put();
 
     // Calling event.cancelEvent() skips animations and penalties. Neat!
     if (event.eventCanceled) return;
@@ -3500,8 +3519,9 @@ class PlayState extends MusicBeatSubState
     #end
 
     // Check if any events want to prevent the song from ending.
-    var event = new ScriptEvent(SONG_END, true);
+    var event = ScriptEvent.get(SONG_END, true);
     dispatchEvent(event);
+    event.put();
     if (event.eventCanceled) return;
 
     deathCounter = 0;
@@ -3769,7 +3789,9 @@ class PlayState extends MusicBeatSubState
     cancelAllCameraTweens();
 
     // Dispatch the destroy event.
-    dispatchEvent(new ScriptEvent(DESTROY, false));
+    var event:ScriptEvent = ScriptEvent.get(DESTROY, false);
+    dispatchEvent(event);
+    event.put();
 
     if (currentConversation != null)
     {

--- a/source/funkin/play/cutscene/dialogue/Conversation.hx
+++ b/source/funkin/play/cutscene/dialogue/Conversation.hx
@@ -111,7 +111,7 @@ class Conversation extends FunkinSpriteGroup implements IDialogueScriptedClass i
     this.state = ConversationState.Start;
 
     // Start the dialogue.
-    dispatchEvent(new DialogueScriptEvent(DIALOGUE_START, this, false));
+    startConversation();
   }
 
   function setupMusic():Void
@@ -204,7 +204,9 @@ class Conversation extends FunkinSpriteGroup implements IDialogueScriptedClass i
   {
     super.update(elapsed);
 
-    dispatchEvent(new UpdateScriptEvent(elapsed));
+    var event:UpdateScriptEvent = UpdateScriptEvent.get(elapsed);
+    dispatchEvent(event);
+    event.put();
   }
 
   function showCurrentSpeaker():Void
@@ -237,7 +239,9 @@ class Conversation extends FunkinSpriteGroup implements IDialogueScriptedClass i
     }
     if (!nextSpeaker.alive) nextSpeaker.revive();
 
-    ScriptEventDispatcher.callEvent(nextSpeaker, new ScriptEvent(CREATE, true));
+    var event:ScriptEvent = ScriptEvent.get(CREATE);
+    ScriptEventDispatcher.callEvent(nextSpeaker, event);
+    event.put();
 
     currentSpeaker = nextSpeaker;
     currentSpeaker.zIndex = 200;
@@ -277,7 +281,9 @@ class Conversation extends FunkinSpriteGroup implements IDialogueScriptedClass i
     }
     if (!nextDialogueBox.alive) nextDialogueBox.revive();
 
-    ScriptEventDispatcher.callEvent(nextDialogueBox, new ScriptEvent(CREATE, true));
+    var event:ScriptEvent = ScriptEvent.get(CREATE);
+    ScriptEventDispatcher.callEvent(nextDialogueBox, event);
+    event.put();
 
     currentDialogueBox = nextDialogueBox;
     currentDialogueBox.zIndex = 300;
@@ -312,7 +318,16 @@ class Conversation extends FunkinSpriteGroup implements IDialogueScriptedClass i
 
   public function startConversation():Void
   {
-    dispatchEvent(new DialogueScriptEvent(DIALOGUE_START, this, true));
+    var event:DialogueScriptEvent = DialogueScriptEvent.get(DIALOGUE_START, this, true);
+    dispatchEvent(event);
+    event.put();
+  }
+
+  public function endConversation():Void
+  {
+    var event:DialogueScriptEvent = DialogueScriptEvent.get(DIALOGUE_END, this, true);
+    dispatchEvent(event);
+    event.put;
   }
 
   /**
@@ -324,21 +339,29 @@ class Conversation extends FunkinSpriteGroup implements IDialogueScriptedClass i
    */
   public function advanceConversation():Void
   {
+    var event:Null<DialogueScriptEvent> = null;
+
     switch (state)
     {
       case ConversationState.Start:
-        dispatchEvent(new DialogueScriptEvent(DIALOGUE_START, this, true));
-      case ConversationState.Opening:
-        dispatchEvent(new DialogueScriptEvent(DIALOGUE_COMPLETE_LINE, this, true));
-      case ConversationState.Speaking:
-        dispatchEvent(new DialogueScriptEvent(DIALOGUE_COMPLETE_LINE, this, true));
+        startConversation();
+        return;
+      case ConversationState.Opening | ConversationState.Speaking:
+        event = DialogueScriptEvent.get(DIALOGUE_COMPLETE_LINE, this, true);
       case ConversationState.Idle:
-        dispatchEvent(new DialogueScriptEvent(DIALOGUE_LINE, this, true));
+        event = DialogueScriptEvent.get(DIALOGUE_LINE, this, true);
       case ConversationState.Ending:
         // Skip the outro.
         endOutro();
+        return;
       default:
         // Do nothing.
+    }
+
+    if (event != null)
+    {
+      dispatchEvent(event);
+      event.put();
     }
   }
 
@@ -401,7 +424,9 @@ class Conversation extends FunkinSpriteGroup implements IDialogueScriptedClass i
    */
   public function skipConversation():Void
   {
-    dispatchEvent(new DialogueScriptEvent(DIALOGUE_SKIP, this, true));
+    var event:DialogueScriptEvent = DialogueScriptEvent.get(DIALOGUE_SKIP, this, true);
+    dispatchEvent(event);
+    event.put();
   }
 
   var outroTween:Null<FlxTween> = null;
@@ -436,7 +461,9 @@ class Conversation extends FunkinSpriteGroup implements IDialogueScriptedClass i
 
   public function endOutro():Void
   {
-    ScriptEventDispatcher.callEvent(this, new ScriptEvent(DESTROY, false));
+    var event:ScriptEvent = ScriptEvent.get(DESTROY);
+    ScriptEventDispatcher.callEvent(this, event);
+    event.put();
   }
 
   /**
@@ -475,7 +502,7 @@ class Conversation extends FunkinSpriteGroup implements IDialogueScriptedClass i
 
       if (currentDialogueEntry >= currentDialogueEntryCount)
       {
-        dispatchEvent(new DialogueScriptEvent(DIALOGUE_END, this, false));
+        endConversation();
       }
       else
       {
@@ -515,7 +542,7 @@ class Conversation extends FunkinSpriteGroup implements IDialogueScriptedClass i
     propagateEvent(event);
     if (event.eventCanceled) return;
 
-    dispatchEvent(new DialogueScriptEvent(DIALOGUE_END, this, false));
+    endConversation();
   }
 
   public function onDialogueEnd(event:DialogueScriptEvent):Void

--- a/source/funkin/play/cutscene/dialogue/Conversation.hx
+++ b/source/funkin/play/cutscene/dialogue/Conversation.hx
@@ -327,7 +327,7 @@ class Conversation extends FunkinSpriteGroup implements IDialogueScriptedClass i
   {
     var event:DialogueScriptEvent = DialogueScriptEvent.get(DIALOGUE_END, this, true);
     dispatchEvent(event);
-    event.put;
+    event.put();
   }
 
   /**

--- a/source/funkin/play/stage/Stage.hx
+++ b/source/funkin/play/stage/Stage.hx
@@ -515,7 +515,9 @@ class Stage extends FlxSpriteGroup implements IPlayStateScriptedClass implements
 
     if (PlayState.instance != null)
     {
-      ScriptEventDispatcher.callEvent(character, new ScriptEvent(ADDED, false));
+      var event:ScriptEvent = ScriptEvent.get(ADDED);
+      ScriptEventDispatcher.callEvent(character, event);
+      event.put();
 
       #if FEATURE_DEBUG_FUNCTIONS
       debugIconGroup.add(debugIcon);

--- a/source/funkin/ui/MusicBeatState.hx
+++ b/source/funkin/ui/MusicBeatState.hx
@@ -179,7 +179,10 @@ class MusicBeatState extends FlxTransitionableState implements IEventHandler
 
     Conductor.beatHit.add(this.beatHit);
     Conductor.stepHit.add(this.stepHit);
-    dispatchEvent(new ScriptEvent(STATE_CREATE));
+
+    var event:ScriptEvent = ScriptEvent.get(STATE_CREATE);
+    dispatchEvent(event);
+    event.put();
   }
 
   override public function destroy():Void
@@ -208,21 +211,27 @@ class MusicBeatState extends FlxTransitionableState implements IEventHandler
   {
     super.update(elapsed);
 
-    dispatchEvent(new UpdateScriptEvent(elapsed));
+    var event:UpdateScriptEvent = UpdateScriptEvent.get(elapsed);
+    dispatchEvent(event);
+    event.put();
   }
 
   override function onFocus():Void
   {
     super.onFocus();
 
-    dispatchEvent(new FocusScriptEvent(FOCUS_GAINED));
+    var event:ScriptEvent = FocusScriptEvent.get(FOCUS_GAINED);
+    dispatchEvent(event);
+    event.put();
   }
 
   override function onFocusLost():Void
   {
     super.onFocusLost();
 
-    dispatchEvent(new FocusScriptEvent(FOCUS_LOST));
+    var event:ScriptEvent = FocusScriptEvent.get(FOCUS_LOST);
+    dispatchEvent(event);
+    event.put();
   }
 
   function createWatermarkText()
@@ -259,9 +268,10 @@ class MusicBeatState extends FlxTransitionableState implements IEventHandler
   {
     if (this.subState != null && !persistentUpdate) return false;
 
-    var event = new SongTimeScriptEvent(SONG_STEP_HIT, conductorInUse.currentBeat, conductorInUse.currentStep);
+    var event:SongTimeScriptEvent = SongTimeScriptEvent.get(SONG_STEP_HIT, conductorInUse.currentBeat, conductorInUse.currentStep);
 
     dispatchEvent(event);
+    event.put();
 
     if (event.eventCanceled) return false;
 
@@ -272,9 +282,10 @@ class MusicBeatState extends FlxTransitionableState implements IEventHandler
   {
     if (this.subState != null && !persistentUpdate) return false;
 
-    var event = new SongTimeScriptEvent(SONG_BEAT_HIT, conductorInUse.currentBeat, conductorInUse.currentStep);
+    var event:SongTimeScriptEvent = SongTimeScriptEvent.get(SONG_BEAT_HIT, conductorInUse.currentBeat, conductorInUse.currentStep);
 
     dispatchEvent(event);
+    event.put();
 
     if (event.eventCanceled) return false;
 
@@ -293,9 +304,10 @@ class MusicBeatState extends FlxTransitionableState implements IEventHandler
   @:nullSafety(Off)
   override function startOutro(onComplete:() -> Void):Void
   {
-    var event = new StateChangeScriptEvent(STATE_CHANGE_BEGIN, null, true);
+    var event:StateChangeScriptEvent = StateChangeScriptEvent.get(STATE_CHANGE_BEGIN, null, true);
 
     dispatchEvent(event);
+    event.put();
 
     if (event.eventCanceled)
     {
@@ -311,9 +323,10 @@ class MusicBeatState extends FlxTransitionableState implements IEventHandler
 
   override public function openSubState(targetSubState:FlxSubState):Void
   {
-    var event = new SubStateScriptEvent(SUBSTATE_OPEN_BEGIN, targetSubState, true);
+    var event = SubStateScriptEvent.get(SUBSTATE_OPEN_BEGIN, targetSubState, true);
 
     dispatchEvent(event);
+    event.put();
 
     if (event.eventCanceled) return;
 
@@ -322,14 +335,17 @@ class MusicBeatState extends FlxTransitionableState implements IEventHandler
 
   function onOpenSubStateComplete(targetState:FlxSubState):Void
   {
-    dispatchEvent(new SubStateScriptEvent(SUBSTATE_OPEN_END, targetState, true));
+    var event:SubStateScriptEvent = SubStateScriptEvent.get(SUBSTATE_OPEN_END, targetState, false);
+    dispatchEvent(event);
+    event.put();
   }
 
   override public function closeSubState():Void
   {
-    var event = new SubStateScriptEvent(SUBSTATE_CLOSE_BEGIN, this.subState, true);
+    var event:SubStateScriptEvent = SubStateScriptEvent.get(SUBSTATE_CLOSE_BEGIN, this.subState, true);
 
     dispatchEvent(event);
+    event.put();
 
     if (event.eventCanceled) return;
 
@@ -338,6 +354,8 @@ class MusicBeatState extends FlxTransitionableState implements IEventHandler
 
   function onCloseSubStateComplete(targetState:FlxSubState):Void
   {
-    dispatchEvent(new SubStateScriptEvent(SUBSTATE_CLOSE_END, targetState, true));
+    var event:SubStateScriptEvent = SubStateScriptEvent.get(SUBSTATE_CLOSE_END, targetState, false);
+    dispatchEvent(event);
+    event.put();
   }
 }

--- a/source/funkin/ui/MusicBeatSubState.hx
+++ b/source/funkin/ui/MusicBeatSubState.hx
@@ -160,21 +160,27 @@ class MusicBeatSubState extends FlxSubState implements IEventHandler
     FlxG.watch.addQuick('musicTime', FlxG.sound.music?.time ?? 0.0);
     Conductor.watchQuick(conductorInUse);
 
-    dispatchEvent(new UpdateScriptEvent(elapsed));
+    var event:UpdateScriptEvent = UpdateScriptEvent.get(elapsed);
+    dispatchEvent(event);
+    event.put();
   }
 
   override function onFocus():Void
   {
     super.onFocus();
 
-    dispatchEvent(new FocusScriptEvent(FOCUS_GAINED));
+    var event:ScriptEvent = FocusScriptEvent.get(FOCUS_GAINED);
+    dispatchEvent(event);
+    event.put();
   }
 
   override function onFocusLost():Void
   {
     super.onFocusLost();
 
-    dispatchEvent(new FocusScriptEvent(FOCUS_LOST));
+    var event:ScriptEvent = FocusScriptEvent.get(FOCUS_LOST);
+    dispatchEvent(event);
+    event.put();
   }
 
   public function initConsoleHelpers():Void
@@ -207,9 +213,10 @@ class MusicBeatSubState extends FlxSubState implements IEventHandler
   {
     if (this.subState != null && !persistentUpdate) return false;
 
-    var event:ScriptEvent = new SongTimeScriptEvent(SONG_STEP_HIT, conductorInUse.currentBeat, conductorInUse.currentStep);
+    var event:ScriptEvent = SongTimeScriptEvent.get(SONG_STEP_HIT, conductorInUse.currentBeat, conductorInUse.currentStep);
 
     dispatchEvent(event);
+    event.put();
 
     if (event.eventCanceled) return false;
 
@@ -225,9 +232,10 @@ class MusicBeatSubState extends FlxSubState implements IEventHandler
   {
     if (this.subState != null && !persistentUpdate) return false;
 
-    var event:ScriptEvent = new SongTimeScriptEvent(SONG_BEAT_HIT, conductorInUse.currentBeat, conductorInUse.currentStep);
+    var event:ScriptEvent = SongTimeScriptEvent.get(SONG_BEAT_HIT, conductorInUse.currentBeat, conductorInUse.currentStep);
 
     dispatchEvent(event);
+    event.put();
 
     if (event.eventCanceled) return false;
 
@@ -270,9 +278,10 @@ class MusicBeatSubState extends FlxSubState implements IEventHandler
   @:nullSafety(Off)
   override function startOutro(onComplete:() -> Void):Void
   {
-    var event = new StateChangeScriptEvent(STATE_CHANGE_BEGIN, null, true);
+    var event = StateChangeScriptEvent.get(STATE_CHANGE_BEGIN, null, true);
 
     dispatchEvent(event);
+    event.put();
 
     if (event.eventCanceled)
     {
@@ -288,9 +297,10 @@ class MusicBeatSubState extends FlxSubState implements IEventHandler
 
   override public function openSubState(targetSubState:FlxSubState):Void
   {
-    var event = new SubStateScriptEvent(SUBSTATE_OPEN_BEGIN, targetSubState, true);
+    var event = SubStateScriptEvent.get(SUBSTATE_OPEN_BEGIN, targetSubState, true);
 
     dispatchEvent(event);
+    event.put();
 
     if (event.eventCanceled) return;
 
@@ -299,14 +309,17 @@ class MusicBeatSubState extends FlxSubState implements IEventHandler
 
   function onOpenSubStateComplete(targetState:FlxSubState):Void
   {
-    dispatchEvent(new SubStateScriptEvent(SUBSTATE_OPEN_END, targetState, true));
+    var event:SubStateScriptEvent = SubStateScriptEvent.get(SUBSTATE_OPEN_END, targetState, true);
+    dispatchEvent(event);
+    event.put();
   }
 
   override public function closeSubState():Void
   {
-    var event = new SubStateScriptEvent(SUBSTATE_CLOSE_BEGIN, this.subState, true);
+    var event = SubStateScriptEvent.get(SUBSTATE_CLOSE_BEGIN, this.subState, true);
 
     dispatchEvent(event);
+    event.put();
 
     if (event.eventCanceled) return;
 
@@ -315,6 +328,8 @@ class MusicBeatSubState extends FlxSubState implements IEventHandler
 
   function onCloseSubStateComplete(targetState:FlxSubState):Void
   {
-    dispatchEvent(new SubStateScriptEvent(SUBSTATE_CLOSE_END, targetState, true));
+    var event:SubStateScriptEvent = SubStateScriptEvent.get(SUBSTATE_CLOSE_END, targetState, true);
+    dispatchEvent(event);
+    event.put();
   }
 }

--- a/source/funkin/ui/charSelect/CharSelectSubState.hx
+++ b/source/funkin/ui/charSelect/CharSelectSubState.hx
@@ -866,7 +866,9 @@ class CharSelectSubState extends MusicBeatSubState
         mobileDeny = false;
         cursors.unconfirm();
 
-        dispatchEvent(new CharacterSelectScriptEvent(CHARACTER_DESELECTED, curChar));
+        var event:CharacterSelectScriptEvent = CharacterSelectScriptEvent.get(CHARACTER_DESELECTED, curChar);
+        dispatchEvent(event);
+        event.put();
 
         #if FEATURE_TOUCH_CONTROLS
         if (backButton != null)
@@ -903,7 +905,9 @@ class CharSelectSubState extends MusicBeatSubState
 
         FunkinSound.playOnce(Paths.sound('ui/character-select/sounds/confirm'));
 
-        dispatchEvent(new CharacterSelectScriptEvent(CHARACTER_CONFIRMED, curChar));
+        var event:CharacterSelectScriptEvent = CharacterSelectScriptEvent.get(CHARACTER_CONFIRMED, curChar);
+        dispatchEvent(event);
+        event.put();
 
         #if FEATURE_TOUCH_CONTROLS
         if (backButton != null)

--- a/source/funkin/ui/debug/cameraeditor/CameraEditorState.hx
+++ b/source/funkin/ui/debug/cameraeditor/CameraEditorState.hx
@@ -875,8 +875,9 @@ class CameraEditorState extends UIState implements ConsoleClass
         default:
           if (doSongEvents)
           {
-            var ev:SongEventScriptEvent = new SongEventScriptEvent(eventData);
+            var ev:SongEventScriptEvent = SongEventScriptEvent.get(eventData);
             currentStage.onSongEvent(ev);
+            ev.put();
           }
           else
           {
@@ -887,6 +888,7 @@ class CameraEditorState extends UIState implements ConsoleClass
       if (doDispatch)
       {
         dispatchEvent(eventEvent);
+        eventEvent.put();
       }
 
       cachedEventIndex = i + 1;

--- a/source/funkin/ui/debug/charting/ChartEditorState.hx
+++ b/source/funkin/ui/debug/charting/ChartEditorState.hx
@@ -7822,7 +7822,7 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
    */
   var _scriptNoteObj:NoteSprite = null;
 
-  var _noteScriptEvent:NoteScriptEvent = null;
+  var _noteScriptEvent:HitNoteScriptEvent = null;
   var _currentEvents = null;
   var _allowedEvents = null;
   var _eventTarget:Null<CharacterPlayer> = null;
@@ -7854,14 +7854,14 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
       _scriptNoteObj.direction = _scriptNoteObj.noteData?.getDirection() ?? 0;
       _scriptNoteObj.scrollFactor.set();
 
-      _noteScriptEvent = new HitNoteScriptEvent(_scriptNoteObj, 0.0, 0, (noteData.getStrumlineIndex() == 0 ? 'perfect' : 'sick'), false, 0);
+      _noteScriptEvent = HitNoteScriptEvent.get(_scriptNoteObj, 0.0, 0, (noteData.getStrumlineIndex() == 0 ? 'perfect' : 'sick'), false, 0);
       dispatchEvent(_noteScriptEvent);
+      _noteScriptEvent.put();
 
       // Calling event.cancelEvent() skips all the other logic! Neat!
       if (_noteScriptEvent.eventCanceled)
       {
         _scriptNoteObj = null;
-        _noteScriptEvent = null;
 
         continue;
       }
@@ -7878,10 +7878,6 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
         }
       }
     }
-
-    // Clearing memory before next event call.
-    _scriptNoteObj = null;
-    _noteScriptEvent = null;
 
     for (data in _allowedEvents)
     {

--- a/source/funkin/ui/debug/dialogue/ConversationDebugState.hx
+++ b/source/funkin/ui/debug/dialogue/ConversationDebugState.hx
@@ -39,8 +39,9 @@ class ConversationDebugState extends MusicBeatState
     add(conversation);
     refresh();
 
-    var event:ScriptEvent = new ScriptEvent(CREATE, false);
+    var event:ScriptEvent = ScriptEvent.get(CREATE, false);
     ScriptEventDispatcher.callEvent(conversation, event);
+    event.put();
   }
 
   function onConversationComplete():Void

--- a/source/funkin/ui/freeplay/FreeplayState.hx
+++ b/source/funkin/ui/freeplay/FreeplayState.hx
@@ -450,7 +450,11 @@ class FreeplayState extends MusicBeatSubState
 
     backingCard.instance = this;
     add(backingCard);
-    ScriptEventDispatcher.callEvent(backingCard, new ScriptEvent(CREATE, false));
+
+    var event:ScriptEvent = ScriptEvent.get(CREATE);
+    ScriptEventDispatcher.callEvent(backingCard, event);
+    event.put();
+
     backingCard.applyExitMovers(exitMovers, exitMoversCharSel);
 
     if (currentCharacter?.getFreeplayDJData() != null)
@@ -758,7 +762,9 @@ class FreeplayState extends MusicBeatSubState
     {
       if (!uiStateMachine.is(Interacting)) uiStateMachine.transition(Idle);
 
-      dispatchEvent(new FreeplayScriptEvent(FREEPLAY_INTRO));
+      var event:FreeplayScriptEvent = FreeplayScriptEvent.get(FREEPLAY_INTRO);
+      dispatchEvent(event);
+      event.put();
 
       // when boyfriend hits dat shiii
 
@@ -1083,7 +1089,9 @@ class FreeplayState extends MusicBeatSubState
     changeSelection();
     refreshCapsuleDisplays();
 
-    dispatchEvent(new CapsuleScriptEvent(DIFFICULTY_SWITCH, currentCapsule, currentDifficulty, currentVariation));
+    var event:CapsuleScriptEvent = CapsuleScriptEvent.get(DIFFICULTY_SWITCH, currentCapsule, currentDifficulty, currentVariation);
+    dispatchEvent(event);
+    event.put();
   }
 
   /**
@@ -2475,7 +2483,9 @@ class FreeplayState extends MusicBeatSubState
     FlxTimer.globalManager.clear();
     dj?.onIntroDone.removeAll();
 
-    dispatchEvent(new FreeplayScriptEvent(FREEPLAY_OUTRO));
+    var event:FreeplayScriptEvent = FreeplayScriptEvent.get(FREEPLAY_OUTRO);
+    dispatchEvent(event);
+    event.put();
 
     FunkinSound.playOnce(Paths.sound('ui/main-menu/cancel-menu'));
 
@@ -3004,7 +3014,9 @@ class FreeplayState extends MusicBeatSubState
   {
     uiStateMachine.transition(Exiting);
 
-    dispatchEvent(new CapsuleScriptEvent(SONG_SELECTED, currentCapsule, currentDifficulty, currentVariation));
+    var event:CapsuleScriptEvent = CapsuleScriptEvent.get(SONG_SELECTED, currentCapsule, currentDifficulty, currentVariation);
+    dispatchEvent(event);
+    event.put();
 
     PlayStatePlaylist.isStoryMode = false;
 
@@ -3244,7 +3256,9 @@ class FreeplayState extends MusicBeatSubState
     // Small vibrations every selection change.
     if (change != 0) HapticUtil.vibrate(0, 0.01, 0.5);
 
-    dispatchEvent(new CapsuleScriptEvent(CAPSULE_SELECTED, currentCapsule, currentDifficulty, currentVariation));
+    var event:CapsuleScriptEvent = CapsuleScriptEvent.get(CAPSULE_SELECTED, currentCapsule, currentDifficulty, currentVariation);
+    dispatchEvent(event);
+    event.put();
   }
 
   public function playCurSongPreview(?daSongCapsule:SongMenuItem):Void

--- a/source/funkin/util/macro/ScriptEventPoolMacro.hx
+++ b/source/funkin/util/macro/ScriptEventPoolMacro.hx
@@ -1,0 +1,156 @@
+package funkin.util.macro;
+
+#if macro
+import haxe.macro.Context;
+import haxe.macro.Expr;
+import haxe.macro.Type.ClassType;
+
+using haxe.macro.ExprTools;
+using haxe.macro.TypeTools;
+using thx.Arrays;
+
+/**
+ * This macro creates necessary pooling fields for script events.
+ */
+class ScriptEventPoolMacro
+{
+  /**
+   * A meta to indicate that pooling functions have been added.
+   */
+  public static final PROCESSED_META:String = ':hasBuiltPool';
+
+  public static macro function buildPool():Array<Field>
+  {
+    var cls:ClassType = Context.getLocalClass().get();
+    if (cls.meta.has(PROCESSED_META)) return null;
+
+    var pos:Position = Context.currentPos();
+    var buildFields:Array<Field> = Context.getBuildFields().copy();
+
+    cls.meta.add(PROCESSED_META, [], pos);
+
+    var retType:ComplexType = Context.getType('${cls.module}.${cls.name}').toComplexType();
+    buildFields.push({
+      name: 'pool',
+      doc: 'The pool of the events to recycle events from.',
+      access: [APublic, AStatic],
+      pos: pos,
+      kind: FVar(macro :Array<$retType>, {
+        expr: EArrayDecl([]),
+        pos: pos
+      })
+    });
+
+    var constructor:Null<Field> = buildFields.find((fld) -> fld.name == 'new');
+    if (constructor == null)
+    {
+      Context.error('ScriptEventPoolMacro: Missing constructor for ${cls.name}.', pos);
+      return null;
+    }
+
+    switch (constructor?.kind)
+    {
+      case FFun(f):
+        var argNames:Array<Expr> = [for (arg in f.args) macro $i{arg.name}];
+        var name:String = cls.pack.copy().concat([cls.name]).join('.');
+
+        // To create the resetting function, the expression of the constructor is copied and the 'super(args)' part is replaced with an appropriate reset function.
+        // The exception to this is `ScriptEvent`, whose constructor can be copied over without any adjustments, as it doesn't extend anything.
+        var resetFunction:String = 'reset_${cls.name}';
+        var resetExpr:Expr = {
+          expr: f.expr.expr,
+          pos: pos
+        };
+
+        if (cls.superClass != null)
+        {
+          switch (resetExpr.expr)
+          {
+            case EBlock(exprs):
+              var exprArray:Array<Expr> = exprs.copy();
+
+              for (i in 0...exprArray.length)
+              {
+                switch (exprArray[i].expr)
+                {
+                  case ECall(e, params) if (Type.enumEq(e.expr, EConst(CIdent('super')))):
+                    exprArray[i] = {
+                      pos: exprArray[i].pos,
+                      expr: ECall({
+                        pos: e.pos,
+                        expr: EConst(CIdent('reset_${cls.superClass.t.get().name}'))
+                      }, params)
+                    }
+                    break;
+                  default:
+                }
+              }
+
+              resetExpr.expr = EBlock(exprArray);
+            case ECall(e, params) if (Type.enumEq(e.expr, EConst(CIdent('super')))):
+              resetExpr.expr = ECall({
+                pos: e.pos,
+                expr: EConst(CIdent('reset_${cls.superClass.t.get().name}'))
+              }, params);
+
+            default:
+              Context.error('ScriptEventPoolMacro: The constructor for $name must be either a block or a super() call.', pos);
+              return null;
+          }
+        }
+
+        buildFields.push({
+          name: resetFunction,
+          doc: 'An alternative way of resetting an event without calling the constructor.',
+          access: [APrivate],
+          pos: pos,
+          kind: FFun({
+            args: f.args,
+            ret: f.ret,
+            params: f.params,
+            expr: resetExpr
+          })
+        });
+
+        buildFields.push({
+          name: 'get',
+          doc: 'Returns a recycled instance of an event, if possible.\nIf not, creates a new event and adds it to the pool.',
+          access: [APublic, AStatic],
+          pos: pos,
+          kind: FFun({
+            args: f.args,
+            ret: retType,
+            params: f.params,
+            expr: macro
+            {
+              var event = null;
+              for (item in pool)
+              {
+                if (!item.hasBeenUsed)
+                {
+                  event = item;
+                  event.hasBeenUsed = true;
+                  event.$resetFunction($a{argNames});
+                  return event;
+                }
+              }
+
+              event = Type.createInstance(Type.resolveClass($v{name}), [$a{argNames}]);
+              if (event == null) throw 'Couldn\'t instantiate the event class ' + $v{name};
+
+              event.hasBeenUsed = true;
+              pool.push(event);
+              return event;
+            }
+          })
+        });
+
+      default:
+        Context.error('ScriptEventPoolMacro: Incorrect type of constructor for ${cls.name}, expected a function.', pos);
+        return null;
+    }
+
+    return buildFields;
+  }
+}
+#end


### PR DESCRIPTION
## Linked Issues
None.

## Description
This PR implements a pooling system for script events, making the garbage collector get triggered way less frequently. There's a crap ton of changes because I've had to change **every single time** a script event is dispatched to accomodate for this.

This implementation might look a bit confusing, so let me explain:
A lot of read-only event fields had to be changed to `(default, set)` with an empty setter like this
```haxe
function set_field(value:Bool) return value;
```
This makes the field unable to be set, unless called with `@:bypassAccessor`, which negates the functionality of the setter. This is perfect, because in scripts we can't use it (and neither does reflection really work with it) but we can in source, making us be able to re-use the event instance while only changing the field values.

Also I've *slightly* changed whether some events are cancelable or not. It's mostly the `CREATE` events being cancelable, despite no logic being implemented to account for this.