### PR TITLE
[BUGFIX] Properly mute legacy song voices that use the opponent track

### DIFF
--- a/source/funkin/play/PlayState.hx
+++ b/source/funkin/play/PlayState.hx
@@ -3191,7 +3191,11 @@ class PlayState extends MusicBeatSubState
     if (playSound)
     {
       var tempVocals:Bool = currentStage != null && currentStage.getBoyfriend()?.tempVocals;
-      if (vocals != null && !tempVocals) vocals.playerVolume = 0;
+      if (vocals != null && !tempVocals)
+      {
+        if (vocals.legacyVoiceSystem && !vocals.legacyVoiceUsesPlayer) vocals.opponentVolume = 0;
+        vocals.playerVolume = 0;
+      }
       FunkinSound.playOnce(Paths.soundRandom('missnote', 1, 3), FlxG.random.float(0.5, 0.6));
     }
   }
@@ -3233,7 +3237,11 @@ class PlayState extends MusicBeatSubState
     if (event.playSound)
     {
       var tempVocals:Bool = currentStage != null && currentStage.getBoyfriend()?.tempVocals;
-      if (vocals != null && !tempVocals) vocals.playerVolume = 0;
+      if (vocals != null && !tempVocals)
+      {
+        if (vocals.legacyVoiceSystem && !vocals.legacyVoiceUsesPlayer) vocals.opponentVolume = 0;
+        vocals.playerVolume = 0;
+      }
       FunkinSound.playOnce(Paths.soundRandom('missnote', 1, 3), FlxG.random.float(0.1, 0.2));
     }
   }


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
None

<!-- Briefly describe the issue(s) fixed. -->
## Description
Previously, only dropped held notes had checks to properly mute the correct voice track. This PR adds the same check to all parts of the code where voices become muted.

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos
Before: 

https://github.com/user-attachments/assets/a050c356-b2cd-4e8c-84b9-fb51794c5574


After: 

https://github.com/user-attachments/assets/63d97e7d-8fb5-43db-a02a-d36bc2bf78df

