### PR TITLE
[FEATURE/BUGFIX] Framerate-independent sustains + Moved `songScore` to a new class

### DIFF
--- a/source/funkin/modding/events/ScriptEvent.hx
+++ b/source/funkin/modding/events/ScriptEvent.hx
@@ -258,11 +258,12 @@ class HoldNoteScriptEvent extends NoteScriptEvent
   public var doesNotesplash:Bool = false;
 
   public function new(type:ScriptEventType, holdNote:SustainTrail, healthChange:Float, score:Float, isComboBreak:Bool, comboCount:Int = 0,
-      cancelable:Bool = false):Void
+      hitDiff:Float = 0):Void
   {
     super(type, null, healthChange, comboCount, true);
     this.holdNote = holdNote;
     this.score = score;
+    this.hitDiff = hitDiff;
     this.isComboBreak = isComboBreak;
   }
 

--- a/source/funkin/play/PlayState.hx
+++ b/source/funkin/play/PlayState.hx
@@ -789,7 +789,6 @@ class PlayState extends MusicBeatSubState
     camSubtitles = new FunkinCamera('playStateCamSubtitles');
     camPause = new FunkinCamera('playStateCamPause');
     camTransition = new FunkinCamera('playStateCamTransition');
-
     var currentChart = currentSong.getDifficulty(currentDifficulty, currentVariation);
     var noteStyleId:Null<String> = currentChart?.noteStyle;
     var nulNoteStyle:Null<NoteStyle> = NoteStyleRegistry.instance.fetchEntry(noteStyleId ?? Constants.DEFAULT_NOTE_STYLE);
@@ -813,6 +812,9 @@ class PlayState extends MusicBeatSubState
     pauseButton = FunkinSprite.createSparrow(0, 0, "pauseButton");
     pauseCircle = FunkinSprite.create(0, 0, 'pauseCircle');
     #end
+
+    // Score
+    SongScore.instance.reset();
 
     // Don't do anything else here! Wait until create() when we attach to the camera.
   }
@@ -2750,7 +2752,7 @@ class PlayState extends MusicBeatSubState
     {
       final SHOW_DECIMALS:Bool = false;
       final COMMA_SEPARATED:Bool = true;
-      scoreText.text = 'Score: ${FlxStringUtil.formatMoney(SongScore.instance.getScore(), SHOW_DECIMALS, COMMA_SEPARATED)}';
+      scoreText.text = 'Score: ${FlxStringUtil.formatMoney(SongScore.instance.getScoreWithPending(), SHOW_DECIMALS, COMMA_SEPARATED)}';
     }
   }
 
@@ -2838,11 +2840,12 @@ class PlayState extends MusicBeatSubState
       // While the hold note is being hit, and there is length on the hold note...
       if (holdNote.hitNote && !holdNote.missedNote && holdNote.sustainLength > 0)
       {
-        // Make sure the opponent keeps singing while the note is held.
-        if (currentStage != null && currentStage.getDad() != null && currentStage.getDad().isSinging())
-        {
-          currentStage.getDad().holdTimer = 0;
-        }
+        // Dispatch the event, which should make the opponent keep singing while the note is held.
+        var event:HoldNoteScriptEvent = new HoldNoteScriptEvent(NOTE_HOLD_HIT, holdNote, 0, 0, false, 0);
+        dispatchEvent(event);
+
+        // Drop the held note if the event is cancelled.
+        if (event.eventCanceled) holdNote.missedNote = true;
       }
 
       if (holdNote.missedNote && !holdNote.handledMiss)
@@ -2854,7 +2857,8 @@ class PlayState extends MusicBeatSubState
         {
           // We dropped a hold note.
           // Play miss animation, but don't penalize.
-          if (currentStage != null) currentStage.getOpponent().playSingAnimation(holdNote.noteData.getDirection(), true);
+          var event:HoldNoteScriptEvent = new HoldNoteScriptEvent(NOTE_HOLD_DROP, holdNote, 0, 0, true, 0);
+          dispatchEvent(event);
         }
       }
     }
@@ -2915,6 +2919,7 @@ class PlayState extends MusicBeatSubState
 
     // Process hold notes on the player's side.
     // This handles scoring so we don't need it on the opponent's side.
