### PR TITLE
[BUGFIX] Use ASCII case conversion in AtlasText to fix Turkish-locale glyph misses

### DIFF
--- a/source/funkin/ui/AtlasText.hx
+++ b/source/funkin/ui/AtlasText.hx
@@ -83,6 +83,8 @@ class AtlasText extends FlxTypedSpriteGroup<AtlasChar>
 
   /**
    * Converts all characters to fit the font's `allowedCase`.
+   * Uses ASCII-only conversion so Turkish (and other) locales don't substitute
+   * dotted/dotless `İ`/`ı` for `I`/`i` and break atlas glyph lookups.
    * @param str
    */
   function restrictCase(str:String):String
@@ -92,10 +94,34 @@ class AtlasText extends FlxTypedSpriteGroup<AtlasChar>
       case Both:
         str;
       case Upper:
-        str.toUpperCase();
+        asciiUpperCase(str);
       case Lower:
-        str.toLowerCase();
+        asciiLowerCase(str);
     }
+  }
+
+  static function asciiUpperCase(str:String):String
+  {
+    var buf = new StringBuf();
+    for (i in 0...str.length)
+    {
+      var c = str.charCodeAt(i);
+      if (c != null && c >= 0x61 && c <= 0x7A) buf.addChar(c - 0x20);
+      else if (c != null) buf.addChar(c);
+    }
+    return buf.toString();
+  }
+
+  static function asciiLowerCase(str:String):String
+  {
+    var buf = new StringBuf();
+    for (i in 0...str.length)
+    {
+      var c = str.charCodeAt(i);
+      if (c != null && c >= 0x41 && c <= 0x5A) buf.addChar(c + 0x20);
+      else if (c != null) buf.addChar(c);
+    }
+    return buf.toString();
   }
 
   /**


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues

https://github.com/FunkinCrew/Funkin/issues/6700

<!-- Briefly describe the issue(s) fixed. -->
## Description

Fixes text rendering on Linux + Turkish locale (`tr_TR.UTF-8`), where letters `I`/`i` (and similar) failed to render. Reporter independently diagnosed it: `LANG=C` makes it work.

`AtlasText.restrictCase` calls `String.toUpperCase()` / `toLowerCase()`. On hxcpp these go through the C++ stdlib which is locale-aware. In Turkish, `"i".toUpperCase()` returns `"İ"` (dotted I) and `"I".toLowerCase()` returns `"ı"` (dotless i). The font atlas only has ASCII glyphs, so the lookup misses and the character disappears.

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos
