### PR TITLE
[ENHANCEMENT] Implement a better selection method for stacked events

### DIFF
--- a/source/funkin/ui/debug/charting/ChartEditorState.hx
+++ b/source/funkin/ui/debug/charting/ChartEditorState.hx
@@ -78,6 +78,7 @@ import funkin.ui.debug.charting.commands.SelectItemsCommand;
 import funkin.ui.debug.charting.commands.SetItemSelectionCommand;
 import funkin.ui.debug.charting.commands.SwitchDifficultyCommand;
 import funkin.ui.debug.charting.components.ChartEditorEventSprite;
+import funkin.ui.debug.charting.components.ChartEditorEventStack;
 import funkin.ui.debug.charting.components.ChartEditorHoldNoteSprite;
 import funkin.ui.debug.charting.components.ChartEditorMeasureTicks;
 import funkin.ui.debug.charting.components.ChartEditorNotePreview;
@@ -2328,6 +2329,11 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
   var gridGhostEvent:Null<ChartEditorEventSprite> = null;
 
   /**
+   * The event stack that contains events overlapping the current selected one.
+   */
+  var eventStack:Null<ChartEditorEventStack> = null;
+
+  /**
    * The sprite used to display the note preview area.
    * We move this up and down to scroll the preview.
    */
@@ -2816,6 +2822,13 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
     gridGhostEvent.visible = false;
     add(gridGhostEvent);
     gridGhostEvent.zIndex = 22;
+
+    eventStack = new ChartEditorEventStack(this);
+    eventStack.x = gridTiledSprite.x + gridTiledSprite.width;
+    eventStack.y = gridTiledSprite.y;
+    eventStack.zIndex = 24;
+    eventStack.kill();
+    add(eventStack);
 
     buildNoteGroup();
 
@@ -4357,6 +4370,7 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
         if (noteTooltipsDirty) noteSprite.updateTooltipText();
       }
 
+      var stackedEvents:Array<ChartEditorEventSprite> = [];
       for (eventSprite in renderedEvents.members)
       {
         if (eventSprite == null || eventSprite.eventData == null || !eventSprite.exists || !eventSprite.visible) continue;
@@ -4380,6 +4394,16 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
               // Then reapply the note sprite's position relative to the grid.
               eventSprite.updateEventPosition(renderedEvents);
             }
+
+            // Add notes to the stack array. Update the stack after the for-loop to prevent later notes not being positioned properly!
+            if (eventStack.parentEvent == eventSprite && eventStack.alive)
+            {
+              for (event in renderedEvents.members)
+              {
+                if (event == null || event.eventData == null || !event.exists || !event.visible) continue;
+                if (event != eventSprite && event.x == eventSprite.x && event.y == eventSprite.y) stackedEvents.push(event);
+              }
+            }
           }
 
           // Then, render the selection square.
@@ -4397,6 +4421,17 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
 
         // Additional cleanup on notes.
         if (noteTooltipsDirty) eventSprite.updateTooltipText();
+      }
+
+      // Now we update the stack.
+      if (stackedEvents.length > 0)
+      {
+        eventStack.clearStack();
+        eventStack.addMultipleToStack(stackedEvents);
+      }
+      else
+      {
+        eventStack.kill();
       }
 
       noteTooltipsDirty = false;
@@ -4706,6 +4741,8 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
       if (gridGhostHoldNote != null) gridGhostHoldNote.visible = false;
       if (gridGhostEvent != null) gridGhostEvent.visible = false;
 
+      eventStack.kill();
+
       // Do not set Cursor.cursorMode here, because it will be set by the HaxeUI.
       return;
     }
@@ -4718,6 +4755,7 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
     if (gridTiledSprite == null) throw 'ERROR: Tried to handle cursor, but gridTiledSprite is null! Check ChartEditorState.buildGrid()';
 
     var overlapsGrid:Bool = FlxG.mouse.overlaps(gridTiledSprite);
+    var overlapsStack:Bool = (FlxG.mouse.overlaps(eventStack) && eventStack.alive);
 
     var overlapsRenderedNotes:Bool = true;
     var overlapsRenderedEvents:Bool = true;
@@ -4745,7 +4783,7 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
 
     // Find the first event that is at the cursor position.
     // Skip this if we're already highlighting a note.
