### PR TITLE
[ENHANCEMENT] Implement Note Hitsound Types

### DIFF
--- a/source/funkin/Preferences.hx
+++ b/source/funkin/Preferences.hx
@@ -6,6 +6,7 @@ import funkin.mobile.ui.FunkinHitbox;
 #if FEATURE_MOBILE_IAP
 import funkin.mobile.util.InAppPurchasesUtil;
 #end
+import funkin.play.notes.notehitsound.NoteHitsound.NoteHitsoundType;
 import funkin.save.Save;
 import funkin.util.WindowUtil;
 import funkin.util.HapticUtil.HapticsMode;
@@ -148,6 +149,44 @@ class Preferences
   {
     var save:Save = Save.instance;
     save.options.zoomCamera = value;
+    Save.system.flush();
+    return value;
+  }
+
+  /**
+   * The type of sound played when a note is hit.
+   * @default `None`
+   */
+  public static var hitsoundType(get, set):NoteHitsoundType;
+
+  static function get_hitsoundType():NoteHitsoundType
+  {
+    return Save?.instance?.options?.hitsoundType ?? NoteHitsoundType.None;
+  }
+
+  static function set_hitsoundType(value:NoteHitsoundType):NoteHitsoundType
+  {
+    var save:Save = Save.instance;
+    save.options.hitsoundType = value;
+    Save.system.flush();
+    return value;
+  }
+
+  /**
+   * Adjust the volume of the note hitsound type.
+   * @default `50`
+   */
+  public static var hitsoundVolume(get, set):Int;
+
+  static function get_hitsoundVolume():Int
+  {
+    return Save?.instance?.options?.hitsoundVolume ?? 0;
+  }
+
+  static function set_hitsoundVolume(value:Int):Int
+  {
+    var save:Save = Save.instance;
+    save.options.hitsoundVolume = value;
     Save.system.flush();
     return value;
   }

--- a/source/funkin/play/notes/Strumline.hx
+++ b/source/funkin/play/notes/Strumline.hx
@@ -9,8 +9,11 @@ import flixel.group.FlxSpriteGroup.FlxTypedSpriteGroup;
 import flixel.tweens.FlxEase;
 import flixel.tweens.FlxTween;
 import flixel.util.FlxSort;
+import flixel.util.FlxTimer;
+import funkin.audio.FunkinSound;
 import funkin.graphics.FunkinSprite;
 import funkin.data.song.SongData.SongNoteData;
+import funkin.play.notes.notehitsound.NoteHitsound;
 import funkin.util.SortUtil;
 import funkin.util.GRhythmUtil;
 import funkin.play.notes.notekind.NoteKind;
@@ -1007,6 +1010,11 @@ class Strumline extends FlxSpriteGroup
         note.holdNoteSprite.fullSustainLength,
         (note.holdNoteSprite.strumTime + note.holdNoteSprite.fullSustainLength) - conductorInUse.songPosition
       );
+    }
+
+    if (isPlayer && Preferences.hitsoundVolume > 0)
+    {
+      NoteHitsound.playType(Preferences.hitsoundType, Preferences.hitsoundVolume / 100.0);
     }
 
     #if FEATURE_GHOST_TAPPING

--- a/source/funkin/play/notes/notehitsound/NoteHitsound.hx
+++ b/source/funkin/play/notes/notehitsound/NoteHitsound.hx
@@ -1,0 +1,74 @@
+package funkin.play.notes.notehitsound;
+
+import funkin.audio.FunkinSound;
+
+/**
+ * Handles playback of note hitsounds, routing to the correct audio asset
+ * based on the user's selected `NoteHitsoundType`.
+ */
+class NoteHitsound extends FunkinSound
+{
+  /**
+   * The base asset path for all hitsound files.
+   */
+  static final HITSOUND_PATH:String = 'gameplay/hitsounds/';
+
+  /**
+   * Play a hitsound of the given type at the given volume.
+   *
+   * @param type The hitsound type to play.
+   * @param volume `Preferences.hitsoundVolume` from 0.0 to 1.0.
+   * @return The playing `FunkinSound`, or `null`.
+   */
+  public static function playType(type:NoteHitsoundType = NoteHitsoundType.Default, volume:Float = 1.0):Null<FunkinSound>
+  {
+    if (type == NoteHitsoundType.None || volume <= 0.0) return null;
+
+    var path:Null<String> = getAssetPath(type);
+    if (path == null) return null;
+
+    var sound:Null<FunkinSound> = FunkinSound.playOnce(Paths.sound(path), volume);
+    if (sound != null) sound.volume = volume;
+    return sound;
+  }
+
+  /**
+   * Resolve the asset path for a given `NoteHitsoundType`.
+   *
+   * @param type The hitsound type to play.
+   * @return The asset path string, or `null` if not found.
+   */
+  public static function getAssetPath(type:NoteHitsoundType):Null<String>
+  {
+    return switch (type)
+    {
+      case NoteHitsoundType.Default: return HITSOUND_PATH + 'hitsound_DEFAULT';
+      case NoteHitsoundType.PingPong: return HITSOUND_PATH + 'hitsound_PINGPONG';
+      case NoteHitsoundType.None: return null;
+      default: return null;
+    }
+  }
+}
+
+/**
+ * The different types of note hitsounds available.
+ * Note: Any new hitsound types must be added here, and in `NoteHitsound.getAssetPath()`.
+ */
+abstract NoteHitsoundType(String) from String to String
+{
+  /**
+   * The note hitsound option is fully disabled.
+   */
+  public static inline var None:NoteHitsoundType = "None";
+
+  /**
+   * The default note hitsound.
+   * Can be heard when using the chart editor.
+   */
+  public static inline var Default:NoteHitsoundType = "Default";
+
+  /**
+   * Custom ping pong note hitsound.
+   */
+  public static inline var PingPong:NoteHitsoundType = "Ping Pong";
+}

