### PR TITLE
[ENHANCEMENT] Add ``Edit Notes`` to Chart Editor Selection Context Menu

### DIFF
--- a/source/funkin/ui/debug/charting/contextmenus/ChartEditorSelectionContextMenu.hx
+++ b/source/funkin/ui/debug/charting/contextmenus/ChartEditorSelectionContextMenu.hx
@@ -21,6 +21,7 @@ import funkin.ui.debug.charting.commands.DeselectAllItemsCommand;
 @:access(funkin.ui.debug.charting.ChartEditorState) @:build(haxe.ui.ComponentBuilder.build("assets/exclude/data/ui/chart-editor/context-menus/selection.xml"))
 class ChartEditorSelectionContextMenu extends ChartEditorBaseContextMenu
 {
+  var contextmenuEdit:MenuItem;
   var contextmenuOffset:NumberStepper;
   var contextmenuUnit:DropDown;
   var contextmenuOffsetMove:MenuItem;
@@ -53,6 +54,11 @@ class ChartEditorSelectionContextMenu extends ChartEditorBaseContextMenu
   public function initialize():Void
   {
     // NOTE: Remember to use commands here to ensure undo/redo works properly
+    contextmenuEdit.onClick = function(_)
+    {
+      chartEditorState.showToolbox(ChartEditorState.CHART_EDITOR_TOOLBOX_NOTE_DATA_LAYOUT);
+    }
+
     contextmenuUnit.onChange = function(_)
     {
       // Why does the dropdown do this after I specifically set the value of the damn thing?


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
None.

<!-- Briefly describe the issue(s) fixed. -->
## Description
> [!IMPORTANT]
> Requires https://github.com/FunkinCrew/funkin.assets/pull/421

This PR adds a new option to the charting editor selection context menu that works as a shortcut for the note kinds toolbox.
This is a continuation of https://github.com/FunkinCrew/Funkin/pull/7010 in which I completly forgot to add this feature to the selection context menu.

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos
Sadly I'm unable to compile at the moment but should work as intended because it does the exact same thing as the previous PR.
Anyone interested on testing this out would be appreciated.
