### PR TITLE
chore: fix typos in class and field names

### DIFF
--- a/source/funkin/audio/visualize/PolygonSpectrogram.hx
+++ b/source/funkin/audio/visualize/PolygonSpectrogram.hx
@@ -8,14 +8,14 @@ import funkin.audio.visualize.VisShit.CurAudioInfo;
 import funkin.graphics.rendering.MeshRender;
 import lime.utils.Int16Array;
 
-class PolygonSpectogram extends MeshRender
+class PolygonSpectrogram extends MeshRender
 {
   var sampleRate:Int;
 
   public var vis:VisShit;
   public var visType:VISTYPE = UPDATED;
   public var daHeight:Float = FlxG.height;
-  public var realtimeVisLenght:Float = 0.2;
+  public var realtimeVisLength:Float = 0.2;
   public var realtimeStartOffset:Float = 0;
 
   var numSamples:Int = 0;
@@ -130,7 +130,7 @@ class PolygonSpectogram extends MeshRender
 
         curTime = vis.snd.time;
 
-        if (vis.snd.time < vis.snd.length - realtimeVisLenght) generateSection(vis.snd.time + realtimeStartOffset, realtimeVisLenght);
+        if (vis.snd.time < vis.snd.length - realtimeVisLength) generateSection(vis.snd.time + realtimeStartOffset, realtimeVisLength);
       }
     }
   }

--- a/source/funkin/audio/visualize/PolygonVisGroup.hx
+++ b/source/funkin/audio/visualize/PolygonVisGroup.hx
@@ -4,17 +4,17 @@ import flixel.group.FlxGroup.FlxTypedGroup;
 import flixel.sound.FlxSound;
 
 @:nullSafety