+    var pendingPoints:Float = 0;
     for (holdNote in playerStrumline.holdNotes.members)
     {
       if (holdNote == null || !holdNote.alive) continue;
@@ -2923,70 +2928,65 @@ class PlayState extends MusicBeatSubState
       if (holdNote.hitNote && !holdNote.missedNote && holdNote.sustainLength > 0)
       {
         // Grant the player health.
-        if (!isBotPlayMode && holdNote.scoreable)
+        if (isBotPlayMode)
         {
-          health += Constants.HEALTH_HOLD_BONUS_PER_SECOND * elapsed;
-          SongScore.instance.addScore(Constants.SCORE_HOLD_BONUS_PER_SECOND * elapsed);
+          // Dispatch the event, which should make the bot keep singing while the note is held.
+          var event:HoldNoteScriptEvent = new HoldNoteScriptEvent(NOTE_HOLD_HIT, holdNote, 0, 0, false, 0);
+          dispatchEvent(event);
+
+          // Drop the held note if the event is cancelled.
+          if (event.eventCanceled) holdNote.missedNote = true;
+        }
+        else
+        {
+          // Reward the player.
+          goodNoteHoldHit(holdNote, elapsed);
+        }
+      }
+
+      if (holdNote.endedNote && !holdNote.handledEnding)
+      {
+        // The player dropped a hold note.
+        holdNote.handledEnding = true;
+        if (!isBotPlayMode)
+        {
+          goodNoteHoldRelease(holdNote);
+        }
+        else
+        {
+          var event:HoldNoteScriptEvent = new HoldNoteScriptEvent(NOTE_HOLD_DROP, holdNote, 0.0, 0.0, false, Highscore.tallies.combo, 0.0);
+          dispatchEvent(event);
         }
 
-        // Make sure the player keeps singing while the note is held by the bot.
-        if (isBotPlayMode && currentStage != null && currentStage.getBoyfriend() != null && currentStage.getBoyfriend().isSinging())
-        {
-          currentStage.getBoyfriend().holdTimer = 0;
-        }
+        holdNote.visible = false;
+        holdNote.kill();
       }
 
       if (holdNote.missedNote && !holdNote.handledMiss)
       {
         // The player dropped a hold note.
         holdNote.handledMiss = true;
+        holdNote.endedNote = true;
+        holdNote.handledEnding = true;
 
         // Mute vocals and play miss animation.
         // vocals.playerVolume = 0;
         // if (currentStage != null && currentStage.getBoyfriend() != null) currentStage.getBoyfriend().playSingAnimation(holdNote.noteData.getDirection(), true);
 
-        if (!isBotPlayMode && holdNote.scoreable)
+        if (!isBotPlayMode)
         {
-          if (holdNote.sustainLength > Constants.HOLD_DROP_PENALTY_THRESHOLD_MS)
-          {
-            // Penalize the player for letting go of a hold note too early.
-            trace('Player dropped a hold note, penalizing... (has hit: ${holdNote.hitNote})');
-
-            // Different penalty based on whether the note itself was missed,
-            // or the note was hit and then the hold was dropped.
-            var remainingLengthSec = holdNote.sustainLength / Constants.MS_PER_SEC;
-            var healthChangeUncapped = remainingLengthSec * Constants.HEALTH_HOLD_DROP_PENALTY_PER_SECOND;
-            // If the base note of the hold was missed, don't penalize them more on top of that.
-            var healthChangeMax = Constants.HEALTH_HOLD_DROP_PENALTY_MAX - (holdNote.hitNote ? -Constants.HEALTH_MISS_PENALTY : 0);
-            var healthChange = healthChangeUncapped.clamp(healthChangeMax, 0);
-            var scoreChange:Float = Constants.SCORE_HOLD_DROP_PENALTY_PER_SECOND * remainingLengthSec;
-
-            var event:HoldNoteScriptEvent = new HoldNoteScriptEvent(NOTE_HOLD_DROP, holdNote, healthChange, scoreChange, true, Highscore.tallies.combo);
-            dispatchEvent(event);
-
-            // Calling event.cancelEvent() skips all the other logic! Neat!
-            if (event.eventCanceled) continue;
-
-            trace('Penalizing score by ${event.score} and health by ${event.healthChange} for dropping hold note (is combo break: ${event.isComboBreak})!');
-            applyScore(event.score, '', event.healthChange, event.isComboBreak);
-
-            // Play the miss sound.
-            if (event.playSound)
-            {
-              if (vocals != null)
-              {
-                if (vocals.legacyVoiceSystem && !vocals.legacyVoiceUsesPlayer) vocals.opponentVolume = 0;
-                vocals.playerVolume = 0;
-              }
-              FunkinSound.playOnce(Paths.soundRandom('missnote', 1, 3), FlxG.random.float(0.5, 0.6));
-            }
-          }
-          else
-          {
-            trace('Hold note too short, not penalizing...');
-          }
+          goodNoteHoldRelease(holdNote, lastReleased[holdNote.noteDirection]);
+        }
+        else
+        {
+          var event:HoldNoteScriptEvent = new HoldNoteScriptEvent(NOTE_HOLD_DROP, holdNote, 0.0, 0.0, false, Highscore.tallies.combo, 0.0);
+          dispatchEvent(event);
         }
       }
+
+      pendingPoints += holdNote.appliedScore;
+      SongScore.instance.setPendingScore(pendingPoints);
+      trace('Pending points: ${pendingPoints}');
     }
   }
 
