### PR TITLE
[BUGFIX] Hide Chart Editor toolboxes from every playtest entry point

### DIFF
--- a/source/funkin/ui/debug/charting/ChartEditorState.hx
+++ b/source/funkin/ui/debug/charting/ChartEditorState.hx
@@ -6395,7 +6395,6 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
     if (!isHaxeUIDialogOpen && !isHaxeUIFocused && FlxG.keys.justPressed.ENTER)
     {
       var minimal = FlxG.keys.pressed.SHIFT;
-      this.hideAllToolboxes();
       testSongInPlayState(minimal);
     }
   }
@@ -6527,6 +6526,8 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
   function testSongInPlayState(minimal:Bool = false):Void
   {
     autoSave(true);
+
+    this.hideAllToolboxes();
 
     // Force pauses audio preview from OffsetsToolbox, if it exists.
     cast(this.getToolbox(CHART_EDITOR_TOOLBOX_OFFSETS_LAYOUT), ChartEditorOffsetsToolbox)?.pauseAudioPreview();

--- a/source/funkin/ui/debug/charting/handlers/ChartEditorGamepadHandler.hx
+++ b/source/funkin/ui/debug/charting/handlers/ChartEditorGamepadHandler.hx
@@ -44,7 +44,6 @@ class ChartEditorGamepadHandler
       if (gamepad.justPressed.START)
       {
         var minimal = gamepad.pressed.LEFT_SHOULDER;
-        chartEditorState.hideAllToolboxes();
         trace('Gamepad: Start pressed, opening playtest (minimal: ${minimal})');
         chartEditorState.testSongInPlayState(minimal);
       }


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues

Closes #6851

<!-- Briefly describe the issue(s) fixed. -->
## Description

Chart editor toolbox dialogs (Window → Events, Playtest Properties, etc.) stayed open during playtest when launched from the menubar (Test → Playtest Full) or from gamepad START. Reopening the same toolbox after returning to the chart editor crashed.

Only the Enter-keybind playtest path called `hideAllToolboxes()` before launching the substate, so other entry points left toolbox HaxeUI components in an inconsistent state across the substate cycle.

The fix moves the call into `testSongInPlayState` itself so every entry point — menubar, gamepad START, Enter, and retest-from-PlayState — hides toolboxes before the playtest substate starts. The now-redundant calls in `handleTestKeybinds` and `ChartEditorGamepadHandler` are removed.

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos

https://github.com/user-attachments/assets/5c760efd-e83e-406e-8193-44f914cb6c69