--- a/source/funkin/save/Save.hx
+++ b/source/funkin/save/Save.hx
@@ -4,6 +4,7 @@ import funkin.util.tools.ISerializable;
 import flixel.util.FlxSave;
 import funkin.input.Controls.Device;
 import funkin.data.character.CharacterData.CharacterDataParser;
+import funkin.play.notes.notehitsound.NoteHitsound.NoteHitsoundType;
 import funkin.play.scoring.Scoring;
 import funkin.play.scoring.Scoring.ScoringRank;
 import funkin.save.migrator.RawSaveData_v1_0_0;
@@ -141,6 +142,8 @@ class Save implements ConsoleClass implements ISerializable
         autoPause: true,
         vsyncMode: 'Off',
         strumlineBackgroundOpacity: 0,
+        hitsoundType: NoteHitsoundType.None,
+        hitsoundVolume: 50,
         autoFullscreen: false,
         globalOffset: 0,
         audioVisualOffset: 0,
@@ -1371,6 +1374,18 @@ typedef SaveDataOptions =
    * @default `false`
    */
   var zoomCamera:Bool;
+
+  /**
+   * The type of sound played when a note is hit.
+   * @default `None`
+   */
+  var hitsoundType:String;
+
+  /**
+   * Adjust the volume of the note hitsound type.
+   * @default `50`
+   */
+  var hitsoundVolume:Int;
 
   /**
    * If enabled, an FPS and memory counter will be displayed even if this is not a debug build.

--- a/source/funkin/ui/options/PreferencesMenu.hx
+++ b/source/funkin/ui/options/PreferencesMenu.hx
@@ -8,6 +8,8 @@ import flixel.util.FlxColor;
 import flixel.FlxG;
 import flixel.group.FlxSpriteGroup.FlxTypedSpriteGroup;
 import flixel.math.FlxPoint;
+import funkin.play.notes.notehitsound.NoteHitsound;
+import funkin.play.notes.notehitsound.NoteHitsound.NoteHitsoundType;
 import funkin.ui.AtlasText.AtlasFont;
 import funkin.ui.Page;
 import funkin.graphics.FunkinCamera;
@@ -125,6 +127,26 @@ class PreferencesMenu extends Page<OptionsState.OptionsMenuPageName>
     {
       Preferences.strumlineBackgroundOpacity = value;
     }, Preferences.strumlineBackgroundOpacity);
+    createPrefItemEnum('Note Hitsound Type', 'The sound played when a note is hit.', [
+      NoteHitsoundType.None => "None",
+      NoteHitsoundType.Default => "Default",
+      NoteHitsoundType.PingPong => "Ping Pong",
+    ], (key:String, value:NoteHitsoundType) ->
+      {
+        Preferences.hitsoundType = value;
+        if (Preferences.hitsoundType != NoteHitsoundType.None)
+        {
+          NoteHitsound.playType(value, Preferences.hitsoundVolume / 100.0);
+        }
+      }, Preferences.hitsoundType);
+    createPrefItemPercentage('Note Hitsound Volume', 'Adjust the volume of the note hitsound type.', function(value:Int):Void
+    {
+      Preferences.hitsoundVolume = value;
+      if (Preferences.hitsoundType != NoteHitsoundType.None)
+      {
+        NoteHitsound.playType(Preferences.hitsoundType, value / 100.0);
+      }
+    }, Preferences.hitsoundVolume);
     #if FEATURE_HAPTICS
     createPrefItemEnum('Haptics', 'When enabled, the game plays haptic feedback effects.', [
       "All" => HapticsMode.ALL,


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
- #7396

## Associated Funkin Pr
- FunkinCrew/funkin.assets#440

<!-- Briefly describe the issue(s) fixed. -->
## Description
This PR adds a new feature where if you hit a note, a 'tick' sound effect plays.

### Changes:
- Added new option(s):
  * Note Hitsound Type (None, Default, Ping Pong)
  * Note Hitsound Volume (0-100)
- Note hitsounds are now synced to the note's strum time, accounting for early and late hits.

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos
### Options Menu:
<img width="1280" height="720" alt="screenshot-2026-06-26-15-05-44" src="https://github.com/user-attachments/assets/95ec1eea-34e0-407f-82b6-7034f31eb67a" />

### Gameplay Snippets:

>[!WARNING]
> Depending on your note offets, the hitsounds might be too early, or too late. I'm doing my best to prevent this from happening.

**Default Hitsounds**

https://github.com/user-attachments/assets/941cf330-4b82-41b8-a415-971959e95672

**Ping Pong Hitsounds**

https://github.com/user-attachments/assets/ef9a56b5-23c8-4c95-903a-862bd355b041


