### PR TITLE
[FIX] Fix runtime errors due to tempVocals being nullable

### DIFF
--- a/source/funkin/play/PlayState.hx
+++ b/source/funkin/play/PlayState.hx
@@ -3193,7 +3193,7 @@ class PlayState extends MusicBeatSubState
 
     if (playSound)
     {
-      var tempVocals:Bool = currentStage != null && currentStage.getBoyfriend().tempVocals;
+      var tempVocals:Bool = currentStage != null && currentStage.getBoyfriend()?.tempVocals;
       if (vocals != null && !tempVocals) vocals.playerVolume = 0;
       FunkinSound.playOnce(Paths.soundRandom('missnote', 1, 3), FlxG.random.float(0.5, 0.6));
     }
@@ -3235,7 +3235,7 @@ class PlayState extends MusicBeatSubState
 
     if (event.playSound)
     {
-      var tempVocals:Bool = currentStage != null && currentStage.getBoyfriend().tempVocals;
+      var tempVocals:Bool = currentStage != null && currentStage.getBoyfriend()?.tempVocals;
       if (vocals != null && !tempVocals) vocals.playerVolume = 0;
       FunkinSound.playOnce(Paths.soundRandom('missnote', 1, 3), FlxG.random.float(0.1, 0.2));
     }


### PR DESCRIPTION
## Description
- Fixes a0ccf3a36efebe64de92b732a366318df59c4e21 due to Eric not properly accounting for tempVocals being null since no-vocal songs are a thing.

## Screenshots/Videos

<img width="1018" height="789" alt="image" src="https://github.com/user-attachments/assets/22ded81f-5167-4d66-810c-549520d0c3db" />