### PR TITLE
[BUGFIX] Close Chart Editor menubar dropdowns before playtest

### DIFF
--- a/source/funkin/ui/debug/charting/ChartEditorState.hx
+++ b/source/funkin/ui/debug/charting/ChartEditorState.hx
@@ -6521,12 +6521,22 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
    */
   // ====================
 
+  @:access(haxe.ui.backend.ComponentBase)
+  function hideMenubarDropdowns():Void
+  {
+    if (menubar == null) return;
+    var events:Dynamic = menubar._internalEvents;
+    if (events != null) events.hideCurrentMenu(true);
+  }
+
   /**
    * Transitions to the Play State to test the song
    */
   function testSongInPlayState(minimal:Bool = false):Void
   {
     autoSave(true);
+
+    hideMenubarDropdowns();
 
     // Force pauses audio preview from OffsetsToolbox, if it exists.
     cast(this.getToolbox(CHART_EDITOR_TOOLBOX_OFFSETS_LAYOUT), ChartEditorOffsetsToolbox)?.pauseAudioPreview();


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
Closes #7533

<!-- Briefly describe the issue(s) fixed. -->
## Description
Top-bar dropdown menus (File, Edit, View, etc.) stayed open after pressing Enter to playtest from the chart editor. The dropdown panel was hidden during playtest, but it reappeared on return — and the menubar's internal selected-button state was stale, so clicking the same dropdown afterwards behaved incorrectly.

Dropdowns are added to `Screen.instance` (not the chart editor's own UI tree), so they survive the substate transition. The fix calls the menubar's internal `hideCurrentMenu` from `testSongInPlayState`, which both hides the panel and clears `_currentMenu`/`_currentButton.selected` — so every entry point (Enter, gamepad START, menubar Test → Playtest) leaves the menubar in a clean state.

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos
https://github.com/user-attachments/assets/1c29c4ef-edea-4d00-b1f9-2c6437890fdb

