### PR TITLE
[GITHUB] Bump some actions dependencies to use Node 24

### DIFF
--- a/.github/actions/setup-haxe/action.yml
+++ b/.github/actions/setup-haxe/action.yml
@@ -5,7 +5,7 @@ inputs:
   haxe:
     description: 'Version of haxe to install'
     required: true
-    default: '4.3.6'
+    default: '4.3.7'
   hxcpp-cache:
     description: 'Whether to use a shared hxcpp compile cache'
     required: true
@@ -71,7 +71,7 @@ runs:
 
   - name: Restore cached dependencies
     id: cache-hmm
-    uses: actions/cache@v4
+    uses: actions/cache@v5
     with:
       path: .haxelib
       key: haxe-hmm-${{ runner.os }}-${{ hashFiles('**/hmm.json') }}
@@ -98,7 +98,7 @@ runs:
   # by default use a shared hxcpp cache
   - if: ${{ inputs.hxcpp-cache == 'true' }}
     name: Restore hxcpp cache
-    uses: actions/cache@v4
+    uses: actions/cache@v5
     with:
       path: ${{ inputs.hxcpp-cache-path }}
       key: haxe-hxcpp-${{ runner.os }}-${{ github.ref_name }}-${{ github.sha }}
@@ -114,7 +114,7 @@ runs:
   # if it's explicitly disabled, still cache export/ since that then contains the builds
   - if: ${{ inputs.hxcpp-cache != 'true' }}
     name: Restore export cache
-    uses: actions/cache@v4
+    uses: actions/cache@v5
     with:
       path: ${{ inputs.hxcpp-cache-path }}
       key: haxe-export-${{ runner.os }}-${{ github.ref_name }}-${{ github.sha }}

--- a/.github/workflows/cancel-merged-branches.yml
+++ b/.github/workflows/cancel-merged-branches.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
     - name: Cancel queued workflows for ${{ github.event.pull_request.head.ref }}
-      uses: actions/github-script@v7
+      uses: actions/github-script@v8
       with:
         result-encoding: string
         retries: 3

--- a/.github/workflows/label-actions.yml
+++ b/.github/workflows/label-actions.yml
@@ -27,4 +27,4 @@ jobs:
   action:
     runs-on: ubuntu-latest
     steps:
-      - uses: dessant/label-actions@v4
+      - uses: dessant/label-actions@v5

--- a/.github/workflows/label-pull-request.yml
+++ b/.github/workflows/label-pull-request.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Set basic labels
-      uses: actions/labeler@v5
+      uses: actions/labeler@v6
       with:
         sync-labels: true
   # Apply labels to pull requests based on how many lines were edited


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Briefly describe the issue(s) fixed. -->
Since node.js 20 is deprecated, I had to update `dessant/label-actions` from v4 to v5 to fix the deprecation warning to use node.js 24.
https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
