### PR TITLE
[FEATURE] Move `songScore` to a new class

### DIFF
--- a/source/funkin/play/PlayState.hx
+++ b/source/funkin/play/PlayState.hx
@@ -814,6 +814,9 @@ class PlayState extends MusicBeatSubState
     pauseCircle = FunkinSprite.create(0, 0, 'pauseCircle');
     #end
 
+    // Score
+    SongScore.instance.reset();
+
     // Don't do anything else here! Wait until create() when we attach to the camera.
   }
 

--- a/source/funkin/play/PlayState.hx
+++ b/source/funkin/play/PlayState.hx
@@ -52,6 +52,7 @@ import funkin.play.notes.Strumline;
 import funkin.play.notes.SustainTrail;
 import funkin.play.notes.NoteVibrationsHandler;
 import funkin.play.scoring.Scoring;
+import funkin.play.scoring.SongScore;
 import funkin.play.song.Song;
 import funkin.play.stage.Stage;
 import funkin.save.Save;
@@ -235,13 +236,6 @@ class PlayState extends MusicBeatSubState
    * The player's current health.
    */
   public var health:Float = Constants.HEALTH_STARTING;
-
-  /**
-   * The player's current score.
-   * This needs to be a float because you gain partial points as you hold a hold note,
-   * possibly less than one point each update depending on your framerate.
-   */
-  public var songScore:Float = 0;
 
   /**
    * Start at this point in the song once the countdown is done.
@@ -1111,7 +1105,7 @@ class PlayState extends MusicBeatSubState
       cameraZoomRate = Constants.DEFAULT_ZOOM_RATE;
 
       health = Constants.HEALTH_STARTING;
-      songScore = 0.0;
+      SongScore.instance.reset();
       Highscore.tallies.combo = 0;
 
       // so the song doesn't start too early :D
@@ -1443,7 +1437,7 @@ class PlayState extends MusicBeatSubState
 
     vwooshTimer.cancel();
 
-    songScore = 0.0;
+    SongScore.instance.reset();
     updateScoreText();
 
     health = Constants.HEALTH_STARTING;
@@ -2756,7 +2750,7 @@ class PlayState extends MusicBeatSubState
     {
       final SHOW_DECIMALS:Bool = false;
       final COMMA_SEPARATED:Bool = true;
-      scoreText.text = 'Score: ${FlxStringUtil.formatMoney(songScore, SHOW_DECIMALS, COMMA_SEPARATED)}';
+      scoreText.text = 'Score: ${FlxStringUtil.formatMoney(SongScore.instance.getScore(), SHOW_DECIMALS, COMMA_SEPARATED)}';
     }
   }
 
@@ -2932,7 +2926,7 @@ class PlayState extends MusicBeatSubState
         if (!isBotPlayMode && holdNote.scoreable)
         {
           health += Constants.HEALTH_HOLD_BONUS_PER_SECOND * elapsed;
-          songScore += Constants.SCORE_HOLD_BONUS_PER_SECOND * elapsed;
+          SongScore.instance.addScore(Constants.SCORE_HOLD_BONUS_PER_SECOND * elapsed);
         }
 
         // Make sure the player keeps singing while the note is held by the bot.
@@ -3066,7 +3060,7 @@ class PlayState extends MusicBeatSubState
 
         // Play the strumline animation.
         playerStrumline.playPress(input.noteDirection);
-        trace('PENALTY Score: ${songScore}');
+        trace('PENALTY Score: ${SongScore.instance.getScore()}');
       }
     else if (notesInDirection.length == 0)
     {
@@ -3074,7 +3068,7 @@ class PlayState extends MusicBeatSubState
 
       // Play the strumline animation.
       playerStrumline.playPress(input.noteDirection);
-      trace('NO PENALTY Score: ${songScore}');
+      trace('NO PENALTY Score: ${SongScore.instance.getScore()}');
     }
     else
     {
@@ -3217,7 +3211,7 @@ class PlayState extends MusicBeatSubState
     if (event.eventCanceled) return;
 
     health += event.healthChange;
-    songScore += event.scoreChange;
+    SongScore.instance.addScore(event.scoreChange);
 
     if (!isPracticeMode)
     {
@@ -3358,7 +3352,7 @@ class PlayState extends MusicBeatSubState
       Highscore.tallies.combo++;
       if (Highscore.tallies.combo > Highscore.tallies.maxCombo) Highscore.tallies.maxCombo = Highscore.tallies.combo;
     }
-    songScore += score;
+    SongScore.instance.addScore(score);
   }
 
   /**
@@ -3486,7 +3480,7 @@ class PlayState extends MusicBeatSubState
     {
       // crackhead double thingie, sets whether was new highscore, AND saves the song!
       var data = {
-        score: Std.int(songScore),
+        score: SongScore.instance.getScoreInt(),
         tallies: {
           sick: Highscore.tallies.sick,
           good: Highscore.tallies.good,
@@ -3504,7 +3498,7 @@ class PlayState extends MusicBeatSubState
       Highscore.talliesLevel = Highscore.combineTallies(Highscore.tallies, Highscore.talliesLevel);
 
       #if FEATURE_NEWGROUNDS
-      Leaderboards.submitSongScore(currentSong.id, suffixedDifficulty, Std.int(songScore));
+      Leaderboards.submitSongScore(currentSong.id, suffixedDifficulty, SongScore.instance.getScoreInt());
       #end
 
       if (!isPracticeMode && !isBotPlayMode)
@@ -3535,7 +3529,7 @@ class PlayState extends MusicBeatSubState
 
       // Determine the score rank for this song we just finished.
       var scoreRank:Null<ScoringRank> = Scoring.calculateRank({
-        score: Std.int(songScore),
+        score: SongScore.instance.getScoreInt(),
         tallies: {
           sick: Highscore.tallies.sick,
           good: Highscore.tallies.good,
@@ -3570,7 +3564,7 @@ class PlayState extends MusicBeatSubState
     {
       isNewHighscore = false;
 
-      PlayStatePlaylist.campaignScore += Std.int(songScore);
+      PlayStatePlaylist.campaignScore += SongScore.instance.getScoreInt();
 
       // Pop the next song ID from the list.
       // Returns null if the list is empty.
@@ -3894,7 +3888,7 @@ class PlayState extends MusicBeatSubState
       title: PlayStatePlaylist.isStoryMode ? ('${PlayStatePlaylist.campaignTitle}') : ('${currentChart.songName} by ${currentChart.songArtist}'),
       prevScoreData: prevScoreData,
       scoreData: {
-        score: PlayStatePlaylist.isStoryMode ? PlayStatePlaylist.campaignScore : Std.int(songScore),
+        score: PlayStatePlaylist.isStoryMode ? PlayStatePlaylist.campaignScore : SongScore.instance.getScoreInt(),
         tallies: {
           sick: talliesToUse.sick,
           good: talliesToUse.good,

--- a/source/funkin/play/scoring/SongScore.hx
+++ b/source/funkin/play/scoring/SongScore.hx
@@ -1,0 +1,56 @@
+package funkin.play.scoring;
+
+import funkin.util.tools.ISingleton;
+
+/**
+ * A class that handles storing the current score in PlayState.
+ */
+class SongScore implements ISingleton
+{
+  /**
+   * The player's current score.
+   * This needs to be a float because you gain partial points as you hold a hold note.
+   */
+  private var points:Float = 0;
+
+  public function new()
+  {
+  }
+
+  /**
+   * Returns the current score points.
+   * Should be used for retrieving the score, like when doing script shenanigans.
+   * @return Points
+   */
+  public function getScore():Float
+  {
+    return points;
+  }
+
+  /**
+   * Returns the current score points, as an integer.
+   * Should be used for storing the score, like after a song ends.
+   * @return Points
+   */
+  public function getScoreInt():Int
+  {
+    return Std.int(points);
+  }
+
+  /**
+   * Adds points to the song score.
+   * @param score The score to add
+   */
+  public function addScore(score:Float):Void
+  {
+    points += score;
+  }
+
+  /**
+   * Resets the score back to zero.
+   */
+  public function reset():Void
+  {
+    points = 0;
+  }
+}


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

