### PR TITLE
[ORGANIZATION] Organize Results Music

### DIFF
--- a/source/funkin/play/ResultState.hx
+++ b/source/funkin/play/ResultState.hx
@@ -502,11 +502,11 @@ class ResultState extends MusicBeatSubState
     new FlxTimer().start(rank.getMusicDelay(), _ ->
     {
       var musicPath = getMusicPath(playerCharacter, rank);
-      var introMusic:String = Paths.music('$musicPath/$musicPath-intro');
+      var introMusic:String = Paths.music('$musicPath-intro');
 
       if (Assets.exists(introMusic))
       {
-        var mainMusic:String = Paths.music('$musicPath/$musicPath'); // wraps how FunkinSound load audios
+        var mainMusic:String = Paths.music('$musicPath'); // wraps how FunkinSound load audios
 
         // preload the loop music
         @:nullSafety(Off)
@@ -528,14 +528,24 @@ class ResultState extends MusicBeatSubState
       }
       else
       {
-        if (!isChartingMode) FunkinSound.playMusic(musicPath, {
-          startingVolume: 1.0,
-          overrideExisting: true,
-          restartTrack: true
-        });
+        if (!isChartingMode)
+        {
+          var mainMusic:String = Paths.music('$musicPath'); // wraps how FunkinSound load audios
+          // preload the loop music
+          @:nullSafety(Off)
+          var musicLoop:FunkinSound = FunkinSound.load(mainMusic, 1.0, true, true, false, false, null, null, true);
+          musicLoop.play();
+          if (!isChartingMode) // Don't override the music and cause problems on the chart editor
+            FunkinSound.setMusic(musicLoop);
+          else // Play the results music as a looped sound instead (that we cancel before closing and returning to the chart editor)
+          {
+            resultsMusic = musicLoop;
+            false; // Why is this necessary for this to work?
+          }
+        }
         else
         {
-          resultsMusic = FunkinSound.load(Paths.music(getMusicPath(playerCharacter, rank) + '/' + getMusicPath(playerCharacter, rank)), 1.0, true, false, true);
+          resultsMusic = FunkinSound.load(Paths.music(getMusicPath(playerCharacter, rank)), 1.0, true, false, true);
         }
       }
     });

--- a/source/funkin/ui/freeplay/charselect/PlayableCharacter.hx
+++ b/source/funkin/ui/freeplay/charselect/PlayableCharacter.hx
@@ -128,19 +128,19 @@ class PlayableCharacter implements IRegistryEntry<PlayerData>
     switch (rank)
     {
       case PERFECT_GOLD:
-        return _data?.results?.music?.PERFECT_GOLD ?? "resultsPERFECT";
+        return _data?.results?.music?.PERFECT_GOLD ?? "results/bf/resultsPERFECT/resultsPERFECT";
       case PERFECT:
-        return _data?.results?.music?.PERFECT ?? "resultsPERFECT";
+        return _data?.results?.music?.PERFECT ?? "results/bf/resultsPERFECT/resultsPERFECT";
       case EXCELLENT:
-        return _data?.results?.music?.EXCELLENT ?? "resultsEXCELLENT";
+        return _data?.results?.music?.EXCELLENT ?? "results/bf/resultsEXCELLENT/resultsEXCELLENT";
       case GREAT:
-        return _data?.results?.music?.GREAT ?? "resultsNORMAL";
+        return _data?.results?.music?.GREAT ?? "results/bf/resultsNORMAL/resultsNORMAL";
       case GOOD:
-        return _data?.results?.music?.GOOD ?? "resultsNORMAL";
+        return _data?.results?.music?.GOOD ?? "results/bf/resultsNORMAL/resultsNORMAL";
       case SHIT:
-        return _data?.results?.music?.SHIT ?? "resultsSHIT";
+        return _data?.results?.music?.SHIT ?? "results/bf/resultsSHIT/resultsSHIT";
       default:
-        return _data?.results?.music?.GOOD ?? "resultsNORMAL";
+        return _data?.results?.music?.GOOD ?? "results/bf/resultsNORMAL/resultsNORMAL";
     }
   }
 


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
No Linked Issues.

<!-- Briefly describe the issue(s) fixed. -->
## Description
This pull request cleans up the results music files, as they were a bit unorganized. This also reworks the system of how the results music is loaded.

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos
### Before:
<img width="464" height="202" alt="image" src="https://github.com/user-attachments/assets/a263dff8-c7a3-45ce-be4c-54506c7f11d8" />

### After:
<img width="619" height="156" alt="image" src="https://github.com/user-attachments/assets/572e6a46-43ec-4092-90e1-f329bb6d2359" />
<img width="480" height="67" alt="image" src="https://github.com/user-attachments/assets/ac3d113b-cae1-457e-9cd3-aebe454467ec" />

## Note:
> [!NOTE]
> This requires FunkinCrew/funkin.assets#409 to work!
