### PR TITLE
[BUGFIX] Fix PlayState using the incorrect script when loading playlist songs with non-default variations

### DIFF
--- a/source/funkin/play/PlayState.hx
+++ b/source/funkin/play/PlayState.hx
@@ -3670,7 +3670,8 @@ class PlayState extends MusicBeatSubState
         }
         else
         {
-          var targetSong:Song = SongRegistry.instance.fetchEntry(targetSongId) ?? throw 'Could not find a song with ID $targetSongId';
+          var targetSong:Song = SongRegistry.instance.fetchEntry(targetSongId,
+            {variation: currentVariation}) ?? throw 'Could not find a song with ID $targetSongId';
           var targetVariation:String = currentVariation;
           if (!targetSong.hasDifficulty(PlayStatePlaylist.campaignDifficulty, currentVariation))
           {


### PR DESCRIPTION
<!-- Briefly describe the issue(s) fixed. -->
## Description
This Pull Request fixes PlayState only ever using default scripts when going to a new song in the playlist.
