### PR TITLE
[BUGFIX] Fix background elements not pausing in Camera Editor

### DIFF
--- a/source/funkin/ui/debug/cameraeditor/CameraEditorState.hx
+++ b/source/funkin/ui/debug/cameraeditor/CameraEditorState.hx
@@ -32,6 +32,7 @@ import funkin.graphics.FunkinSprite;
 import funkin.input.Cursor;
 import funkin.modding.events.ScriptEvent.SongEventScriptEvent;
 import funkin.modding.events.ScriptEvent;
+import funkin.modding.events.ScriptEvent.PauseScriptEvent;
 import funkin.modding.events.ScriptEventDispatcher;
 import funkin.play.PlayState;
 import funkin.util.SortUtil;
@@ -219,7 +220,6 @@ class CameraEditorState extends UIState implements ConsoleClass
   public var cameraRect:VirtualCameraRectangle = new VirtualCameraRectangle(0, 0);
 
   public var vCamDebug:FunkinSprite = null;
-
   var cachedEventIndex = 0;
   var cachedNoteIndex = 0;
 
@@ -903,9 +903,11 @@ class CameraEditorState extends UIState implements ConsoleClass
 
     if (currentStage != null)
     {
-      ScriptEventDispatcher.callEvent(currentStage, event);
-
-      currentStage.dispatchToCharacters(event);
+      if (event.type != UPDATE || !paused)
+      {
+        ScriptEventDispatcher.callEvent(currentStage, event);
+        currentStage.dispatchToCharacters(event);
+      }
     }
   }
 
@@ -992,6 +994,7 @@ class CameraEditorState extends UIState implements ConsoleClass
 
     if (currentStage != null)
     {
+      currentStage.active = !paused;
       currentStage.vcamPoint = cameraRect.vcamPoint;
       vCamDebug.x = cameraRect.vcamPoint.x;
       vCamDebug.y = cameraRect.vcamPoint.y;
@@ -1222,6 +1225,7 @@ class CameraEditorState extends UIState implements ConsoleClass
     _shouldResetCameraPosition = true;
 
     currentStage.onEventReset();
+    pauseStage();
   }
 
   function resetScrollPosition()
@@ -1829,6 +1833,8 @@ class CameraEditorState extends UIState implements ConsoleClass
     timeline.setStepLengthMs(conductorInUse.stepLengthMs);
   }
 
+  var paused:Bool = true;
+
   /**
    * Toggles playback of the current instrumental and vocal tracks.
    *
@@ -1840,10 +1846,12 @@ class CameraEditorState extends UIState implements ConsoleClass
 
     if (currentInstrumental.playing || forceStop)
     {
+      pauseStage();
       pauseAudioPlayback();
     }
     else
     {
+      resumeStage();
       playAudioPlayback();
     }
 
@@ -1893,6 +1901,20 @@ class CameraEditorState extends UIState implements ConsoleClass
   function syncTogglePlaybackButton():Void
   {
     timeline.toolbar.btnTogglePlayback.selected = currentInstrumental != null && currentInstrumental.playing;
+  }
+
+  function pauseStage():Void
+  {
+    paused = true;
+    
+    dispatchEvent(new PauseScriptEvent(false));
+  }
+
+  function resumeStage():Void
+  {
+    paused = false;
+    
+    dispatchEvent(new ScriptEvent(RESUME));
   }
 
   var lastSeekReplay:Float = 0;


### PR DESCRIPTION
## Linked Issues
https://github.com/FunkinCrew/Funkin/issues/7445

## Description
This Pull Request ensures the stage and all scripted elements freeze immediately when the editor is paused or a new stage is built. It prevents background drift and unintended movement by centralizing the pause logic and blocking update signals until audio playback starts.
## Screenshots/Videos
Before

https://github.com/user-attachments/assets/19bd9042-d724-46e1-ba4b-e0120c94f8fb

After

https://github.com/user-attachments/assets/a2c7b361-71e2-4dcd-8936-0c36087ffa0f
