### PR TITLE
[ENHANCEMENT] Bring back strumline end splash on Bot Play / Opponent

### DIFF
--- a/source/funkin/FunkinMemory.hx
+++ b/source/funkin/FunkinMemory.hx
@@ -309,9 +309,16 @@ class FunkinMemory
     cacheTexture(Paths.image(style.buildJudgementSpritePath('bad') ?? 'bad'));
     cacheTexture(Paths.image(style.buildJudgementSpritePath('shit') ?? 'shit'));
 
-    for(i in 0...10) {
-      cacheTexture(Paths.image(style.buildComboNumSpritePath(i) ?? '$i'));
-    }
+    cacheTexture(Paths.image(style.buildComboNumSpritePath(0) ?? '0'));
+    cacheTexture(Paths.image(style.buildComboNumSpritePath(1) ?? '1'));
+    cacheTexture(Paths.image(style.buildComboNumSpritePath(2) ?? '2'));
+    cacheTexture(Paths.image(style.buildComboNumSpritePath(3) ?? '3'));
+    cacheTexture(Paths.image(style.buildComboNumSpritePath(4) ?? '4'));
+    cacheTexture(Paths.image(style.buildComboNumSpritePath(5) ?? '5'));
+    cacheTexture(Paths.image(style.buildComboNumSpritePath(6) ?? '6'));
+    cacheTexture(Paths.image(style.buildComboNumSpritePath(7) ?? '7'));
+    cacheTexture(Paths.image(style.buildComboNumSpritePath(8) ?? '8'));
+    cacheTexture(Paths.image(style.buildComboNumSpritePath(9) ?? '9'));
   }
 
   ///// SOUND //////

--- a/source/funkin/FunkinMemory.hx
+++ b/source/funkin/FunkinMemory.hx
@@ -309,16 +309,9 @@ class FunkinMemory
     cacheTexture(Paths.image(style.buildJudgementSpritePath('bad') ?? 'bad'));
     cacheTexture(Paths.image(style.buildJudgementSpritePath('shit') ?? 'shit'));
 
-    cacheTexture(Paths.image(style.buildComboNumSpritePath(0) ?? '0'));
-    cacheTexture(Paths.image(style.buildComboNumSpritePath(1) ?? '1'));
-    cacheTexture(Paths.image(style.buildComboNumSpritePath(2) ?? '2'));
-    cacheTexture(Paths.image(style.buildComboNumSpritePath(3) ?? '3'));
-    cacheTexture(Paths.image(style.buildComboNumSpritePath(4) ?? '4'));
-    cacheTexture(Paths.image(style.buildComboNumSpritePath(5) ?? '5'));
-    cacheTexture(Paths.image(style.buildComboNumSpritePath(6) ?? '6'));
-    cacheTexture(Paths.image(style.buildComboNumSpritePath(7) ?? '7'));
-    cacheTexture(Paths.image(style.buildComboNumSpritePath(8) ?? '8'));
-    cacheTexture(Paths.image(style.buildComboNumSpritePath(9) ?? '9'));
+    for(i in 0...10) {
+      cacheTexture(Paths.image(style.buildComboNumSpritePath(i) ?? '$i'));
+    }
   }
 
   ///// SOUND //////

--- a/source/funkin/play/notes/Strumline.hx
+++ b/source/funkin/play/notes/Strumline.hx
@@ -668,7 +668,7 @@ class Strumline extends FlxSpriteGroup
           playStatic(holdNote.noteDirection);
         }
 
-        if (holdNote.cover != null && isPlayer)
+        if (holdNote.cover != null)
         {
           holdNote.cover.playEnd();
         }
@@ -1075,7 +1075,7 @@ class Strumline extends FlxSpriteGroup
    */
   public function playNoteSplash(direction:NoteDirection):Void
   {
-    if (!showNotesplash || !isPlayer) return;
+    if (!showNotesplash) return;
     if (!noteStyle.isNoteSplashEnabled()) return;
 
     var splash:NoteSplash = this.constructNoteSplash();
@@ -1103,7 +1103,7 @@ class Strumline extends FlxSpriteGroup
    */
   public function playNoteHoldCover(holdNote:SustainTrail):Void
   {
-    if (!showNotesplash || !isPlayer) return;
+    if (!showNotesplash) return;
     if (!noteStyle.isHoldNoteCoverEnabled()) return;
 
     var cover:NoteHoldCover = this.constructNoteHoldCover();

--- a/source/funkin/play/notes/Strumline.hx
+++ b/source/funkin/play/notes/Strumline.hx
@@ -1075,7 +1075,7 @@ class Strumline extends FlxSpriteGroup
    */
   public function playNoteSplash(direction:NoteDirection):Void
   {
-    if (!showNotesplash) return;
+    if (!showNotesplash || !isPlayer) return;
     if (!noteStyle.isNoteSplashEnabled()) return;
 
     var splash:NoteSplash = this.constructNoteSplash();
@@ -1103,7 +1103,7 @@ class Strumline extends FlxSpriteGroup
    */
   public function playNoteHoldCover(holdNote:SustainTrail):Void
   {
-    if (!showNotesplash) return;
+    if (!showNotesplash || !isPlayer) return;
     if (!noteStyle.isHoldNoteCoverEnabled()) return;
 
     var cover:NoteHoldCover = this.constructNoteHoldCover();


### PR DESCRIPTION
## Description
Redo of #6832 since I somehow managed to create merge conflicts :exploding_head: 

I noticed something that I thought would be nice to be enhanced, disabling the opponent's strumline (and, your strumline during Bot Play's) hold note splash. I just had a pet peeve with since it doesn't play the final splash after the hold notes are finished and it looks a little weird without that final splash.

## Screenshots/Videos
### Opponent strumline not showing hold note splash

https://github.com/user-attachments/assets/f7476b4e-56ab-427d-b01b-70b2a8375da7

### Bot Play strumline not showing hold splash

https://github.com/user-attachments/assets/949f82f4-9663-4039-bfbc-3cc8700fa461

## Sidenote
There's also an absolutely tiny change in the FunkinMemory that I just thought looked nicer. It just changes how the combo numbers are loaded to a for loop rather than doing 1, 2, 3, etc etc manually.
Also sorry about my horrid commit from a few years back, I was 14 and barely knew anything about coding, let alone the idea of animated sprites lol