### PR TITLE
[FIX] Sort `null` elements by `zIndex` correctly

### DIFF
--- a/source/funkin/util/SortUtil.hx
+++ b/source/funkin/util/SortUtil.hx
@@ -36,7 +36,9 @@ class SortUtil
    */
   public static inline function byZIndex(order:Int, a:FlxBasic, b:FlxBasic):Int
   {
-    if (a == null || b == null) return 0;
+    if (a == null && b == null) return 0;
+    if (a == null) return order;
+    if (b == null) return -order;
     return FlxSort.byValues(order, a.zIndex, b.zIndex);
   }
 


### PR DESCRIPTION

## Linked Issues
Alternative - and better in the long term - fix for #6671
<!-- Briefly describe the issue(s) fixed. -->
## Description
The problem with the current sort method is that when either of the elements is `null`, they are kept intact. This might make sense, but it violates the **strict weak ordering** rule that the [sort function used in the C++ target under the hood adheres to.](https://github.com/HaxeFoundation/hxcpp/issues/1347#issuecomment-4646843949)
To fix this, we instead move `null` elements to either end of the array, depending of the specified order.

<details><summary>Test Code & Results</summary>
<p>
Let's consider this tiny snippet, that represents how elements could be in a `PlayState` game scene and how they are sorted on `refresh`.

```haxe
   var sortArr = [0, 0, 1000, null, 450, 100, 100];

    sortArr.sort((a, b) ->
    {
      var order:Int = flixel.util.FlxSort.ASCENDING;
      if (a == null || b == null) return 0;
      if (a < b)
      {
        return order;
      }
      else if (a > b)
      {
        return -order;
      }
      return 0;
    });

    trace(sortArr);
```
Running this will result in the array `[0,0,1000,null,100,100,450]`. Note that `1000` is not in the place it should be.
Modifying the checks to how the PR did it will result in an array that instead is `[null,0,0,100,100,450,1000]`, which better fits the expectancy.
</p>
</details> 

## Screenshots/Videos
N/A