@@ -3009,6 +3009,8 @@ class PlayState extends MusicBeatSubState
     playerStrumline.handleSkippedNotes();
     opponentStrumline.handleSkippedNotes();
   }
+
+  var lastReleased:Array<Null<PreciseInputEvent>> = [null, null, null, null];
 
   /**
      * PreciseInputEvents are put into a queue between update() calls,
@@ -3094,6 +3096,7 @@ class PlayState extends MusicBeatSubState
 
       // Play the strumline animation.
       playerStrumline.playStatic(input.noteDirection);
+      lastReleased[input.noteDirection] = input;
 
       playerStrumline.releaseKey(input.noteDirection, input.keyCode);
     }
@@ -3157,6 +3160,104 @@ class PlayState extends MusicBeatSubState
       Highscore.tallies.totalNotesHit++;
       applyScore(event.score, event.judgement, event.healthChange, event.isComboBreak);
       popUpScore(event.judgement);
+    }
+  }
+
+  function goodNoteHoldHit(holdNote:SustainTrail, elapsed:Float):Void
+  {
+    var healthChange:Float = Constants.HEALTH_HOLD_BONUS_PER_SECOND * elapsed;
+    var scoreChange:Float = Constants.SCORE_HOLD_BONUS_PER_SECOND * elapsed;
+
+    var event:HoldNoteScriptEvent = new HoldNoteScriptEvent(NOTE_HOLD_HIT, holdNote, healthChange, scoreChange, false, Highscore.tallies.combo);
+    dispatchEvent(event);
+
+    // Drop the held note if the event is cancelled.
+    if (event.eventCanceled)
+    {
+      holdNote.missedNote = true;
+      return;
+    }
+
+    if (holdNote.scoreable)
+    {
+      health += healthChange;
+      holdNote.appliedScore = scoreChange;
+    }
+  }
+
+  function goodNoteHoldRelease(holdNote:SustainTrail, ?input:PreciseInputEvent = null):Void
+  {
+    // Remove all the applied score, we're adding the real score now!
+    holdNote.appliedScore = 0;
+    var event:HoldNoteScriptEvent = new HoldNoteScriptEvent(NOTE_HOLD_DROP, holdNote, 0.0, 0.0, false, Highscore.tallies.combo, 0.0);
+
+    if (!holdNote.scoreable)
+    {
+      dispatchEvent(event);
+      return;
+    }
+
+    if (input == null)
+    {
+      event.score = Constants.SCORE_HOLD_BONUS_PER_SECOND * (holdNote.fullSustainLength / Constants.MS_PER_SEC);
+      dispatchEvent(event);
+
+      if (event.eventCanceled) return;
+      applyScore(event.score, '', event.healthChange, event.isComboBreak);
+    }
+    else
+    {
+      var inputLatencyNs:Int64 = PreciseInputManager.getCurrentTimestamp() - input.timestamp;
+      var inputLatencyMs:Float = inputLatencyNs.toFloat() / Constants.NS_PER_MS;
+
+      // Get the offset and compensate for input latency.
+      // Round inward (trim remainder) for consistency.
+      var consumedLength:Int = Std.int(Math.max(0, Conductor.instance.songPosition - holdNote.strumTime - inputLatencyMs));
+      var remainingLength:Int = Std.int(Math.max(0, (holdNote.strumTime + holdNote.fullSustainLength) - Conductor.instance.songPosition + inputLatencyMs));
+      event.hitDiff = remainingLength;
+      event.score = Constants.SCORE_HOLD_BONUS_PER_SECOND * consumedLength / Constants.MS_PER_SEC;
+
+      if (remainingLength > Constants.HOLD_DROP_PENALTY_THRESHOLD_MS)
+      {
+        // Penalize the player for letting go of a hold note too early.
+        trace('Player dropped a hold note, penalizing... (has hit: ${holdNote.hitNote})');
+        event.isComboBreak = true;
+
+        // Different penalty based on whether the note itself was missed,
+        // or the note was hit and then the hold was dropped.
+        var remainingLengthSec = remainingLength / Constants.MS_PER_SEC;
+        var healthChangeUncapped = remainingLengthSec * Constants.HEALTH_HOLD_DROP_PENALTY_PER_SECOND;
+
+        // If the base note of the hold was missed, don't penalize them more on top of that.
+        var healthChangeMax = Constants.HEALTH_HOLD_DROP_PENALTY_MAX - (holdNote.hitNote ? -Constants.HEALTH_MISS_PENALTY : 0);
+        event.healthChange = healthChangeUncapped.clamp(healthChangeMax, 0);
+        event.score += Constants.SCORE_HOLD_DROP_PENALTY_PER_SECOND * remainingLengthSec;
+
+        dispatchEvent(event);
+
+        // Calling event.cancel() skips all the other logic! Neat!
+        if (event.eventCanceled) return;
+
+        trace('Penalizing score by ${event.score} and health by ${event.healthChange} for dropping hold note (is combo break: ${event.isComboBreak})!');
+        applyScore(event.score, '', event.healthChange, event.isComboBreak);
+
+        // Play the miss sound.
+        if (event.playSound)
+        {
+          if (vocals != null)
+          {
+            if (vocals.legacyVoiceSystem && !vocals.legacyVoiceUsesPlayer) vocals.opponentVolume = 0;
+            vocals.playerVolume = 0;
+          }
+          FunkinSound.playOnce(Paths.soundRandom('missnote', 1, 3), FlxG.random.float(0.5, 0.6));
+        }
+      }
+      else
+      {
+        trace('Hold note too short, not penalizing...');
+        event.isComboBreak = false;
+        dispatchEvent(event);
+      }
     }
   }
 

--- a/source/funkin/play/PlayState.hx
+++ b/source/funkin/play/PlayState.hx
@@ -2986,7 +2986,6 @@ class PlayState extends MusicBeatSubState
 
       pendingPoints += holdNote.appliedScore;
       SongScore.instance.setPendingScore(pendingPoints);
-      trace('Pending points: ${pendingPoints}');
     }
   }
 
@@ -3091,7 +3090,7 @@ class PlayState extends MusicBeatSubState
 
     while (inputReleaseQueue.length > 0)
     {
-      var input:Null<PreciseInputEvent> = inputReleaseQueue.shift();
+      var input:Null<PreciseInputEvent> = inputReleaseQueue.pop();
       if (input == null) continue;
 
       // Play the strumline animation.
@@ -3181,7 +3180,7 @@ class PlayState extends MusicBeatSubState
     if (holdNote.scoreable)
     {
       health += healthChange;
-      holdNote.appliedScore = scoreChange;
+      holdNote.appliedScore += scoreChange;
     }
   }
 
@@ -3197,9 +3196,22 @@ class PlayState extends MusicBeatSubState
       return;
     }
 
-    if (input == null)
+    if (!holdNote.hitNote)
     {
-      event.score = Constants.SCORE_HOLD_BONUS_PER_SECOND * (holdNote.fullSustainLength / Constants.MS_PER_SEC);
+      // If the initial note was missed.
+      var lengthSeconds = holdNote.fullSustainLength / Constants.MS_PER_SEC;
+      if (lengthSeconds > Constants.HOLD_DROP_PENALTY_THRESHOLD_MS) event.score = Constants.SCORE_HOLD_DROP_PENALTY_PER_SECOND * lengthSeconds;
+
+      dispatchEvent(event);
+
+      if (event.eventCanceled) return;
+      applyScore(event.score, '', event.healthChange, event.isComboBreak);
+    }
+    else if (input == null)
+    {
+      // If the note was fully completed.
+      var lengthSeconds = holdNote.fullSustainLength / Constants.MS_PER_SEC;
+      event.score = Constants.SCORE_HOLD_BONUS_PER_SECOND * lengthSeconds;
       dispatchEvent(event);
 
       if (event.eventCanceled) return;
@@ -3207,6 +3219,7 @@ class PlayState extends MusicBeatSubState
     }
     else
     {
+      // If the note was released before completion.
       var inputLatencyNs:Int64 = PreciseInputManager.getCurrentTimestamp() - input.timestamp;
       var inputLatencyMs:Float = inputLatencyNs.toFloat() / Constants.NS_PER_MS;
 
@@ -3238,7 +3251,7 @@ class PlayState extends MusicBeatSubState
         // Calling event.cancel() skips all the other logic! Neat!
         if (event.eventCanceled) return;
 
-        trace('Penalizing score by ${event.score} and health by ${event.healthChange} for dropping hold note (is combo break: ${event.isComboBreak})!');
+        trace('Penalizing score by ${event.score} and health by ${event.healthChange} for dropping hold note (is combo break: ${event.isComboBreak}, was hit: ${holdNote.hitNote})!');
         applyScore(event.score, '', event.healthChange, event.isComboBreak);
 
         // Play the miss sound.

--- a/source/funkin/play/PlayState.hx
+++ b/source/funkin/play/PlayState.hx
@@ -52,6 +52,7 @@ import funkin.play.notes.Strumline;
 import funkin.play.notes.SustainTrail;
 import funkin.play.notes.NoteVibrationsHandler;
 import funkin.play.scoring.Scoring;
+import funkin.play.scoring.SongScore;
 import funkin.play.song.Song;
 import funkin.play.stage.Stage;
 import funkin.save.Save;
@@ -235,13 +236,6 @@ class PlayState extends MusicBeatSubState
    * The player's current health.
    */
   public var health:Float = Constants.HEALTH_STARTING;
