### PR TITLE
[BUGFIX] Fix note input latency being doubled when hit late

### DIFF
--- a/source/funkin/play/PlayState.hx
+++ b/source/funkin/play/PlayState.hx
@@ -3113,14 +3113,7 @@ class PlayState extends MusicBeatSubState
 
     // Get the offset and compensate for input latency.
     // Round inward (trim remainder) for consistency.
-    var diff:Float = Conductor.instance.songPosition - note.noteData.time;
-
-    var totalDiff:Float = diff;
-    if (diff < 0) totalDiff = diff + inputLatencyMs;
-    else
-      totalDiff = diff - inputLatencyMs;
-
-    var noteDiff:Int = Std.int(totalDiff);
+    var noteDiff:Int = Std.int(Conductor.instance.songPosition - note.noteData.time - inputLatencyMs);
 
     var score = Scoring.scoreNote(noteDiff, PBOT1);
     var daRating = Scoring.judgeNote(noteDiff, PBOT1);


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
Fixes https://github.com/FunkinCrew/Funkin/issues/5793
<!-- Briefly describe the issue(s) fixed. -->
## Description

The input latency is already included in every input hit. All we have to do is calculate and remove it to get the actual time the note was hit.

While adding input latency when a note is hit after it's timestamp does sometimes turn late bad note hits into better ones, it doubles the input latency and shifts the hit further away from where the player actually hit it (something we do not want to be doing or causing to happen).

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos
