### PR TITLE
[BUGFIX] Update event duration in the panel when resizing a block

### DIFF
--- a/source/funkin/ui/debug/cameraeditor/CameraEditorState.hx
+++ b/source/funkin/ui/debug/cameraeditor/CameraEditorState.hx
@@ -1345,6 +1345,7 @@ class CameraEditorState extends UIState implements ConsoleClass
 
     timeline.viewport.registerEvent(TimelineEvent.EVENT_RESIZED, function(e:TimelineEvent)
     {
+      CameraEditorPropertiesPanelHandler.loadSelectedSongEvent(this);
       var layerName:String = e.eventData.editorLayer ?? 'Default';
       var cmd = new MoveResizeEventCommand(e.eventData, e.eventData.time, e.oldDuration, layerName, e.eventData.time, e.newDuration, layerName);
       CameraEditorCommandHandler.performCommand(this, cmd);


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues

Nope

<!-- Briefly describe the issue(s) fixed. -->
## Description

This PR fixes a bug where resizing a block in the timeline doesn't show the updated duration in the panel

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos

Before:

https://github.com/user-attachments/assets/74992013-e779-4f0f-8a5a-c0c770fb0a8e

After:

https://github.com/user-attachments/assets/551c1f94-a0a2-4db0-aa05-38ce4c6dcae2



