### PR TITLE
[BUGFIX] Fix Camera Editor window title starting as null

### DIFF
--- a/source/funkin/ui/debug/cameraeditor/CameraEditorState.hx
+++ b/source/funkin/ui/debug/cameraeditor/CameraEditorState.hx
@@ -239,7 +239,7 @@ class CameraEditorState extends UIState implements ConsoleClass
   }
 
   /**
-   * The current file path which the chart editor is working with.
+   * The current file path which the camera editor is working with.
    * If `null`, the current chart has not been saved yet.
    */
   public var currentWorkingFilePath(get, set):Null<String>;
@@ -482,7 +482,7 @@ class CameraEditorState extends UIState implements ConsoleClass
   }
 
   /**
-   * If true, we are currently in the process of quitting the chart editor.
+   * If true, we are currently in the process of quitting the camera editor.
    * Skip any update functions as most of them will call a crash.
    */
   var criticalFailure:Bool = false;
@@ -608,7 +608,7 @@ class CameraEditorState extends UIState implements ConsoleClass
 
     if (params != null && params.fnfcTargetPath != null)
     {
-      // Chart editor was opened from the command line. Open the FNFC file now!
+      // Camera editor was opened from the command line. Open the FNFC file now!
       var selectedFileBytes:Null<Bytes> = FileUtil.readBytesFromPath(params.fnfcTargetPath);
       if (selectedFileBytes == null)
       {

--- a/source/funkin/ui/debug/cameraeditor/CameraEditorState.hx
+++ b/source/funkin/ui/debug/cameraeditor/CameraEditorState.hx
@@ -1169,17 +1169,19 @@ class CameraEditorState extends UIState implements ConsoleClass
   /**
    * Modify the title of the game window to reflect the current state of the editor.
    */
-  public function updateWindowTitle()
+  public function updateWindowTitle():Void
   {
-    var defaultTitle = "Friday Night Funkin\' Camera Editor";
-
-    if (currentWorkingFilePath == '') defaultTitle += ' - New File'
-    else
-      defaultTitle += ' - ' + currentWorkingFilePath;
-
-    if (!saved) defaultTitle += '*';
-
-    WindowUtil.setWindowTitle(defaultTitle);
+    var inner:String = 'New File';
+    var cwfp:Null<String> = currentWorkingFilePath;
+    if (cwfp != null)
+    {
+      inner = cwfp;
+    }
+    if (currentWorkingFilePath == null || !saved)
+    {
+      inner += '*';
+    }
+    WindowUtil.setWindowTitle('Friday Night Funkin\' Camera Editor - ${inner}');
   }
 
   /**


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Briefly describe the issue(s) fixed. -->
## Description
Changes how the Camera Editor sets the window title to be the same as how the Chart Editor does it.
This fixes an issue where when you first enter the state the title will show a null.

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos
Before:

<img width="388" height="32" alt="image" src="https://github.com/user-attachments/assets/6b94db11-4cfb-4691-a5c7-92b5de624cb3" />

After:

<img width="350" height="30" alt="image" src="https://github.com/user-attachments/assets/f9c4fc9f-a2aa-42aa-8a40-cd6ea2549a7a" />