> [!NOTE]
> Breaking change - all scripts using `songScore` must now reference `SongScore.instance.getScore()`.

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
N/A

<!-- Briefly describe the issue(s) fixed. -->
## Description
In PlayState.hx, songScore used to have a TODO comment saying "Move this to a class."
Not sure if that's still needed, but I did it anyway! This allows us to add further logic into score logic when needed.

This used to be part of a bigger PR I was working on, regarding held note scoring consistency.
However, I'm holding off (giving up?) on that for now until some other PRs are pulled (namely #6914) and until my psyche recovers (my contributions to FNF last about as long as I am motivated, and I can't promise anything :sob: )

For the details on the incomplete held note scoring PR, if anyone wants to tackle it themselves if I die or just out of curiosity (it's worked on in my `accurate-sustains` branch):
- Add a field called `pendingPoints` and function `getWithPending()` to the new `SongScore` class
- Currently held notes will apply their score there as an integer, instead of at the real `points` variable
- Hold notes will also hold a new `appliedScore` field, tracking how much score they've applied to `pendingScore` so far
- Move player hold note logic to `processInputQueue` (maybe into a function called `goodHoldNoteHit()`)
- When held notes are released, calculate the diff like you would in `goodNoteHit()`, remove the `appliedScore` from the `pendingScore`, and apply the real score to `points`.
This would be a massive change in input handling, which is why I didn't do it :sweat_smile: 

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos
N/A