-
-  /**
-   * The player's current score.
-   * This needs to be a float because you gain partial points as you hold a hold note,
-   * possibly less than one point each update depending on your framerate.
-   */
-  public var songScore:Float = 0;
 
   /**
    * Start at this point in the song once the countdown is done.
@@ -1111,7 +1105,7 @@ class PlayState extends MusicBeatSubState
       cameraZoomRate = Constants.DEFAULT_ZOOM_RATE;
 
       health = Constants.HEALTH_STARTING;
-      songScore = 0.0;
+      SongScore.instance.reset();
       Highscore.tallies.combo = 0;
 
       // so the song doesn't start too early :D
@@ -1443,7 +1437,7 @@ class PlayState extends MusicBeatSubState
 
     vwooshTimer.cancel();
 
-    songScore = 0.0;
+    SongScore.instance.reset();
     updateScoreText();
 
     health = Constants.HEALTH_STARTING;
@@ -2756,7 +2750,7 @@ class PlayState extends MusicBeatSubState
     {
       final SHOW_DECIMALS:Bool = false;
       final COMMA_SEPARATED:Bool = true;
-      scoreText.text = 'Score: ${FlxStringUtil.formatMoney(songScore, SHOW_DECIMALS, COMMA_SEPARATED)}';
+      scoreText.text = 'Score: ${FlxStringUtil.formatMoney(SongScore.instance.getScore(), SHOW_DECIMALS, COMMA_SEPARATED)}';
     }
   }
 
@@ -2932,7 +2926,7 @@ class PlayState extends MusicBeatSubState
         if (!isBotPlayMode && holdNote.scoreable)
         {
           health += Constants.HEALTH_HOLD_BONUS_PER_SECOND * elapsed;
-          songScore += Constants.SCORE_HOLD_BONUS_PER_SECOND * elapsed;
+          SongScore.instance.addScore(Constants.SCORE_HOLD_BONUS_PER_SECOND * elapsed);
         }
 
         // Make sure the player keeps singing while the note is held by the bot.
@@ -3066,7 +3060,7 @@ class PlayState extends MusicBeatSubState
 
         // Play the strumline animation.
         playerStrumline.playPress(input.noteDirection);
-        trace('PENALTY Score: ${songScore}');
+        trace('PENALTY Score: ${SongScore.instance.getScore()}');
       }
     else if (notesInDirection.length == 0)
     {
@@ -3074,7 +3068,7 @@ class PlayState extends MusicBeatSubState
 
       // Play the strumline animation.
       playerStrumline.playPress(input.noteDirection);
-      trace('NO PENALTY Score: ${songScore}');
+      trace('NO PENALTY Score: ${SongScore.instance.getScore()}');
     }
     else
     {
@@ -3217,7 +3211,7 @@ class PlayState extends MusicBeatSubState
     if (event.eventCanceled) return;
 
     health += event.healthChange;
-    songScore += event.scoreChange;
+    SongScore.instance.addScore(event.scoreChange);
 
     if (!isPracticeMode)
     {
@@ -3358,7 +3352,7 @@ class PlayState extends MusicBeatSubState
       Highscore.tallies.combo++;
       if (Highscore.tallies.combo > Highscore.tallies.maxCombo) Highscore.tallies.maxCombo = Highscore.tallies.combo;
     }
-    songScore += score;
+    SongScore.instance.addScore(score);
   }
 
   /**
@@ -3486,7 +3480,7 @@ class PlayState extends MusicBeatSubState
     {
       // crackhead double thingie, sets whether was new highscore, AND saves the song!
       var data = {
-        score: Std.int(songScore),
+        score: SongScore.instance.getScoreInt(),
         tallies: {
           sick: Highscore.tallies.sick,
           good: Highscore.tallies.good,
@@ -3504,7 +3498,7 @@ class PlayState extends MusicBeatSubState
       Highscore.talliesLevel = Highscore.combineTallies(Highscore.tallies, Highscore.talliesLevel);
 
       #if FEATURE_NEWGROUNDS
-      Leaderboards.submitSongScore(currentSong.id, suffixedDifficulty, Std.int(songScore));
+      Leaderboards.submitSongScore(currentSong.id, suffixedDifficulty, SongScore.instance.getScoreInt());
       #end
 
       if (!isPracticeMode && !isBotPlayMode)
@@ -3535,7 +3529,7 @@ class PlayState extends MusicBeatSubState
 
       // Determine the score rank for this song we just finished.
       var scoreRank:Null<ScoringRank> = Scoring.calculateRank({
-        score: Std.int(songScore),
+        score: SongScore.instance.getScoreInt(),
         tallies: {
           sick: Highscore.tallies.sick,
           good: Highscore.tallies.good,
@@ -3570,7 +3564,7 @@ class PlayState extends MusicBeatSubState
     {
       isNewHighscore = false;
 
-      PlayStatePlaylist.campaignScore += Std.int(songScore);
+      PlayStatePlaylist.campaignScore += SongScore.instance.getScoreInt();
 
       // Pop the next song ID from the list.
       // Returns null if the list is empty.
@@ -3894,7 +3888,7 @@ class PlayState extends MusicBeatSubState
       title: PlayStatePlaylist.isStoryMode ? ('${PlayStatePlaylist.campaignTitle}') : ('${currentChart.songName} by ${currentChart.songArtist}'),
       prevScoreData: prevScoreData,
       scoreData: {
-        score: PlayStatePlaylist.isStoryMode ? PlayStatePlaylist.campaignScore : Std.int(songScore),
+        score: PlayStatePlaylist.isStoryMode ? PlayStatePlaylist.campaignScore : SongScore.instance.getScoreInt(),
         tallies: {
           sick: talliesToUse.sick,
           good: talliesToUse.good,

--- a/source/funkin/play/character/BaseCharacter.hx
+++ b/source/funkin/play/character/BaseCharacter.hx
@@ -627,7 +627,7 @@ class BaseCharacter extends Bopper
     super.onNoteHoldDrop(event);
 
     // If another script cancelled the event, don't do anything.
-    if (event.eventCanceled) return;
+    if (event.eventCanceled || !event.isComboBreak) return;
 
     if (event.holdNote.noteData.getMustHitNote() && characterType == BF)
     {

--- a/source/funkin/play/event/SongEvent.hx
+++ b/source/funkin/play/event/SongEvent.hx
@@ -162,6 +162,10 @@ class SongEvent implements IPlayStateScriptedClass
   {
   }
 
+  public function onNoteHoldHit(event:HoldNoteScriptEvent)
+  {
+  }
+
   public function onSongEvent(event:SongEventScriptEvent)
   {
   }

--- a/source/funkin/play/notes/Strumline.hx
+++ b/source/funkin/play/notes/Strumline.hx
@@ -679,8 +679,7 @@ class Strumline extends FlxSpriteGroup
           holdNote.cover.kill();
         }
 
-        holdNote.visible = false;
-        holdNote.kill();
+        holdNote.endedNote = true;
       }
       else if (holdNote.missedNote && (holdNote.fullSustainLength > holdNote.sustainLength))
       {

--- a/source/funkin/play/notes/SustainTrail.hx
+++ b/source/funkin/play/notes/SustainTrail.hx
@@ -59,6 +59,12 @@ class SustainTrail extends FlxSprite
   public var scoreable:Bool = true;
 
   /**
+   * Used by PlayState to track how much display score the held note has given.
+   * Does not influence the actual score; only the score shown while holding the note.
+   */
+  public var appliedScore:Float = 0;
+
+  /**
    * The Y Offset of the note.
    */
   public var yOffset:Float = 0.0;
