### PR TITLE
[BUGFIX] Reset Conductor songPositionDelta on suspend/resume ticks

### DIFF
--- a/source/funkin/Conductor.hx
+++ b/source/funkin/Conductor.hx
@@ -421,6 +421,8 @@ class Conductor
    */
   public function update(?songPos:Float, applyOffsets:Bool = true, forceDispatch:Bool = false):Void
   {
+    if (FlxG.elapsed > 1.0) this.songPositionDelta = 0;
+
     var currentTime:Float = (FlxG.sound.music != null) ? FlxG.sound.music.time : 0.0;
     var currentLength:Float = (FlxG.sound.music != null) ? FlxG.sound.music.length : 0.0;
 


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues

May mitigate one failure mode reported in #7326. Does not claim to fully resolve it.

<!-- Briefly describe the issue(s) fixed. -->
## Description

`Conductor.update()` had no guard against pathologically large `FlxG.elapsed` ticks. On OS suspend/resume (e.g. Windows minimizing the window for hours), one resume tick carries the full suspend duration through `songPositionDelta`, inflating `getTimeWithDelta()` for one frame. Reset `songPositionDelta` when `elapsed > 1s` at the top of `update()`. Threshold is well above any normal frame, so this only fires on a true suspend/resume edge. Does not touch OpenAL state, where #7326's persistent corruption likely lives.

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos
