### PR TITLE
[CRASHFIX] Fix crash when hot-reloading in Lag Adjustment menu

### DIFF
--- a/source/funkin/ui/options/OptionsState.hx
+++ b/source/funkin/ui/options/OptionsState.hx
@@ -180,7 +180,7 @@ class OptionsMenu extends Page<OptionsMenuPageName>
     #if FEATURE_LAG_ADJUSTMENT
     createItem('LAG ADJUSTMENT', function()
     {
-      FlxG.sound.music.fadeOut(0.5, 0, function(tw)
+      var switchToOffsets = function()
       {
         FunkinSound.playMusic('offsetsLoop', {
           startingVolume: 0,
@@ -190,9 +190,20 @@ class OptionsMenu extends Page<OptionsMenuPageName>
         });
         OptionsState.instance.drumsBG.play(true);
         FlxG.sound.music.fadeIn(1, 1);
-      });
+        codex.switchPage(Offsets);
+      };
 
-      codex.switchPage(Offsets);
+      if (FlxG.sound.music != null)
+      {
+        FlxG.sound.music.fadeOut(0.5, 0, function(tw)
+        {
+          switchToOffsets();
+        });
+      }
+      else
+      {
+        switchToOffsets();
+      }
     });
     #end
     #if FEATURE_MOBILE_IAP


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
- #7285

<!-- Briefly describe the issue(s) fixed. -->
## Description
This PR fixes an obscure crash when hot-reloading in the lag adjustments menu.
### Changes:
- Added a null check for `FlxG.sound.music` before calling `fadeOut()`.
- Created `switchToOffsets()` to avoid duplicating the original code.

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos
### BEFORE:
https://github.com/user-attachments/assets/f8139ebd-8318-4d4a-8220-8feed8da6060
### AFTER:
https://github.com/user-attachments/assets/7041ad57-3205-45cc-9d97-4f9fa43da1a2