### PR TITLE
make discord-rpc use characters icon data

### DIFF
--- a/source/funkin/play/PlayState.hx
+++ b/source/funkin/play/PlayState.hx
@@ -2169,7 +2169,7 @@ class PlayState extends MusicBeatSubState
       {
         var albumEntry:Null<funkin.ui.freeplay.Album> = funkin.data.freeplay.album.AlbumRegistry.instance.fetchEntry(currentChart?.album ?? '');
         var album:Null<String> = albumEntry?.getDiscordRPCImage() ?? (currentChart?.album ?? '');
-        var icon:Null<String> = currentChart?.discordRPCImage ?? 'icon-${currentCharacterData.opponent}';
+        var icon:Null<String> = currentChart?.discordRPCImage ?? 'icon-${dad.getHealthIconId()}';
 
         discordRPCAlbum = album;
         discordRPCIcon = icon;


### PR DESCRIPTION
discord rpc uses the characters id rather then its icon id in its character json, this is an easy fix and it removes alot of the duplicate
icons in the funkin.art/discord folder and i think will help modders 


i have not playtested this pr (ik make fun of me but i cant build develop rn) so if someone can try if it works before that would be 
helpful


these are icons that do not exist in the funkin.art/discord folder so they will not show up:
all of lesserafims icon
pico pixel
week5 parents
tankmen (bloody)