-class PolygonVisGroup extends FlxTypedGroup<PolygonSpectogram>
+class PolygonVisGroup extends FlxTypedGroup<PolygonSpectrogram>
 {
-  public var playerVis:Null<PolygonSpectogram>;
-  public var opponentVis:Null<PolygonSpectogram>;
-  public var instVis:Null<PolygonSpectogram>;
+  public var playerVis:Null<PolygonSpectrogram>;
+  public var opponentVis:Null<PolygonSpectrogram>;
+  public var instVis:Null<PolygonSpectrogram>;
 
   public function new()
   {
     super();
-    playerVis = new PolygonSpectogram();
-    opponentVis = new PolygonSpectogram();
+    playerVis = new PolygonSpectrogram();
+    opponentVis = new PolygonSpectrogram();
   }
 
   /**
@@ -23,7 +23,7 @@ class PolygonVisGroup extends FlxTypedGroup<PolygonSpectogram>
    */
   public function addPlayerVis(visSnd:FlxSound):Void
   {
-    var vis:PolygonSpectogram = new PolygonSpectogram(visSnd);
+    var vis:PolygonSpectrogram = new PolygonSpectrogram(visSnd);
     super.add(vis);
     playerVis = vis;
   }
@@ -34,7 +34,7 @@ class PolygonVisGroup extends FlxTypedGroup<PolygonSpectogram>
    */
   public function addOpponentVis(visSnd:FlxSound):Void
   {
-    var vis:PolygonSpectogram = new PolygonSpectogram(visSnd);
+    var vis:PolygonSpectrogram = new PolygonSpectrogram(visSnd);
     super.add(vis);
     opponentVis = vis;
   }
@@ -45,7 +45,7 @@ class PolygonVisGroup extends FlxTypedGroup<PolygonSpectogram>
    */
   public function addInstVis(visSnd:FlxSound):Void
   {
-    var vis:PolygonSpectogram = new PolygonSpectogram(visSnd);
+    var vis:PolygonSpectrogram = new PolygonSpectrogram(visSnd);
     super.add(vis);
     instVis = vis;
   }
@@ -92,9 +92,9 @@ class PolygonVisGroup extends FlxTypedGroup<PolygonSpectogram>
    * @param vis The visualizer to add.
    * @return The added visualizer.
    */
-  override public function add(vis:PolygonSpectogram):PolygonSpectogram
+  override public function add(vis:PolygonSpectrogram):PolygonSpectrogram
   {
-    var result:PolygonSpectogram = super.add(vis);
+    var result:PolygonSpectrogram = super.add(vis);
     return result;
   }
 

--- a/source/funkin/audio/visualize/SpectogramSprite.hx
+++ b/source/funkin/audio/visualize/SpectogramSprite.hx
@@ -6,7 +6,7 @@ import flixel.math.FlxMath;
 import flixel.math.FlxPoint;
 import flixel.sound.FlxSound;
 import flixel.util.FlxColor;
-import funkin.audio.visualize.PolygonSpectogram.VISTYPE;
+import funkin.audio.visualize.PolygonSpectrogram.VISTYPE;
 import funkin.audio.visualize.VisShit.CurAudioInfo;
 import lime.utils.Int16Array;
 

--- a/source/funkin/mobile/ui/FunkinHitbox.hx
+++ b/source/funkin/mobile/ui/FunkinHitbox.hx
@@ -284,7 +284,7 @@ class FunkinHitbox extends FlxTypedSpriteGroup<FunkinHint>
   /**
    * Creates a new `FunkinHitbox` object.
    */
-  public function new(?schemeOverride:String, ?showGradint:Bool = true, ?directionsOverride:Array<NoteDirection>, ?colorsOverride:Array<FlxColor>):Void
+  public function new(?schemeOverride:String, ?showGradient:Bool = true, ?directionsOverride:Array<NoteDirection>, ?colorsOverride:Array<FlxColor>):Void
   {
     super();
 
@@ -303,7 +303,7 @@ class FunkinHitbox extends FlxTypedSpriteGroup<FunkinHint>
         for (i in 0...hintsNoteDirections.length)
         {
           add(createHintLane(i * hintWidth, 0, hintsNoteDirections[i % hintsNoteDirections.length], hintWidth, hintHeight,
-            hintsColors[i % hintsColors.length], true, showGradint));
+            hintsColors[i % hintsColors.length], true, showGradient));
         }
       case FunkinHitboxControlSchemes.DoubleThumbTriangle:
         final screenHalf:Int = Math.floor(FlxG.width / 2);
@@ -312,12 +312,12 @@ class FunkinHitbox extends FlxTypedSpriteGroup<FunkinHint>
         {
           final xOffset:Int = (i == 1) ? screenHalf : 0;
 
-          add(createHintTriangle(xOffset, 0, hintsNoteDirections[0], Math.floor(FlxG.width / 4), FlxG.height, hintsColors[0], showGradint));
+          add(createHintTriangle(xOffset, 0, hintsNoteDirections[0], Math.floor(FlxG.width / 4), FlxG.height, hintsColors[0], showGradient));
           add(createHintTriangle(xOffset, FlxG.height / 2, hintsNoteDirections[1], Math.floor(FlxG.width / 2), Math.floor(FlxG.height / 2), hintsColors[1],
-            showGradint));
-          add(createHintTriangle(xOffset, 0, hintsNoteDirections[2], Math.floor(FlxG.width / 2), Math.floor(FlxG.height / 2), hintsColors[2], showGradint));
+            showGradient));
+          add(createHintTriangle(xOffset, 0, hintsNoteDirections[2], Math.floor(FlxG.width / 2), Math.floor(FlxG.height / 2), hintsColors[2], showGradient));
           add(createHintTriangle(xOffset + Math.floor(FlxG.width / 4), 0, hintsNoteDirections[3], Math.floor(FlxG.width / 4), FlxG.height, hintsColors[3],
-            showGradint));
+            showGradient));
         }
       case FunkinHitboxControlSchemes.DoubleThumbSquare:
         final screenHalf:Int = Math.floor(FlxG.width / 2);
