### PR TITLE
[BUGFIX] Fix `getScriptedEntryClassName` package oversight

### DIFF
--- a/source/funkin/data/song/SongRegistry.hx
+++ b/source/funkin/data/song/SongRegistry.hx
@@ -142,9 +142,14 @@ class SongRegistry extends BaseRegistry<Song, SongMetadata, SongEntryParams> imp
     var variation:String = params?.variation ?? Constants.DEFAULT_VARIATION;
     if (variation != Constants.DEFAULT_VARIATION)
     {
-      final variationSongId:ScriptedSong = cast scriptedSongVariations.get('${id}:${variation}');
-      @:privateAccess
-      var path:String = variationSongId._asc._c.name;
+      var classDecl:polymod.hscript._internal.Expr.ClassDecl = @:privateAccess
+        {
+          final variationSongId:ScriptedSong = cast scriptedSongVariations.get('${id}:${variation}');
+          variationSongId._asc._c;
+        };
+
+      var path:String = classDecl.name;
+      if (classDecl.pkg != null) path = '${classDecl.pkg.join('.')}.${path}';
       return path;
     }
     return super.getScriptedEntryClassName(id, params);


### PR DESCRIPTION
<!-- Briefly describe the issue(s) fixed. -->
## Description
This PR fixes an oversight done in `SongRegistry.getScriptedEntryClassName` that wouldn't return the proper path if the script mentioned included a package. In return, this would not let any packaged song scripts be playtested in the chart editor, and throw an error.