### PR TITLE
[ENHANCEMENT] Note Quantization

### DIFF
--- a/source/funkin/Preferences.hx
+++ b/source/funkin/Preferences.hx
@@ -95,6 +95,25 @@ class Preferences
   }
 
   /**
+   * If enabled, notes are colored by their quantization (4th, 8th, 16th, etc.).
+   * @default `false`
+   */
+  public static var noteQuantColors(get, set):Bool;
+
+  static function get_noteQuantColors():Bool
+  {
+    return Save?.instance?.options?.noteQuantColors ?? false;
+  }
+
+  static function set_noteQuantColors(value:Bool):Bool
+  {
+    var save:Save = Save.instance;
+    save.options.noteQuantColors = value;
+    Save.system.flush();
+    return value;
+  }
+
+  /**
    * If enabled, the strumline is at the bottom of the screen rather than the top.
    * @default `false`
    */

--- a/source/funkin/Preferences.hx
+++ b/source/funkin/Preferences.hx
@@ -93,6 +93,25 @@ class Preferences
   }
 
   /**
+   * If enabled, notes are colored by their quantization (4th, 8th, 16th, etc.).
+   * @default `false`
+   */
+  public static var noteQuantColors(get, set):Bool;
+
+  static function get_noteQuantColors():Bool
+  {
+    return Save?.instance?.options?.noteQuantColors ?? false;
+  }
+
+  static function set_noteQuantColors(value:Bool):Bool
+  {
+    var save:Save = Save.instance;
+    save.options.noteQuantColors = value;
+    Save.system.flush();
+    return value;
+  }
+
+  /**
    * If enabled, the strumline is at the bottom of the screen rather than the top.
    * @default `false`
    */

--- a/source/funkin/graphics/shaders/NoteQuantTintShader.hx
+++ b/source/funkin/graphics/shaders/NoteQuantTintShader.hx
@@ -1,0 +1,30 @@
+package funkin.graphics.shaders;
+
+import flixel.addons.display.FlxRuntimeShader;
+import flixel.util.FlxColor;
+
+/**
+ * Replaces every visible pixel of a sprite with `targetColor`, preserving alpha.
+ * Used by NoteQuantColors so hold sustains and end caps render as a single
+ * uniform quant color regardless of the underlying atlas tile.
+ */
+class NoteQuantTintShader extends FlxRuntimeShader
+{
+  static inline final FRAGMENT:String = "#pragma header\n"
+    + "uniform vec3 targetColor;\n"
+    + "void main() {\n"
+    + "  vec4 src = texture2D(bitmap, openfl_TextureCoordv);\n"
+    + "  float luma = (src.r + src.g + src.b) / 3.0;\n"
+    + "  gl_FragColor = vec4(targetColor * luma * src.a, src.a);\n"
+    + "}";
+
+  public function new()
+  {
+    super(FRAGMENT);
+  }
+
+  public function setColor(c:FlxColor):Void
+  {
+    this.setFloatArray('targetColor', [c.redFloat, c.greenFloat, c.blueFloat]);
+  }
+}

