### PR TITLE
[Enhancement] Add Funkin' version as compilation flag

### DIFF
--- a/project.hxp
+++ b/project.hxp
@@ -1011,6 +1011,9 @@ class Project extends HXProject
    */
   function configureCompileDefines()
   {
+    // Add Funkin's version as a compilation flag so Polymod scripts can use it.
+    setHaxedef("funkin", VERSION);
+
     // Enable OpenFL's error handler. Required for the crash logger.
     setHaxedef("openfl-enable-handle-error");
 


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
This would not close https://github.com/FunkinCrew/Funkin/issues/7658, but is related.

<!-- Briefly describe the issue(s) fixed. -->
## Description
In the far future where backwards compatibility may become an important focus in Funkin', allowing modders to query the current version in pre-processing would allow modders to only create one set of scripts that adapt to multiple versions at once.
Even now, when developing PRs, if you're implementing breaking changes but have scripts that rely on said breaking changes, if those scripts constantly break while switching between release and compiled versions then this may be an easy fix to use.
This relates to my enhancement issue at #7658, but it does not implement mod-specific API version rules. (Seems more like a Polymod thing, and I'm not well-versed in that codebase)

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos
N/A