### PR TITLE
[FIX + OPTIMIZATION] Improve `onExit` cleanup & resource disposal 

### DIFF
--- a/.github/actions/setup-haxe/action.yml
+++ b/.github/actions/setup-haxe/action.yml
@@ -5,7 +5,7 @@ inputs:
   haxe:
     description: 'Version of haxe to install'
     required: true
-    default: '4.3.6'
+    default: '4.3.7'
   hxcpp-cache:
     description: 'Whether to use a shared hxcpp compile cache'
     required: true
@@ -71,7 +71,7 @@ runs:
 
   - name: Restore cached dependencies
     id: cache-hmm
-    uses: actions/cache@v4
+    uses: actions/cache@v5
     with:
       path: .haxelib
       key: haxe-hmm-${{ runner.os }}-${{ hashFiles('**/hmm.json') }}
@@ -98,7 +98,7 @@ runs:
   # by default use a shared hxcpp cache
   - if: ${{ inputs.hxcpp-cache == 'true' }}
     name: Restore hxcpp cache
-    uses: actions/cache@v4
+    uses: actions/cache@v5
     with:
       path: ${{ inputs.hxcpp-cache-path }}
       key: haxe-hxcpp-${{ runner.os }}-${{ github.ref_name }}-${{ github.sha }}
@@ -114,7 +114,7 @@ runs:
   # if it's explicitly disabled, still cache export/ since that then contains the builds
   - if: ${{ inputs.hxcpp-cache != 'true' }}
     name: Restore export cache
-    uses: actions/cache@v4
+    uses: actions/cache@v5
     with:
       path: ${{ inputs.hxcpp-cache-path }}
       key: haxe-export-${{ runner.os }}-${{ github.ref_name }}-${{ github.sha }}

--- a/.github/workflows/cancel-merged-branches.yml
+++ b/.github/workflows/cancel-merged-branches.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
     - name: Cancel queued workflows for ${{ github.event.pull_request.head.ref }}
-      uses: actions/github-script@v7
+      uses: actions/github-script@v8
       with:
         result-encoding: string
         retries: 3

--- a/.github/workflows/label-actions.yml
+++ b/.github/workflows/label-actions.yml
@@ -27,4 +27,4 @@ jobs:
   action:
     runs-on: ubuntu-latest
     steps:
-      - uses: dessant/label-actions@v4
+      - uses: dessant/label-actions@v5

--- a/.github/workflows/label-pull-request.yml
+++ b/.github/workflows/label-pull-request.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Set basic labels
-      uses: actions/labeler@v5
+      uses: actions/labeler@v6
       with:
         sync-labels: true
   # Apply labels to pull requests based on how many lines were edited

--- a/hmm.json
+++ b/hmm.json
@@ -184,7 +184,7 @@
       "name": "lime",
       "type": "git",
       "dir": null,
