### PR TITLE
[BUGFIX] Fix getting a new rank making the clip size incorrect

### DIFF
--- a/source/funkin/ui/freeplay/FreeplayState.hx
+++ b/source/funkin/ui/freeplay/FreeplayState.hx
@@ -1173,11 +1173,11 @@ class FreeplayState extends MusicBeatSubState
 
     new FlxTimer().start(0.1, _ ->
     {
+      capsuleToRank.fakeRanking.visible = false;
+      capsuleToRank.fakeBlurredRanking.visible = false;
+
       if (fromResults?.oldRank != null)
       {
-        capsuleToRank.fakeRanking.visible = false;
-        capsuleToRank.fakeBlurredRanking.visible = false;
-
         sparks.visible = true;
         sparksADD.visible = true;
         sparks.animation.play('sparks', true);


### PR DESCRIPTION
## Linked Issues
Trayfellow

## Description
The bug the title refers to is that, after getting a new rank, the clip responsible for the song titles wouldn't get updated. This is particularly noticable when getting a new rank on a favorited song, then scrolling to the difficulty within the same variation that hasn't been beated before.

## Screenshots/Videos

https://github.com/user-attachments/assets/98f9125c-5881-441c-9f6f-1dab0e7e751e

