### PR TITLE
[GITHUB] Bump some actions dependencies to use Node 24

### DIFF
--- a/.github/actions/setup-haxe/action.yml
+++ b/.github/actions/setup-haxe/action.yml
@@ -5,7 +5,7 @@ inputs:
   haxe:
     description: 'Version of haxe to install'
     required: true
-    default: '4.3.6'
+    default: '4.3.7'
   hxcpp-cache:
     description: 'Whether to use a shared hxcpp compile cache'
     required: true
@@ -71,7 +71,7 @@ runs:
 
   - name: Restore cached dependencies
     id: cache-hmm
-    uses: actions/cache@v4
+    uses: actions/cache@v5
     with:
       path: .haxelib
       key: haxe-hmm-${{ runner.os }}-${{ hashFiles('**/hmm.json') }}
@@ -98,7 +98,7 @@ runs:
   # by default use a shared hxcpp cache
   - if: ${{ inputs.hxcpp-cache == 'true' }}
     name: Restore hxcpp cache
-    uses: actions/cache@v4
+    uses: actions/cache@v5
     with:
       path: ${{ inputs.hxcpp-cache-path }}
       key: haxe-hxcpp-${{ runner.os }}-${{ github.ref_name }}-${{ github.sha }}
@@ -114,7 +114,7 @@ runs:
   # if it's explicitly disabled, still cache export/ since that then contains the builds
   - if: ${{ inputs.hxcpp-cache != 'true' }}
     name: Restore export cache
-    uses: actions/cache@v4
+    uses: actions/cache@v5
     with:
       path: ${{ inputs.hxcpp-cache-path }}
       key: haxe-export-${{ runner.os }}-${{ github.ref_name }}-${{ github.sha }}

--- a/.github/actions/upload-itch/action.yml
+++ b/.github/actions/upload-itch/action.yml
@@ -70,7 +70,7 @@ runs:
 
   - name: Try to get butler from cache
     id: cache-butler
-    uses: actions/cache@v4
+    uses: actions/cache@v5
     with:
       path: ${{ env.BUTLER_INSTALL_PATH }}
       key: butler-${{ runner.os }}-${{ env.BUTLER_LATEST }}

--- a/.github/workflows/build-game.yml
+++ b/.github/workflows/build-game.yml
@@ -24,7 +24,7 @@ jobs:
       trigger-build: ${{ steps.should-trigger.outputs.result }}
     steps:
       - name: Checkout repo
-        uses: funkincrew/ci-checkout@v7.3.3
+        uses: funkincrew/ci-checkout@v7.4
         with:
           submodules: false
       - uses: dorny/paths-filter@v3
@@ -59,7 +59,7 @@ jobs:
       list: ${{ steps.build-tags.outputs.list }}
     steps:
       - name: Gather build tags
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         id: build-tags
         with:
           script: |
@@ -96,7 +96,7 @@ jobs:
       packages: write
     steps:
       - name: Checkout repo
-        uses: funkincrew/ci-checkout@v7.3.3
+        uses: funkincrew/ci-checkout@v7.4
         with:
           submodules: false
       - name: Log into GitHub Container Registry
@@ -106,7 +106,7 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push Docker image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: ./build
           push: true
@@ -143,14 +143,14 @@ jobs:
         run: |
           git config --global --replace-all safe.directory $GITHUB_WORKSPACE
       - name: Get checkout token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v3
         id: app_token
         with:
           app-id: ${{ vars.APP_ID }}
           private-key: ${{ secrets.APP_PEM }}
           owner: ${{ github.repository_owner }}
       - name: Checkout repo
-        uses: funkincrew/ci-checkout@v7.3.3
+        uses: funkincrew/ci-checkout@v7.4
         with:
           submodules: 'recursive'
           token: ${{ steps.app_token.outputs.token }}
@@ -184,7 +184,7 @@ jobs:
         timeout-minutes: 120
       - name: Save build artifact to Github Actions
         if: ${{ github.event.inputs.save-artifact }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: build-${{ matrix.target }}
           path: export/release/${{matrix.target}}/bin/
@@ -219,7 +219,7 @@ jobs:
           private-key: ${{ secrets.APP_PEM }}
           owner: ${{ github.repository_owner }}
       - name: Checkout repo
-        uses: funkincrew/ci-checkout@v7.3.3
+        uses: funkincrew/ci-checkout@v7.4
         with:
           submodules: 'recursive'
           token: ${{ steps.app_token.outputs.token }}
@@ -233,7 +233,7 @@ jobs:
           echo "HAXEPATH=$(haxelib config)" >> "$GITHUB_ENV"
       - name: Restore cached dependencies
         id: cache-hmm
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: .haxelib
           key: haxe-hmm-${{ runner.os }}-${{ hashFiles('**/hmm.json') }}
@@ -246,7 +246,7 @@ jobs:
           cd .haxelib/hxcpp/git/tools/hxcpp && haxe compile.hxml
       - if: ${{ matrix.target != 'html5' }}
         name: Restore hxcpp cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: /usr/share/hxcpp
           key: haxe-hxcpp-${{ runner.os }}-${{ github.ref_name }}-${{ github.sha }}
@@ -262,7 +262,7 @@ jobs:
         timeout-minutes: 120
       - name: Save build artifact to Github Actions
         if: ${{ github.event.inputs.save-artifact }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: build-${{ matrix.target }}
           path: export/release/${{matrix.target}}/bin/

--- a/.github/workflows/cancel-merged-branches.yml
+++ b/.github/workflows/cancel-merged-branches.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
     - name: Cancel queued workflows for ${{ github.event.pull_request.head.ref }}
-      uses: actions/github-script@v7
+      uses: actions/github-script@v8
       with:
         result-encoding: string
         retries: 3

--- a/.github/workflows/label-actions.yml
+++ b/.github/workflows/label-actions.yml
@@ -27,4 +27,4 @@ jobs:
   action:
     runs-on: ubuntu-latest
     steps:
-      - uses: dessant/label-actions@v4
+      - uses: dessant/label-actions@v5

--- a/.github/workflows/label-pull-request.yml
+++ b/.github/workflows/label-pull-request.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Set basic labels
-      uses: actions/labeler@v5
+      uses: actions/labeler@v6
       with:
         sync-labels: true
   # Apply labels to pull requests based on how many lines were edited


### PR DESCRIPTION
Redo of https://github.com/FunkinCrew/Funkin/pull/7645, but in `main` branch this time as what @EliteMasterEric told me to do.

New description:
Since node.js 20 is deprecated, I had to bump some actions dependencies to fix the deprecation warnings to use node.js 24.
https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

Also when this pr https://github.com/FunkinCrew/ci-haxe/pull/1 will ever be merged, I'll update `funkincrew/ci-haxe` too.