### PR TITLE
[BUGFIX] Prevent Stage Editor crash on animate atlas props

### DIFF
--- a/source/funkin/ui/debug/stageeditor/StageEditorObject.hx
+++ b/source/funkin/ui/debug/stageeditor/StageEditorObject.hx
@@ -2,6 +2,7 @@ package funkin.ui.debug.stageeditor;
 
 #if FEATURE_STAGE_EDITOR
 import funkin.data.animation.AnimationData;
+import funkin.data.stage.StageData.StageDataProp;
 import funkin.graphics.FunkinSprite;
 import funkin.graphics.shaders.InverseDotsShader;
 
@@ -23,6 +24,12 @@ class StageEditorObject extends FunkinSprite
   public var startingAnimation:String = "";
 
   public var animDatas:Map<String, AnimationData> = [];
+
+  /**
+   * Original prop data preserved verbatim for asset formats the Stage Editor cannot represent (e.g. animate atlas).
+   * When non-null, the editor renders a placeholder for this prop and writes this data unchanged on save.
+   */
+  public var preservedData:Null<StageDataProp> = null;
 
   override public function new()
   {

--- a/source/funkin/ui/debug/stageeditor/handlers/StageDataHandler.hx
+++ b/source/funkin/ui/debug/stageeditor/handlers/StageDataHandler.hx
@@ -1,6 +1,7 @@
 package funkin.ui.debug.stageeditor.handlers;
 
 #if FEATURE_STAGE_EDITOR
+import flixel.util.FlxColor;
 import haxe.io.Bytes;
 import funkin.util.FileUtil;
 import openfl.display.BitmapData;
@@ -9,6 +10,7 @@ import funkin.play.character.BaseCharacter.CharacterType;
 import funkin.play.character.BaseCharacter;
 import funkin.data.stage.StageData;
 import funkin.data.stage.StageData.StageDataCharacter;
+import funkin.data.stage.StageData.StageDataProp;
 import funkin.data.stage.StageRegistry;
 import openfl.utils.Assets as OpenFLAssets;
 import lime.utils.Assets as LimeAssets;
@@ -17,6 +19,12 @@ using StringTools;
 
 class StageDataHandler
 {
+  static final PRESERVED_PLACEHOLDER_SIZE:Int = 150;
+  static final PRESERVED_PLACEHOLDER_COLOR:FlxColor = FlxColor.MAGENTA;
+  static final PRESERVED_PLACEHOLDER_ALPHA:Float = 0.5;
+  // Editor's grid bg has zIndex 0; the placeholder must sort strictly above it to be visible.
+  static final PRESERVED_PLACEHOLDER_MIN_Z_INDEX:Int = 1;
+
   public static function checkForCharacter(char:BaseCharacter) return char != null;
 
   public static function packShitToZip(state:StageEditorState)
@@ -32,6 +40,12 @@ class StageDataHandler
 
     for (obj in state.spriteArray)
     {
+      if (obj.preservedData != null)
+      {
+        endData.props.push(obj.preservedData);
+        continue;
+      }
+
       var data = obj.toData(false);
       endData.props.push({
         name: data.name,
@@ -197,10 +211,20 @@ class StageDataHandler
     state.loadCharDatas(stageData);
 
     // objects
+    var preservedCount:Int = 0;
+
     for (objData in stageData.props)
     {
-      // make the data and roll with it
       var spr = new StageEditorObject();
+
+      if (!objData.assetPath.startsWith("#") && !state.bitmaps.exists(objData.assetPath))
+      {
+        applyPreservedPlaceholder(spr, objData);
+        state.add(spr);
+        preservedCount++;
+        continue;
+      }
+
       spr.fromData({
         name: objData.name ?? "Unnamed",
         assetPath: objData.assetPath,
@@ -227,6 +251,7 @@ class StageDataHandler
     state.updateArray();
     state.sortAssets();
     state.updateMarkerPos();
+    notifyPreservedProps(state, preservedCount);
   }
 
   static function loadCharDatas(state:StageEditorState, data:StageData)
@@ -302,9 +327,20 @@ class StageDataHandler
 
     state.loadCharDatas(data);
 
+    var preservedCount:Int = 0;
+
     for (objData in data.props)
     {
       var spr = new StageEditorObject();
+
+      if (!objData.assetPath.startsWith("#") && !Assets.exists(Paths.image(objData.assetPath)))
+      {
+        applyPreservedPlaceholder(spr, objData);
+        state.add(spr);
+        preservedCount++;
+        continue;
+      }
+
       if (!objData.assetPath.startsWith("#")) state.bitmaps.set(objData.assetPath, Assets.getBitmapData(Paths.image(objData.assetPath)));
 
       var usePacker:Bool = objData.animType == "packer";
@@ -336,6 +372,25 @@ class StageDataHandler
 
     state.updateArray();
     state.updateMarkerPos();
+    notifyPreservedProps(state, preservedCount);
+  }
+
+  static function applyPreservedPlaceholder(spr:StageEditorObject, objData:StageDataProp):Void
+  {
+    spr.preservedData = objData;
+    spr.name = objData.name ?? "Unnamed";
+    spr.makeGraphic(PRESERVED_PLACEHOLDER_SIZE, PRESERVED_PLACEHOLDER_SIZE, PRESERVED_PLACEHOLDER_COLOR);
+    spr.setPosition(objData.position[0], objData.position[1]);
+    spr.zIndex = objData.zIndex > 0 ? objData.zIndex : PRESERVED_PLACEHOLDER_MIN_Z_INDEX;
+    spr.alpha = PRESERVED_PLACEHOLDER_ALPHA;
+    spr.scrollFactor.set(objData.scroll[0], objData.scroll[1]);
+  }
+
+  static function notifyPreservedProps(state:StageEditorState, count:Int):Void
+  {
+    if (count <= 0) return;
+    state.notifyChange("Unsupported Props",
+      '$count prop(s) use asset formats the Stage Editor cannot edit yet. They will be preserved unchanged on save.');
   }
 
   public static function loadDummyData(state:StageEditorState)


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
Fixes #7499

<!-- Briefly describe the issue(s) fixed. -->
## Description
  Opening any stage with an animate-atlas prop (e.g. Spooky Mansion's `halloween_bg`) crashed the Stage Editor because `StageDataHandler` called
  `Assets.getBitmapData(Paths.image(...))` on every prop, but animate-atlas assets are directories, not flat PNGs.

  Now both load paths guard with `Assets.exists` first. Unsupported props are stashed on the `StageEditorObject` as `preservedData` and rendered as a magenta
  placeholder; `packShitToZip` writes `preservedData` verbatim so save round-trips the original block unchanged with no data loss. A notification fires on load
  when any props are preserved.

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos

https://github.com/user-attachments/assets/6e8b8a21-459d-4a51-b41c-594342eb3e69

