### PR TITLE
[BUGFIX] Fix hold note covers disappearing when there are too many covers

### DIFF
--- a/source/funkin/play/notes/Strumline.hx
+++ b/source/funkin/play/notes/Strumline.hx
@@ -229,7 +229,7 @@ class Strumline extends FlxSpriteGroup
     this.notesVwoosh.zIndex = 31;
     this.add(this.notesVwoosh);
 
-    this.noteHoldCovers = new FlxTypedSpriteGroup<NoteHoldCover>(0, 0, 4);
+    this.noteHoldCovers = new FlxTypedSpriteGroup<NoteHoldCover>();
     this.noteHoldCovers.zIndex = 40;
     this.add(this.noteHoldCovers);
 
@@ -1261,30 +1261,18 @@ class Strumline extends FlxSpriteGroup
    */
   function constructNoteHoldCover():NoteHoldCover
   {
-    var result:NoteHoldCover = null;
+    var result:NoteHoldCover = this.noteHoldCovers.getFirstAvailable();
 
-    // If we haven't filled the pool yet...
-    if (noteHoldCovers.length < noteHoldCovers.maxSize)
+    if (result != null)
     {
-      // Create a new note hold cover.
-      result = new NoteHoldCover(noteStyle);
-      this.noteHoldCovers.add(result);
+      result.revive();
     }
     else
     {
-      // Else, find a note splash which is inactive so we can revive it.
-      result = this.noteHoldCovers.getFirstAvailable();
-
-      if (result != null)
-      {
-        result.revive();
-      }
-      else
-      {
-        // The note hold cover pool is full and all note hold covers are active,
-        // so we just pick one at random to destroy and restart.
-        result = FlxG.random.getObject(this.noteHoldCovers.members);
-      }
+      // The note hold cover pool is full and all note hold covers are active,
+      // We have to create a new note hold cover.
+      result = new NoteHoldCover(noteStyle);
+      this.noteHoldCovers.add(result);
     }
 
     return result;


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
None I don't think

<!-- Briefly describe the issue(s) fixed. -->
## Description

This PR fixes an issue where overlapping sustain trails cause there to missing hold covers. This is because the hold cover pool is full and the game picks a random hold cover to use. This is resolved by removing the limit for hold note covers, which shouldn't be a huge deal anyways.

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos

Before:

https://github.com/user-attachments/assets/7737266f-e594-444c-9b4d-f2478c1ce088

After:

https://github.com/user-attachments/assets/6af3943e-d760-489a-b282-870fdcf7cc6a