### PR TITLE
[BUGFIX] Hide OFFICIAL OST label on Freeplay random capsule

### DIFF
--- a/source/funkin/ui/freeplay/AlbumRoll.hx
+++ b/source/funkin/ui/freeplay/AlbumRoll.hx
@@ -251,7 +251,7 @@ class AlbumRoll extends FlxSpriteGroup
     {
       return ostOverride;
     }
-    else if (albumId == null || AlbumRegistry.instance.listBaseGameEntryIds().contains(albumId))
+    else if (albumId != null && AlbumRegistry.instance.listBaseGameEntryIds().contains(albumId))
     {
       return Constants.DEFAULT_OST_NAME;
     }


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues

Fixes #7338

<!-- Briefly describe the issue(s) fixed. -->
## Description

AlbumRoll.getOSTNameOverride() returned Constants.DEFAULT_OST_NAME for any albumId == null, so the random capsule's OST label stayed at "OFFICIAL OST" even though its album image and title were hidden. Per @NotHyper-474's https://github.com/FunkinCrew/Funkin/issues/7338#issuecomment-4201312205, the null branch should fall through to return null; FreeplayState.updateOSTName already coalesces a null return to an empty string.

The class is @:nullSafety, so a straight removal of albumId == null || doesn't compile (contains rejects Null<String>). Inverted the predicate to albumId != null && … for the same end-effect.

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos

https://github.com/user-attachments/assets/64978b49-9a43-4dce-b400-31c4d9ac9315