@@ -79,6 +85,16 @@ class SustainTrail extends FlxSprite
    * Set to `true` after handling additional logic for missing notes.
    */
   public var handledMiss:Bool = false;
+
+  /**
+   * Set to `true` when the user successfully exhausts the hold, or if they let go too early.
+   */
+  public var endedNote:Bool = false;
+
+  /**
+   * Set to `true` after handling additional logic for completing notes.
+   */
+  public var handledEnding:Bool = false;
 
   // maybe BlendMode.MULTIPLY if missed somehow, drawTriangles does not support!
 
@@ -437,10 +453,12 @@ class SustainTrail extends FlxSprite
     noteDirection = 0;
     sustainLength = 0;
     fullSustainLength = 0;
+    appliedScore = 0;
     noteData = null;
 
     hitNote = false;
     missedNote = false;
+    endedNote = false;
   }
 
   override public function revive():Void
@@ -451,11 +469,14 @@ class SustainTrail extends FlxSprite
     noteDirection = 0;
     sustainLength = 0;
     fullSustainLength = 0;
+    appliedScore = 0;
     noteData = null;
 
     hitNote = false;
     missedNote = false;
     handledMiss = false;
+    endedNote = false;
+    handledEnding = false;
   }
 
   override public function destroy():Void

--- a/source/funkin/play/scoring/SongScore.hx
+++ b/source/funkin/play/scoring/SongScore.hx
@@ -1,0 +1,56 @@
+package funkin.play.scoring;
+
+import funkin.util.tools.ISingleton;
+
+/**
+ * A class that handles storing the current score in PlayState.
+ */
+class SongScore implements ISingleton
+{
+  /**
+   * The player's current score.
+   * This needs to be a float because you gain partial points as you hold a hold note.
+   */
+  private var points:Float = 0;
+
+  public function new()
+  {
+  }
+
+  /**
+   * Returns the current score points.
+   * Should be used for retrieving the score, like when doing script shenanigans.
+   * @return Points
+   */
+  public function getScore():Float
+  {
+    return points;
+  }
+
+  /**
+   * Returns the current score points, as an integer.
+   * Should be used for storing the score, like after a song ends.
+   * @return Points
+   */
+  public function getScoreInt():Int
+  {
+    return Std.int(points);
+  }
+
+  /**
+   * Adds points to the song score.
+   * @param score The score to add
+   */
+  public function addScore(score:Float):Void
+  {
+    points += score;
+  }
+
+  /**
+   * Resets the score back to zero.
+   */
+  public function reset():Void
+  {
+    points = 0;
+  }
+}

