### PR TITLE
[BUGFIX] Fix switch editor button getting stuck highlighted

### DIFF
--- a/source/funkin/ui/debug/cameraeditor/CameraEditorState.hx
+++ b/source/funkin/ui/debug/cameraeditor/CameraEditorState.hx
@@ -101,6 +101,7 @@ import haxe.ui.core.Screen;
 import haxe.ui.events.KeyboardEvent;
 import haxe.ui.events.MouseEvent;
 import haxe.ui.events.UIEvent;
+import haxe.ui.Toolkit;
 import haxe.ui.focus.FocusManager;
 import haxe.ui.notifications.NotificationManager;
 import haxe.ui.notifications.NotificationType;
@@ -740,6 +741,20 @@ class CameraEditorState extends UIState implements ConsoleClass
         openBackupAvailableDialog(welcomeDialog);
       }
     }
+
+    Toolkit.callLater(() ->
+    {
+      @:nullSafety(Off)
+      {
+        final f = FocusManager.instance.focus;
+        if (f != null) f.focus = false;
+      }
+      for (root in haxe.ui.core.Screen.instance.rootComponents)
+      {
+        root.removeClass(":hover", false, true);
+        root.removeClass(":down", false, true);
+      }
+    });
   }
 
   var goToPoint:FlxPoint = new FlxPoint();

--- a/source/funkin/ui/debug/cameraeditor/CameraEditorState.hx
+++ b/source/funkin/ui/debug/cameraeditor/CameraEditorState.hx
@@ -2637,6 +2637,12 @@ class CameraEditorState extends UIState implements ConsoleClass
 
       performCleanup();
 
+      @:nullSafety(Off)
+      {
+        final f = FocusManager.instance.focus;
+        if (f != null) f.focus = false;
+      }
+
       FlxG.switchState(() -> new ChartEditorState({
         loadFromPath: this.currentWorkingFilePath,
         targetSongDifficulty: this.currentDifficulty,

--- a/source/funkin/ui/debug/charting/ChartEditorState.hx
+++ b/source/funkin/ui/debug/charting/ChartEditorState.hx
@@ -2692,6 +2692,20 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
     #if FEATURE_DISCORD_RPC
     updateDiscordRPC();
     #end
+
+    Toolkit.callLater(() ->
+    {
+      @:nullSafety(Off)
+      {
+        final f = FocusManager.instance.focus;
+        if (f != null) f.focus = false;
+      }
+      for (root in haxe.ui.core.Screen.instance.rootComponents)
+      {
+        root.removeClass(":hover", false, true);
+        root.removeClass(":down", false, true);
+      }
+    });
   }
 
   #if FEATURE_DISCORD_RPC

--- a/source/funkin/ui/debug/charting/ChartEditorState.hx
+++ b/source/funkin/ui/debug/charting/ChartEditorState.hx
@@ -6879,6 +6879,12 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
 
       var startTimestamp:Float = scrollPositionInMs + playheadPositionInMs;
 
+      @:nullSafety(Off)
+      {
+        final f = FocusManager.instance.focus;
+        if (f != null) f.focus = false;
+      }
+
       FlxG.switchState(() -> new CameraEditorState({
         loadFromPath: this.currentWorkingFilePath,
         targetSongDifficulty: this.selectedDifficulty,


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues

Fixes #7493

<!-- Briefly describe the issue(s) fixed. -->
## Description

Clicking "Go to Camera Editor" (in Chart Editor) or "Go to Chart Editor" (in Camera Editor) left a blue focus outline on the destination editor's matching menubar item until the user moused over something else. The clicked menu item retained focus across `FlxG.switchState` because HaxeUI's focus reference lives on `Screen.instance` (a singleton) and persists.

Same archetype as #7528 — directly clear the focused `IFocusable` via `FocusManager.instance.focus` before `FlxG.switchState`, in both `ChartEditorState.moveToCameraEditor` and `CameraEditorState.tryMoveToChartEditor`.

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos

https://github.com/user-attachments/assets/d56b9d25-e759-4c33-a1bd-791850743307