@@ -337,12 +337,12 @@ class FunkinHitbox extends FlxTypedSpriteGroup<FunkinHint>
             if (j == 1 || j == 2)
             {
               add(createHintLane(xOffset + hintWidth, (j == 1) ? boxHeight : 0, hintsNoteDirections[j], boxWidth, boxHeight,
-                hintsColors[j % hintsColors.length], false, showGradint));
+                hintsColors[j % hintsColors.length], false, showGradient));
             }
             else
             {
               add(createHintLane(xOffset + (j == 0 ? 0 : hintWidth + boxWidth), 0, hintsNoteDirections[j], hintWidth, hintHeight,
-                hintsColors[j % hintsColors.length], false, showGradint));
+                hintsColors[j % hintsColors.length], false, showGradient));
             }
           }
         }

--- a/source/funkin/play/ResultState.hx
+++ b/source/funkin/play/ResultState.hx
@@ -204,9 +204,9 @@ class ResultState extends MusicBeatSubState
 
     trace('Got playable character: ${playerCharacter?.getName()}');
     // Query JSON data based on the rank, then use that to build the animation(s) the player sees.
-    var playerAnimationDatas:Array<PlayerResultsAnimationData> = playerCharacter != null ? playerCharacter.getResultsAnimationDatas(rank) : [];
+    var playerAnimationData:Array<PlayerResultsAnimationData> = playerCharacter != null ? playerCharacter.getResultsAnimationData(rank) : [];
 