--- a/source/funkin/play/notes/NoteQuantColors.hx
+++ b/source/funkin/play/notes/NoteQuantColors.hx
@@ -1,0 +1,77 @@
+package funkin.play.notes;
+
+import flixel.FlxSprite;
+import flixel.util.FlxColor;
+import funkin.graphics.shaders.NoteQuantTintShader;
+import funkin.util.Constants;
+
+/**
+ * Note quantization color palette and helpers.
+ */
+class NoteQuantColors
+{
+  public static final QUANT_COLOR_4TH:FlxColor = 0xFFFF3030;
+  public static final QUANT_COLOR_8TH:FlxColor = 0xFF3080FF;
+  public static final QUANT_COLOR_12TH:FlxColor = 0xFFC050FF;
+  public static final QUANT_COLOR_16TH:FlxColor = 0xFFFFD030;
+  public static final QUANT_COLOR_24TH:FlxColor = 0xFFFF80C0;
+  public static final QUANT_COLOR_32ND:FlxColor = 0xFFFF9030;
+  public static final QUANT_COLOR_48TH:FlxColor = 0xFF40E0E0;
+  public static final QUANT_COLOR_64TH:FlxColor = 0xFF50FF80;
+  public static final QUANT_COLOR_OTHER:FlxColor = 0xFFB0B0B0;
+
+  public static function getQuantColor(stepTime:Float):FlxColor
+  {
+    var beatNotes:Float = Constants.STEPS_PER_BEAT * 4;
+    if (alignsTo(stepTime, beatNotes / 4)) return QUANT_COLOR_4TH;
+    if (alignsTo(stepTime, beatNotes / 8)) return QUANT_COLOR_8TH;
+    if (alignsTo(stepTime, beatNotes / 12)) return QUANT_COLOR_12TH;
+    if (alignsTo(stepTime, beatNotes / 16)) return QUANT_COLOR_16TH;
+    if (alignsTo(stepTime, beatNotes / 24)) return QUANT_COLOR_24TH;
+    if (alignsTo(stepTime, beatNotes / 32)) return QUANT_COLOR_32ND;
+    if (alignsTo(stepTime, beatNotes / 48)) return QUANT_COLOR_48TH;
+    if (alignsTo(stepTime, beatNotes / 64)) return QUANT_COLOR_64TH;
+    return QUANT_COLOR_OTHER;
+  }
+
+  public static function apply(sprite:FlxSprite, enable:Bool, stepTime:Float, flat:Bool = false):Void
+  {
+    if (!enable || stepTime < 0)
+    {
+      if (Std.isOfType(sprite.shader, NoteQuantTintShader)) sprite.shader = null;
+      sprite.setColorTransform(1, 1, 1, 1, 0, 0, 0, 0);
+      return;
+    }
+    var c:FlxColor = getQuantColor(stepTime);
+    if (flat)
+    {
+      sprite.shader = sharedShaderFor(c);
+    }
+    else
+    {
+      if (Std.isOfType(sprite.shader, NoteQuantTintShader)) sprite.shader = null;
+      sprite.setColorTransform(0.3, 0.3, 0.3, 1, Std.int(c.red * 0.7), Std.int(c.green * 0.7), Std.int(c.blue * 0.7), 0);
+    }
+  }
+
+  static var shaderCache:Map<Int, NoteQuantTintShader> = new Map();
+
+  static function sharedShaderFor(c:FlxColor):NoteQuantTintShader
+  {
+    var key:Int = c;
+    var s:Null<NoteQuantTintShader> = shaderCache.get(key);
+    if (s == null)
+    {
+      s = new NoteQuantTintShader();
+      s.setColor(c);
+      shaderCache.set(key, s);
+    }
+    return s;
+  }
+
+  static inline function alignsTo(stepTime:Float, gridSteps:Float):Bool
+  {
+    var ratio:Float = stepTime / gridSteps;
+    return Math.abs(ratio - Math.round(ratio)) < 0.01;
+  }
+}

--- a/source/funkin/play/notes/NoteQuantColors.hx
+++ b/source/funkin/play/notes/NoteQuantColors.hx
@@ -45,19 +45,28 @@ class NoteQuantColors
     var c:FlxColor = getQuantColor(stepTime);
     if (flat)
     {
-      var s:NoteQuantTintShader = Std.downcast(sprite.shader, NoteQuantTintShader);
-      if (s == null)
-      {
-        s = new NoteQuantTintShader();
-        sprite.shader = s;
-      }
-      s.setColor(c);
+      sprite.shader = sharedShaderFor(c);
     }
     else
     {
       if (Std.isOfType(sprite.shader, NoteQuantTintShader)) sprite.shader = null;
       sprite.setColorTransform(0.3, 0.3, 0.3, 1, Std.int(c.red * 0.7), Std.int(c.green * 0.7), Std.int(c.blue * 0.7), 0);
     }
+  }
+
+  static var shaderCache:Map<Int, NoteQuantTintShader> = new Map();
+
+  static function sharedShaderFor(c:FlxColor):NoteQuantTintShader
+  {
+    var key:Int = c;
+    var s:Null<NoteQuantTintShader> = shaderCache.get(key);
+    if (s == null)
+    {
+      s = new NoteQuantTintShader();
+      s.setColor(c);
+      shaderCache.set(key, s);
+    }
+    return s;
   }
 
   static inline function alignsTo(stepTime:Float, gridSteps:Float):Bool

