### PR TITLE
[Modding] Remove the popup error when a directory in mods has no metadata.

### DIFF
--- a/source/funkin/modding/PolymodErrorHandler.hx
+++ b/source/funkin/modding/PolymodErrorHandler.hx
@@ -29,8 +29,6 @@ class PolymodErrorHandler
       case MOD_MISSING_METADATA:
         // A mod ID was included in the list of mods to load, but the mod folder doesn't have metadata.
         trace(' ERROR '.error() + ' Tried to load a mod with no metadata: ${error.message}');
-        // Notify the user via popup.
-        funkin.util.WindowUtil.showError('Mod Load Error', error.message);
 
       case MOD_METADATA_PARSE_FAILED:
         // Polymod tries to load the mod's metadata, but it could not be parsed.


### PR DESCRIPTION
## Description
This PR removes the alert pop-up error when a directory from the mods folder has no metadata.
This is annoying if people just want to have directories for dumping or anything there like other mods without loading them. Or if they want to disable mods.