### PR TITLE
[VULNERABILITY] Blacklist `haxe.Http`

### DIFF
--- a/source/funkin/modding/PolymodHandler.hx
+++ b/source/funkin/modding/PolymodHandler.hx
@@ -328,6 +328,10 @@ class PolymodHandler
     // Lib.load() can load malicious DLLs
     Polymod.blacklistImport('cpp.Lib');
 
+    // `haxe.Http`
+    // An alias for `sys.Http`, which is also a blacklisted package.
+    Polymod.blacklistImport('haxe.Http');
+    
     // `haxe.Unserializer`
     // Unserializer.DEFAULT_RESOLVER.resolveClass() can access blacklisted packages
     Polymod.blacklistImport('haxe.Unserializer');


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Briefly describe the issue(s) fixed. -->
## Description
self-explanatory, `haxe.Http` is literally just an alias for `sys.Http`, which is already... blacklisted...

(kinda regret doing this, but had to do it outta instinct im sorry💔)