### PR TITLE
[CHORE] Fix 4 Typos within FreeplayState class

### DIFF
--- a/source/funkin/ui/freeplay/FreeplayState.hx
+++ b/source/funkin/ui/freeplay/FreeplayState.hx
@@ -3336,22 +3336,22 @@ class FreeplaySongData
 
   /**
    * The default opponent for the song.
-   * Does the getter stuff for you depending on your current (or rather, rememberd) variation and difficulty.
+   * Does the getter stuff for you depending on your current (or rather, remembered) variation and difficulty.
    */
   public var songCharacter(get, never):String;
 
   /**
-   * The full song name, dynamically generated depending on your current (or rather, rememberd) variation and difficulty.
+   * The full song name, dynamically generated depending on your current (or rather, remembered) variation and difficulty.
    */
   public var fullSongName(get, never):String;
 
   /**
-   * The song's id and variation, combined with a colon. Dynamically generated depending on your current (or rather, rememberd) variation and difficulty.
+   * The song's id and variation, combined with a colon. Dynamically generated depending on your current (or rather, remembered) variation and difficulty.
    */
   public var idAndVariation(get, never):String;
 
   /**
-   * The starting BPM of the song, dynamically generated depending on your current (or rather, rememberd) variation and difficulty.
+   * The starting BPM of the song, dynamically generated depending on your current (or rather, remembered) variation and difficulty.
    */
   public var songStartingBpm(get, never):Float;
 


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
No Linked Issues.

<!-- Briefly describe the issue(s) fixed. -->
## Description
Fixes 4 typos within the FreeplayState class, changing "rememberd" -> "remembered".

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos
<img width="1021" height="705" alt="image" src="https://github.com/user-attachments/assets/594c5dc7-585e-4831-8aab-598e8ae20494" />