### PR TITLE
[VULNERABILITY] Blacklist openfl.Assets

### DIFF
--- a/source/funkin/modding/PolymodHandler.hx
+++ b/source/funkin/modding/PolymodHandler.hx
@@ -331,7 +331,7 @@ class PolymodHandler
     // `haxe.Http`
     // An alias for `sys.Http`, which is also a blacklisted package.
     Polymod.blacklistImport('haxe.Http');
-    
+
     // `haxe.Unserializer`
     // Unserializer.DEFAULT_RESOLVER.resolveClass() can access blacklisted packages
     Polymod.blacklistImport('haxe.Unserializer');
@@ -513,6 +513,9 @@ class PolymodHandler
 
     // Blacklists accessing the interp for polymod hscript
     Polymod.blacklistInstanceFields(polymod.hscript._internal.PolymodScriptClass.PolymodScriptClass, ['_interp']);
+
+    // Alias for openfl.utils.Assets, which gives access to a `resolveClass()` method.
+    Polymod.blacklistImport('openfl.Assets');
   }
 
   /**


### PR DESCRIPTION
## Description
Alias for openfl.utils.Assets, which has a resolveClass method.

<img width="48" height="48" alt="image" src="https://github.com/user-attachments/assets/2ed03f2e-ca86-444b-87d2-97988704483d" />


funkin.Assets should be used instead.