### PR TITLE
[BUGFIX] Fix song events not dispatching in the cameraeditor 

### DIFF
--- a/source/funkin/ui/debug/cameraeditor/CameraEditorState.hx
+++ b/source/funkin/ui/debug/cameraeditor/CameraEditorState.hx
@@ -239,7 +239,7 @@ class CameraEditorState extends UIState implements ConsoleClass
   }
 
   /**
-   * The current file path which the chart editor is working with.
+   * The current file path which the camera editor is working with.
    * If `null`, the current chart has not been saved yet.
    */
   public var currentWorkingFilePath(get, set):Null<String>;
@@ -482,7 +482,7 @@ class CameraEditorState extends UIState implements ConsoleClass
   }
 
   /**
-   * If true, we are currently in the process of quitting the chart editor.
+   * If true, we are currently in the process of quitting the camera editor.
    * Skip any update functions as most of them will call a crash.
    */
   var criticalFailure:Bool = false;
@@ -608,7 +608,7 @@ class CameraEditorState extends UIState implements ConsoleClass
 
     if (params != null && params.fnfcTargetPath != null)
     {
-      // Chart editor was opened from the command line. Open the FNFC file now!
+      // Camera editor was opened from the command line. Open the FNFC file now!
       var selectedFileBytes:Null<Bytes> = FileUtil.readBytesFromPath(params.fnfcTargetPath);
       if (selectedFileBytes == null)
       {

--- a/source/funkin/ui/debug/cameraeditor/CameraEditorState.hx
+++ b/source/funkin/ui/debug/cameraeditor/CameraEditorState.hx
@@ -42,6 +42,7 @@ import funkin.graphics.FunkinCamera;
 import funkin.input.Cursor;
 import funkin.modding.events.ScriptEvent;
 import funkin.modding.events.ScriptEventDispatcher;
+import funkin.modding.events.ScriptEvent.SongEventScriptEvent;
 import funkin.play.PlayState;
 import funkin.play.character.BaseCharacter;
 import funkin.play.stage.Stage;
@@ -721,7 +722,9 @@ class CameraEditorState extends UIState implements ConsoleClass
       if (completedEvents.contains(eventData)) continue;
       if (eventData == null || eventData.time > conductorInUse.songPosition || eventData.time < previousTime) continue;
       trace('Processing event: ' + eventData.eventKind + ' at ' + eventData.time);
-
+      
+      dispatchEvent(new SongEventScriptEvent(eventData));
+      
       switch (eventData.eventKind)
       {
         case 'FocusCamera':


### PR DESCRIPTION
## Description
This pull request fixes song events not dispatching in the camera editor so now scripts can correctly detect and trigger actions through the onSongEvent function. It ensures that events like camera movement and animations stay synced with the chart while previewing in the editor.

## Screenshots/Videos
Example : Abot pupils


https://github.com/user-attachments/assets/662361f8-e1e5-4c26-9125-ff99a801f0e0

