### PR TITLE
[BUGFIX] Fix non scripted variation songs using default variation script

### DIFF
--- a/source/funkin/data/song/SongRegistry.hx
+++ b/source/funkin/data/song/SongRegistry.hx
@@ -32,6 +32,8 @@ class SongRegistry extends BaseRegistry<Song, SongMetadata, SongEntryParams> imp
 
   public var scriptedSongVariations:Map<String, Song> = new Map<String, Song>();
 
+  public var unscriptedSongVariations:Map<String, Song> = new Map<String, Song>();
+
   static function get_DEFAULT_GENERATEDBY():String
   {
     return '${Constants.TITLE} - ${Constants.VERSION}';
@@ -85,10 +87,7 @@ class SongRegistry extends BaseRegistry<Song, SongMetadata, SongEntryParams> imp
     // UNSCRIPTED ENTRIES
     //
     var entryIdList:Array<String> = funkin.modding.compat.RegistryData.listEntryIds('gameplay/songs/', '-metadata', true);
-    var unscriptedEntryIds:Array<String> = entryIdList.filter((entryId:String) ->
-    {
-      return !entries.exists(entryId);
-    });
+    var unscriptedEntryIds:Array<String> = entryIdList;
     log('Parsing ${unscriptedEntryIds.length} unscripted entries...');
     for (entryId in unscriptedEntryIds)
     {
@@ -97,9 +96,20 @@ class SongRegistry extends BaseRegistry<Song, SongMetadata, SongEntryParams> imp
         var entry:Null<Song> = createEntry(entryId);
         if (entry != null)
         {
-          log('Loaded entry data: ${entry}');
-          entries.set(entry.id, entry);
-        }
+          for(variation in entry.variations)
+          {
+            if(variation != Constants.DEFAULT_VARIATION && !scriptedSongVariations.exists('${entryId}:${variation}'))
+            {
+              log('Loaded entry data: ${entryId}, ${variation}');
+              unscriptedSongVariations.set('${entryId}:${variation}', entry);
+            } 
+            else if(!entries.exists(entryId))
+            {
+              log('Loaded entry data: ${entry}');
+              entries.set(entryId, entry);
+            }
+          }
+        } 
       }
       catch (e:Dynamic)
       {
@@ -165,6 +175,14 @@ class SongRegistry extends BaseRegistry<Song, SongMetadata, SongEntryParams> imp
         if (variationSongScript != null)
         {
           return variationSongScript;
+        }
+      }
+      else if(unscriptedSongVariations.exists('${id}:${variation}'))
+      {
+        var variationSong:Null<Song> = unscriptedSongVariations.get('${id}:${variation}');
+        if (variationSong != null)
+        {
+          return variationSong;
         }
       }
     }


### PR DESCRIPTION
## Description
This PR fixes an issue where custom variation songs were running the default variation script if there is no script for them

## Changelog
- **ADD:** Added `unscriptedSongVariations` map to register and track non-scripted song variations.
- **UPD:** Updated `loadEntries()` to safely iterate through entry variations and populate the new unscripted variations map.
- **UPD:** Updated `fetchEntry()` to prioritize scripted variations first, then unscripted variations, preventing them from falling back to the default variation script.
## Screenshots/Videos
Before

https://github.com/user-attachments/assets/2f5da286-c404-400f-9ad0-5f1fbc2dcc87

After

https://github.com/user-attachments/assets/de8f002b-5d4c-44e5-b044-9c19a77deffe


