### PR TITLE
[ENHANCEMENT] Hide 'Change Difficulty' entry from Pause Menu if there is only 1 difficulty

### DIFF
--- a/source/funkin/play/PauseSubState.hx
+++ b/source/funkin/play/PauseSubState.hx
@@ -66,7 +66,8 @@ class PauseSubState extends MusicBeatSubState
     },
     {
       text: 'Change Difficulty',
-      callback: switchMode.bind(_, Difficulty)
+      callback: switchMode.bind(_, Difficulty),
+      filter: () -> (PlayState.instance?.currentSong?.listDifficulties(PlayState.instance?.currentChart?.variation ?? Constants.DEFAULT_VARIATION, true)?.length ?? 0) > 1
     },
     {
       text: 'Enable Practice Mode',


### PR DESCRIPTION
## Description
This PR improves the Pause Menu by filtering the "Change Difficulty" option when the current song only has one difficulty available. Instead of showing an unusable menu entry, the Pause Menu now dynamically hides this option to ensure it only appears when there are multiple difficulties to switch between

## Screenshots/Videos


https://github.com/user-attachments/assets/c5c92a7d-5d38-4c63-b76d-8392cd5c0d69

