### PR TITLE
[ENHANCEMENT] Version check banner

### DIFF
--- a/source/funkin/Preferences.hx
+++ b/source/funkin/Preferences.hx
@@ -301,6 +301,33 @@ class Preferences
   }
 
   /**
+   * If enabled, the title screen shows a banner when a newer GitHub release is available. Desktop only.
+   * @default `true`
+   */
+  public static var checkForUpdates(get, set):Bool;
+
+  static function get_checkForUpdates():Bool
+  {
+    #if !desktop
+    return false;
+    #else
+    return Save?.instance?.options?.checkForUpdates ?? true;
+    #end
+  }
+
+  static function set_checkForUpdates(value:Bool):Bool
+  {
+    #if !desktop
+    return false;
+    #else
+    var save:Save = Save.instance;
+    save.options.checkForUpdates = value;
+    Save.system.flush();
+    return value;
+    #end
+  }
+
+  /**
    * If enabled, the game will automatically launch in fullscreen on startup.
    * @default `true`
    */

--- a/source/funkin/save/Save.hx
+++ b/source/funkin/save/Save.hx
@@ -108,6 +108,7 @@ class Save implements ConsoleClass
         hapticsMode: 'All',
         hapticsIntensityMultiplier: 1,
         autoPause: true,
+        checkForUpdates: true,
         vsyncMode: 'Off',
         strumlineBackgroundOpacity: 0,
         autoFullscreen: false,
@@ -1168,6 +1169,12 @@ typedef SaveDataOptions =
    * @default `true`
    */
   var autoPause:Bool;
+
+  /**
+   * If enabled, the title screen shows a banner when a newer GitHub release is available. Desktop only.
+   * @default `true`
+   */
+  var checkForUpdates:Bool;
 
   /**
    * If enabled, the game will utilize VSync (or adaptive VSync) on startup.

--- a/source/funkin/ui/options/PreferencesMenu.hx
+++ b/source/funkin/ui/options/PreferencesMenu.hx
@@ -183,6 +183,13 @@ class PreferencesMenu extends Page<OptionsState.OptionsMenuPageName>
     {
       Preferences.autoFullscreen = value;
     }, Preferences.autoFullscreen);
+    #if desktop
+    createPrefItemCheckbox('Check for Updates', 'When enabled, the title screen pings GitHub once per session and shows a banner if a newer release is out.',
+      function(value:Bool):Void
+      {
+        Preferences.checkForUpdates = value;
+      }, Preferences.checkForUpdates);
+    #end
     #end
 
     // disable on mobile and web since it barely has any effect

--- a/source/funkin/ui/title/TitleState.hx
+++ b/source/funkin/ui/title/TitleState.hx
@@ -1,7 +1,9 @@
 package funkin.ui.title;
 
 import flixel.group.FlxGroup;
+import flixel.group.FlxSpriteGroup;
 import flixel.input.gamepad.FlxGamepad;
+import flixel.text.FlxText;
 import funkin.ui.FullScreenScaleMode;
 import flixel.tweens.FlxEase;
 import flixel.tweens.FlxTween;
@@ -9,6 +11,7 @@ import flixel.util.FlxColor;
 import flixel.util.FlxDirectionFlags;
 import flixel.util.FlxTimer;
 import funkin.util.HapticUtil;
+import funkin.util.VersionCheck;
 import funkin.graphics.shaders.ColorSwap;
 import funkin.graphics.FunkinSprite;
 import funkin.ui.MusicBeatState;
@@ -26,10 +29,18 @@ import funkin.util.SwipeUtil;
 
 class TitleState extends MusicBeatState
 {
+  static final UPDATE_BANNER_HEIGHT:Int = 40;
+  static final UPDATE_BANNER_FONT_SIZE:Int = 18;
+  static final UPDATE_BANNER_BG_COLOR:FlxColor = 0xCC000000;
+  static final UPDATE_BANNER_HOLD_SECONDS:Float = 5.0;
+  static final UPDATE_BANNER_HIDE_SECONDS:Float = 0.5;
+
   /**
    * Only play the credits once per session.
    */
   public static var initialized:Bool = false;
+
+  static var updateBannerShown:Bool = false;
 
   var blackScreen:FunkinSprite;
   var credGroup:FlxGroup;
@@ -38,6 +49,8 @@ class TitleState extends MusicBeatState
   var curWacky:Array<String> = [];
   var lastBeat:Int = 0;
   var swagShader:ColorSwap;
+  var updateBanner:Null<FlxSpriteGroup> = null;
+  var pendingUpdateTag:Null<String> = null;
 
   override public function create():Void
   {
@@ -46,6 +59,8 @@ class TitleState extends MusicBeatState
 
     curWacky = FlxG.random.getObject(getIntroTextShit());
     funkin.FunkinMemory.cacheSound(Paths.music('girlfriendsRingtone/girlfriendsRingtone'));
+
+    VersionCheck.check(showUpdateBanner);
 
     // DEBUG BULLSHIT
 
@@ -514,6 +529,49 @@ class TitleState extends MusicBeatState
 
       if (credGroup != null) remove(credGroup);
       skippedIntro = true;
+
+      var tag = pendingUpdateTag;
+      if (tag != null && updateBanner == null) addUpdateBanner(tag);
     }
