### PR TITLE
[BUGFIX] Fix sing animations only playing once in Cameron Editor

### DIFF
--- a/source/funkin/ui/debug/cameraeditor/CameraEditorState.hx
+++ b/source/funkin/ui/debug/cameraeditor/CameraEditorState.hx
@@ -1964,9 +1964,13 @@ class CameraEditorState extends UIState implements ConsoleClass
     if (dad != null) dadSingTime = dad.singTimeSteps * (conductorInUse.stepLengthMs / Constants.MS_PER_SEC);
     if (bf != null) bfSingTime = bf.singTimeSteps * (conductorInUse.stepLengthMs / Constants.MS_PER_SEC);
 
-    // replay notes
-    if (notes != null)
+    if (notes == null || notes.length > 0 && notes[0].time > position)
     {
+      cachedNoteIndex = 0;
+    }
+    else
+    {
+      // replay notes
       var latestDadNote:SongNoteData = null;
       var latestBFNote:SongNoteData = null;
 


### PR DESCRIPTION

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
Fixes #7467 
<!-- Briefly describe the issue(s) fixed. -->
## Description
There was an issue with the logic for changing the currently cached note index to the last played note, where it didn't account for song positions before the starting note. We fix it by resetting it to zero if we've not reached the first note yet.
<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos

https://github.com/user-attachments/assets/305b8d0c-312e-482a-aada-55ebae33f256