-    if (overlapsGrid && !overlapsRenderedNotes && FlxG.mouse.overlaps(renderedEvents))
+    if ((overlapsGrid || overlapsStack) && !overlapsRenderedNotes && FlxG.mouse.overlaps(renderedEvents))
     {
       highlightedEvent = renderedEvents.members.find(function(event:ChartEditorEventSprite):Bool
       {
@@ -4758,6 +4796,28 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
     {
       // Cursor is not overlapping an event
       overlapsRenderedEvents = false;
+    }
+
+    // If the stack's event is no longer hovered over, remove the stack.
+    if (eventStack.parentEvent != highlightedEvent && !overlapsStack) eventStack.kill();
+
+    // If there's no event tied to the stack, use the current overlapped one.
+    if (eventStack.parentEvent == null && highlightedEvent != null)
+    {
+      var stackedEvents:Array<ChartEditorEventSprite> = [];
+      for (event in renderedEvents.members)
+      {
+        if (event == null || event.eventData == null || !event.exists || !event.visible) continue;
+        if (event != highlightedEvent && event.x == highlightedEvent.x && event.y == highlightedEvent.y) stackedEvents.push(event);
+      }
+
+      if (stackedEvents.length > 0)
+      {
+        eventStack.revive();
+        eventStack.parentEvent = highlightedEvent;
+        eventStack.y = highlightedEvent.y;
+        eventStack.addMultipleToStack(stackedEvents);
+      }
     }
 
     // Find the first hold note that is at the cursor position.
@@ -5047,7 +5107,7 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
         selectionBoxStartPos = null;
         setSelectionBoxBounds();
 
-        if (overlapsGrid)
+        if (overlapsGrid || (overlapsStack && highlightedEvent != null))
         {
           // We clicked on the grid without moving the mouse.
 
@@ -5104,6 +5164,7 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
             else if (highlightedEvent != null && highlightedEvent.eventData != null)
             {
               // Click an event to select it.
+              if (eventStack.alive) eventStack.parentEvent = highlightedEvent;
               performCommand(new SetItemSelectionCommand([], [highlightedEvent.eventData]));
             }
             else if (highlightedHoldNote != null && highlightedHoldNote.noteData != null)
@@ -5339,7 +5400,7 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
       if (FlxG.mouse.justPressed)
       {
         // Just clicked to place a note.
-        if (!isCursorOverHaxeUI && overlapsGrid && !overlapsSelectionBorder)
+        if (!isCursorOverHaxeUI && (overlapsGrid || (overlapsStack && highlightedEvent != null)) && !overlapsSelectionBorder)
         {
           // We clicked on the grid without moving the mouse.
 
@@ -5405,10 +5466,12 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
               {
                 // Clicked a selected event, start dragging.
                 dragTargetEvent = highlightedEvent;
+                if (eventStack.alive && eventStack.parentEvent == highlightedEvent) eventStack.kill();
               }
               else
               {
                 // If you click an unselected event, and aren't holding Control, deselect everything else.
+                if (eventStack.alive) eventStack.parentEvent = highlightedEvent;
                 performCommand(new SetItemSelectionCommand([], [highlightedEvent.eventData]));
               }
             }
@@ -5450,7 +5513,7 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
 
       var rightMouseUpdated:Bool = (FlxG.mouse.justPressedRight)
         || (FlxG.mouse.pressedRight && (FlxG.mouse.deltaX > 0 || FlxG.mouse.deltaY > 0));
-      if (rightMouseUpdated && overlapsGrid)
+      if (rightMouseUpdated && (overlapsGrid || (overlapsStack && highlightedEvent != null)))
       {
         // We right clicked on the grid.
 
@@ -5504,6 +5567,20 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
           else
           {
             // Right click removes the event.
+            // Remove from stack, if available.
+            if (eventStack.stack.contains(highlightedEvent))
+            {
+              eventStack.stack.remove(highlightedEvent);
+            }
+
+            // Make the stack parent use the first stack member, if possible.
+            if (eventStack.parentEvent == highlightedEvent)
+            {
+              var firstEvent:ChartEditorEventSprite = eventStack.stack.shift();
+              eventStack.parentEvent = firstEvent;
+              if (eventStack.stack.length == 0) eventStack.kill();
+            }
+
             performCommand(new RemoveEventsCommand([highlightedEvent.eventData]));
           }
         }

--- a/source/funkin/ui/debug/charting/components/ChartEditorEventStack.hx
+++ b/source/funkin/ui/debug/charting/components/ChartEditorEventStack.hx
@@ -1,0 +1,120 @@
+package funkin.ui.debug.charting.components;
+
+#if FEATURE_CHART_EDITOR
+import flixel.addons.display.FlxGridOverlay;
+import flixel.group.FlxSpriteGroup;
+import flixel.util.FlxColor;
+import flixel.FlxSprite;
+import funkin.ui.debug.charting.handlers.ChartEditorThemeHandler;
+import funkin.ui.debug.charting.ChartEditorState.ChartEditorTheme;
+import openfl.geom.Rectangle;
+
+@:access(funkin.ui.debug.charting.ChartEditorState)
+class ChartEditorEventStack extends FlxSprite
+{
+  /**
+   * The actual event stack. Don't add directly to it, but rather use `addToStack()` to apply the position changes!
+   */
+  public var stack:Array<ChartEditorEventSprite> = [];
+
+  /**
+   * The event tied to this stack. Overlapping this event will cause the stack to be made visible.
+   */
+  public var parentEvent:Null<ChartEditorEventSprite> = null;
+
+  var state:ChartEditorState;
+
+  public function new(state:ChartEditorState)
+  {
+    super();
+
+    this.active = false;
+    this.state = state;
+  }
+
+  /**
+   * Add multiple events to the stack. Also updates the background after fully adding them.
+   */
+  public function addMultipleToStack(events:Array<ChartEditorEventSprite>)
+  {
+    for (event in events) addToStack(event);
+    updateBackground();
+  }
+
+  /**
+   * Adds an event to the stack and applies the relevant positions.
+   */
+  public function addToStack(event:ChartEditorEventSprite)
+  {
+    event.x = this.x + ChartEditorState.GRID_SIZE * stack.length;
+    event.y = this.y;
+    event.updateTooltipPosition();
+    stack.push(event);
+  }
+
+  /**
+   * Fully clear the stack while repositioning the event sprites back to normal.
+   */
+  public function clearStack()
+  {
+    while (stack.length > 0)
+    {
+      var event:ChartEditorEventSprite = stack.pop();
+      event.updateEventPosition(state.renderedEvents);
+    }
+
+    stack.resize(0);
+  }
+
+  /**
+   * Update the background if the theme or the stack size has updated.
+   */
+  public function updateBackground()
+  {
+    var cellSize:Int = ChartEditorState.GRID_SIZE;
+    var gridWidth:Int = Std.int(cellSize * stack.length);
+
+    var isDark:Bool = (state.currentTheme == Dark);
+    var gridColor1:FlxColor = (isDark ? ChartEditorThemeHandler.GRID_COLOR_1_DARK : ChartEditorThemeHandler.GRID_COLOR_1_LIGHT);
+    var gridColor2:FlxColor = (isDark ? ChartEditorThemeHandler.GRID_COLOR_2_DARK : ChartEditorThemeHandler.GRID_COLOR_2_LIGHT);
+
+    var bitmap:openfl.display.BitmapData = FlxGridOverlay.createGrid(cellSize, cellSize, gridWidth, cellSize, true, gridColor2, gridColor1);
+
+    var selectionBorderColor:FlxColor = (isDark ? ChartEditorThemeHandler.GRID_COLOR_3_DARK : ChartEditorThemeHandler.GRID_COLOR_3_LIGHT);
+
+    // Create borders for the outer edges.
+    bitmap.fillRect(new Rectangle(0, -(ChartEditorState.GRID_SELECTION_BORDER_WIDTH / 2), bitmap.width, ChartEditorState.GRID_SELECTION_BORDER_WIDTH),
+      selectionBorderColor);
+
+    bitmap.fillRect(new Rectangle(0, bitmap.height - (ChartEditorState.GRID_SELECTION_BORDER_WIDTH / 2), bitmap.width,
+      ChartEditorState.GRID_SELECTION_BORDER_WIDTH),
+      selectionBorderColor);
+
+    bitmap.fillRect(new Rectangle(-(ChartEditorState.GRID_SELECTION_BORDER_WIDTH / 2), 0, ChartEditorState.GRID_SELECTION_BORDER_WIDTH, bitmap.height),
+      selectionBorderColor);
+
+    bitmap.fillRect(new Rectangle(bitmap.width - (ChartEditorState.GRID_SELECTION_BORDER_WIDTH / 2), 0, ChartEditorState.GRID_SELECTION_BORDER_WIDTH,
+      bitmap.height),
+      selectionBorderColor);
+
+    // Selection borders across the middle.
+    for (i in 1...stack.length)
+    {
+      bitmap.fillRect(new Rectangle((cellSize * i) - (ChartEditorState.GRID_SELECTION_BORDER_WIDTH / 2), 0, ChartEditorState.GRID_SELECTION_BORDER_WIDTH,
+        bitmap.height),
+        selectionBorderColor);
+    }
+
+    this.loadGraphic(bitmap);
+  }
+
+  override public function kill()
+  {
+    // Clear the stack and the parent event link when killing.
+    clearStack();
+    parentEvent = null;
+
+    super.kill();
+  }
+}
+#end

--- a/source/funkin/ui/debug/charting/handlers/ChartEditorThemeHandler.hx
+++ b/source/funkin/ui/debug/charting/handlers/ChartEditorThemeHandler.hx
@@ -77,6 +77,7 @@ class ChartEditorThemeHandler
   {
     updateBackground(state);
     updateGridBitmap(state);
+    state.eventStack?.updateBackground();
     updateOffsetTicks(state);
     updateSelectionSquare(state);
     updateNotePreview(state);


### PR DESCRIPTION
## Linked Issues
There's probably one for more event lanes but I'm not sure if you could count this PR fixing it.

## Description
This PR implements event stacks - a "holder" sprite of every event that's placed on the same tile, allowing for selection of individual events in a stack.
The PR is quite big, so a lot of testing might be needed!

## Screenshots/Videos

https://github.com/user-attachments/assets/b8cb160a-42c5-4a73-8efa-630ba0a4a860

