### PR TITLE
[BUGFIX] Save Camera Editor settings across sessions

### DIFF
--- a/source/funkin/save/Save.hx
+++ b/source/funkin/save/Save.hx
@@ -419,6 +419,33 @@ class Save implements ConsoleClass implements ISerializable
   @:saveProperty(data.optionsCameraEditor.hasBackup, false)
   public var cameraEditorHasBackup:SaveProperty<Bool>;
 
+  @:saveProperty(data.optionsCameraEditor.relativeView, false)
+  public var cameraEditorRelativeView:SaveProperty<Bool>;
+
+  @:saveProperty(data.optionsCameraEditor.extendedBounds, false)
+  public var cameraEditorExtendedBounds:SaveProperty<Bool>;
+
+  @:saveProperty(data.optionsCameraEditor.passepartout, false)
+  public var cameraEditorPassepartout:SaveProperty<Bool>;
+
+  @:saveProperty(data.optionsCameraEditor.passepartoutTransparency, 50.0)
+  public var cameraEditorPassepartoutTransparency:SaveProperty<Float>;
+
+  @:saveProperty(data.optionsCameraEditor.bopping, false)
+  public var cameraEditorBopping:SaveProperty<Bool>;
+
+  @:saveProperty(data.optionsCameraEditor.fitCameraToViewport, false)
+  public var cameraEditorFitCameraToViewport:SaveProperty<Bool>;
+
+  @:saveProperty(data.optionsCameraEditor.autoScrollMode, 1)
+  public var cameraEditorAutoScrollMode:SaveProperty<Int>;
+
+  @:saveProperty(data.optionsCameraEditor.snapEnabled, true)
+  public var cameraEditorSnapEnabled:SaveProperty<Bool>;
+
+  @:saveProperty(data.optionsCameraEditor.zoomLevel, 1.0)
+  public var cameraEditorZoomLevel:SaveProperty<Float>;
+
   /// UTIL FUNCTIONS
 
   /**
@@ -1820,6 +1847,16 @@ typedef SaveDataCameraEditorOptions =
    * @default `ChartEditorTheme.Light`
    */
   var ?theme:ChartEditorTheme;
+
+  var ?relativeView:Bool;
+  var ?extendedBounds:Bool;
+  var ?passepartout:Bool;
+  var ?passepartoutTransparency:Float;
+  var ?bopping:Bool;
+  var ?fitCameraToViewport:Bool;
+  var ?autoScrollMode:Int;
+  var ?snapEnabled:Bool;
+  var ?zoomLevel:Float;
 }
 
 typedef SaveDataQuickMenuOptions =

--- a/source/funkin/ui/debug/cameraeditor/CameraEditorState.hx
+++ b/source/funkin/ui/debug/cameraeditor/CameraEditorState.hx
@@ -629,6 +629,8 @@ class CameraEditorState extends UIState implements ConsoleClass
 
     menubar.height = 35;
 
+    haxe.ui.Toolkit.callLater(applySavedUIPreferences);
+
     WindowManager.instance.container = root;
     Screen.instance.addComponent(root);
 
@@ -1432,6 +1434,37 @@ class CameraEditorState extends UIState implements ConsoleClass
     }
   }
 
+  public function applySavedUIPreferences():Void
+  {
+    var save:Save = Save.instance;
+
+    var relView = save.cameraEditorRelativeView.value;
+    var extBounds = save.cameraEditorExtendedBounds.value;
+    var passe = save.cameraEditorPassepartout.value;
+    var passeAlpha = save.cameraEditorPassepartoutTransparency.value;
+    var bop = save.cameraEditorBopping.value;
+
+    if (menubarItemRelativeView != null) menubarItemRelativeView.selected = relView;
+    if (menubarItemExtendedBounds != null) menubarItemExtendedBounds.selected = extBounds;
+    if (menubarItemPassepartout != null) menubarItemPassepartout.selected = passe;
+    if (menubarSliderPassepartoutTransparency != null) menubarSliderPassepartoutTransparency.pos = passeAlpha;
+    if (menubarItemDoBopping != null) menubarItemDoBopping.selected = bop;
+    if (menubarItemFitCameraToViewport != null) menubarItemFitCameraToViewport.selected = save.cameraEditorFitCameraToViewport.value;
+
+    isCameraRelative = relView;
+    showCameraExtendedBounds = extBounds;
+    showCameraPassepartout = passe;
+    cameraPassepartoutTransparency = passeAlpha;
+    doBopping = bop;
+
+    if (timeline?.toolbar != null)
+    {
+      timeline.toolbar.ddAutoScroll.selectedIndex = save.cameraEditorAutoScrollMode.value;
+      timeline.toolbar.chkSnap.selected = save.cameraEditorSnapEnabled.value;
+      timeline.toolbar.zoomSlider.pos = save.cameraEditorZoomLevel.value;
+    }
+  }
+
   /**
    * Write preferences for the Camera Editor to the user's save data.
    *
@@ -1450,6 +1483,20 @@ class CameraEditorState extends UIState implements ConsoleClass
     if (hasBackup) trace('Queuing backup prompt for next time!');
     save.cameraEditorHasBackup.value = hasBackup;
     trace(save.cameraEditorHasBackup.value);
+
+    save.cameraEditorRelativeView.value = isCameraRelative;
+    save.cameraEditorExtendedBounds.value = showCameraExtendedBounds;
+    save.cameraEditorPassepartout.value = showCameraPassepartout;
+    save.cameraEditorPassepartoutTransparency.value = cameraPassepartoutTransparency;
+    save.cameraEditorBopping.value = doBopping;
+    if (menubarItemFitCameraToViewport != null) save.cameraEditorFitCameraToViewport.value = menubarItemFitCameraToViewport.selected;
+
+    if (timeline?.toolbar != null)
+    {
+      save.cameraEditorAutoScrollMode.value = timeline.toolbar.ddAutoScroll.selectedIndex;
+      save.cameraEditorSnapEnabled.value = timeline.toolbar.chkSnap.selected;
+      save.cameraEditorZoomLevel.value = timeline.toolbar.zoomSlider.pos;
+    }
 
     // save.cameraEditorTheme.value = currentTheme;
   }


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues

Fixes #7495

<!-- Briefly describe the issue(s) fixed. -->
## Description

Camera Editor view-menu toggles (Relative View, Extended Bounds, Passepartout, Passepartout Opacity, Camera Bopping, Fit Camera to Viewport) and timeline toolbar settings (Auto-scroll mode, Snap, Zoom) now persist across editor re-entry, rather than resetting to defaults.

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos

https://github.com/user-attachments/assets/7f339d93-8352-4e7e-af56-b85d3e519457