### PR TITLE
[BUGFIX] Fix ABot Viz getting offset when switching stages in the Camera Editor

### DIFF
--- a/source/funkin/ui/debug/cameraeditor/CameraEditorState.hx
+++ b/source/funkin/ui/debug/cameraeditor/CameraEditorState.hx
@@ -1005,6 +1005,7 @@ class CameraEditorState extends UIState implements ConsoleClass
 
     if (currentStage != null)
     {
+      currentStage.vcamPoint = null;
       ScriptEventDispatcher.callEvent(currentStage, new ScriptEvent(DESTROY, false));
       remove(currentStage);
       currentStage.kill();


### PR DESCRIPTION
## Linked Issues
Closes https://github.com/FunkinCrew/Funkin/issues/7459

## Description
When switching the stage in the Camera Editor, the VCam Point link still persists, as the stages never get destroyed. This makes them improperly position any stage prop, even in the main gameplay.

## Screenshots/Videos

https://github.com/user-attachments/assets/d7a70dc4-fcda-4ed1-80ba-4071da3bbe95
