### PR TITLE
[ENHANCEMENT] Customizable Freeplay Random Song

### DIFF
--- a/source/funkin/data/freeplay/style/FreeplayStyleData.hx
+++ b/source/funkin/data/freeplay/style/FreeplayStyleData.hx
@@ -35,6 +35,11 @@ typedef FreeplayStyleData =
   public var capsuleAsset:String;
 
   /**
+   * Asset key for the freeplay random ost.
+   */
+  public var randomSong:String;
+
+  /**
    * Color data for the capsule text outline.
    * the order of this array goes as follows: [DESELECTED, SELECTED]
    */

--- a/source/funkin/ui/freeplay/FreeplayState.hx
+++ b/source/funkin/ui/freeplay/FreeplayState.hx
@@ -2987,7 +2987,7 @@ class FreeplayState extends MusicBeatSubState
 
     if (curSelected == 0)
     {
-      FunkinSound.playMusic('freeplayRandom', {
+      FunkinSound.playMusic(styleData?.getRandomOst() ?? "freeplayRandom", {
         startingVolume: 0.0,
         overrideExisting: true,
         restartTrack: false

--- a/source/funkin/ui/freeplay/FreeplayStyle.hx
+++ b/source/funkin/ui/freeplay/FreeplayStyle.hx
@@ -88,6 +88,15 @@ class FreeplayStyle implements IRegistryEntry<FreeplayStyleData>
   }
 
   /**
+   * Return the selected song for the random audio
+   * @return The random song
+   */
+  public function getRandomOst():String
+  {
+    return _data?.randomSong ?? "freeplayRandom";
+  }
+
+  /**
    * Return the song selection transition delay.
    * @return The start delay
    */


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
None

<!-- Briefly describe the issue(s) fixed. -->
## Description

With a friend (YasFunny63), one day we talked about the possibility to customize the random song freeplay that play when the random capsule is selected. So this afternoon I've decided to give it a try and I've succeed. 

How does it works ? : In the date/ui/freeplay/styles/character.json, I've added a randomSong field where you add the freeplay audio for the random Song, if the audio is freeplayRandom-darnell, it will play the file in : "music/freeplayRandom-darnell/freeplayRandom-darnell.ogg" 

Why should it be implemented ? : Personally, I think it could really be a nice little touch that adds customization to the game !

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos

https://github.com/user-attachments/assets/e31f9037-1386-465c-a1c1-1dbf5f601c98