### PR TITLE
[ENHANCEMENT/MODDING] Freeplay Rank Callbacks

### DIFF
--- a/source/funkin/modding/IScriptedClass.hx
+++ b/source/funkin/modding/IScriptedClass.hx
@@ -207,6 +207,21 @@ interface IFreeplayScriptedClass extends IScriptedClass
    * Called when Freeplay is closed.
    */
   public function onFreeplayClose(event:FreeplayScriptEvent):Void;
+
+  /**
+   * Called when a capsule receives a new rank.
+   */
+  public function onCapsuleNewRank(event:CapsuleScriptEvent):Void;
+
+  /**
+   * Called when the new rank letter slams onto the current freeplay capsule.
+   */
+  public function onRankSlam(event:CapsuleScriptEvent):Void;
+
+  /**
+   * Called when the entire freeplay capsule slams down, after a new rank transition.
+   */
+  public function onCapsuleSlam(event:CapsuleScriptEvent):Void;
 }
 
 /**

--- a/source/funkin/modding/events/ScriptEvent.hx
+++ b/source/funkin/modding/events/ScriptEvent.hx
@@ -10,6 +10,7 @@ import funkin.play.cutscene.dialogue.Conversation;
 import funkin.play.Countdown.CountdownStep;
 import funkin.play.notes.NoteDirection;
 import funkin.ui.freeplay.SongMenuItem;
+import funkin.play.scoring.Scoring.ScoringRank;
 import openfl.events.KeyboardEvent;
 
 /**
@@ -584,12 +585,18 @@ class CapsuleScriptEvent extends ScriptEvent
    */
   public var variationId(default, null):String;
 
-  public function new(type:ScriptEventType, capsule:SongMenuItem, difficultyId:String, variationId:String):Void
+  /**
+   * The rank achieved on the selected song.
+   */
+  public var rank(default, null):ScoringRank;
+
+  public function new(type:ScriptEventType, capsule:SongMenuItem, difficultyId:String, variationId:String, ?rank:ScoringRank):Void
   {
     super(type, false);
     this.capsule = capsule;
     this.difficultyId = difficultyId;
     this.variationId = variationId;
+    this.rank = rank;
   }
 
   override public function toString():String

--- a/source/funkin/modding/events/ScriptEventDispatcher.hx
+++ b/source/funkin/modding/events/ScriptEventDispatcher.hx
@@ -280,6 +280,15 @@ class ScriptEventDispatcher
         case FREEPLAY_CLOSE:
           t.onFreeplayClose(cast event);
           return;
+        case FREEPLAY_NEW_RANK:
+          t.onCapsuleNewRank(cast event);
+          return;
+        case FREEPLAY_RANK_SLAM:
+          t.onRankSlam(cast event);
+          return;
+        case FREEPLAY_CAPSULE_SLAM:
+          t.onCapsuleSlam(cast event);
+          return;
         default: // Continue;
       }
     }
@@ -292,7 +301,10 @@ class ScriptEventDispatcher
         ScriptEventType.SONG_SELECTED,
         ScriptEventType.FREEPLAY_INTRO,
         ScriptEventType.FREEPLAY_OUTRO,
-        ScriptEventType.FREEPLAY_CLOSE
+        ScriptEventType.FREEPLAY_CLOSE,
+        ScriptEventType.FREEPLAY_NEW_RANK,
+        ScriptEventType.FREEPLAY_RANK_SLAM,
+        ScriptEventType.FREEPLAY_CAPSULE_SLAM
       ].contains(event.type)) return;
     }
 

--- a/source/funkin/modding/events/ScriptEventType.hx
+++ b/source/funkin/modding/events/ScriptEventType.hx
@@ -300,6 +300,27 @@ enum abstract ScriptEventType(String) from String to String
   public var FREEPLAY_CLOSE = 'FREEPLAY_CLOSE';
 
   /**
+   * Called when the player gets a new rank on a capsule.
+   *
+   * This event is not cancelable.
+   */
+  public var FREEPLAY_NEW_RANK = 'FREEPLAY_NEW_RANK';
+
+  /**
+   * Called when the new rank slams down on a capsule.
+   *
+   * This event is not cancelable.
+   */
+  public var FREEPLAY_RANK_SLAM = 'FREEPLAY_RANK_SLAM';
+  
+  /**
+   * Called when the entire freeplay capsule slams down.
+   *
+   * This event is not cancelable.
+   */
+  public var FREEPLAY_CAPSULE_SLAM = 'FREEPLAY_CAPSULE_SLAM';
+
+  /**
    * Called when a character is selected, but not confirmed, in Character Select.
    *
    * This event is not cancelable.

--- a/source/funkin/modding/module/Module.hx
+++ b/source/funkin/modding/module/Module.hx
@@ -347,6 +347,27 @@ class Module implements IPlayStateScriptedClass implements IStateChangingScripte
   }
 
   /**
+   * Called when a capsule receives a new rank.
+   */
+  public function onCapsuleNewRank(event:CapsuleScriptEvent):Void
+  {
+  }
+
+  /**
+   * Called when the rank letter slams down on a freeplay capsule.
+   */
+  public function onRankSlam(event:CapsuleScriptEvent):Void
+  {
+  }
+
+  /**
+   * Called when the entire capsule slams down, after a new rank has been applied.
+   */
+  public function onCapsuleSlam(event:CapsuleScriptEvent):Void
+  {
+  }
+
+  /**
    * Called when a character is selected.
    */
   public function onCharacterSelect(event:CharacterSelectScriptEvent):Void

