### PR TITLE
[BUGFIX] Fix some actions not updating the Freeplay hint properly

### DIFF
--- a/source/funkin/input/Controls.hx
+++ b/source/funkin/input/Controls.hx
@@ -491,9 +491,16 @@ class Controls extends FlxActionSet
     #end
 
     var action = byName[name];
-    if (gamepadOnly) return action.checkFiltered(trigger, GAMEPAD);
+    if (gamepadOnly)
+    {
+      if(action.checkFiltered(trigger, GAMEPAD)) action.updateLastDeviceUsed();
+      return action.checkFiltered(trigger, GAMEPAD);
+    }
     else
+    {
+      if(action.checkFiltered(trigger)) action.updateLastDeviceUsed();
       return action.checkFiltered(trigger);
+    }
   }
 
   public function getKeysForAction(name:Action):Array<FlxKey>

--- a/source/funkin/ui/freeplay/FreeplayState.hx
+++ b/source/funkin/ui/freeplay/FreeplayState.hx
@@ -550,14 +550,8 @@ class FreeplayState extends MusicBeatSubState
     charSelectHint.alignment = CENTER;
     charSelectHint.font = '5by7';
     charSelectHint.color = 0xFF5F5F5F;
-    #if FEATURE_TOUCH_CONTROLS
-    if (ControlsHandler.hasExternalInputDevice)
-      charSelectHint.text = 'Press [ ${controls.getDialogueNameFromControl(FREEPLAY_CHAR_SELECT, true)} ] to change characters';
-    else
-      charSelectHint.text = 'Tap the DJ to change characters';
-    #else
-    charSelectHint.text = 'Press [ ${controls.getDialogueNameFromControl(FREEPLAY_CHAR_SELECT, true)} ] to change characters';
-    #end
+    updateFreeplayHintText();
+
     if (!fromCharSelect)
     {
       charSelectHint.y -= 100;
@@ -1759,14 +1753,7 @@ class FreeplayState extends MusicBeatSubState
     handleTouchSelectionScroll(elapsed);
     #end
 
-    #if FEATURE_TOUCH_CONTROLS
-    if (ControlsHandler.usingExternalInputDevice)
-      charSelectHint.text = 'Press [ ${controls.getDialogueNameFromControl(FREEPLAY_CHAR_SELECT, true)} ] to change characters';
-    else
-      charSelectHint.text = 'Tap the DJ to change characters';
-    #else
-    charSelectHint.text = 'Press [ ${controls.getDialogueNameFromControl(FREEPLAY_CHAR_SELECT, true)} ] to change characters';
-    #end
+    updateFreeplayHintText();
 
     handleDirectionalInput(elapsed);
 
@@ -3146,6 +3133,18 @@ class FreeplayState extends MusicBeatSubState
         });
       }
     }
+  }
+
+  function updateFreeplayHintText()
+  {
+    #if FEATURE_TOUCH_CONTROLS
+    if (ControlsHandler.usingExternalInputDevice)
+      charSelectHint.text = 'Press [ ${controls.getDialogueNameFromControl(FREEPLAY_CHAR_SELECT, true)} ] to change characters';
+    else
+      charSelectHint.text = 'Tap the DJ to change characters';
+    #else
+    charSelectHint.text = 'Press [ ${controls.getDialogueNameFromControl(FREEPLAY_CHAR_SELECT, true)} ] to change characters';
+    #end
   }
 }
 


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues

<!-- Briefly describe the issue(s) fixed. -->
## Description

THIRD ATTEMPT. (i promise i will learn how to rebase... 🥹)

This PR fixes a tiny bug caused by my last merged pull request (https://github.com/FunkinCrew/Funkin/pull/6609 ) where the freeplay hint won't update properly with some actions

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos

### Before:

https://github.com/user-attachments/assets/6bbb0c20-4ffd-48b4-9095-2ae0ff0af2c0

### After:

https://github.com/user-attachments/assets/a53741b7-679f-4ba8-ad36-20f2eea4593f