### PR TITLE
[ENHANCEMENT] Add a PlayState check to initHealthIcon() and playAnimation()

### DIFF
--- a/source/funkin/play/character/BaseCharacter.hx
+++ b/source/funkin/play/character/BaseCharacter.hx
@@ -362,6 +362,9 @@ class BaseCharacter extends Bopper
 
   public function initHealthIcon(isOpponent:Bool):Void
   {
+    // Modders may want to use characters outside of PlayState and this still gets called, so we ignore it.
+    if (PlayState.instance == null) return;
+
     if (!isOpponent)
     {
       if (PlayState.instance.iconP1 == null)
@@ -719,7 +722,7 @@ class BaseCharacter extends Bopper
 
   override public function playAnimation(name:String, restart:Bool = false, ignoreOther:Bool = false, reversed:Bool = false):Void
   {
-    if (tempVocals)
+    if (tempVocals && PlayState.instance != null)
     {
       // restart the character's vocals for the duration of the animation
       if (characterType == BF && PlayState.instance.vocals.playerVolume == 0)


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
None I could find

<!-- Briefly describe the issue(s) fixed. -->
## Description
Before this PR, stages were unable to be utilized to their full potential outside PlayState (`addCharacter()` would call `initHealthIcon()` which promptly throws an error outside of PlayState)
By adding checks here, we allow both stages and characters to function independently from PlayState.

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos
(Shown: `bf` in `mainStage` with `characterType = BF` in a custom state)
<img width="1280" height="720" alt="screenshot-2026-05-28-21-41-18" src="https://github.com/user-attachments/assets/828a55c7-d526-4fcd-996f-0ab4fa4c1c4b" />

