### PR TITLE
[BUGFIX] Fix camera movement not working when pausing

### DIFF
--- a/source/funkin/play/PlayState.hx
+++ b/source/funkin/play/PlayState.hx
@@ -1499,7 +1499,7 @@ class PlayState extends MusicBeatSubState
           dispatchEvent(eventEvent);
 
           // Calling event.cancelEvent() skips the event. Neat!
-          if (!eventEvent.eventCanceled && !shouldSubstatePause)
+          if (!eventEvent.eventCanceled)
           {
             SongEventRegistry.handleEvent(event);
           }
@@ -3941,6 +3941,8 @@ class PlayState extends MusicBeatSubState
     FlxG.camera.follow(cameraFollowPoint, LOCKON, Constants.DEFAULT_CAMERA_FOLLOW_RATE);
     FlxG.camera.targetOffset.set();
 
+    if (shouldSubstatePause) FlxG.camera.followLerp = 0;
+
     if (resetZoom)
     {
       resetCameraZoom();
@@ -3989,6 +3991,12 @@ class PlayState extends MusicBeatSubState
           resetCamera(false, false); // Re-enable camera following when the tween is complete.
         }
       });
+
+      if (shouldSubstatePause)
+      {
+        cameraFollowTween.active = false;
+        cameraTweensPausedBySubState.add(cameraFollowTween);
+      }
     }
   }
 
@@ -4022,6 +4030,12 @@ class PlayState extends MusicBeatSubState
       // Zoom tween! Caching it so we can cancel/pause it later if needed.
       var adjustedDuration:Float = duration / playbackRate;
       cameraZoomTween = FlxTween.tween(this, {currentCameraZoom: targetZoom}, adjustedDuration, {ease: ease});
+
+      if (shouldSubstatePause)
+      {
+        cameraZoomTween.active = false;
+        cameraTweensPausedBySubState.add(cameraZoomTween);
+      }
     }
   }
 


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
Fixes #7472

<!-- Briefly describe the issue(s) fixed. -->
## Description

This PR fixes a bug where camera movement doesn't work when doing a frame perfect pause. This fixes my stupid dumb commit from like a month ago.

Below is a mod you can use to test this PR AND be frame perfect.

[pause.on.camera.event.zip](https://github.com/user-attachments/files/27145019/pause.on.camera.event.zip)

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos

https://github.com/user-attachments/assets/6b9f5cf1-c2a3-4e70-8b5a-bc0051bf9324