+  }
+
+  function showUpdateBanner(latestTag:String):Void
+  {
+    if (updateBannerShown) return;
+    pendingUpdateTag = latestTag;
+    if (skippedIntro && updateBanner == null) addUpdateBanner(latestTag);
+  }
+
+  function addUpdateBanner(latestTag:String):Void
+  {
+    updateBannerShown = true;
+    final banner = new FlxSpriteGroup();
+
+    final bg = new FunkinSprite().makeSolidColor(FlxG.width, UPDATE_BANNER_HEIGHT, UPDATE_BANNER_BG_COLOR);
+    bg.scrollFactor.set();
+    banner.add(bg);
+
+    final text = new FlxText(0, 0, FlxG.width, 'A new version is available: $latestTag', UPDATE_BANNER_FONT_SIZE);
+    text.alignment = CENTER;
+    text.color = FlxColor.YELLOW;
+    text.borderStyle = OUTLINE;
+    text.borderColor = FlxColor.BLACK;
+    text.scrollFactor.set();
+    text.y = (UPDATE_BANNER_HEIGHT - text.height) / 2;
+    banner.add(text);
+
+    add(banner);
+    updateBanner = banner;
+
+    FlxTween.tween(banner, {y: -UPDATE_BANNER_HEIGHT}, UPDATE_BANNER_HIDE_SECONDS,
+      {
+        startDelay: UPDATE_BANNER_HOLD_SECONDS,
+        ease: FlxEase.cubeIn,
+        onComplete: function(_) {
+          remove(banner);
+          banner.destroy();
+          updateBanner = null;
+        }
+      });
   }
 }

--- a/source/funkin/util/VersionCheck.hx
+++ b/source/funkin/util/VersionCheck.hx
@@ -1,0 +1,72 @@
+package funkin.util;
+
+import haxe.Http;
+import haxe.Json;
+import funkin.Preferences;
+import lime.app.Application;
+import thx.semver.Version;
+
+using StringTools;
+
+/**
+ * Checks the FunkinCrew GitHub repository for a newer release than the running version.
+ * The result is cached for the lifetime of the session.
+ */
+class VersionCheck
+{
+  static final RELEASES_URL:String = "https://api.github.com/repos/FunkinCrew/Funkin/releases/latest";
+  static final TAG_PREFIX:String = "v";
+
+  static var checked:Bool = false;
+  static var cachedTag:Null<String> = null;
+
+  /**
+   * Calls `onResult(tag)` if a newer release tag exists on GitHub.
+   * Silent on errors, when disabled in preferences, or on non-desktop targets.
+   */
+  public static function check(onResult:String->Void):Void
+  {
+    #if !desktop
+    return;
+    #else
+    if (!Preferences.checkForUpdates) return;
+
+    if (checked)
+    {
+      if (cachedTag != null) onResult(cachedTag);
+      return;
+    }
+
+    var http = new Http(RELEASES_URL);
+    // GitHub's API rejects requests without a User-Agent header.
+    http.setHeader('User-Agent', 'FunkinCrew-Funkin');
+    http.onData = function(data:String) {
+      checked = true;
+      try
+      {
+        var json:Dynamic = Json.parse(data);
+        var tag:Null<String> = json.tag_name;
+        if (tag == null) return;
+
+        var currentStr:Null<String> = Application.current.meta.get('version');
+        if (currentStr == null) return;
+
+        var latestStr:String = tag.startsWith(TAG_PREFIX) ? tag.substr(TAG_PREFIX.length) : tag;
+        var latest:Version = latestStr;
+        var current:Version = currentStr;
+
+        if (latest > current)
+        {
+          cachedTag = tag;
+          onResult(tag);
+        }
+      }
+      catch (_:Dynamic) {}
+    };
+    http.onError = function(_:String) {
+      checked = true;
+    };
+    http.request(false);
+    #end
+  }
+}


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
Implements item 3 of #2262

<!-- Briefly describe the issue(s) fixed. -->
## Description
Once per session on `TitleState`, the game pings `api.github.com/repos/FunkinCrew/Funkin/releases/latest`, parses
`tag_name`, and compares against `Application.current.meta.get('version')` via `thx.semver`. If the release is newer, a
semi-opaque dark banner with a yellow update message appears at the top of the screen after the title intro, holds for 5
seconds, then tweens off-screen and destroys itself.

Failures (no network, rate limit, parse error) are silent. Gated behind a new `Preferences.checkForUpdates` toggle in
Options → Preferences (default on, desktop only — `#if desktop`, hidden on web/mobile to respect the Newgrounds/Itch/App Store update channels that handle updates for those distributions).

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos
https://github.com/user-attachments/assets/63821e3d-313f-4905-b6df-655db2d39d86

