### PR TITLE
[BUGFIX] Return full package path for scripted variation songs

### DIFF
--- a/source/funkin/data/song/SongRegistry.hx
+++ b/source/funkin/data/song/SongRegistry.hx
@@ -144,7 +144,7 @@ class SongRegistry extends BaseRegistry<Song, SongMetadata, SongEntryParams> imp
     {
       final variationSongId:ScriptedSong = cast scriptedSongVariations.get('${id}:${variation}');
       @:privateAccess
-      var path:String = variationSongId._asc._c.name;
+      var path:String = variationSongId._asc.fullyQualifiedName;
       return path;
     }
     return super.getScriptedEntryClassName(id, params);


### PR DESCRIPTION
## Description
This pull request fixes an issue in `SongRegistry` where `getScriptedEntryClassName()` returned the class name without its package path for scripted variation songs. This prevented the engine from locating or initializing the class correctly. By ensuring the full package path is included, scripted variations can now be resolved and loaded as intended.

Example:
In the Chart Editor, a song script like the one below would previously fail because the registry only looked for `WtfSong` instead of the full path:
```
package funkin.play.song;
import funkin.play.song.Song;

class WtfSong extends Song
{
    public function new()
    {
        super('spookeez',{variation:'pico'});
    }
}
```
With this fix, it correctly identifies it as `funkin.play.song.WtfSong`

## Changelog
used  `variationSongId._asc.fullyQualifiedName` instead of `variationSongId._asc._c.name`
## Screenshots/Videos
Before 

https://github.com/user-attachments/assets/873e200c-1809-44b3-b93d-32374286f3cc

After 

https://github.com/user-attachments/assets/3088c554-991a-4ae8-8850-fdafa0380d04

