### PR TITLE
[BUGFIX] Pause dialogue fade out transition when pausing game

### DIFF
--- a/source/funkin/play/PlayState.hx
+++ b/source/funkin/play/PlayState.hx
@@ -1359,7 +1359,7 @@ class PlayState extends MusicBeatSubState
         final event = new PauseScriptEvent(false);
         dispatchEvent(event);
 
-        if (!event.eventCanceled) openPauseSubState(Conversation, camPause, lostFocus, () -> currentConversation?.pauseMusic());
+        if (!event.eventCanceled) openPauseSubState(Conversation, camPause, lostFocus, () -> currentConversation?.pause());
 
       case Cutscene:
         preparePauseUI();
@@ -1687,7 +1687,7 @@ class PlayState extends MusicBeatSubState
 
       if (currentConversation != null)
       {
-        currentConversation.resumeMusic();
+        currentConversation.resume();
       }
 
       // Re-sync vocals.

--- a/source/funkin/play/cutscene/dialogue/Conversation.hx
+++ b/source/funkin/play/cutscene/dialogue/Conversation.hx
@@ -134,12 +134,24 @@ class Conversation extends FlxSpriteGroup implements IDialogueScriptedClass impl
     }
   }
 
+  public function pause():Void
+  {
+    if (outroTween != null) outroTween.active = false;
+    pauseMusic();
+  }
+
   public function pauseMusic():Void
   {
     if (music != null)
     {
       music.pause();
     }
+  }
+
+  public function resume():Void
+  {
+    if (outroTween != null) outroTween.active = true;
+    resumeMusic();
   }
 
   public function resumeMusic():Void


### PR DESCRIPTION
## Description
This PR fixes a bug where the Dialogue Conversation Outro would continue playing even when the game was paused. The code now ensures that the outro audio and animations properly pause and resume along with the rest of the game state.

## Changelog
Created pause() and resume() functions in Conversation.hx to handle both audio and outroTween states.
Updated PlayState.hx to trigger these new functions instead of only pausing the music

## Screenshots/Videos
Before 

https://github.com/user-attachments/assets/a5ba2d57-6524-41c0-8c58-5cb56fba19c5

After

https://github.com/user-attachments/assets/75683649-9610-4dbd-9388-909a1f511d33

