### PR TITLE
[TYPO/CHORE] Fix Typo in `FunkinSprite.hx`

### DIFF
--- a/source/funkin/graphics/FunkinSprite.hx
+++ b/source/funkin/graphics/FunkinSprite.hx
@@ -738,7 +738,7 @@ class FunkinSprite extends FlxAnimate
   }
 
   /**
-   * Ensure scale is applied when cloning a sprite.R
+   * Ensure scale is applied when cloning a sprite.
    * The default `clone()` method acts kinda weird TBH.
    * @return A clone of this sprite.
    */


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
No Linked Issues.

<!-- Briefly describe the issue(s) fixed. -->
## Description
This Pull Request removes a typo for the documentation of the `clone()` function.
sprite.R -> sprite.

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos
<img width="999" height="416" alt="image" src="https://github.com/user-attachments/assets/6cfe0a15-b2de-402b-accd-aab956ff7672" />
