### PR TITLE
[BUGFIX] Fix Camera Editor event data pasting into layer name

### DIFF
--- a/source/funkin/ui/debug/cameraeditor/CameraEditorState.hx
+++ b/source/funkin/ui/debug/cameraeditor/CameraEditorState.hx
@@ -2455,7 +2455,7 @@ class CameraEditorState extends UIState implements ConsoleClass
         hasClipboardEvent = true;
         var removeCmds:Array<CameraEditorCommand> = [for (ev in selectedSongEvents) new RemoveEventCommand(ev)];
         CameraEditorCommandHandler.performCommand(this, new CompoundCommand(removeCmds, 'Cut ${removeCmds.length} Events', []));
-      case [FlxKey.V, true, false, false, _] if (hasClipboardEvent): // ctrl + v -> paste at playhead
+      case [FlxKey.V, true, false, false, _] if (hasClipboardEvent && !timeline.layerPanel.isEditing): // ctrl + v -> paste at playhead
         var pasteMs = Conductor.instance.songPosition;
 
         if (pasteMs < 0) pasteMs = 0;

--- a/source/funkin/ui/haxeui/components/editors/timeline/TimelineLayerPanel.hx
+++ b/source/funkin/ui/haxeui/components/editors/timeline/TimelineLayerPanel.hx
@@ -2,6 +2,7 @@ package funkin.ui.haxeui.components.editors.timeline;
 
 #if FEATURE_CAMERA_EDITOR
 import funkin.ui.haxeui.components.IconButton;
+import funkin.util.ClipboardUtil;
 import haxe.ui.components.TextField;
 import haxe.ui.containers.Box;
 import haxe.ui.containers.HBox;
@@ -41,6 +42,14 @@ class TimelineLayerPanel extends VBox
   var _editingLayer:TimelineLayerData = null;
   var _editingHandles:LayerRowHandles = null;
   var _screenMouseDownBound:MouseEvent->Void;
+  var _savedClipboard:Null<String> = null;
+
+  public var isEditing(get, never):Bool;
+
+  function get_isEditing():Bool
+  {
+    return _editingLayer != null;
+  }
 
   public function setScrollOffset(offsetPx:Float):Void
   {
@@ -77,6 +86,24 @@ class TimelineLayerPanel extends VBox
     _editingHandles.cancelling = false;
     _editingHandles = null;
     _editingLayer = null;
+    _restoreSavedClipboard();
+  }
+
+  function _stashClipboardIfSongData():Void
+  {
+    var clip:String = ClipboardUtil.getClipboard();
+    if (clip != null && _looksLikeSongClipboard(clip))
+    {
+      _savedClipboard = clip;
+      ClipboardUtil.setClipboard('');
+    }
+  }
+
+  function _restoreSavedClipboard():Void
+  {
+    if (_savedClipboard == null) return;
+    if (ClipboardUtil.getClipboard() == '') ClipboardUtil.setClipboard(_savedClipboard);
+    _savedClipboard = null;
   }
 
   public function insertLayerRow(layer:TimelineLayerData, index:Int):Void
@@ -230,6 +257,8 @@ class TimelineLayerPanel extends VBox
     handles.field.disabled = false;
     handles.field.focus = true;
 
+    _stashClipboardIfSongData();
+
     _screenMouseDownBound = _onScreenMouseDown;
     Screen.instance.registerEvent(MouseEvent.MOUSE_DOWN, _screenMouseDownBound);
   }
@@ -319,6 +348,7 @@ class TimelineLayerPanel extends VBox
     handles.editOriginal = null;
     _editingLayer = null;
     _editingHandles = null;
+    _restoreSavedClipboard();
 
     if (handles.cancelling)
     {
@@ -351,6 +381,14 @@ class TimelineLayerPanel extends VBox
     ev.newLayerName = trimmed;
     ev.bubble = true;
     dispatch(ev);
+  }
+
+  static function _looksLikeSongClipboard(text:String):Bool
+  {
+    var trimmed:String = StringTools.trim(text);
+    return trimmed.length > 0
+      && trimmed.charAt(0) == '{'
+      && (trimmed.indexOf('"events"') != -1 || trimmed.indexOf('"notes"') != -1);
   }
 }
 


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues

Fixes #7440

<!-- Briefly describe the issue(s) fixed. -->
## Description

Camera Editor copies the event JSON to the OS clipboard. Pasting it into a layer name field dumped the JSON into the name. HaxeUI's native TextField paste happens before any Haxe-level handler can pre-empt it, so cancel/revert approaches lose the race on spam Ctrl+V. When entering edit mode, stash the OS clipboard locally and clear it (only if it looks like song JSON). Restore on exit if it's still empty, so any new copy during edit is preserved. Also gate the screen-level PasteEventsCommand on !timeline.layerPanel.isEditing.

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos

https://github.com/user-attachments/assets/4cd5c22f-2a9e-4c69-800a-92ab3bf05b39