### PR TITLE
[BUGFIX] Unfocus Chart Editor dropdown after selecting item

### DIFF
--- a/source/funkin/ui/debug/charting/ChartEditorState.hx
+++ b/source/funkin/ui/debug/charting/ChartEditorState.hx
@@ -3793,6 +3793,13 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
     handleMusicPlayback(elapsed);
     handleNoteDisplay();
 
+    if (isHaxeUIFocused
+      && !isCursorOverHaxeUI
+      && (FlxG.mouse.justPressedRight || FlxG.mouse.deltaWheel.y != 0))
+    {
+      ChartEditorToolboxHandler.clearHaxeUIFocus();
+    }
+
     // These ones only happen if the modal dialog is not open.
     handleScrollKeybinds();
     handleCursor();

--- a/source/funkin/ui/debug/charting/handlers/ChartEditorToolboxHandler.hx
+++ b/source/funkin/ui/debug/charting/handlers/ChartEditorToolboxHandler.hx
@@ -35,6 +35,14 @@ class ChartEditorToolboxHandler
     }
   }
 
+  public static function clearHaxeUIFocus():Void
+  {
+    @:nullSafety(Off) {
+      final f = FocusManager.instance.focus;
+      if (f != null) f.focus = false;
+    }
+  }
+
   public static function showToolbox(state:ChartEditorState, id:String):Void
   {
     var toolbox:Null<CollapsibleDialog> = state.activeToolboxes.get(id);
@@ -44,10 +52,7 @@ class ChartEditorToolboxHandler
     if (toolbox != null)
     {
       toolbox.showDialog(false);
-      @:nullSafety(Off) {
-        final f = FocusManager.instance.focus;
-        if (f != null) f.focus = false;
-      }
+      clearHaxeUIFocus();
 
       state.playSound(Paths.sound('chartingSounds/openWindow'));
 
@@ -91,10 +96,7 @@ class ChartEditorToolboxHandler
 
     if (toolbox != null)
     {
-      @:nullSafety(Off) {
-        final f = FocusManager.instance.focus;
-        if (f != null) f.focus = false;
-      }
+      clearHaxeUIFocus();
       toolbox.hideDialog(DialogButton.CANCEL);
 
       state.playSound(Paths.sound('chartingSounds/exitWindow'));

--- a/source/funkin/ui/debug/charting/handlers/ChartEditorToolboxHandler.hx
+++ b/source/funkin/ui/debug/charting/handlers/ChartEditorToolboxHandler.hx
@@ -8,6 +8,7 @@ import haxe.ui.components.CheckBox;
 import haxe.ui.containers.dialogs.CollapsibleDialog;
 import haxe.ui.containers.dialogs.Dialog.DialogButton;
 import haxe.ui.containers.dialogs.Dialog.DialogEvent;
+import haxe.ui.focus.FocusManager;
 import funkin.ui.debug.charting.toolboxes.ChartEditorBaseToolbox;
 import funkin.ui.debug.charting.toolboxes.ChartEditorMetadataToolbox;
 import funkin.ui.debug.charting.toolboxes.ChartEditorOffsetsToolbox;
@@ -43,6 +44,10 @@ class ChartEditorToolboxHandler
     if (toolbox != null)
     {
       toolbox.showDialog(false);
+      @:nullSafety(Off) {
+        final f = FocusManager.instance.focus;
+        if (f != null) f.focus = false;
+      }
 
       state.playSound(Paths.sound('chartingSounds/openWindow'));
 
@@ -86,6 +91,10 @@ class ChartEditorToolboxHandler
 
     if (toolbox != null)
     {
+      @:nullSafety(Off) {
+        final f = FocusManager.instance.focus;
+        if (f != null) f.focus = false;
+      }
       toolbox.hideDialog(DialogButton.CANCEL);
 
       state.playSound(Paths.sound('chartingSounds/exitWindow'));


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
Fixes #2956

<!-- Briefly describe the issue(s) fixed. -->
## Description
  Fixes the chart editor input lockout that occurred when a HaxeUI toolbox field had focus (blue outline). After interacting with a field, playtesting with the toolbox open,
  and reopening the toolbox, the field's focus was auto-restored, and `isHaxeUIFocused` returning true gated all chart editor input (scroll, note placement, playtest hotkey,
   etc.).

  **The fix:** in `ChartEditorToolboxHandler.showToolbox` and `.hideToolbox`, directly call `IFocusable.focus = false` on the currently-focused element via
  `FocusManager.instance.focus`. This bypasses HaxeUI's `set_focus(null)` API, which has an asymmetric implementation: `get_focus` walks all root components, but
  `set_focus(null)` only clears `_lastFocuses` for `Screen.instance.topComponent`, so focus living on a non-top root (like a dialog) can't be cleared through it.

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos

https://github.com/user-attachments/assets/d429120b-addd-4c78-9b8d-7d08d168bcbb