-    for (animData in playerAnimationDatas)
+    for (animData in playerAnimationData)
     {
       if (animData == null) continue;
 

--- a/source/funkin/play/components/ClearPercentCounter.hx
+++ b/source/funkin/play/components/ClearPercentCounter.hx
@@ -60,25 +60,25 @@ class ClearPercentCounter extends FlxTypedSpriteGroup<FlxSprite>
 
   function drawNumbers():Void
   {
-    var seperatedScore:Array<Int> = [];
+    var separatedScore:Array<Int> = [];
     var tempCombo:Int = Math.round(curNumber);
 
     while (tempCombo > 0 && tempCombo != 0)
     {
-      seperatedScore.push(tempCombo % 10);
+      separatedScore.push(tempCombo % 10);
       tempCombo = Math.floor(tempCombo / 10);
     }
 
-    if (seperatedScore.length == 0) seperatedScore.push(0);
+    if (separatedScore.length == 0) separatedScore.push(0);
 
-    seperatedScore.reverse();
+    separatedScore.reverse();
 
-    for (ind => num in seperatedScore)
+    for (ind => num in separatedScore)
     {
       var digitIndex:Int = ind + 1;
       // If there's only one digit, move it to the right
       // If there's three digits, move them all to the left
-      var digitOffset = (seperatedScore.length == 1) ? 1 : (seperatedScore.length == 3) ? -1 : 0;
+      var digitOffset = (separatedScore.length == 1) ? 1 : (separatedScore.length == 3) ? -1 : 0;
       var digitSize = small ? 32 : 72;
       var digitHeightOffset = small ? -4 : 0;
 
@@ -90,7 +90,7 @@ class ClearPercentCounter extends FlxTypedSpriteGroup<FlxSprite>
       if (digitIndex >= members.length)
       {
         // Three digits = LLR because the 1 and 0 won't be the same anyway.
-        var variant:Bool = (seperatedScore.length == 3) ? (digitIndex >= 2) : (digitIndex >= 1);
+        var variant:Bool = (separatedScore.length == 3) ? (digitIndex >= 2) : (digitIndex >= 1);
         // var variant:Bool = (seperatedScore.length % 2 != 0) ? (digitIndex % 2 == 0) : (digitIndex % 2 == 1);
         var numb:ClearPercentNumber = new ClearPercentNumber(xPos, yPos, num, variant, this.small);
         numb.scale.set(this.scale.x, this.scale.y);
@@ -107,7 +107,7 @@ class ClearPercentCounter extends FlxTypedSpriteGroup<FlxSprite>
         members[digitIndex].visible = true;
       }
     }
-    for (ind in (seperatedScore.length + 1)...(members.length))
+    for (ind in (separatedScore.length + 1)...(members.length))
     {
       members[ind].visible = false;
     }

--- a/source/funkin/play/components/PopUpStuff.hx
+++ b/source/funkin/play/components/PopUpStuff.hx
@@ -71,21 +71,21 @@ class PopUpStuff extends FlxTypedGroup<FunkinSprite>
 
   public function displayCombo(combo:Int = 0):Void
   {
-    var seperatedScore:Array<Int> = [];
+    var separatedScore:Array<Int> = [];
     var tempCombo:Int = combo;
 
     while (tempCombo != 0)
     {
-      seperatedScore.push(tempCombo % 10);
+      separatedScore.push(tempCombo % 10);
       tempCombo = Std.int(tempCombo / 10);
     }
-    while (seperatedScore.length < 3)
-      seperatedScore.push(0);
+    while (separatedScore.length < 3)
+      separatedScore.push(0);
 
     // seperatedScore.reverse();
 
     var daLoop:Int = 1;
-    for (digit in seperatedScore)
+    for (digit in separatedScore)
     {
       var numScore:Null<FunkinSprite> = noteStyle.buildComboNumSprite(digit);
       if (numScore == null) continue;

--- a/source/funkin/play/components/TallyCounter.hx
+++ b/source/funkin/play/components/TallyCounter.hx
@@ -38,22 +38,22 @@ class TallyCounter extends FlxTypedSpriteGroup<FlxSprite>
 
   function drawNumbers()
   {
-    var seperatedScore:Array<Int> = [];
+    var separatedScore:Array<Int> = [];
     var tempCombo:Int = Math.round(curNumber);
 
     var fullNumberDigits:Int = Std.int(Math.max(1, Math.ceil(MathUtil.logBase(10, neededNumber))));
 
     while (tempCombo != 0)
     {
-      seperatedScore.push(tempCombo % 10);
+      separatedScore.push(tempCombo % 10);
       tempCombo = Math.floor(tempCombo / 10);
     }
 
-    if (seperatedScore.length == 0) seperatedScore.push(0);
+    if (separatedScore.length == 0) separatedScore.push(0);
 
-    seperatedScore.reverse();
+    separatedScore.reverse();
 
-    for (ind => num in seperatedScore)
+    for (ind => num in separatedScore)
     {
       if (ind >= members.length)
       {

--- a/source/funkin/play/notes/notekind/NoteKindManager.hx
+++ b/source/funkin/play/notes/notekind/NoteKindManager.hx
@@ -159,15 +159,15 @@ class NoteKindManager
   /**
    * Get a list of all the note styles used by the given notes.
    * Great for preloading.
-   * @param songNoteDatas The notes to query for note styles.
+   * @param songNoteData The notes to query for note styles.
    * @return The note styles to load.
    */
-  public static function listNoteStylesByNoteData(songNoteDatas:Array<SongNoteData>):Array<NoteStyle>
+  public static function listNoteStylesByNoteData(songNoteData:Array<SongNoteData>):Array<NoteStyle>
   {
     var results:Array<NoteStyle> = [];
-    for (songNoteData in songNoteDatas)
+    for (noteData in songNoteData)
     {
-      var noteStyle:NoteStyle = getNoteStyle(songNoteData.kind, null);
+      var noteStyle:NoteStyle = getNoteStyle(noteData.kind, null);
       if (noteStyle != null && !results.contains(noteStyle))
       {
         results.push(noteStyle);

--- a/source/funkin/ui/debug/charting/ChartEditorState.hx
+++ b/source/funkin/ui/debug/charting/ChartEditorState.hx
@@ -21,7 +21,7 @@ import flixel.util.FlxSort;
 import flixel.util.FlxStringUtil;
 import flixel.util.FlxTimer;
 import funkin.audio.FunkinSound;
-import funkin.audio.visualize.PolygonSpectogram;
+import funkin.audio.visualize.PolygonSpectrogram;
 import funkin.audio.VoicesGroup;
 import funkin.audio.waveform.WaveformSprite;
 import funkin.data.notestyle.NoteStyleRegistry;
@@ -3863,8 +3863,8 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
     {
       var currentMeasureTime:Float = Conductor.instance.getMeasureTimeInMs(Conductor.instance.currentMeasure);
       var currentStepTime:Float = Conductor.instance.getStepTimeInMs(Conductor.instance.currentStep);
-      final msTreshold:Float = 10.0;
-      playMetronomeTick(currentMeasureTime >= currentStepTime - msTreshold && currentMeasureTime <= currentStepTime + msTreshold);
+      final msThreshold:Float = 10.0;
+      playMetronomeTick(currentMeasureTime >= currentStepTime - msThreshold && currentMeasureTime <= currentStepTime + msThreshold);
     }
 
     // Show the mouse cursor.

--- a/source/funkin/ui/debug/charting/handlers/ChartEditorImportExportHandler.hx
+++ b/source/funkin/ui/debug/charting/handlers/ChartEditorImportExportHandler.hx
@@ -269,8 +269,8 @@ class ChartEditorImportExportHandler
     var baseMetadata:SongMetadata = SongRegistry.instance.parseEntryMetadataRawWithMigration(baseMetadataString, baseMetadataPath,
       baseMetadataVersion) ?? throw 'Could not read metadata (default).';
 
-    var songMetadatas:Map<String, SongMetadata> = [];
-    songMetadatas.set(Constants.DEFAULT_VARIATION, baseMetadata);
+    var songMetadata:Map<String, SongMetadata> = [];
+    songMetadata.set(Constants.DEFAULT_VARIATION, baseMetadata);
 
     var baseChartDataPath:String = manifest.getChartDataFileName();
     var baseChartDataString:String = mappedFileEntries.get(baseChartDataPath)?.data?.toString() ?? throw 'Could not locate chart data (default).';
@@ -278,8 +278,8 @@ class ChartEditorImportExportHandler
     var baseChartData:SongChartData = SongRegistry.instance.parseEntryChartDataRawWithMigration(baseChartDataString, baseChartDataPath,
       baseChartDataVersion) ?? throw 'Could not read chart data (default).';
 
-    var songChartDatas:Map<String, SongChartData> = [];
-    songChartDatas.set(Constants.DEFAULT_VARIATION, baseChartData);
+    var songChartData:Map<String, SongChartData> = [];
+    songChartData.set(Constants.DEFAULT_VARIATION, baseChartData);
 
     var variationList:Array<String> = baseMetadata.playData.songVariations;
 
@@ -291,16 +291,16 @@ class ChartEditorImportExportHandler
       var variMetadata:SongMetadata = SongRegistry.instance.parseEntryMetadataRawWithMigration(variMetadataString, variMetadataPath, variMetadataVersion,
         variation) ?? throw 'Could not read metadata ($variation).';
 
-      songMetadatas.set(variation, variMetadata);
+      songMetadata.set(variation, variMetadata);
 
       var variChartDataPath:String = manifest.getChartDataFileName(variation);
       var variChartDataString:String = mappedFileEntries.get(variChartDataPath)?.data?.toString() ?? throw 'Could not locate chart data ($variation).';
       var variChartDataVersion:SemverVersion = VersionUtil.getVersionFromJSON(variChartDataString) ?? throw 'Could not read chart data version ($variation).';
       var variChartData:SongChartData = SongRegistry.instance.parseEntryChartDataRawWithMigration(variChartDataString, variChartDataPath,
         variChartDataVersion, variation) ?? throw 'Could not read chart data ($variation).';
-      songChartDatas.set(variation, variChartData);
+      songChartData.set(variation, variChartData);
     }
-    loadSong(state, songMetadatas, songChartDatas, manifest);
+    loadSong(state, songMetadata, songChartData, manifest);
 
     state.sortChartData();
 
@@ -310,7 +310,7 @@ class ChartEditorImportExportHandler
     // Load instrumentals
     for (variation in state.availableVariations)
     {
-      var variMetadata:Null<SongMetadata> = songMetadatas.get(variation);
+      var variMetadata:Null<SongMetadata> = songMetadata.get(variation);
       if (variMetadata == null) continue;
 
       var instId:String = variMetadata?.playData?.characters?.instrumental ?? '';
@@ -355,8 +355,8 @@ class ChartEditorImportExportHandler
     }
 
     // Apply chart data.
-    trace(songMetadatas);
-    trace(songChartDatas);
+    trace(songMetadata);
+    trace(songChartData);
 
     state.switchToCurrentInstrumental();
     state.postLoadInstrumental();

--- a/source/funkin/ui/freeplay/LetterSort.hx
+++ b/source/funkin/ui/freeplay/LetterSort.hx
@@ -29,7 +29,7 @@ class LetterSort extends FlxSpriteGroup
 
   var leftArrow:FlxSprite;
   var rightArrow:FlxSprite;
-  var grpSeperators:FlxSpriteGroup;
+  var grpSeparators:FlxSpriteGroup;
 
   public var instance(default, set):FreeplayState;
 
@@ -39,8 +39,8 @@ class LetterSort extends FlxSpriteGroup
   {
     super(x, y);
 
-    grpSeperators = new FlxSpriteGroup();
-    add(grpSeperators);
+    grpSeparators = new FlxSpriteGroup();
+    add(grpSeparators);
 
     leftArrow = new FlxSprite(-20, 15).loadGraphic(Paths.image('freeplay/miniArrow'));
     // leftArrow.animation.play("arrow");
@@ -78,7 +78,7 @@ class LetterSort extends FlxSpriteGroup
       var sep:FlxSprite = new FlxSprite((i * 80) + 60, 20).loadGraphic(Paths.image('freeplay/seperator'));
       // sep.animation.play("seperator");
       sep.color = letter.color.getDarkened(darkness);
-      grpSeperators.add(sep);
+      grpSeparators.add(sep);
     }
 
     var letterHitbox:FlxObject = new FlxObject(0, 0, 1, 1);
@@ -182,7 +182,7 @@ class LetterSort extends FlxSpriteGroup
     // if we're moving left, we want to move the positions the same amount, but negative direciton
     var multiPosOrNeg:Float = diff > 0 ? 1 : -1;
 
-    for (sep in grpSeperators.members)
+    for (sep in grpSeparators.members)
     {
       ezTimer(0, sep, positions[0] * multiPosOrNeg);
       ezTimer(1, sep, positions[1] * multiPosOrNeg);

--- a/source/funkin/ui/freeplay/charselect/PlayableCharacter.hx
+++ b/source/funkin/ui/freeplay/charselect/PlayableCharacter.hx
@@ -99,7 +99,7 @@ class PlayableCharacter implements IRegistryEntry<PlayerData>
    * @param rank Which rank to get info for
    * @return An array of animations. For example, BF Great has two animations, one for BF and one for GF
    */
-  public function getResultsAnimationDatas(rank:ScoringRank):Array<PlayerResultsAnimationData>
+  public function getResultsAnimationData(rank:ScoringRank):Array<PlayerResultsAnimationData>
   {
     if (_data == null || _data.results == null)
     {

--- a/source/funkin/util/file/FNFCUtil.hx
+++ b/source/funkin/util/file/FNFCUtil.hx
@@ -157,8 +157,8 @@ class FNFCUtil
     var baseMetadata:SongMetadata = SongRegistry.instance.parseEntryMetadataRawWithMigration(baseMetadataString, baseMetadataPath,
       baseMetadataVersion) ?? throw 'Could not read metadata (default).';
 
-    var songMetadatas:Map<String, SongMetadata> = [];
-    songMetadatas.set(Constants.DEFAULT_VARIATION, baseMetadata);
+    var songMetadata:Map<String, SongMetadata> = [];
+    songMetadata.set(Constants.DEFAULT_VARIATION, baseMetadata);
 
     // id-chart.json
 
@@ -168,8 +168,8 @@ class FNFCUtil
     var baseChartData:SongChartData = SongRegistry.instance.parseEntryChartDataRawWithMigration(baseChartDataString, baseChartDataPath,
       baseChartDataVersion) ?? throw 'Could not read chart data (default).';
 
-    var songChartDatas:Map<String, SongChartData> = [];
-    songChartDatas.set(Constants.DEFAULT_VARIATION, baseChartData);
+    var songChartData:Map<String, SongChartData> = [];
+    songChartData.set(Constants.DEFAULT_VARIATION, baseChartData);
 
     // Variation metadata and chart data
 
@@ -183,7 +183,7 @@ class FNFCUtil
       var variMetadata:SongMetadata = SongRegistry.instance.parseEntryMetadataRawWithMigration(variMetadataString, variMetadataPath, variMetadataVersion,
         variation) ?? throw 'Could not read metadata ($variation).';
 
-      songMetadatas.set(variation, variMetadata);
+      songMetadata.set(variation, variMetadata);
 
       var variChartDataPath:String = manifest.getChartDataFileName(variation);
       var variChartDataString:String = mappedFileEntries.get(variChartDataPath)?.data?.toString() ?? throw 'Could not locate chart data ($variation).';
@@ -191,11 +191,11 @@ class FNFCUtil
       var variChartData:SongChartData = SongRegistry.instance.parseEntryChartDataRawWithMigration(variChartDataString, variChartDataPath,
         variChartDataVersion) ?? throw 'Could not read chart data ($variation).';
 
-      songChartDatas.set(variation, variChartData);
+      songChartData.set(variation, variChartData);
     }
 
     // Combine into a Song object that can be played in PlayState.
-    var song = Song.buildRaw(songId, songMetadatas.values(), Constants.DEFAULT_VARIATION, songChartDatas, false, false);
+    var song = Song.buildRaw(songId, songMetadata.values(), Constants.DEFAULT_VARIATION, songChartData, false, false);
 
     return song;
   }

--- a/source/funkin/util/tools/StringTools.hx
+++ b/source/funkin/util/tools/StringTools.hx
@@ -94,7 +94,7 @@ class StringTools
   /**
    * The regular expression to sanitize strings.
    */
-  static final SANTIZE_REGEX:EReg = ~/[^-a-zA-Z0-9]/g;
+  static final SANITIZE_REGEX:EReg = ~/[^-a-zA-Z0-9]/g;
 
   /**
    * Remove all instances of symbols other than alpha-numeric characters (and dashes)from a string.
@@ -103,7 +103,7 @@ class StringTools
    */
   public static function sanitize(value:String):String
   {
-    return SANTIZE_REGEX.replace(value, '');
+    return SANITIZE_REGEX.replace(value, '');
   }
 
   /**


### PR DESCRIPTION
## Description

Just fixes some typos in class/field names.

Changes:
`PolygonSpectogram` -> `PolygonSpectrogram`
`realtimeVisLenght` -> `realtimeVisLength`
`showGradint` -> `showGradient`
`*Datas` -> `*Data` (Data is the plural form)
`*Metadatas` -> `*Metadata`
`seperated` -> `separated`
`SANTIZE_REGEX` -> `SANITIZE_REGEX`
`msTreshold` -> `msThreshold`