### PR TITLE
[VISUAL-BUGFIX] Adjust overlay to fit screen in Lag Adjustment menu

### DIFF
--- a/source/funkin/ui/options/OffsetMenu.hx
+++ b/source/funkin/ui/options/OffsetMenu.hx
@@ -171,9 +171,10 @@ class OffsetMenu extends Page<OptionsState.OptionsMenuPageName>
     camera = menuCamera;
 
     blackRect = new FlxSprite(0, 0);
-    blackRect.makeGraphic(FlxG.width, FlxG.height, FlxColor.BLACK);
+    blackRect.makeGraphic(FlxG.width + 50, FlxG.height + 50, FlxColor.BLACK);
     blackRect.alpha = 0;
     blackRect.scrollFactor.set(0, 0);
+    blackRect.screenCenter();
     add(blackRect);
 
     receptor = new FunkinSprite(0, 0);


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
No Linked Issues.

<!-- Briefly describe the issue(s) fixed. -->
## Description
The `blackRect` sprite in the Lag Adjustment Menu was too small, and on certain devices, you could see the edge of where it cuts off. This pull request fixes that issue.

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos

# Before:
<img width="1278" height="723" alt="Screenshot 2026-04-10 143010" src="https://github.com/user-attachments/assets/ccc22c5f-e386-4bb0-b385-621f44abc4aa" />
<img width="906" height="428" alt="image" src="https://github.com/user-attachments/assets/380516ee-5235-4c21-862a-ee351430e4b3" />
# After:
<img width="1085" height="636" alt="image" src="https://github.com/user-attachments/assets/765e7b46-c496-454c-9d8d-1559279b1476" />



