### PR TITLE
[BUGFIX] Unregister Chart Editor note/event tooltips on sprite destroy

### DIFF
--- a/source/funkin/ui/debug/charting/components/ChartEditorEventSprite.hx
+++ b/source/funkin/ui/debug/charting/components/ChartEditorEventSprite.hx
@@ -215,6 +215,12 @@ class ChartEditorEventSprite extends FlxSprite
     ToolTipManager.instance.unregisterTooltipRegion(this.tooltip);
   }
 
+  override public function destroy()
+  {
+    ToolTipManager.instance.unregisterTooltipRegion(this.tooltip);
+    super.destroy();
+  }
+
   /**
    * Return whether this event is currently visible.
    */

--- a/source/funkin/ui/debug/charting/components/ChartEditorNoteSprite.hx
+++ b/source/funkin/ui/debug/charting/components/ChartEditorNoteSprite.hx
@@ -264,6 +264,12 @@ class ChartEditorNoteSprite extends FlxSprite
     ToolTipManager.instance.unregisterTooltipRegion(this.tooltip);
   }
 
+  override public function destroy()
+  {
+    ToolTipManager.instance.unregisterTooltipRegion(this.tooltip);
+    super.destroy();
+  }
+
   function get_noteStyle():Null<String>
   {
     if (this.noteStyle == null)


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues

Closes #5929

<!-- Briefly describe the issue(s) fixed. -->
## Description

`ChartEditorNoteSprite` / `ChartEditorEventSprite` register tooltip regions with HaxeUI's `ToolTipManager` singleton but only unregister them in `kill()`, not `destroy()`. Closing and re-opening the Chart Editor leaves stale regions on the singleton, so hovering the same screen coordinates in a new session shows tooltips from the previous chart.

Fix: override `destroy()` on both sprites to unregister the tooltip before `super.destroy()`.

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos

https://github.com/user-attachments/assets/2e74950f-5f9e-47d5-8788-221569e0b5ab