### PR TITLE
[Enhancement] Add 'collapsed' field to allow collapsible event frames to start closed by default

### DIFF
--- a/source/funkin/data/event/SongEventSchema.hx
+++ b/source/funkin/data/event/SongEventSchema.hx
@@ -242,6 +242,11 @@ typedef SongEventSchemaField =
    */
   ?collapsible:Bool,
   /**
+   * Used for FRAME values.
+   * Whether to make the collapsible frame start collapsed.
+   */
+  ?collapsed:Bool,
+  /**
    * An optional default value for the field.
    */
   ?defaultValue:Dynamic,

--- a/source/funkin/ui/debug/charting/toolboxes/ChartEditorEventDataToolbox.hx
+++ b/source/funkin/ui/debug/charting/toolboxes/ChartEditorEventDataToolbox.hx
@@ -317,7 +317,11 @@ class ChartEditorEventDataToolbox extends ChartEditorBaseToolbox
           if (field.collapsible != null)
           {
             var targetFrame:Frame = cast(input, Frame);
-            if (targetFrame != null) targetFrame.collapsible = field.collapsible;
+            if (targetFrame != null)
+            {
+              targetFrame.collapsible = field.collapsible;
+              if (field.collapsed != null) targetFrame.collapsed = field.collapsed;
+            }
           }
 
           var frameVBox:VBox = new VBox();


### PR DESCRIPTION
## Linked Issues
https://github.com/FunkinCrew/Funkin/issues/7131

## Description
This enhancement adds a new option in the Chart Editor that allows collapsible frames to start collapsed by default. Instead of all sections being open when displayed, developers or modders can specify that certain fields begin closed, making the event interface more organized and easier to use when dealing with many settings

How it should be in the event schema
```
    {
      name: "frame name",
      title: "Frame Name",
      type: "frame",
      collapsible: true,
      collapsed: true, // New field: controls whether the frame starts collapsed (true) or expanded (false)
      children: [
      ]
    }
```

## Screenshots/Videos
Before

https://github.com/user-attachments/assets/96c45807-6021-460a-baa5-77e9c4ceb4a0

After

https://github.com/user-attachments/assets/cb11d0bf-25e3-41c6-a2d6-9f17e4e21666

