### PR TITLE
[BUGFIX] Fix TextureSwap not setting the variables

### DIFF
--- a/source/funkin/graphics/shaders/TextureSwap.hx
+++ b/source/funkin/graphics/shaders/TextureSwap.hx
@@ -16,6 +16,7 @@ class TextureSwap extends FlxShader
   function set_swappedImage(_bitmapData:BitmapData):BitmapData
   {
     image.input = _bitmapData;
+    this.swappedImage = _bitmapData;
 
     return _bitmapData;
   }
@@ -23,6 +24,7 @@ class TextureSwap extends FlxShader
   function set_amount(val:Float):Float
   {
     fadeAmount.value = [val];
+    this.amount = val;
 
     return val;
   }


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
MEEEEEEEE

<!-- Briefly describe the issue(s) fixed. -->
## Description
This pr sets the variables correctly in the setters, which fixes the variables not giving the right values when trying to use them (like when trying to tween `amount`).