### PR TITLE
[BUGFIX] Fix ANOTHER Freeplay crash caused by `FlxG.sound.music` being null

### DIFF
--- a/source/funkin/ui/freeplay/FreeplayState.hx
+++ b/source/funkin/ui/freeplay/FreeplayState.hx
@@ -2309,7 +2309,7 @@ class FreeplayState extends MusicBeatSubState
           // Continue playing this music between states, until a different music track gets played.
           persist: true
         });
-        FlxG.sound.music.fadeIn(4.0, 0.0, 1.0);
+        if (FlxG.sound.music != null) FlxG.sound.music.fadeIn(4.0, 0.0, 1.0);
         dispatchEvent(new FreeplayScriptEvent(FREEPLAY_CLOSE));
         close();
       }


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
Contributors Discord Server

<!-- Briefly describe the issue(s) fixed. -->
## Description

Freeplay if not crashing was a class

<img width="498" height="374" alt="denzel-crocker-timmy-turner" src="https://github.com/user-attachments/assets/89c5a4d1-2021-4507-b3e2-a9423b0da033" />

Fixes ANOTHER potential crash caused by `FlxG.sound.music` being `null...` while trying to fade in.