--- a/source/funkin/play/notes/NoteQuantColors.hx
+++ b/source/funkin/play/notes/NoteQuantColors.hx
@@ -1,0 +1,68 @@
+package funkin.play.notes;
+
+import flixel.FlxSprite;
+import flixel.util.FlxColor;
+import funkin.graphics.shaders.NoteQuantTintShader;
+import funkin.util.Constants;
+
+/**
+ * Note quantization color palette and helpers.
+ */
+class NoteQuantColors
+{
+  public static final QUANT_COLOR_4TH:FlxColor = 0xFFFF3030;
+  public static final QUANT_COLOR_8TH:FlxColor = 0xFF3080FF;
+  public static final QUANT_COLOR_12TH:FlxColor = 0xFFC050FF;
+  public static final QUANT_COLOR_16TH:FlxColor = 0xFFFFD030;
+  public static final QUANT_COLOR_24TH:FlxColor = 0xFFFF80C0;
+  public static final QUANT_COLOR_32ND:FlxColor = 0xFFFF9030;
+  public static final QUANT_COLOR_48TH:FlxColor = 0xFF40E0E0;
+  public static final QUANT_COLOR_64TH:FlxColor = 0xFF50FF80;
+  public static final QUANT_COLOR_OTHER:FlxColor = 0xFFB0B0B0;
+
+  public static function getQuantColor(stepTime:Float):FlxColor
+  {
+    var beatNotes:Float = Constants.STEPS_PER_BEAT * 4;
+    if (alignsTo(stepTime, beatNotes / 4)) return QUANT_COLOR_4TH;
+    if (alignsTo(stepTime, beatNotes / 8)) return QUANT_COLOR_8TH;
+    if (alignsTo(stepTime, beatNotes / 12)) return QUANT_COLOR_12TH;
+    if (alignsTo(stepTime, beatNotes / 16)) return QUANT_COLOR_16TH;
+    if (alignsTo(stepTime, beatNotes / 24)) return QUANT_COLOR_24TH;
+    if (alignsTo(stepTime, beatNotes / 32)) return QUANT_COLOR_32ND;
+    if (alignsTo(stepTime, beatNotes / 48)) return QUANT_COLOR_48TH;
+    if (alignsTo(stepTime, beatNotes / 64)) return QUANT_COLOR_64TH;
+    return QUANT_COLOR_OTHER;
+  }
+
+  public static function apply(sprite:FlxSprite, enable:Bool, stepTime:Float, flat:Bool = false):Void
+  {
+    if (!enable || stepTime < 0)
+    {
+      if (Std.isOfType(sprite.shader, NoteQuantTintShader)) sprite.shader = null;
+      sprite.setColorTransform(1, 1, 1, 1, 0, 0, 0, 0);
+      return;
+    }
+    var c:FlxColor = getQuantColor(stepTime);
+    if (flat)
+    {
+      var s:NoteQuantTintShader = Std.downcast(sprite.shader, NoteQuantTintShader);
+      if (s == null)
+      {
+        s = new NoteQuantTintShader();
+        sprite.shader = s;
+      }
+      s.setColor(c);
+    }
+    else
+    {
+      if (Std.isOfType(sprite.shader, NoteQuantTintShader)) sprite.shader = null;
+      sprite.setColorTransform(0.3, 0.3, 0.3, 1, Std.int(c.red * 0.7), Std.int(c.green * 0.7), Std.int(c.blue * 0.7), 0);
+    }
+  }
+
+  static inline function alignsTo(stepTime:Float, gridSteps:Float):Bool
+  {
+    var ratio:Float = stepTime / gridSteps;
+    return Math.abs(ratio - Math.round(ratio)) < 0.01;
+  }
+}

--- a/source/funkin/play/notes/Strumline.hx
+++ b/source/funkin/play/notes/Strumline.hx
@@ -635,6 +635,8 @@ class Strumline extends FlxSpriteGroup
       onNoteIncoming.dispatch(noteSprite);
     }
 
+    var quantColorsOn:Bool = Preferences.noteQuantColors;
+
     // Update rendering of notes.
     var noteOriginY:Float = this.y - INITIAL_OFFSET;
     var noteRate:Float = NotefieldTransform.scrollRate(scrollSpeed, isDownscroll);
@@ -644,6 +646,8 @@ class Strumline extends FlxSpriteGroup
       if (note == null || !note.alive) continue;
       // Set the note's position.
       if (!customPositionData) note.y = NotefieldTransform.noteY(noteOriginY, note.strumTime - conductorInUse.songPosition, noteRate, note.yOffset);
+
+      if (quantColorsOn && !note.hasBeenHit) NoteQuantColors.apply(note, true, Conductor.instance.getTimeInSteps(note.strumTime));
 
       // If the note is miss
       var isOffscreen:Bool = isDownscroll ? note.y > FlxG.height : note.y < -note.height;
