### PR TITLE
[BUGFIX] Fix song script events not dispatching in the Camera Editor

### DIFF
--- a/source/funkin/ui/debug/cameraeditor/CameraEditorState.hx
+++ b/source/funkin/ui/debug/cameraeditor/CameraEditorState.hx
@@ -41,6 +41,7 @@ import funkin.data.stage.StageRegistry;
 import funkin.graphics.FunkinCamera;
 import funkin.input.Cursor;
 import funkin.modding.events.ScriptEvent;
+import funkin.modding.events.ScriptEvent.SongEventScriptEvent;
 import funkin.modding.events.ScriptEventDispatcher;
 import funkin.play.PlayState;
 import funkin.play.character.BaseCharacter;
@@ -743,6 +744,8 @@ class CameraEditorState extends UIState implements ConsoleClass
       if (eventData == null || eventData.time > conductorInUse.songPosition || eventData.time < previousTime) continue;
       trace('Processing event: ' + eventData.eventKind + ' at ' + eventData.time);
 
+      dispatchEvent(new SongEventScriptEvent(eventData));
+      
       switch (eventData.eventKind)
       {
         case 'FocusCamera':

--- a/source/funkin/ui/debug/cameraeditor/CameraEditorState.hx
+++ b/source/funkin/ui/debug/cameraeditor/CameraEditorState.hx
@@ -744,7 +744,10 @@ class CameraEditorState extends UIState implements ConsoleClass
       if (eventData == null || eventData.time > conductorInUse.songPosition || eventData.time < previousTime) continue;
       trace('Processing event: ' + eventData.eventKind + ' at ' + eventData.time);
 
-      dispatchEvent(new SongEventScriptEvent(eventData));
+      var eventEvent:SongEventScriptEvent = new SongEventScriptEvent(eventData);
+      dispatchEvent(eventEvent);
+      
+      if (eventEvent.eventCanceled) continue;
       
       switch (eventData.eventKind)
       {


### PR DESCRIPTION
(Reopening of https://github.com/FunkinCrew/Funkin/pull/7458)

## Description
This pull request fixes song events not dispatching in the camera editor so now scripts can correctly detect and trigger actions through the onSongEvent function. It ensures that events like camera movement and animations stay synced with the chart while previewing in the editor.

## Screenshots/Videos
Example : Abot pupils


https://github.com/user-attachments/assets/662361f8-e1e5-4c26-9125-ff99a801f0e0

