### PR TITLE
[BUGFIX] Stop game over sounds on retry and exit

### DIFF
--- a/source/funkin/play/GameOverSubState.hx
+++ b/source/funkin/play/GameOverSubState.hx
@@ -78,6 +78,8 @@ class GameOverSubState extends MusicBeatSubState
    */
   var gameOverMusic:Null<FunkinSound> = null;
 
+  static var blueBalledSFX:Null<FunkinSound> = null;
+
   /**
    * Whether the player has confirmed and prepared to restart the level or to go back to the freeplay menu.
    * This means the animation and transition have already started.
@@ -366,6 +368,12 @@ class GameOverSubState extends MusicBeatSubState
         deathQuoteSound = null;
       }
 
+      if (blueBalledSFX != null)
+      {
+        blueBalledSFX.stop();
+        blueBalledSFX = null;
+      }
+
       startDeathMusic(1.0, true); // isEnding changes this function's behavior.
 
       if ((parentPlayState?.isMinimalMode ?? true) || boyfriend == null)
@@ -558,6 +566,12 @@ class GameOverSubState extends MusicBeatSubState
       deathQuoteSound = null;
     }
 
+    if (blueBalledSFX != null)
+    {
+      blueBalledSFX.stop();
+      blueBalledSFX = null;
+    }
+
     if (isChartingMode)
     {
       this.close();
@@ -601,9 +615,15 @@ class GameOverSubState extends MusicBeatSubState
   {
     blueballed = true;
 
+    if (blueBalledSFX != null)
+    {
+      blueBalledSFX.stop();
+      blueBalledSFX = null;
+    }
+
     if (Assets.exists(Paths.sound('gameplay/gameover/fnf_loss_sfx' + blueBallSuffix)))
     {
-      FunkinSound.playOnce(Paths.sound('gameplay/gameover/fnf_loss_sfx' + blueBallSuffix));
+      blueBalledSFX = FunkinSound.playOnce(Paths.sound('gameplay/gameover/fnf_loss_sfx' + blueBallSuffix));
     }
     else
     {
@@ -620,6 +640,11 @@ class GameOverSubState extends MusicBeatSubState
     {
       gameOverMusic.stop();
       gameOverMusic = null;
+    }
+    if (blueBalledSFX != null)
+    {
+      blueBalledSFX.stop();
+      blueBalledSFX = null;
     }
     blueballed = false;
     instance = null;


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues

Fixes #6788

<!-- Briefly describe the issue(s) fixed. -->
## Description

`GameOverSubState.playBlueBalledSFX` played the SFX via `FunkinSound.playOnce(...)` and dropped the returned reference. With nothing tracking it, nothing could stop it when the substate closed — the remaining tail kept playing through the song restart.

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos

https://github.com/user-attachments/assets/a1e8af39-b2f4-43f5-b524-8ac1edf57c0b