### PR TITLE
[BUGFIX] Fix cursor container remaining visible after exiting editors

### DIFF
--- a/source/funkin/input/Cursor.hx
+++ b/source/funkin/input/Cursor.hx
@@ -348,7 +348,7 @@ class Cursor
 
     if (CursorHelper.hasCursor(name) || openfl.Assets.exists(name))
     {
-      container.visible = true;
+      container.visible = FlxG.mouse.visible;
       window.cursor = cast null;
       return;
     }


### PR DESCRIPTION
## Linked Issues
https://github.com/FunkinCrew/Funkin/issues/7450
## Description
This Pull Request fixes a bug where moving the mouse would force the cursor container to become visible even while hidden. By syncing container.visible with FlxG.mouse.visible, the cursor no longer "wakes up" or leaves a ghost sprite on screen when moved.

## Screenshots/Videos
Before

https://github.com/user-attachments/assets/0785213c-c013-4f9c-b021-e7dfaf7dc44c

After

https://github.com/user-attachments/assets/dec506b0-6dd2-41e6-bc85-bc50c9be239a


