### PR TITLE
[CHECKSTYLE] [CHORE] Use `Constants` for time conversions

### DIFF
--- a/source/funkin/play/Countdown.hx
+++ b/source/funkin/play/Countdown.hx
@@ -65,7 +65,7 @@ class Countdown
     // The timer function gets called based on the beat of the song.
     countdownTimer = new FlxTimer();
 
-    countdownTimer.start(Conductor.instance.beatLengthMs / 1000, function(tmr:FlxTimer)
+    countdownTimer.start(Conductor.instance.beatLengthMs / Constants.MS_PER_SEC, function(tmr:FlxTimer)
     {
       if (PlayState.instance == null)
       {
@@ -228,7 +228,7 @@ class Countdown
     if (noteStyle.isCountdownSpritePixel(index)) fadeEase = EaseUtil.stepped(8);
 
     // Fade sprite in, then out, then destroy it.
-    FlxTween.tween(countdownSprite, {alpha: 0}, Conductor.instance.beatLengthMs / 1000, {
+    FlxTween.tween(countdownSprite, {alpha: 0}, Conductor.instance.beatLengthMs / Constants.MS_PER_SEC, {
       ease: fadeEase,
       onComplete: function(twn:FlxTween)
       {

--- a/source/funkin/play/event/FocusCameraSongEvent.hx
+++ b/source/funkin/play/event/FocusCameraSongEvent.hx
@@ -146,7 +146,7 @@ class FocusCameraSongEvent extends SongEvent
       case 'INSTANT': // Instant ease. Duration is automatically 0.
         PlayState.instance.tweenCameraToPosition(targetX, targetY, 0);
       default:
-        var durSeconds = Conductor.instance.stepLengthMs * duration / 1000;
+        var durSeconds = Conductor.instance.stepLengthMs * duration / Constants.MS_PER_SEC;
         var easeFunctionName = '$ease$easeDir';
         var easeFunction:Null<Float->Float> = Reflect.field(FlxEase, easeFunctionName);
         if (easeFunction == null)

--- a/source/funkin/play/event/ScrollSpeedEvent.hx
+++ b/source/funkin/play/event/ScrollSpeedEvent.hx
@@ -78,7 +78,7 @@ class ScrollSpeedEvent extends SongEvent
       case 'INSTANT':
         PlayState.instance.tweenScrollSpeed(scroll, 0, null, strumlineNames);
       default:
-        var durSeconds = Conductor.instance.stepLengthMs * duration / 1000;
+        var durSeconds = Conductor.instance.stepLengthMs * duration / Constants.MS_PER_SEC;
         var easeFunctionName = '$ease$easeDir';
         var easeFunction:Null<Float->Float> = Reflect.field(FlxEase, easeFunctionName);
         if (easeFunction == null)

--- a/source/funkin/play/event/ZoomCameraSongEvent.hx
+++ b/source/funkin/play/event/ZoomCameraSongEvent.hx
@@ -65,7 +65,7 @@ class ZoomCameraSongEvent extends SongEvent
       case 'INSTANT':
         PlayState.instance.tweenCameraZoom(scaledZoom, 0, isDirectMode);
       default:
-        var durSeconds = Conductor.instance.stepLengthMs * duration / 1000;
+        var durSeconds = Conductor.instance.stepLengthMs * duration / Constants.MS_PER_SEC;
         var easeFunctionName = '$ease$easeDir';
         var easeFunction:Null<Float->Float> = Reflect.field(FlxEase, easeFunctionName);
         if (easeFunction == null)

--- a/source/funkin/ui/debug/WaveformTestState.hx
+++ b/source/funkin/ui/debug/WaveformTestState.hx
@@ -98,7 +98,7 @@ class WaveformTestState extends MusicBeatState
     if (waveformAudio.isPlaying)
     {
       // waveformSprite takes a time in fractional seconds, not milliseconds.
-      var timeSeconds = waveformAudio.time / 1000;
+      var timeSeconds = waveformAudio.time / Constants.MS_PER_SEC;
       // waveformSprite.time = timeSeconds;
       // waveformSprite2.time = timeSeconds;
     }

--- a/source/funkin/ui/debug/charting/ChartEditorState.hx
+++ b/source/funkin/ui/debug/charting/ChartEditorState.hx
@@ -5775,18 +5775,18 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
     playbarHeadLayout.y = FlxG.height - 48 - 8;
 
     var songPos:Float = Conductor.instance.songPosition + Conductor.instance.instrumentalOffset;
-    var songPosMilliseconds:String = Std.string(Math.floor(Math.abs(songPos) % 1000)).lpad('0', 3).substr(0, 2);
-    var songPosSeconds:String = Std.string(Math.floor((Math.abs(songPos) / 1000) % 60)).lpad('0', 2);
-    var songPosMinutes:String = Std.string(Math.floor((Math.abs(songPos) / 1000) / 60)).lpad('0', 2);
+    var songPosMilliseconds:String = Std.string(Math.floor(Math.abs(songPos) % Constants.MS_PER_SEC)).lpad('0', 3).substr(0, 2);
+    var songPosSeconds:String = Std.string(Math.floor((Math.abs(songPos) / Constants.MS_PER_SEC) % Constants.SECS_PER_MIN)).lpad('0', 2);
+    var songPosMinutes:String = Std.string(Math.floor((Math.abs(songPos) / Constants.MS_PER_SEC) / Constants.SECS_PER_MIN)).lpad('0', 2);
     if (songPos < 0) songPosMinutes = '-' + songPosMinutes;
     var songPosString:String = '${songPosMinutes}:${songPosSeconds}.${songPosMilliseconds}';
 
     if (playbarSongPos.value != songPosString) playbarSongPos.value = songPosString;
 
     var songRemaining:Float = Math.max(songLengthInMs - songPos, 0.0);
-    var songRemainingMilliseconds:String = Std.string(Math.floor(Math.abs(songRemaining) % 1000)).lpad('0', 3).substr(0, 2);
-    var songRemainingSeconds:String = Std.string(Math.floor((songRemaining / 1000) % 60)).lpad('0', 2);
-    var songRemainingMinutes:String = Std.string(Math.floor((songRemaining / 1000) / 60)).lpad('0', 2);
+    var songRemainingMilliseconds:String = Std.string(Math.floor(Math.abs(songRemaining) % Constants.MS_PER_SEC)).lpad('0', 3).substr(0, 2);
+    var songRemainingSeconds:String = Std.string(Math.floor((songRemaining / Constants.MS_PER_SEC) % Constants.SECS_PER_MIN)).lpad('0', 2);
+    var songRemainingMinutes:String = Std.string(Math.floor((songRemaining / Constants.MS_PER_SEC) / Constants.SECS_PER_MIN)).lpad('0', 2);
     var songRemainingString:String = '-${songRemainingMinutes}:${songRemainingSeconds}.${songRemainingMilliseconds}';
 
     if (playbarSongRemaining.value != songRemainingString) playbarSongRemaining.value = songRemainingString;

--- a/source/funkin/ui/debug/charting/toolboxes/ChartEditorFreeplayToolbox.hx
+++ b/source/funkin/ui/debug/charting/toolboxes/ChartEditorFreeplayToolbox.hx
@@ -318,14 +318,14 @@ class ChartEditorFreeplayToolbox extends ChartEditorBaseToolbox
     var integerSeconds = Math.floor(seconds);
     var decimalSeconds = Math.floor((seconds - integerSeconds) * 10);
 
-    if (integerSeconds < 60)
+    if (integerSeconds < Constants.SECS_PER_MIN)
     {
       return '${integerSeconds}.${decimalSeconds}';
     }
     else
     {
-      var integerMinutes = Math.floor(integerSeconds / 60);
-      var remainingSeconds = integerSeconds % 60;
+      var integerMinutes = Math.floor(integerSeconds / Constants.SECS_PER_MIN);
+      var remainingSeconds = integerSeconds % Constants.SECS_PER_MIN;
       var remainingSecondsPad:String = remainingSeconds < 10 ? '0$remainingSeconds' : '$remainingSeconds';
 
       return '${integerMinutes}:${remainingSecondsPad}${decimalSeconds > 0 ? '.$decimalSeconds' : ''}';

--- a/source/funkin/ui/debug/charting/toolboxes/ChartEditorOffsetsToolbox.hx
+++ b/source/funkin/ui/debug/charting/toolboxes/ChartEditorOffsetsToolbox.hx
@@ -337,14 +337,14 @@ class ChartEditorOffsetsToolbox extends ChartEditorBaseToolbox
     var integerSeconds = Math.floor(seconds);
     var decimalSeconds = Math.floor((seconds - integerSeconds) * 10);
 
-    if (integerSeconds < 60)
+    if (integerSeconds < Constants.SECS_PER_MIN)
     {
       return '${integerSeconds}.${decimalSeconds}';
     }
     else
     {
-      var integerMinutes = Math.floor(integerSeconds / 60);
-      var remainingSeconds = integerSeconds % 60;
+      var integerMinutes = Math.floor(integerSeconds / Constants.SECS_PER_MIN);
+      var remainingSeconds = integerSeconds % Constants.SECS_PER_MIN;
       var remainingSecondsPad:String = remainingSeconds < 10 ? '0$remainingSeconds' : '$remainingSeconds';
 
       return '${integerMinutes}:${remainingSecondsPad}${decimalSeconds > 0 ? '.$decimalSeconds' : ''}';

--- a/source/funkin/ui/freeplay/FreeplayState.hx
+++ b/source/funkin/ui/freeplay/FreeplayState.hx
@@ -3033,14 +3033,14 @@ class FreeplayState extends MusicBeatSubState
         {
           FlxG.sound.music.fadeIn(2, 0, previewVolume);
 
-          var fadeStart:Float = (FlxG.sound.music.length / 1000) - 2;
+          var fadeStart:Float = (FlxG.sound.music.length / Constants.MS_PER_SEC) - 2;
 
           previewTimers.push(new FlxTimer().start(fadeStart, function(_)
           {
             FlxG.sound.music.fadeOut(2, 0);
           }));
 
-          previewTimers.push(new FlxTimer().start(FlxG.sound.music.length / 1000, function(_)
+          previewTimers.push(new FlxTimer().start(FlxG.sound.music.length / Constants.MS_PER_SEC, function(_)
           {
             playCurSongPreview();
           }));

--- a/source/funkin/ui/haxeui/components/CharacterPlayer.hx
+++ b/source/funkin/ui/haxeui/components/CharacterPlayer.hx
@@ -234,7 +234,8 @@ class CharacterPlayer extends Box
       character.onNoteHit(event);
 
       if ((event.note.noteData.getMustHitNote() && characterType == BF)
-        || (!event.note.noteData.getMustHitNote() && characterType == DAD)) character.holdTimer = -event.note.noteData?.length / 1000;
+        || (!event.note.noteData.getMustHitNote()
+          && characterType == DAD)) character.holdTimer = -event.note.noteData?.length / Constants.MS_PER_SEC;
       // At least i tried yaknow?
     }
   }

--- a/source/funkin/ui/options/FunkinSoundTray.hx
+++ b/source/funkin/ui/options/FunkinSoundTray.hx
@@ -72,7 +72,7 @@ class FunkinSoundTray extends FlxSoundTray
 
   override public function update(ms:Float):Void
   {
-    var elapsed = ms / 1000.0;
+    var elapsed = ms / Constants.MS_PER_SEC;
 
     // If it has volume, we want to auto-hide after 1 second (1000ms), we simply decrement a timer
     var hasVolume:Bool = (!FlxG.sound.muted && FlxG.sound.volume > 0);

--- a/source/funkin/util/Constants.hx
+++ b/source/funkin/util/Constants.hx
@@ -398,6 +398,16 @@ class Constants
   public static final NS_PER_SEC:Int = NS_PER_US * US_PER_MS * MS_PER_SEC;
 
   /**
+   * Constant for the number of minutes in an hour.
+   */
+  public static final MIN_PER_HOUR:Int = 60;
+
+  /**
+   * The number of seconds in an hour.
+   */
+  public static final SECS_PER_HOUR:Int = SECS_PER_MIN * MIN_PER_HOUR;
+
+  /**
    * Duration, in milliseconds, until toast notifications are automatically hidden.
    */
   public static final NOTIFICATION_DISMISS_TIME:Int = 5 * MS_PER_SEC;

--- a/source/funkin/util/SRTUtil.hx
+++ b/source/funkin/util/SRTUtil.hx
@@ -161,7 +161,7 @@ class SRTParser
         frac += "0";
       ms = Std.parseInt(frac);
     }
-    return (hh * 3600 + mm * 60 + ss + (ms / 1000.0)) * 1000;
+    return (hh * Constants.SECS_PER_HOUR + mm * Constants.SECS_PER_MIN + ss + (ms / Constants.MS_PER_SEC)) * Constants.MS_PER_SEC;
   }
 }
 


### PR DESCRIPTION
<!-- Briefly describe the issue(s) fixed. -->
## Description
A lot of time conversions in the repository use inline values. This goes against the magic number rule of the repository, so this PR makes sure to replace those values with ones that are in `Constants` to make `checkstyle` happy.

This PR also adds `Constants.MIN_PER_HOUR` and `Constants.SECS_PER_HOUR`. The names are very self explanatory, so I won't elaborate.