### PR TITLE
[BUGFIX] Fix newly created charts improperly setting the voice list

### DIFF
--- a/source/funkin/data/song/SongData.hx
+++ b/source/funkin/data/song/SongData.hx
@@ -537,9 +537,6 @@ class SongCharacterData implements ICloneable<SongCharacterData>
     this.altInstrumentals = altInstrumentals ?? [];
     this.opponentVocals = opponentVocals;
     this.playerVocals = playerVocals;
-
-    if (opponentVocals == null) this.opponentVocals = [opponent];
-    if (playerVocals == null) this.playerVocals = [player];
   }
 
   public function clone():SongCharacterData


### PR DESCRIPTION
## Linked Issues
None.

## Description
The issue this PR aims to fix is that newly made charts that use players that aren't bf and opponents that aren't dad won't properly load vocal files in the chart editor. This is because the newly created data for characters in the song metadata files uses default characters, which then also fill the player/opponent voices array. In the chart editor, the aforementioned arrays are **never changed**, meaning that the metadata generated by the editor will always attempt to use dad and bf voices, even for charts that don't have them as characters.
