### PR TITLE
[BUGFIX] Fix controls menu crash while changing a gamepad bind with an unplugged controller

### DIFF
--- a/source/funkin/ui/options/ControlsMenu.hx
+++ b/source/funkin/ui/options/ControlsMenu.hx
@@ -247,10 +247,12 @@ class ControlsMenu extends Page<OptionsState.OptionsMenuPageName>
     {
       case Keys:
         {
+          if (!FlxG.keys.enabled) return;
           keyUsedToEnterPrompt = FlxG.keys.firstJustPressed();
         }
       case Gamepad(id):
         {
+          if (FlxG.gamepads.getByID(id) == null) return;
           buttonUsedToEnterPrompt = FlxG.gamepads.getByID(id).firstJustPressedID();
         }
     }


### PR DESCRIPTION

<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues

Mentioned on this pr #7214 

<!-- Briefly describe the issue(s) fixed. -->
## Description

This PR fixes a crash caused when the player tries to change a gamepad bind with a controller disconnected.

> [!NOTE]
> This change does not fix the fact of **accessing the gamepad binds with a disconnected controller**. It just offers a quick solution to avoid the crash itself

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos

(forget audio being double it's just my bugged obs)

https://github.com/user-attachments/assets/739563bc-c2fc-42b6-8ddf-2c838e3a4f47