@@ -657,6 +661,8 @@ class Strumline extends FlxSpriteGroup
     for (holdNote in holdNotes.members)
     {
       if (holdNote == null || !holdNote.alive) continue;
+
+      if (quantColorsOn) NoteQuantColors.apply(holdNote, true, Conductor.instance.getTimeInSteps(holdNote.strumTime), true);
 
       if (conductorInUse.songPosition > holdNote.strumTime && holdNote.hitNote && !holdNote.missedNote)
       {

--- a/source/funkin/play/notes/Strumline.hx
+++ b/source/funkin/play/notes/Strumline.hx
@@ -606,6 +606,8 @@ class Strumline extends FlxSpriteGroup
       onNoteIncoming.dispatch(noteSprite);
     }
 
+    var quantColorsOn:Bool = Preferences.noteQuantColors;
+
     // Update rendering of notes.
     for (note in notes.members)
     {
@@ -615,6 +617,8 @@ class Strumline extends FlxSpriteGroup
         - INITIAL_OFFSET
         + GRhythmUtil.getNoteY(note.strumTime, scrollSpeed, isDownscroll, conductorInUse)
         + note.yOffset;
+
+      if (quantColorsOn && !note.hasBeenHit) NoteQuantColors.apply(note, true, Conductor.instance.getTimeInSteps(note.strumTime));
 
       // If the note is miss
       var isOffscreen:Bool = isDownscroll ? note.y > FlxG.height : note.y < -note.height;
@@ -628,6 +632,8 @@ class Strumline extends FlxSpriteGroup
     for (holdNote in holdNotes.members)
     {
       if (holdNote == null || !holdNote.alive) continue;
+
+      if (quantColorsOn) NoteQuantColors.apply(holdNote, true, Conductor.instance.getTimeInSteps(holdNote.strumTime), true);
 
       if (conductorInUse.songPosition > holdNote.strumTime && holdNote.hitNote && !holdNote.missedNote)
       {

--- a/source/funkin/save/Save.hx
+++ b/source/funkin/save/Save.hx
@@ -129,6 +129,7 @@ class Save implements ConsoleClass implements ISerializable
         // Reasonable defaults.
         framerate: #if mobile refreshRate #else 60 #end,
         naughtyness: true,
+        noteQuantColors: false,
         downscroll: false,
         flashingLights: true,
         zoomCamera: true,
@@ -1353,6 +1354,12 @@ typedef SaveDataOptions =
    * @default `true`
    */
   var naughtyness:Bool;
+
+  /**
+   * If enabled, notes are colored by their quantization (4th, 8th, 16th, etc.).
+   * @default `false`
+   */
+  var ?noteQuantColors:Bool;
 
   /**
    * If enabled, the strumline is at the bottom of the screen rather than the top.

--- a/source/funkin/save/Save.hx
+++ b/source/funkin/save/Save.hx
@@ -99,6 +99,7 @@ class Save implements ConsoleClass
         // Reasonable defaults.
         framerate: #if mobile refreshRate #else 60 #end,
         naughtyness: true,
+        noteQuantColors: false,
         downscroll: false,
         flashingLights: true,
         zoomCamera: true,
@@ -1114,6 +1115,12 @@ typedef SaveDataOptions =
    * @default `true`
    */
   var naughtyness:Bool;
+
+  /**
+   * If enabled, notes are colored by their quantization (4th, 8th, 16th, etc.).
+   * @default `false`
+   */
+  var ?noteQuantColors:Bool;
 
   /**
    * If enabled, the strumline is at the bottom of the screen rather than the top.

--- a/source/funkin/ui/debug/charting/components/ChartEditorHoldNoteSprite.hx
+++ b/source/funkin/ui/debug/charting/components/ChartEditorHoldNoteSprite.hx
@@ -1,6 +1,7 @@
 package funkin.ui.debug.charting.components;
 
 #if FEATURE_CHART_EDITOR
+import funkin.play.notes.NoteQuantColors;
 import funkin.play.notes.Strumline;
 import funkin.data.notestyle.NoteStyleRegistry;
 import funkin.play.notes.notestyle.NoteStyle;
@@ -283,6 +284,8 @@ class ChartEditorHoldNoteSprite extends SustainTrail
 
     // Account for expanded clickable hitbox.
     this.x += this.offset.x;
+
+    NoteQuantColors.apply(this, Preferences.noteQuantColors, stepTime, true);
   }
 }
 #end

--- a/source/funkin/ui/debug/charting/components/ChartEditorHoldNoteSprite.hx
+++ b/source/funkin/ui/debug/charting/components/ChartEditorHoldNoteSprite.hx
@@ -1,6 +1,7 @@
 package funkin.ui.debug.charting.components;
 
 #if FEATURE_CHART_EDITOR
+import funkin.play.notes.NoteQuantColors;
 import funkin.play.notes.Strumline;
 import funkin.data.notestyle.NoteStyleRegistry;
 import funkin.play.notes.notestyle.NoteStyle;
@@ -282,6 +283,8 @@ class ChartEditorHoldNoteSprite extends SustainTrail
 
     // Account for expanded clickable hitbox.
     this.x += this.offset.x;
+
+    NoteQuantColors.apply(this, Preferences.noteQuantColors, stepTime, true);
   }
 }
 #end

--- a/source/funkin/ui/debug/charting/components/ChartEditorNoteSprite.hx
+++ b/source/funkin/ui/debug/charting/components/ChartEditorNoteSprite.hx
@@ -11,6 +11,7 @@ import flixel.graphics.frames.FlxFrame;
 import funkin.data.animation.AnimationData;
 import funkin.data.song.SongData.SongNoteData;
 import funkin.data.notestyle.NoteStyleRegistry;
+import funkin.play.notes.NoteQuantColors;
 import funkin.play.notes.notestyle.NoteStyle;
 import funkin.play.notes.NoteDirection;
 import haxe.ui.tooltips.ToolTipRegionOptions;
@@ -212,6 +213,7 @@ class ChartEditorNoteSprite extends FlxSprite
       this.y += origin.y;
     }
 
+    NoteQuantColors.apply(this, Preferences.noteQuantColors, stepTime);
     this.updateTooltipPosition();
   }
 

--- a/source/funkin/ui/debug/charting/components/ChartEditorNoteSprite.hx
+++ b/source/funkin/ui/debug/charting/components/ChartEditorNoteSprite.hx
@@ -11,6 +11,7 @@ import flixel.graphics.frames.FlxFrame;
 import funkin.data.animation.AnimationData;
 import funkin.data.song.SongData.SongNoteData;
 import funkin.data.notestyle.NoteStyleRegistry;
+import funkin.play.notes.NoteQuantColors;
 import funkin.play.notes.notestyle.NoteStyle;
 import funkin.play.notes.NoteDirection;
 import haxe.ui.tooltips.ToolTipRegionOptions;
@@ -211,6 +212,7 @@ class ChartEditorNoteSprite extends FlxSprite
       this.y += origin.y;
     }
 
+    NoteQuantColors.apply(this, Preferences.noteQuantColors, stepTime);
     this.updateTooltipPosition();
   }
 

--- a/source/funkin/ui/options/PreferencesMenu.hx
+++ b/source/funkin/ui/options/PreferencesMenu.hx
@@ -121,6 +121,11 @@ class PreferencesMenu extends Page<OptionsState.OptionsMenuPageName>
       #if FEATURE_TOUCH_CONTROLS ControlsHandler.hasExternalInputDevice
       || Preferences.controlsScheme != FunkinHitboxControlSchemes.Arrows
       #end);
+    createPrefItemCheckbox('Note Quantization', 'When enabled, notes are colored by their quantization (4th, 8th, 16th, etc.).',
+      function(value:Bool):Void
+      {
+        Preferences.noteQuantColors = value;
+      }, Preferences.noteQuantColors);
     createPrefItemPercentage('Strumline Background', 'Show a semi-transparent background behind the strumline.', function(value:Int):Void
     {
       Preferences.strumlineBackgroundOpacity = value;

--- a/source/funkin/ui/options/PreferencesMenu.hx
+++ b/source/funkin/ui/options/PreferencesMenu.hx
@@ -120,6 +120,11 @@ class PreferencesMenu extends Page<OptionsState.OptionsMenuPageName>
     },
       Preferences.downscroll, #if mobile ControlsHandler.hasExternalInputDevice
       || Preferences.controlsScheme != FunkinHitboxControlSchemes.Arrows #end);
+    createPrefItemCheckbox('Note Quantization', 'When enabled, notes are colored by their quantization (4th, 8th, 16th, etc.).',
+      function(value:Bool):Void
+      {
+        Preferences.noteQuantColors = value;
+      }, Preferences.noteQuantColors);
     createPrefItemPercentage('Strumline Background', 'Show a semi-transparent background behind the strumline.', function(value:Int):Void
     {
       Preferences.strumlineBackgroundOpacity = value;


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues

Addresses #2933

<!-- Briefly describe the issue(s) fixed. -->
## Description

Adds a "Note Quantization" preference that colors notes by their quantization (4th, 8th, 16th, etc.). Applies to gameplay (including chart playtesting) and the chart editor grid, controlled by a single toggle in Options → Preferences. Default off.

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos

https://github.com/user-attachments/assets/8a37ed9f-f38e-44df-b12a-e7798705ac76


<img width="304" height="316" alt="demopicture" src="https://github.com/user-attachments/assets/2e0a3a0c-3c13-4217-bf57-bbe71ec6acad" />
