### PR TITLE
[ENHANCEMENT] Separate hitsound toggle keybinds for Chart Editor

### DIFF
--- a/source/funkin/ui/debug/charting/ChartEditorState.hx
+++ b/source/funkin/ui/debug/charting/ChartEditorState.hx
@@ -6960,6 +6960,20 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
       // menubarItemVolumeHitsoundPlayer.value = (menubarItemVolumeHitsoundPlayer.value == 0) ? (oldBFValue > menubarItemVolumeHitsoundPlayer.value) ? oldBFValue : 100 : 0;
       // menubarItemVolumeHitsoundOpponent.value = (menubarItemVolumeHitsoundOpponent.value == 0) ? (oldDadValue > menubarItemVolumeHitsoundOpponent.value) ? oldDadValue : 100 : 0;
     }
+    // Dad Hitsound Toggle
+    if (!isHaxeUIFocused && FlxG.keys.pressed.CONTROL && FlxG.keys.justPressed.T)
+    {
+      var oldDadValue = previousAudioVolumes[2];
+      previousAudioVolumes[2] = menubarItemVolumeHitsoundOpponent.value;
+      menubarItemVolumeHitsoundOpponent.value = (menubarItemVolumeHitsoundOpponent.value == 0) ? (oldDadValue > menubarItemVolumeHitsoundOpponent.value) ? oldDadValue : 100 : 0;
+    }
+    // Boyfriend Hitsound Toggle
+    if (!isHaxeUIFocused && FlxG.keys.pressed.CONTROL && FlxG.keys.justPressed.R)
+    {
+      var oldBFValue = previousAudioVolumes[1];
+      previousAudioVolumes[1] = menubarItemVolumeHitsoundPlayer.value;
+      menubarItemVolumeHitsoundPlayer.value = (menubarItemVolumeHitsoundPlayer.value == 0) ? (oldBFValue > menubarItemVolumeHitsoundPlayer.value) ? oldBFValue : 100 : 0;
+    }
     // Instrumental volume toggle
     if (!isHaxeUIFocused && FlxG.keys.pressed.SHIFT && FlxG.keys.justPressed.I)
     {

--- a/source/funkin/ui/debug/results/ResultsDebugSubState.hx
+++ b/source/funkin/ui/debug/results/ResultsDebugSubState.hx
@@ -9,7 +9,6 @@ import funkin.ui.freeplay.charselect.PlayableCharacter;
 import funkin.ui.options.items.CheckboxPreferenceItem;
 import flixel.util.FlxTimer;
 import flixel.tweens.FlxTween;
-import funkin.ui.mainmenu.MainMenuState;
 
 /**
  * Debug substate to configure the results screen for testing purposes,
@@ -32,13 +31,6 @@ class ResultsDebugSubState extends MusicBeatSubState
     add(items);
 
     createItems();
-  }
-
-  override function update(elapsed:Float):Void
-  {
-    super.update(elapsed);
-
-    if (controls.BACK) FlxG.switchState(() -> new MainMenuState());
   }
 
   var returnToDebugScreen:Bool = false;
@@ -79,16 +71,6 @@ class ResultsDebugSubState extends MusicBeatSubState
     createToggleListItem("Ranking", DebugTallies.DEBUG_RANKS, function(result:String)
     {
       resultsParams.scoreData.tallies = DebugTallies.getTallyForRank(result);
-    });
-    createToggleListItem("New Highscore", ["True", "False"], function(result:String) 
-    {
-      var highscoreEnabled:Bool = true;
-      if (result == "False") highscoreEnabled = false;
-      resultsParams.isNewHighscore = highscoreEnabled;
-    });
-    createToggleListItem("Difficulty", Constants.DEFAULT_DIFFICULTY_LIST_FULL, function(result:String)
-    {
-      resultsParams.difficultyId = result;
     });
     createToggleListItem("Force Rank Slam (Freeplay Only)", ["No", "Yes"], function(result:String)
     {
@@ -135,7 +117,7 @@ class ResultsDebugSubState extends MusicBeatSubState
     // We create and call the labelCallback here to initalize it
     var labelCallback:Void->Void = function()
     {
-      menuItem.label.text = name + ": " + toggleList[toggleCounter].charAt(0).toUpperCase() + toggleList[toggleCounter].substr(1);
+      menuItem.label.text = name + ":" + toggleList[toggleCounter];
       onChange(toggleList[toggleCounter]);
     };
     labelCallback();

--- a/source/funkin/ui/debug/results/ResultsDebugSubState.hx
+++ b/source/funkin/ui/debug/results/ResultsDebugSubState.hx
@@ -9,6 +9,7 @@ import funkin.ui.freeplay.charselect.PlayableCharacter;
 import funkin.ui.options.items.CheckboxPreferenceItem;
 import flixel.util.FlxTimer;
 import flixel.tweens.FlxTween;
+import funkin.ui.mainmenu.MainMenuState;
 
 /**
  * Debug substate to configure the results screen for testing purposes,
@@ -31,6 +32,13 @@ class ResultsDebugSubState extends MusicBeatSubState
     add(items);
 
     createItems();
+  }
+
+  override function update(elapsed:Float):Void
+  {
+    super.update(elapsed);
+
+    if (controls.BACK) FlxG.switchState(() -> new MainMenuState());
   }
 
   var returnToDebugScreen:Bool = false;
@@ -71,6 +79,16 @@ class ResultsDebugSubState extends MusicBeatSubState
     createToggleListItem("Ranking", DebugTallies.DEBUG_RANKS, function(result:String)
     {
       resultsParams.scoreData.tallies = DebugTallies.getTallyForRank(result);
+    });
+    createToggleListItem("New Highscore", ["True", "False"], function(result:String) 
+    {
+      var highscoreEnabled:Bool = true;
+      if (result == "False") highscoreEnabled = false;
+      resultsParams.isNewHighscore = highscoreEnabled;
+    });
+    createToggleListItem("Difficulty", Constants.DEFAULT_DIFFICULTY_LIST_FULL, function(result:String)
+    {
+      resultsParams.difficultyId = result;
     });
     createToggleListItem("Force Rank Slam (Freeplay Only)", ["No", "Yes"], function(result:String)
     {
@@ -117,7 +135,7 @@ class ResultsDebugSubState extends MusicBeatSubState
     // We create and call the labelCallback here to initalize it
     var labelCallback:Void->Void = function()
     {
-      menuItem.label.text = name + ":" + toggleList[toggleCounter];
+      menuItem.label.text = name + ": " + toggleList[toggleCounter].charAt(0).toUpperCase() + toggleList[toggleCounter].substr(1);
       onChange(toggleList[toggleCounter]);
     };
     labelCallback();


### PR DESCRIPTION
<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
No Linked Issues.
<!-- Briefly describe the issue(s) fixed. -->
## Description
You can now toggle player and opponent hitsounds separately without the use of `Shift + H` or going to change them manually!
(thanks to @JVNpixels for extra help on this)
<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos
https://github.com/user-attachments/assets/d7eccc7d-62ce-47f1-8b14-f79387500bdd