--- a/source/funkin/ui/freeplay/FreeplayState.hx
+++ b/source/funkin/ui/freeplay/FreeplayState.hx
@@ -1155,6 +1155,8 @@ class FreeplayState extends MusicBeatSubState
 
   function rankAnimStart(fromResults:FromResultsParams, capsuleToRank:SongMenuItem):Void
   {
+    dispatchEvent(new CapsuleScriptEvent(FREEPLAY_NEW_RANK, currentCapsule, currentDifficulty, currentVariation, fromResults?.newRank));
+
     uiStateMachine.transition(Interacting);
     // We get the current selected capsule, in-case someone changes the song selection during a timer
     capsuleToRank.sparkle.alpha = 0;
@@ -1239,9 +1241,10 @@ class FreeplayState extends MusicBeatSubState
     });
   }
 
-  function rankDisplayNew(fromResults:Null<FromResultsParams>,
-    capsuleToRank:SongMenuItem):Void
+  function rankDisplayNew(fromResults:Null<FromResultsParams>, capsuleToRank:SongMenuItem):Void
   {
+    dispatchEvent(new CapsuleScriptEvent(FREEPLAY_RANK_SLAM, currentCapsule, currentDifficulty, currentVariation, fromResults?.newRank));
+
     capsuleToRank.ranking.visible = true;
     capsuleToRank.blurredRanking.visible = true;
     capsuleToRank.ranking.scale.set(20, 20);
@@ -1387,6 +1390,8 @@ class FreeplayState extends MusicBeatSubState
     });
     new FlxTimer().start(0.5, _ ->
     {
+      dispatchEvent(new CapsuleScriptEvent(FREEPLAY_CAPSULE_SLAM, currentCapsule, currentDifficulty, currentVariation, fromResultsParams?.newRank));
+      
       // Capsule slam vibration.
       HapticUtil.vibrate(Constants.DEFAULT_VIBRATION_PERIOD, Constants.DEFAULT_VIBRATION_DURATION, Constants.MAX_VIBRATION_AMPLITUDE);
 

--- a/source/funkin/ui/freeplay/backcards/BackingCard.hx
+++ b/source/funkin/ui/freeplay/backcards/BackingCard.hx
@@ -375,6 +375,27 @@ class BackingCard extends FlxSpriteGroup implements IBPMSyncedScriptedClass impl
   {
   }
 
+  /**
+   * Called when a capsule receives a new rank.
+   */
+  public function onCapsuleNewRank(event:CapsuleScriptEvent):Void
+  {
+  }
+
+  /**
+   * Called when the rank letter slams down on a freeplay capsule.
+   */
+  public function onRankSlam(event:CapsuleScriptEvent):Void
+  {
+  }
+
+  /**
+   * Called when the entire capsule slams down, after a new rank has been applied.
+   */
+  public function onCapsuleSlam(event:CapsuleScriptEvent):Void
+  {
+  }
+
   public function centerObjectOnCard(object:flixel.FlxObject)
   {
     if (pinkBack != null) object.x = (x + ((pinkBack.width - object.width) / 2)) * 0.74;

--- a/source/funkin/ui/freeplay/dj/BaseFreeplayDJ.hx
+++ b/source/funkin/ui/freeplay/dj/BaseFreeplayDJ.hx
@@ -508,4 +508,25 @@ class BaseFreeplayDJ extends FunkinSprite implements IFreeplayScriptedClass
   public function onFreeplayClose(event:FreeplayScriptEvent):Void
   {
   }
+
+  /**
+   * Called when a capsule receives a new rank.
+   */
+  public function onCapsuleNewRank(event:CapsuleScriptEvent):Void
+  {
+  }
+
+  /**
+   * Called when the rank letter slams down on a freeplay capsule.
+   */
+  public function onRankSlam(event:CapsuleScriptEvent):Void
+  {
+  }
+
+  /**
+   * Called when the entire capsule slams down, after a new rank has been applied.
+   */
+  public function onCapsuleSlam(event:CapsuleScriptEvent):Void
+  {
+  }
 }


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
No Linked Issues.

<!-- Briefly describe the issue(s) fixed. -->
## Description
This Pull Request adds new callbacks for the Freeplay menu that modders can use in scripts. These said callbacks are related to new ranks and capsule/rank slamming.

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos
https://github.com/user-attachments/assets/9a2ecc96-de87-4338-8981-3d6fa8fdc859

## Script:
```
import funkin.ui.freeplay.FreeplayState;
import funkin.modding.module.Module;

class FreeplayRankCallbackTests extends Module
{
    public function new()
    {
        super("freeplay-rank-callback-test");
    }

    override function onCapsuleNewRank(event:ScriptEvent)
    {
        super.onCapsuleNewRank(event);

        trace("\n\n\n\n\n New Rank + Rank: " + event.rank + " \n\n\n\n\n");
    }

    override function onRankSlam(event:ScriptEvent)
    {
        super.onRankSlam(event);

        trace("\n\n\n\n\n Rank Slam + Rank: " + event.rank + " \n\n\n\n\n");
    }

    override function onCapsuleSlam(event:ScriptEvent)
    {
        super.onCapsuleSlam(event);

        trace("\n\n\n\n\n Capsule Slam + Rank: " + event.rank + " \n\n\n\n\n");
    }
}
```


