### PR TITLE
[BUGFIX] Fix Nametag being mispositioned on widescreen resolutions

### DIFF
--- a/source/funkin/ui/charSelect/CharSelectSubState.hx
+++ b/source/funkin/ui/charSelect/CharSelectSubState.hx
@@ -687,7 +687,7 @@ class CharSelectSubState extends MusicBeatSubState
     FlxTween.tween(cursors, {alpha: 0}, 0.8, {ease: FlxEase.expoOut});
 
     FlxTween.tween(barthing, {y: barthing.y + 80}, 0.8, {ease: FlxEase.backIn});
-    FlxTween.tween(nametag, {y: nametag.y + 80}, 0.8, {ease: FlxEase.backIn});
+    FlxTween.tween(nametag.midpoint, {y: nametag.midpoint.y + 80}, 0.8, {ease: FlxEase.backIn});
     FlxTween.tween(dipshitBacking, {y: dipshitBacking.y + 210}, 0.8, {ease: FlxEase.backIn});
     FlxTween.tween(chooseDipshit, {y: chooseDipshit.y + 200}, 0.8, {ease: FlxEase.backIn});
     FlxTween.tween(dipshitBlur, {y: dipshitBlur.y + 220}, 0.8, {ease: FlxEase.backIn});

--- a/source/funkin/ui/charSelect/Nametag.hx
+++ b/source/funkin/ui/charSelect/Nametag.hx
@@ -1,15 +1,16 @@
 package funkin.ui.charSelect;
 
+import flixel.FlxCamera;
 import flixel.FlxSprite;
 import funkin.graphics.shaders.MosaicEffect;
 import flixel.util.FlxTimer;
-import funkin.util.TimerUtil;
+import funkin.util.TimerUtil.Sequence;
 import flixel.math.FlxPoint;
 
 @:nullSafety
 class Nametag extends FlxSprite
 {
-  public var midpoint(default, set):FlxPoint = FlxPoint.get(1008, 100);
+  public var midpoint:FlxPoint = FlxPoint.get(1008, 100);
 
   var mosaicShader:MosaicEffect;
   var currentMosaicSequence:Null<Sequence>;
@@ -27,13 +28,15 @@ class Nametag extends FlxSprite
     switchChar(targetCharacter, false);
   }
 
-  public function updatePosition():Void
+  override function getScreenPosition(?result:FlxPoint, ?camera:FlxCamera):FlxPoint
   {
-    var offsetX:Float = getMidpoint().x - midpoint.x;
-    var offsetY:Float = getMidpoint().y - midpoint.y;
+    var pos:FlxPoint = super.getScreenPosition(result, camera);
+    var originalMidpoint:FlxPoint = getMidpoint();
 
-    x -= offsetX;
-    y -= offsetY;
+    pos -= originalMidpoint - midpoint;
+    originalMidpoint.put();
+
+    return pos;
   }
 
   function resetMosaicEffect():Void
@@ -56,7 +59,6 @@ class Nametag extends FlxSprite
     loadGraphic(Paths.image("charSelect/" + path + "Nametag"));
     updateHitbox();
     scale.set(0.77, 0.77);
-    updatePosition();
 
     resetMosaicEffect();
 
@@ -108,12 +110,5 @@ class Nametag extends FlxSprite
         {time: 2 / 30, callback: () -> mosaicShader.setBlockSize(width / 10, height / 10)},
       ]);
     }
-  }
-
-  function set_midpoint(val:FlxPoint):FlxPoint
-  {
-    this.midpoint = val;
-    updatePosition();
-    return val;
   }
 }


### PR DESCRIPTION
## Linked Issues
https://discord.com/channels/1419268615605325907/1419276431032189038/1497990894521946252

## Description
This fixes an issue where, not only the nametag would not appear in the correct position, but it would also not play its intro animation.
This was caused by a refactor done in a `develop` commit to make the nametag use a singular variable for positioning instead of two. The problem is that it was done under the assumption that simply applying a setter for this variable would be enough for an assignment to a property (i.e `midpoint.x = ...`) to trigger `updatePosition`, but it'd actually require doing so to the whole variable (i.e `midpoint = ...`).
The fix? Throwing all this system off the window, we instead use `midpoint` to offset the position when we render the nametag.

## Screenshots/Videos

### Before
https://github.com/user-attachments/assets/7a7281d7-4128-421a-9c96-7b6b4cab2335
### After
https://github.com/user-attachments/assets/841528b0-0ebc-4d4b-8d67-8948e53a16ca

