### PR TITLE
[BUGFIX] Make Countdown react to offsets

### DIFF
--- a/source/funkin/play/Countdown.hx
+++ b/source/funkin/play/Countdown.hx
@@ -67,12 +67,6 @@ class Countdown
     // Handle onBeatHit events manually
     // @:privateAccess
     // PlayState.instance.dispatchEvent(new SongTimeScriptEvent(SONG_BEAT_HIT, 0, 0));
-    var offsetTimer:FlxTimer = null;
-    if (Conductor.instance.globalOffset != 0)
-    {
-      offsetTimer = new FlxTimer();
-      countdownOffsetTimers.push(offsetTimer);
-    }
 
     // The timer function gets called based on the beat of the song.
     countdownTimer = new FlxTimer();
@@ -83,6 +77,13 @@ class Countdown
       {
         tmr.cancel();
         return;
+      }
+
+      var offsetTimer:FlxTimer = null;
+      if (Conductor.instance.globalOffset != 0)
+      {
+        offsetTimer = new FlxTimer();
+        countdownOffsetTimers.push(offsetTimer);
       }
 
       countdownStep = decrement(countdownStep);

--- a/source/funkin/play/Countdown.hx
+++ b/source/funkin/play/Countdown.hx
@@ -39,6 +39,12 @@ class Countdown
   static var countdownTimer:FlxTimer = null;
 
   /**
+   * Secondary timers used when the Global Offset is set.
+   * Sometimes the offset is larger than the beat crochet. In this case, timers are necessary.
+   */
+  static var countdownOffsetTimers:Array<FlxTimer> = [];
+
+  /**
    * Performs the countdown.
    * Pauses the song, plays the countdown graphics/sound, and then starts the song.
    * This will automatically stop and restart the countdown if it is already running.
@@ -61,6 +67,12 @@ class Countdown
     // Handle onBeatHit events manually
     // @:privateAccess
     // PlayState.instance.dispatchEvent(new SongTimeScriptEvent(SONG_BEAT_HIT, 0, 0));
+    var offsetTimer:FlxTimer = null;
+    if (Conductor.instance.globalOffset != 0)
+    {
+      offsetTimer = new FlxTimer();
+      countdownOffsetTimers.push(offsetTimer);
+    }
 
     // The timer function gets called based on the beat of the song.
     countdownTimer = new FlxTimer();
@@ -80,10 +92,30 @@ class Countdown
       // PlayState.instance.dispatchEvent(new SongTimeScriptEvent(SONG_BEAT_HIT, 0, 0));
 
       // Countdown graphic.
-      showCountdownGraphic(countdownStep);
+      if (Conductor.instance.globalOffset >= 0) showCountdownGraphic(countdownStep);
+      else
+        offsetTimer.start(-Conductor.instance.globalOffset / Constants.MS_PER_SEC, (tmr) ->
+        {
+          showCountdownGraphic(countdownStep);
+          countdownOffsetTimers.remove(tmr);
+
+          tmr.cancel();
+          tmr.destroy();
+          tmr = null;
+        });
 
       // Countdown sound.
-      playCountdownSound(countdownStep);
+      if (Conductor.instance.globalOffset <= 0) playCountdownSound(countdownStep);
+      else
+        offsetTimer.start(Conductor.instance.globalOffset / Constants.MS_PER_SEC, (tmr) ->
+        {
+          playCountdownSound(countdownStep);
+          countdownOffsetTimers.remove(tmr);
+
+          tmr.cancel();
+          tmr.destroy();
+          tmr = null;
+        });
 
       // Event handling bullshit.
       var cancelled:Bool = propagateCountdownEvent(countdownStep);


### PR DESCRIPTION
Previously, the countdown didn't react to the global offset at all.
Now it does! Amazing.

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
Still none! But an old pull request https://github.com/FunkinCrew/Funkin/pull/4496

<!-- Briefly describe the issue(s) fixed. -->
## Description
The countdown would always be desynced if you had great audio latency regardless of your offsets.
Here, the game will now check if you have it set to something other than 0, and adjust accordingly.
Which one plays first depends on if your offset is positive or negative (obviously)

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos
Before:

https://github.com/user-attachments/assets/8793179d-e35b-40b0-8e34-be5d800b67bc


After:

https://github.com/user-attachments/assets/b7ad716f-c2f9-4908-89df-10db35bad1ac

