### PR TITLE
[BUGFIX] Don't carry over Camera Editor preview state when loading new chart

### DIFF
--- a/source/funkin/ui/debug/cameraeditor/CameraEditorState.hx
+++ b/source/funkin/ui/debug/cameraeditor/CameraEditorState.hx
@@ -1219,6 +1219,7 @@ class CameraEditorState extends UIState implements ConsoleClass
     add(cameraRect);
     cameraRect.currentStage = currentStage;
 
+    cameraRect.cancelAllTweens();
     cameraRect.zoom = currentStage.camZoom;
     defaultStageZoom = currentStage.camZoom;
     resetScrollPosition();


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues

Fixes #7490

<!-- Briefly describe the issue(s) fixed. -->
## Description

`CameraEditorState.buildStage()` never cancelled `cameraRect`'s in-flight tweens when loading a new chart. The stage's default zoom/scroll gets reassigned, but the next frame's `update()` lerps `zoom` back from the previous chart's still-active `cameraZoomEase` (and same for `cameraFollowEase`, which is why the camera position also fails to update). Calling `cameraRect.cancelAllTweens()` before reapplying zoom and scroll position makes the new chart's defaults stick.

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos

https://github.com/user-attachments/assets/14980de6-665d-4483-887e-e2842cf06b55