### PR TITLE
[BUGFIX] Remove padding in Camera Editor when debug display is off

### DIFF
--- a/source/funkin/ui/debug/cameraeditor/CameraEditorState.hx
+++ b/source/funkin/ui/debug/cameraeditor/CameraEditorState.hx
@@ -239,7 +239,7 @@ class CameraEditorState extends UIState implements ConsoleClass
   }
 
   /**
-   * The current file path which the chart editor is working with.
+   * The current file path which the camera editor is working with.
    * If `null`, the current chart has not been saved yet.
    */
   public var currentWorkingFilePath(get, set):Null<String>;
@@ -482,7 +482,7 @@ class CameraEditorState extends UIState implements ConsoleClass
   }
 
   /**
-   * If true, we are currently in the process of quitting the chart editor.
+   * If true, we are currently in the process of quitting the camera editor.
    * Skip any update functions as most of them will call a crash.
    */
   var criticalFailure:Bool = false;
@@ -608,7 +608,7 @@ class CameraEditorState extends UIState implements ConsoleClass
 
     if (params != null && params.fnfcTargetPath != null)
     {
-      // Chart editor was opened from the command line. Open the FNFC file now!
+      // Camera editor was opened from the command line. Open the FNFC file now!
       var selectedFileBytes:Null<Bytes> = FileUtil.readBytesFromPath(params.fnfcTargetPath);
       if (selectedFileBytes == null)
       {

--- a/source/funkin/ui/debug/cameraeditor/CameraEditorState.hx
+++ b/source/funkin/ui/debug/cameraeditor/CameraEditorState.hx
@@ -2,6 +2,7 @@ package funkin.ui.debug.cameraeditor;
 
 import funkin.util.InputUtil;
 import funkin.ui.debug.charting.handlers.ChartEditorImportExportHandler;
+import funkin.ui.debug.FunkinDebugDisplay.DebugDisplayMode;
 import funkin.util.SortUtil;
 #if FEATURE_CAMERA_EDITOR
 import haxe.ui.containers.Panel;
@@ -545,6 +546,8 @@ class CameraEditorState extends UIState implements ConsoleClass
     root.height = FlxG.height;
 
     menubar.height = 35;
+    if (Preferences.debugDisplay == DebugDisplayMode.Off) menubar.paddingLeft = null;
+
     WindowManager.instance.container = root;
     Screen.instance.addComponent(root);
 


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Briefly describe the issue(s) fixed. -->
## Description
Removes the padding on the menu bar if the debug display is off, similar to how it's done in other editors

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/c8fb65ac-4f85-4c76-bc4f-d569be9c4125" />
