### PR TITLE
[OPTIMIZATION] Change `FunkinGroup.updateChildren` to use the FlxPoint pool

### DIFF
--- a/source/funkin/group/FunkinGroup.hx
+++ b/source/funkin/group/FunkinGroup.hx
@@ -290,7 +290,7 @@ class FunkinGroup<T:FlxSprite> extends FlxSprite
         child.scale.x = scale.x * child.localScale.x;
         child.scale.y = scale.y * child.localScale.y;
 
-        var displace = new FlxPoint(child.localX, child.localY);
+        var displace = FlxPoint.weak(child.localX, child.localY);
 
         var dx:Float = 0;
         var dy:Float = 0;
@@ -333,6 +333,8 @@ class FunkinGroup<T:FlxSprite> extends FlxSprite
 
         child.x = x + displace.x;
         child.y = y + displace.y;
+
+        displace.put();
 
         child.alpha = alpha * child.localAlpha;
         child.visible = visible && child.localVisible;


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Briefly describe the issue(s) fixed. -->
## Description
For some reason I had it make a new FlxPoint every time updateChildren ran so...