--- a/source/funkin/play/scoring/SongScore.hx
+++ b/source/funkin/play/scoring/SongScore.hx
@@ -13,12 +13,28 @@ class SongScore implements ISingleton
    */
   private var points:Float = 0;
 
+  /**
+   * Sometimes there are points that need to be calculated,
+   * but need to be displayed before the calculation is entirely finished (e.g. hold notes)
+   */
+  private var pendingPoints:Float = 0;
+
   public function new()
   {
   }
 
   /**
-   * Returns the current score points.
+   * Returns the current score points, including `pendingPoints`.
+   * Should be used for retrieving the score, like when doing script shenanigans.
+   * @return Points
+   */
+  public function getScoreWithPending():Float
+  {
+    return points + pendingPoints;
+  }
+
+  /**
+   * Returns the current score points, excluding `pendingPoints`.
    * Should be used for retrieving the score, like when doing script shenanigans.
    * @return Points
    */
@@ -28,7 +44,7 @@ class SongScore implements ISingleton
   }
 
   /**
-   * Returns the current score points, as an integer.
+   * Returns the current score points (excluding `pendingPoints`) as an integer.
    * Should be used for storing the score, like after a song ends.
    * @return Points
    */
@@ -44,6 +60,16 @@ class SongScore implements ISingleton
   public function addScore(score:Float):Void
   {
     points += score;
+  }
+
+  /**
+   * Sets the amount of pending score.
+   * Used by PlayState to handle hold notes.
+   * @param score The score to set
+   */
+  public function setPendingScore(score:Float):Void
+  {
+    pendingPoints = score;
   }
 
   /**


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

> [!NOTE]
> Breaking change (at least it used to be) - while `songScore` is kept for backwards-compatibility, it's now merely a getter for `SongScore.instance.getScoreWithPending()`. To get the actual score used in saving, reference  `SongScore.instance.getScore()`.

> [!NOTE]
> Assumes/requires that https://github.com/FunkinCrew/Funkin/pull/6914 is pulled.

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
https://github.com/FunkinCrew/Funkin/issues/4512, semi-revival of https://github.com/FunkinCrew/Funkin/pull/3832, alternative PR to https://github.com/FunkinCrew/Funkin/pull/7647
(This PR relies on # 7647, but that PR makes a new file, so it is simply included here for simplicity.)

<!-- Briefly describe the issue(s) fixed. -->
## Description
In PlayState.hx, songScore used to have a TODO comment saying "Move this to a class."
Not sure if that's still needed, but I did it anyway! (This is the same as in the other PR. Unless maintainers say otherwise, I'm not closing it yet because this may get rejected but the other one pulled. Maybe. Just maybe)

This comes with the benefit of being able to add additional behavior to scores like storing non-real, temporarily-displayed scores. This could be useful... such as in sustains!

The way this PR handles sustain scoring is the following:
- While held, hold notes add display points (non-real scores) to the overall score (allowing players to see a rough estimation of the current score)
- On release/finish, `NOTE_HOLD_DROP` is called and actual score calculations apply, based on `PreciseInputTiming`.

This PR also adds two new PlayState functions `goodNoteHoldHit()` and `goodNoteHoldRelease()` to mirror the existing `goodNoteHit()` function. These handle player inputs related to hold notes, and are skipped entirely when Botplay is active (it dispatches the events directly)

Actual development for this PR is at https://github.com/zxcksharks/Funkin/tree/accurate-sustains-preview, where # 6914 is also pulled. This branch is only for the PR.

### Current Bugs
Would appreciate testing on this! I don't really have the means to benchmark this.
- ~Missing a regular note with a sustain disproportionately damages your score.~ Fixed

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos
> [!NOTE]
> Recordings are taken with a Botplay script that perfects normal notes.
> Held notes logic are unaltered, but the script ensures consistent simulated inputs.

BEFORE (Accuracy is score-based here, so note how it inconsistently rises above 100%)

https://github.com/user-attachments/assets/da396706-de7f-4a44-9d85-47fc6f18124d


AFTER (Score is consistent throughout all attempts, accuracy always corrects after release)

https://github.com/user-attachments/assets/868f2bd0-303b-4fa6-8a5b-2bf599af329e

