### PR TITLE
[BUGFIX] Fix the song restarting instead of ending

### DIFF
--- a/source/funkin/play/PlayState.hx
+++ b/source/funkin/play/PlayState.hx
@@ -2724,7 +2724,7 @@ class PlayState extends MusicBeatSubState
     // Skip this if the music is paused (GameOver, Pause menu, start-of-song offset, etc.)
     if (!(FlxG.sound.music?.playing ?? false)) return;
 
-    var timeToPlayAt:Float = Math.min(FlxG.sound.music.length,
+    var timeToPlayAt:Float = Math.min(FlxG.sound.music.length - 1,
       Math.max(Math.min(Conductor.instance.combinedOffset, 0), Conductor.instance.songPosition) - Conductor.instance.combinedOffset);
     trace('Resyncing vocals to ${timeToPlayAt}');
 


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
Fixes #5449

<!-- Briefly describe the issue(s) fixed. -->
## Description
This PR (hopefully) fixes the bug where the song resets instead of ending. I'm saying hopefully because this bug is weird and also because I tested this using time travel, which probably isn't the best way to test. However, time traveling right to the end of the song is 100% guaranteed to reproduce this bug as if you reproduced it accidentally, which this PR fixes that problem.

Testing is appreciated.