### PR TITLE
[BUGFIX] Make AngleMask respect Alpha changes

### DIFF
--- a/source/funkin/graphics/shaders/AngleMask.hx
+++ b/source/funkin/graphics/shaders/AngleMask.hx
@@ -37,7 +37,7 @@ class AngleMask extends FlxShader
     }
 
     vec4 mainPass(vec2 fragCoord) {
-      vec4 base = texture2D(bitmap, fragCoord);
+      vec4 base = flixel_texture2D(bitmap, fragCoord);
 
       vec2 uv = fragCoord.xy;
 


### PR DESCRIPTION
## Linked Issues
`backingImage` in Freeplay not respecting alpha changes due to AngleMask shader

## Description
just changed texture2D to flixel_texture2D in the shader class to apply alpha/color to it

## Screenshots/Videos
https://github.com/user-attachments/assets/2f72676c-aa83-4c01-bd45-c9e08f55e28f


