### PR TITLE
[BUGFIX] Fall back to default vocal offset when alt instrumental has none

### DIFF
--- a/source/funkin/data/song/SongData.hx
+++ b/source/funkin/data/song/SongData.hx
@@ -296,17 +296,19 @@ class SongOffsets implements ICloneable<SongOffsets>
 
   public function getVocalOffset(charId:String, ?instrumental:String):Float
   {
-    if (instrumental == null)
+    if (instrumental == null || instrumental == '')
     {
       if (!this.vocals.exists(charId)) return 0.0;
       return this.vocals.get(charId);
     }
-    else
+
+    if (this.altVocals.exists(instrumental) && this.altVocals.get(instrumental).exists(charId))
     {
-      if (!this.altVocals.exists(instrumental)) return 0.0;
-      if (!this.altVocals.get(instrumental).exists(charId)) return 0.0;
       return this.altVocals.get(instrumental).get(charId);
     }
+
+    if (this.vocals.exists(charId)) return this.vocals.get(charId);
+    return 0.0;
   }
 
   public function setVocalOffset(charId:String, value:Float):Float


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues

Fixes #7616

<!-- Briefly describe the issue(s) fixed. -->
## Description

`SongOffsets.getVocalOffset(charId, instrumental)` returned `0.0` when the requested alt instrumental had no `altVocals` entry, silently dropping the default `vocals[charId]` offset even though vocal files are shared across instrumentals. Fall back to the default offset unless the alt explicitly overrides it. Also treat `instrumental == ''` the same as `null` — `Song.buildVocals` passes `''` for the default case, which previously fell into the alt branch and dropped the default offset there too. Now matches `getInstrumentalOffset`'s handling.

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos

See the original reporter's video on #7616