### PR TITLE
[CHORE] Remove the instrumental resync

### DIFF
--- a/source/funkin/play/PlayState.hx
+++ b/source/funkin/play/PlayState.hx
@@ -1927,14 +1927,7 @@ class PlayState extends MusicBeatSubState
         }
       }
 
-      if (
-        !startingSong
-        && (
-          Math.abs(FlxG.sound.music.time - correctSync) > RESYNC_THRESHOLD
-          || Math.abs(playerVoicesError) > RESYNC_THRESHOLD
-          || Math.abs(opponentVoicesError) > RESYNC_THRESHOLD
-        )
-      )
+      if (!startingSong && (Math.abs(playerVoicesError) > RESYNC_THRESHOLD || Math.abs(opponentVoicesError) > RESYNC_THRESHOLD))
       {
         trace('VOCALS NEED RESYNC');
         if (vocals != null)
@@ -2771,16 +2764,12 @@ class PlayState extends MusicBeatSubState
     if (!(FlxG.sound.music?.playing ?? false)) return;
 
     var timeToPlayAt:Float = Math.min(
-      FlxG.sound.music.length - 1,
+      FlxG.sound.music.length,
       Math.max(Math.min(Conductor.instance.combinedOffset, 0), Conductor.instance.songPosition) - Conductor.instance.combinedOffset
     );
     trace('Resyncing vocals to ${timeToPlayAt}');
 
-    FlxG.sound.music.pause();
     vocals.pause();
-
-    FlxG.sound.music.time = timeToPlayAt;
-    FlxG.sound.music.play(false, timeToPlayAt);
 
     vocals.time = timeToPlayAt;
     vocals.play(false, timeToPlayAt);
@@ -4253,7 +4242,7 @@ class PlayState extends MusicBeatSubState
     var targetTimeMs:Float = Conductor.instance.getStepTimeInMs(targetTimeSteps);
 
     // Don't go back in time to before the song started.
-    targetTimeMs = Math.max(0, targetTimeMs);
+    targetTimeMs = Math.min(FlxG.sound.music?.length ?? 0, Math.max(0, targetTimeMs));
 
     if (FlxG.sound.music != null)
     {


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

>[!NOTE]
FunkinCrew/lime#94 is needed for this to work properly

<!-- Briefly describe the issue(s) fixed. -->
## Description
This PR removes the instrumental resync. Why? Because it's unnecessary. The conductor ALWAYS tracks the instrumental time while it's playing, so the instrumental shouldn't be desynced from the chart.

Yes I tested this with a lag spike. It works just fine.
Yes I tested this with a different global offset.

<img width="334" height="28" alt="image" src="https://github.com/user-attachments/assets/8ac08399-d16a-44c5-8747-e46fca4cb532" />