-      "ref": "eb0de06b70b6794a4620238ecb91590e17fadb30",
+      "ref": "122b651166c35f2be1e8a473a4e9f5580526e1db",
       "url": "https://github.com/FunkinCrew/lime"
     },
     {

--- a/hmm.json
+++ b/hmm.json
@@ -11,7 +11,7 @@
       "name": "astc-compressor",
       "type": "git",
       "dir": null,
-      "ref": "b7a91b3072dc16e785a9bde847f17ba0ef15dd47",
+      "ref": "6c0fa6f46d3547ca58859b6ede87e659018a7ff5",
       "url": "https://github.com/KarimAkra/astc-compressor"
     },
     {

--- a/hmm.json
+++ b/hmm.json
@@ -191,7 +191,7 @@
       "name": "newgrounds",
       "type": "git",
       "dir": null,
-      "ref": "b2b53cd0a5f030af74efd325732951cddbea8826",
+      "ref": "60162762e6ca65da011ffee7a6617f547ea5dff9",
       "url": "https://github.com/FunkinCrew/Newgrounds"
     },
     {

--- a/project.hxp
+++ b/project.hxp
@@ -2503,7 +2503,13 @@ class Project extends HXProject
     info('Compressing ASTC textures...');
 
     var args:Array<String> = ['run', 'astc-compressor', 'compress-from-json'];
+
     args = args.concat(['-json', './astc-compression-data.json']);
+
+    if (isCleanFlag())
+    {
+      args = args.concat(['-clean']);
+    }
 
     Sys.command('haxelib', args);
 

--- a/project.hxp
+++ b/project.hxp
@@ -773,13 +773,13 @@ class Project extends HXProject
     switch (this.platformType)
     {
       case PlatformType.DESKTOP:
-        info('Platform Type: Desktop');
+        info('Target Platform Type: Desktop');
       case PlatformType.MOBILE:
-        info('Platform Type: Mobile');
+        info('Target Platform Type: Mobile');
       case PlatformType.WEB:
-        info('Platform Type: Web');
+        info('Target Platform Type: Web');
       case PlatformType.CONSOLE:
-        info('Platform Type: Console');
+        info('Target Platform Type: Console');
       default:
         error('Unknown platform type (got ${platformType})');
     }
@@ -824,23 +824,23 @@ class Project extends HXProject
       switch (arch)
       {
         case Architecture.X86:
-          info('Architecture: x86');
+          info('Target Architecture: x86');
         case Architecture.X64:
-          info('Architecture: x64');
+          info('Target Architecture: x64');
         case Architecture.ARMV5:
-          info('Architecture: ARMv5');
+          info('Target Architecture: ARMv5');
         case Architecture.ARMV6:
-          info('Architecture: ARMv6');
+          info('Target Architecture: ARMv6');
         case Architecture.ARMV7:
-          info('Architecture: ARMv7');
+          info('Target Architecture: ARMv7');
         case Architecture.ARMV7S:
-          info('Architecture: ARMv7S');
+          info('Target Architecture: ARMv7S');
         case Architecture.ARM64:
-          info('Architecture: ARMx64');
+          info('Target Architecture: ARMx64');
         case Architecture.MIPS:
-          info('Architecture: MIPS');
+          info('Target Architecture: MIPS');
         case Architecture.MIPSEL:
-          info('Architecture: MIPSEL');
+          info('Target Architecture: MIPSEL');
         case null:
           if (!isWeb())
           {
@@ -848,7 +848,7 @@ class Project extends HXProject
           }
           else
           {
-            info('Architecture: Web');
+            info('Target Architecture: Web');
           }
         default:
           error('Unsupported architecture (got ${arch})');

--- a/project.hxp
+++ b/project.hxp
@@ -543,11 +543,11 @@ class Project extends HXProject
 
     flair();
 
+    displayTarget();
+
     configureApp();
 
     configureOutputDir();
-
-    displayTarget();
 
     if (isRun() || isInstall())
     {

--- a/project.hxp
+++ b/project.hxp
@@ -549,7 +549,7 @@ class Project extends HXProject
 
     displayTarget();
 
-    if (this.command == "run" || this.command == "install")
+    if (isRun() || isInstall())
     {
       // These commands dont really need much in order to run so to improve the speed, we return here.
       return;
@@ -1806,6 +1806,16 @@ class Project extends HXProject
   public function isCleanFlag():Bool
   {
     return this.targetFlags.exists("clean");
+  }
+
+  public function isRun():Bool
+  {
+    return this.command == "run";
+  }
+
+  public function isInstall():Bool
+  {
+    return this.command == "install";
   }
 
   public function isBuild():Bool

--- a/project.hxp
+++ b/project.hxp
@@ -589,7 +589,7 @@ class Project extends HXProject
       buildHxCppTools();
     }
 
-    if (!(isDisplay() || isClean()))
+    if (!(isDisplay() || isCleanCommand()))
     {
       checkLibraries();
     }
@@ -1416,7 +1416,7 @@ class Project extends HXProject
 
   function configureAssets()
   {
-    if (!(isDisplay() || isClean()))
+    if (!(isDisplay() || isCleanCommand()))
     {
       // Delete the assets folder from the export folder before adding anything.
       clearAssets();
@@ -1654,14 +1654,10 @@ class Project extends HXProject
    */
   function configureASTCTextures()
   {
-    if (!(isDisplay() || isClean()))
+    if (!(isDisplay() && isCleanCommand()) && FEATURE_COMPRESSED_TEXTURES.isEnabled(this))
     {
       readASTCExclusion();
-
-      if (FEATURE_COMPRESSED_TEXTURES.isEnabled(this))
-      {
-        runASTCCompressor();
-      }
+      runASTCCompressor();
     }
   }
 
@@ -1802,9 +1798,14 @@ class Project extends HXProject
     return this.command == "display";
   }
 
-  public function isClean():Bool
+  public function isCleanCommand():Bool
   {
     return this.command == "clean";
+  }
+
+  public function isCleanFlag():Bool
+  {
+    return this.targetFlags.exists("clean");
   }
 
   public function isBuild():Bool
@@ -2335,7 +2336,7 @@ class Project extends HXProject
    */
   public function info(message:String):Void
   {
-    if (!(isDisplay() || isClean()))
+    if (!(isDisplay() || isCleanCommand()))
     {
       Sys.println(' INFO '.bold().bg_blue() + " " + message);
     }
@@ -2346,7 +2347,7 @@ class Project extends HXProject
    */
   public function warn(message:String):Void
   {
-    if (!(isDisplay() || isClean()))
+    if (!(isDisplay() || isCleanCommand()))
     {
       Sys.println(' WARNING '.bold().bg_yellow() + " " + message);
     }

--- a/project.hxp
+++ b/project.hxp
@@ -545,13 +545,20 @@ class Project extends HXProject
 
     configureApp();
 
+    configureOutputDir();
+
     displayTarget();
+
+    if (this.command == "run" || this.command == "install")
+    {
+      // These commands dont really need much in order to run so to improve the speed, we return here.
+      return;
+    }
 
     configureFeatureFlags();
     configureCompileDefines();
     configureIncludeMacros();
     configureCustomMacros();
-    configureOutputDir();
     configurePolymod();
     configureHaxelibs();
     configureASTCTextures();

--- a/project.hxp
+++ b/project.hxp
@@ -589,7 +589,7 @@ class Project extends HXProject
       buildHxCppTools();
     }
 
-    if (!isDisplay())
+    if (!(isDisplay() || isClean()))
     {
       checkLibraries();
     }
@@ -1416,7 +1416,7 @@ class Project extends HXProject
 
   function configureAssets()
   {
-    if (!isDisplay())
+    if (!(isDisplay() || isClean()))
     {
       // Delete the assets folder from the export folder before adding anything.
       clearAssets();

--- a/project.hxp
+++ b/project.hxp
@@ -705,6 +705,29 @@ class Project extends HXProject
 
       config.set("android.minimum-sdk-version", ANDROID_MINIMUM_SDK_VERSION);
       config.set("android.target-sdk-version", ANDROID_TARGET_SDK_VERSION);
+
+      if (isRelease())
+      {
+        if (envConfig != null)
+        {
+          keystore = new Keystore();
+          keystore.path = Std.string(envConfig.get('KEYSTORE_PATH'));
+          keystore.alias = Std.string(envConfig.get('KEYSTORE_ALIAS'));
+          keystore.password = Std.string(envConfig.get('KEYSTORE_PASSWORD'));
+        }
+
+        if (isBundle())
+        {
+          config.set("android.gradle-project-directory", "bin-bundle");
+        }
+      }
+    }
+
+    if (isIOS())
+    {
+      config.set("ios.non-exempt-encryption", "false");
+      config.set("ios.team-id", IOS_TEAM_ID);
+      config.set("ios.deployment", "16.0");
     }
   }
 
@@ -1168,22 +1191,6 @@ class Project extends HXProject
   {
     javaPaths.push(Path.join([SOURCE_DIR, 'funkin/external/android/java']));
 
-    if (isRelease())
-    {
-      if (envConfig != null)
-      {
-        keystore = new Keystore();
-        keystore.path = Std.string(envConfig.get('KEYSTORE_PATH'));
-        keystore.alias = Std.string(envConfig.get('KEYSTORE_ALIAS'));
-        keystore.password = Std.string(envConfig.get('KEYSTORE_PASSWORD'));
-      }
-
-      if (isBundle())
-      {
-        config.set("android.gradle-project-directory", "bin-bundle");
-      }
-    }
-
     // Custom android.application XML Children for the AndroidManifest
     final modsFolderProvider:Xml = Xml.createElement('provider');
     modsFolderProvider.set('android:authorities', '$PACKAGE_NAME.docprovider');
@@ -1270,10 +1277,6 @@ class Project extends HXProject
 
   function configureIOS()
   {
-    config.set("ios.non-exempt-encryption", "false");
-    config.set("ios.team-id", IOS_TEAM_ID);
-    config.set("ios.deployment", "16.0");
-
     // launchStoryboard = new LaunchStoryboard();
     // launchStoryboard.path = "./LaunchScreen.storyboard";
 

--- a/project.hxp
+++ b/project.hxp
@@ -2346,7 +2346,7 @@ class Project extends HXProject
    */
   public function info(message:String):Void
   {
-    if (!(isDisplay() || isCleanCommand()))
+    if (!(isDisplay() || isCleanCommand() || isRun() || isInstall()))
     {
       Sys.println(' INFO '.bold().bg_blue() + " " + message);
     }
@@ -2357,7 +2357,7 @@ class Project extends HXProject
    */
   public function warn(message:String):Void
   {
-    if (!(isDisplay() || isCleanCommand()))
+    if (!(isDisplay() || isCleanCommand() || isRun() || isInstall()))
     {
       Sys.println(' WARNING '.bold().bg_yellow() + " " + message);
     }

--- a/source/Main.hx
+++ b/source/Main.hx
@@ -11,6 +11,8 @@ import funkin.util.logging.CrashHandler;
 import funkin.ui.debug.FunkinDebugDisplay;
 import funkin.ui.debug.FunkinDebugDisplay.DebugDisplayMode;
 import funkin.save.Save;
+import funkin.FunkinMemory;
+import funkin.audio.FunkinSound;
 #if hxvlc
 import hxvlc.util.Handle;
 #end
@@ -87,19 +89,21 @@ class Main extends Sprite
       removeEventListener(Event.ADDED_TO_STAGE, init);
     }
 
-    #if (sys && !mobile)
+    #if (!html5 && !mobile)
     // Force-kill the game to prevent background processing.
-    Lib.current.stage.window.onClose.add(function()
+    openfl.Lib.application.onExit.add((_) ->
     {
-      trace(' EXITING '.bold().bg_red() + ' Game is exiting, cleaning up resources...');
+      // Dispose of cached audio and textures.
+      funkin.audio.FunkinSound.stopAllAudio(true, true);
+      funkin.FunkinMemory.purgeCache(true);
 
-      #if hxvlc
-      // Clean up VLC threads to prevent memory leaks.
-      hxvlc.util.Handle.dispose();
-      #end
+      // Dispose of any assets still in the OpenFL cache, just incase.
+      openfl.Assets.cache.clear();
+
+      trace(' EXITING '.bold().bg_red() + ' Resources are disposed, Game is closing now.');
 
       Sys.exit(0);
-    });
+    }, 99);
     #end
 
     // Manually crash the game when using a software renderer in order to give a nicer error message.

--- a/source/funkin/FunkinMemory.hx
+++ b/source/funkin/FunkinMemory.hx
@@ -98,6 +98,8 @@ class FunkinMemory
    */
   public static inline function purgeCache(callGarbageCollector:Bool = false):Void
   {
+    trace(' CLEARING CACHE '.bg_bright_lilac().bold() +  ' Disposing all cached textures, assets and sounds...');
+
     preparePurgeTextureCache();
     purgeTextureCache();
     preparePurgeSoundCache();


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
- #7235 

<!-- Briefly describe the issue(s) fixed. -->
## Description
I just wanted to make some minor improvements to the background processing PR i made for v0.8.4, aswell as fix some issues that involve Mods not being able to properly run `onExit`.

### Changes
- The game now disposes of cached audio / textures, alongside `openfl.Assets` to ensure a proper resource cleanup.
  * Disposing of cached audio / textures upon exiting the game will now be logged to the terminal.
- Set `onExit` handler priority to 99 to ensure cleanup runs after mod exit callbacks.
- Removed HTML5 builds from getting background processed to prevent compilation errors.
- Removed `hxvlc` disposal from background processing.