### PR TITLE
[FEATURE] Add quick-swapping between the Chart and Camera editors through pressing TAB.

### DIFF
--- a/source/funkin/ui/debug/cameraeditor/CameraEditorState.hx
+++ b/source/funkin/ui/debug/cameraeditor/CameraEditorState.hx
@@ -966,6 +966,12 @@ class CameraEditorState extends UIState implements ConsoleClass
       addEventMenu.show();
     }
 
+    // For some reason, HaxeUI elements are constantly focused
+    // when you press TAB, only in this state!
+    //
+    // So I had to ignore the menubar logic below.
+    handleQuickSwapKeybinds();
+
     // NOTE: Menubar commands are handled in `onScreenKeyDown()`
   }
 
@@ -1971,6 +1977,23 @@ class CameraEditorState extends UIState implements ConsoleClass
     {
       menubarItemRedo.disabled = false;
       menubarItemRedo.text = 'Redo ${redoHistory[redoHistory.length - 1].toString()}';
+    }
+  }
+
+  /**
+   * Handle keybinds from quick-swapping between the Camera and Chart editors.
+   */
+  function handleQuickSwapKeybinds():Void
+  {
+    if (currentWorkingFilePath == null) return;
+
+    if (FlxG.keys.justPressed.TAB)
+    {
+      performCleanup();
+
+      FlxG.switchState(() -> new funkin.ui.debug.charting.ChartEditorState({
+        fnfcTargetPath: currentWorkingFilePath
+      }));
     }
   }
 

--- a/source/funkin/ui/debug/charting/ChartEditorState.hx
+++ b/source/funkin/ui/debug/charting/ChartEditorState.hx
@@ -3817,6 +3817,7 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
     handleTestKeybinds();
     handleHelpKeybinds();
     handleAudioKeybinds();
+    handleQuickSwapKeybinds();
 
     #if FEATURE_DEBUG_FUNCTIONS
     handleQuickWatch();
@@ -6486,6 +6487,27 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
       var oldValue = previousAudioVolumes[5];
       previousAudioVolumes[5] = menubarItemVolumeVocalsOpponent.value;
       menubarItemVolumeVocalsOpponent.value = (menubarItemVolumeVocalsOpponent.value == 0) ? (oldValue > menubarItemVolumeVocalsOpponent.value) ? oldValue : 100 : 0;
+    }
+  }
+
+  /**
+   * Handle keybinds from quick-swapping between the Camera and Chart editors.
+   */
+  function handleQuickSwapKeybinds():Void
+  {
+    if (currentWorkingFilePath == null) return;
+
+    if (!isHaxeUIFocused && FlxG.keys.justPressed.TAB)
+    {
+      this.hideAllToolboxes();
+      stopWelcomeMusic();
+      resetWindowTitle();
+
+      criticalFailure = true;
+
+      FlxG.switchState(() -> new funkin.ui.debug.cameraeditor.CameraEditorState({
+        fnfcTargetPath: currentWorkingFilePath
+      }));
     }
   }
 


### PR DESCRIPTION
For now, this feature only works if you have an FNFC file open!
If anyone wants to get that working, pull request your changes to [my fork](https://github.com/ADA-Funni/Funkin-Contributes/tree/adafunni/camera-charting-quick-swap)!

<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues

<!-- Briefly describe the issue(s) fixed. -->
## Description

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos
