### PR TITLE
[BUGFIX] Fix character icons sometimes not appearing in Stage Editor

### DIFF
--- a/source/funkin/data/character/CharacterData.hx
+++ b/source/funkin/data/character/CharacterData.hx
@@ -368,6 +368,7 @@ class CharacterDataParser
       // so, haxe.ui.backend.AssetsImpl uses the parent width and height, which makes the image go crazy when rendered
       // so this is a work around so that it uses the actual width and height
       var imageGraphic = flixel.graphics.FlxGraphic.fromFrame(idleFrame);
+      imageGraphic.destroyOnNoUse = false;
 
       var imageFrame = flixel.graphics.frames.FlxImageFrame.fromImage(imageGraphic);
       frame = imageFrame.frame;


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues

Fixes #7500

<!-- Briefly describe the issue(s) fixed. -->
## Description

CharacterDataParser.getCharPixelIconAsset built a fresh FlxGraphic via FlxGraphic.fromFrame but only held it through a local FlxImageFrame. After the function returned, useCount dropped to 0 and Flixel destroyed the graphic on its next sweep — the returned FlxFrame.parent was now invalid:

[WARNING] Invalid call to getFramesCollections on a destroyed graphic
[ERROR]   Cannot render a destroyed graphic, the placeholder image will be used instead.

The Stage Editor's Character Properties button (and picker grid) were the visible victim — they showed the FlxSprite default placeholder. Set destroyOnNoUse = false on the constructed graphic so it survives past the function scope.

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos

https://github.com/user-attachments/assets/0d7a5d2c-be9a-4f0d-8ccf-a5c937383dac