### PR TITLE
[`polymod/final-access`] Make `scriptInit` calls null-safe

### DIFF
--- a/source/funkin/data/character/CharacterData.hx
+++ b/source/funkin/data/character/CharacterData.hx
@@ -93,7 +93,8 @@ class CharacterDataParser
       {
         try
         {
-          var character:SparrowCharacter = ScriptedSparrowCharacter.scriptInit(charCls, DEFAULT_CHAR_ID);
+          var character:Null<SparrowCharacter> = ScriptedSparrowCharacter.scriptInit(charCls, DEFAULT_CHAR_ID);
+          if (character == null) throw 'Error in the new() function';
           log('Loaded character ${character.characterName} (scripted: $charCls)');
           characterScriptedClass.set(character.characterId, charCls);
         }
@@ -113,7 +114,8 @@ class CharacterDataParser
       {
         try
         {
-          var character:PackerCharacter = ScriptedPackerCharacter.scriptInit(charCls, DEFAULT_CHAR_ID);
+          var character:Null<PackerCharacter> = ScriptedPackerCharacter.scriptInit(charCls, DEFAULT_CHAR_ID);
+          if (character == null) throw 'Error in the new() function';
           log('Loaded character ${character.characterName} (scripted: $charCls)');
           characterScriptedClass.set(character.characterId, charCls);
         }
@@ -133,7 +135,8 @@ class CharacterDataParser
       {
         try
         {
-          var character:MultiSparrowCharacter = ScriptedMultiSparrowCharacter.scriptInit(charCls, DEFAULT_CHAR_ID);
+          var character:Null<MultiSparrowCharacter> = ScriptedMultiSparrowCharacter.scriptInit(charCls, DEFAULT_CHAR_ID);
+          if (character == null) throw 'Error in the new() function';
           log('Loaded character ${character.characterName} (scripted: $charCls)');
           characterScriptedClass.set(character.characterId, charCls);
         }
@@ -153,7 +156,8 @@ class CharacterDataParser
       {
         try
         {
-          var character:AnimateAtlasCharacter = ScriptedAnimateAtlasCharacter.scriptInit(charCls, DEFAULT_CHAR_ID);
+          var character:Null<AnimateAtlasCharacter> = ScriptedAnimateAtlasCharacter.scriptInit(charCls, DEFAULT_CHAR_ID);
+          if (character == null) throw 'Error in the new() function';
           log('Loaded character ${character.characterName} (scripted: $charCls)');
           characterScriptedClass.set(character.characterId, charCls);
         }
@@ -173,7 +177,8 @@ class CharacterDataParser
       {
         try
         {
-          var character:MultiAnimateAtlasCharacter = ScriptedMultiAnimateAtlasCharacter.scriptInit(charCls, DEFAULT_CHAR_ID);
+          var character:Null<MultiAnimateAtlasCharacter> = ScriptedMultiAnimateAtlasCharacter.scriptInit(charCls, DEFAULT_CHAR_ID);
+          if (character == null) throw 'Error in the new() function';
           log('Loaded character ${character.characterName} (scripted: $charCls)');
           characterScriptedClass.set(character.characterId, charCls);
         }
@@ -190,11 +195,13 @@ class CharacterDataParser
     var scriptedCharClassNames:Array<String> = ScriptedBaseCharacter.listScriptClasses();
     scriptedCharClassNames = scriptedCharClassNames.filter(function(charCls:String):Bool
     {
-      return !(scriptedCharClassNames1.contains(charCls)
+      return !(
+        scriptedCharClassNames1.contains(charCls)
         || scriptedCharClassNames2.contains(charCls)
         || scriptedCharClassNames3.contains(charCls)
         || scriptedCharClassNames4.contains(charCls)
-        || scriptedCharClassNames5.contains(charCls));
+        || scriptedCharClassNames5.contains(charCls)
+      );
     });
 
     if (scriptedCharClassNames.length > 0)
@@ -202,7 +209,7 @@ class CharacterDataParser
       log('Instantiating ${scriptedCharClassNames.length} (Base) scripted characters...');
       for (charCls in scriptedCharClassNames)
       {
-        var character:BaseCharacter = ScriptedBaseCharacter.scriptInit(charCls, DEFAULT_CHAR_ID, Custom);
+        var character:Null<BaseCharacter> = ScriptedBaseCharacter.scriptInit(charCls, DEFAULT_CHAR_ID, Custom);
         if (character == null)
         {
           log(' ERROR '.error() + 'Failed to initialize scripted character: $charCls');

--- a/source/funkin/data/event/SongEventRegistry.hx
+++ b/source/funkin/data/event/SongEventRegistry.hx
@@ -68,7 +68,7 @@ class SongEventRegistry
 
     for (eventCls in scriptedEventClassNames)
     {
-      var event:SongEvent = ScriptedSongEvent.scriptInit(eventCls, 'UKNOWN');
+      var event:Null<SongEvent> = ScriptedSongEvent.scriptInit(eventCls, 'UKNOWN');
 
       if (event != null)
       {

--- a/source/funkin/data/song/SongRegistry.hx
+++ b/source/funkin/data/song/SongRegistry.hx
@@ -56,7 +56,7 @@ class SongRegistry extends BaseRegistry<Song, SongMetadata, SongEntryParams> imp
 
     for (entryCls in scriptedEntryClassNames)
     {
-      var entry:Song = createScriptedEntry(entryCls);
+      var entry:Null<Song> = createScriptedEntry(entryCls);
 
       if (entry != null)
       {
@@ -181,7 +181,10 @@ class SongRegistry extends BaseRegistry<Song, SongMetadata, SongEntryParams> imp
 
     switch (loadEntryMetadataFile(id, variation))
     {
-      case {fileName: fileName, contents: contents}:
+      case {
+        fileName: fileName,
+        contents: contents
+      }:
         parser.fromJson(contents, fileName);
       default:
         return null;
@@ -234,8 +237,7 @@ class SongRegistry extends BaseRegistry<Song, SongMetadata, SongEntryParams> imp
     }
   }
 
-  public function parseEntryMetadataRawWithMigration(contents:String, ?fileName:String = 'raw', version:thx.semver.Version,
-      ?variation:String):Null<SongMetadata>
+  public function parseEntryMetadataRawWithMigration(contents:String, ?fileName:String = 'raw', version:thx.semver.Version, ?variation:String):Null<SongMetadata>
   {
     // If a version rule is not specified, do not check against it.
     if (SONG_METADATA_VERSION_RULE == null || VersionUtil.validateVersion(version, SONG_METADATA_VERSION_RULE))
@@ -265,7 +267,10 @@ class SongRegistry extends BaseRegistry<Song, SongMetadata, SongEntryParams> imp
 
     switch (loadEntryMetadataFile(id, variation))
     {
-      case {fileName: fileName, contents: contents}:
+      case {
+        fileName: fileName,
+        contents: contents
+      }:
         parser.fromJson(contents, fileName);
       default:
         return null;
@@ -287,7 +292,10 @@ class SongRegistry extends BaseRegistry<Song, SongMetadata, SongEntryParams> imp
 
     switch (loadEntryMetadataFile(id, variation))
     {
-      case {fileName: fileName, contents: contents}:
+      case {
+        fileName: fileName,
+        contents: contents
+      }:
         parser.fromJson(contents, fileName);
       default:
         return null;
@@ -337,7 +345,10 @@ class SongRegistry extends BaseRegistry<Song, SongMetadata, SongEntryParams> imp
 
     switch (loadMusicDataFile(id, variation))
     {
-      case {fileName: fileName, contents: contents}:
+      case {
+        fileName: fileName,
+        contents: contents
+      }:
         parser.fromJson(contents, fileName);
       default:
         return null;
@@ -402,7 +413,10 @@ class SongRegistry extends BaseRegistry<Song, SongMetadata, SongEntryParams> imp
 
     switch (loadEntryChartFile(id, variation))
     {
-      case {fileName: fileName, contents: contents}:
+      case {
+        fileName: fileName,
+        contents: contents
+      }:
         parser.fromJson(contents, fileName);
       default:
         return null;
@@ -447,8 +461,7 @@ class SongRegistry extends BaseRegistry<Song, SongMetadata, SongEntryParams> imp
     }
   }
 
-  public function parseEntryChartDataRawWithMigration(contents:String, ?fileName:String = 'raw', version:thx.semver.Version,
-      ?variation:String):Null<SongChartData>
+  public function parseEntryChartDataRawWithMigration(contents:String, ?fileName:String = 'raw', version:thx.semver.Version, ?variation:String):Null<SongChartData>
   {
     // If a version rule is not specified, do not check against it.
     if (SONG_CHART_DATA_VERSION_RULE == null || VersionUtil.validateVersion(version, SONG_CHART_DATA_VERSION_RULE))
@@ -473,7 +486,10 @@ class SongRegistry extends BaseRegistry<Song, SongMetadata, SongEntryParams> imp
     var rawJson:Null<String> = openfl.Assets.getText(entryFilePath);
     if (rawJson == null) return null;
     rawJson = rawJson.trim();
-    return {fileName: entryFilePath, contents: rawJson};
+    return {
+      fileName: entryFilePath,
+      contents: rawJson
+    };
   }
 
   function loadMusicDataFile(id:String, ?variation:String):Null<JsonFile>
@@ -484,7 +500,10 @@ class SongRegistry extends BaseRegistry<Song, SongMetadata, SongEntryParams> imp
     var rawJson:String = openfl.Assets.getText(entryFilePath);
     if (rawJson == null) return null;
     rawJson = rawJson.trim();
-    return {fileName: entryFilePath, contents: rawJson};
+    return {
+      fileName: entryFilePath,
+      contents: rawJson
+    };
   }
 
   function loadEntryChartFile(id:String, ?variation:String):Null<JsonFile>
@@ -495,7 +514,10 @@ class SongRegistry extends BaseRegistry<Song, SongMetadata, SongEntryParams> imp
     var rawJson:String = openfl.Assets.getText(entryFilePath);
     if (rawJson == null) return null;
     rawJson = rawJson.trim();
-    return {fileName: entryFilePath, contents: rawJson};
+    return {
+      fileName: entryFilePath,
+      contents: rawJson
+    };
   }
 
   public function fetchEntryMetadataVersion(id:String, ?variation:String):Null<thx.semver.Version>

--- a/source/funkin/data/stickers/StickerRegistry.hx
+++ b/source/funkin/data/stickers/StickerRegistry.hx
@@ -43,7 +43,10 @@ class StickerRegistry extends BaseRegistry<StickerPack, StickerData, StickerEntr
 
     switch (loadEntryFile(id))
     {
-      case {fileName: fileName, contents: contents}:
+      case {
+        fileName: fileName,
+        contents: contents
+      }:
         parser.fromJson(contents, fileName);
       default:
         return null;
@@ -79,7 +82,7 @@ class StickerRegistry extends BaseRegistry<StickerPack, StickerData, StickerEntr
     return parser.value;
   }
 
-  function createScriptedEntry(clsName:String):StickerPack
+  function createScriptedEntry(clsName:String):Null<StickerPack>
   {
     return ScriptedStickerPack.scriptInit(clsName, 'unknown');
   }

--- a/source/funkin/modding/module/ModuleHandler.hx
+++ b/source/funkin/modding/module/ModuleHandler.hx
@@ -32,7 +32,7 @@ class ModuleHandler
     trace(' Instantiating ${scriptedModuleClassNames.length} modules...');
     for (moduleCls in scriptedModuleClassNames)
     {
-      var module:Module = ScriptedModule.scriptInit(moduleCls, moduleCls);
+      var module:Null<Module> = ScriptedModule.scriptInit(moduleCls, moduleCls);
       if (module != null)
       {
         trace('   Loaded module: ${moduleCls}');

--- a/source/funkin/play/ResultState.hx
+++ b/source/funkin/play/ResultState.hx
@@ -228,7 +228,7 @@ class ResultState extends MusicBeatSubState
       {
         case 'animateatlas':
           @:nullSafety(Off)
-          var animation:FunkinSprite = null;
+          var animation:Null<FunkinSprite> = null;
 
           var xPos = offsets[0] + (FullScreenScaleMode.gameCutoutSize.x / 2);
           var yPos = offsets[1];
@@ -295,10 +295,13 @@ class ResultState extends MusicBeatSubState
           add(animation);
         case 'sparrow':
           @:nullSafety(Off)
-          var animation:FunkinSprite = null;
+          var animation:Null<FunkinSprite> = null;
 
-          if (animData.scriptClass != null) animation = ScriptedFunkinSprite.scriptInit(animData.scriptClass,
-            offsets[0] + (FullScreenScaleMode.gameCutoutSize.x / 2), offsets[1]);
+          if (animData.scriptClass != null) animation = ScriptedFunkinSprite.scriptInit(
+            animData.scriptClass,
+            offsets[0] + (FullScreenScaleMode.gameCutoutSize.x / 2),
+            offsets[1]
+          );
           else
             animation = FunkinSprite.createSparrow(offsets[0] + (FullScreenScaleMode.gameCutoutSize.x / 2), offsets[1], animPath);
 
@@ -337,7 +340,13 @@ class ResultState extends MusicBeatSubState
 
     blackTopBar.loadGraphic(funkin.util.BitmapUtil.createResultsBar());
     blackTopBar.y = -blackTopBar.height;
-    FlxTween.tween(blackTopBar, {y: 0}, 7 / 24, {ease: FlxEase.quartOut, startDelay: 3 / 24, onComplete: _ -> songName.visible = true});
+    FlxTween.tween(blackTopBar, {
+      y: 0
+    }, 7 / 24, {
+      ease: FlxEase.quartOut,
+      startDelay: 3 / 24,
+      onComplete: _ -> songName.visible = true
+    });
     blackTopBar.zIndex = 1010;
     add(blackTopBar);
 
@@ -454,24 +463,44 @@ class ResultState extends MusicBeatSubState
 
     hStuf += 2;
 
-    var tallySick:TallyCounter = new TallyCounter(230 + FullScreenScaleMode.gameNotchSize.x, (hStuf * 5) + extraYOffset, params.scoreData.tallies.sick,
-      0xFF89E59E);
+    var tallySick:TallyCounter = new TallyCounter(
+      230 + FullScreenScaleMode.gameNotchSize.x,
+      (hStuf * 5) + extraYOffset,
+      params.scoreData.tallies.sick,
+      0xFF89E59E
+    );
     ratingGrp.add(tallySick);
 
-    var tallyGood:TallyCounter = new TallyCounter(210 + FullScreenScaleMode.gameNotchSize.x, (hStuf * 6) + extraYOffset, params.scoreData.tallies.good,
-      0xFF89C9E5);
+    var tallyGood:TallyCounter = new TallyCounter(
+      210 + FullScreenScaleMode.gameNotchSize.x,
+      (hStuf * 6) + extraYOffset,
+      params.scoreData.tallies.good,
+      0xFF89C9E5
+    );
     ratingGrp.add(tallyGood);
 
-    var tallyBad:TallyCounter = new TallyCounter(190 + FullScreenScaleMode.gameNotchSize.x, (hStuf * 7) + extraYOffset, params.scoreData.tallies.bad,
-      0xFFE6CF8A);
+    var tallyBad:TallyCounter = new TallyCounter(
+      190 + FullScreenScaleMode.gameNotchSize.x,
+      (hStuf * 7) + extraYOffset,
+      params.scoreData.tallies.bad,
+      0xFFE6CF8A
+    );
     ratingGrp.add(tallyBad);
 
-    var tallyShit:TallyCounter = new TallyCounter(220 + FullScreenScaleMode.gameNotchSize.x, (hStuf * 8) + extraYOffset, params.scoreData.tallies.shit,
-      0xFFE68C8A);
+    var tallyShit:TallyCounter = new TallyCounter(
+      220 + FullScreenScaleMode.gameNotchSize.x,
+      (hStuf * 8) + extraYOffset,
+      params.scoreData.tallies.shit,
+      0xFFE68C8A
+    );
     ratingGrp.add(tallyShit);
 
-    var tallyMissed:TallyCounter = new TallyCounter(260 + FullScreenScaleMode.gameNotchSize.x, (hStuf * 9) + extraYOffset, params.scoreData.tallies.missed,
-      0xFFC68AE6);
+    var tallyMissed:TallyCounter = new TallyCounter(
+      260 + FullScreenScaleMode.gameNotchSize.x,
+      (hStuf * 9) + extraYOffset,
+      params.scoreData.tallies.missed,
+      0xFFC68AE6
+    );
     ratingGrp.add(tallyMissed);
 
     score.visible = false;
@@ -484,7 +513,11 @@ class ResultState extends MusicBeatSubState
       new FlxTimer().start((0.3 * ind) + 1.20, _ ->
       {
         rating.visible = true;
-        FlxTween.tween(rating, {curNumber: rating.neededNumber}, 0.5, {ease: FlxEase.quartOut});
+        FlxTween.tween(rating, {
+          curNumber: rating.neededNumber
+        }, 0.5, {
+          ease: FlxEase.quartOut
+        });
       });
     }
 
@@ -535,7 +568,13 @@ class ResultState extends MusicBeatSubState
         });
         else
         {
-          resultsMusic = FunkinSound.load(Paths.music(getMusicPath(playerCharacter, rank) + '/' + getMusicPath(playerCharacter, rank)), 1.0, true, false, true);
+          resultsMusic = FunkinSound.load(
+            Paths.music(getMusicPath(playerCharacter, rank) + '/' + getMusicPath(playerCharacter, rank)),
+            1.0,
+            true,
+            false,
+            true
+          );
         }
       }
     });
@@ -572,7 +611,9 @@ class ResultState extends MusicBeatSubState
   function startRankTallySequence():Void
   {
     bgFlash.visible = true;
-    FlxTween.tween(bgFlash, {alpha: 0}, 5 / 24);
+    FlxTween.tween(bgFlash, {
+      alpha: 0
+    }, 5 / 24);
     // NOTE: Only divide if totalNotes > 0 to prevent divide-by-zero errors.
     var clearPercentFloat = params.scoreData.tallies.totalNotes == 0 ? 0.0 : Scoring.tallyCompletion(params.scoreData.tallies) * 100;
     clearPercentTarget = Math.floor(clearPercentFloat);
@@ -582,9 +623,14 @@ class ResultState extends MusicBeatSubState
 
     trace('Clear percent target: ' + clearPercentFloat + ', round: ' + clearPercentTarget);
 
-    var clearPercentCounter:ClearPercentCounter = new ClearPercentCounter((FlxG.width / 2 + 190) + (FullScreenScaleMode.gameCutoutSize.x / 2),
-      FlxG.height / 2 - 70, clearPercentLerp);
-    FlxTween.tween(clearPercentCounter, {curNumber: clearPercentTarget}, 58 / 24, {
+    var clearPercentCounter:ClearPercentCounter = new ClearPercentCounter(
+      (FlxG.width / 2 + 190) + (FullScreenScaleMode.gameCutoutSize.x / 2),
+      FlxG.height / 2 - 70,
+      clearPercentLerp
+    );
+    FlxTween.tween(clearPercentCounter, {
+      curNumber: clearPercentTarget
+    }, 58 / 24, {
       ease: FlxEase.quartOut,
       onUpdate: _ ->
       {
@@ -629,7 +675,9 @@ class ResultState extends MusicBeatSubState
         // previously 2.0 seconds
         new FlxTimer().start(0.25, _ ->
         {
-          FlxTween.tween(clearPercentCounter, {alpha: 0}, 0.5, {
+          FlxTween.tween(clearPercentCounter, {
+            alpha: 0
+          }, 0.5, {
             startDelay: 0.5,
             ease: FlxEase.quartOut,
             onComplete: _ ->
@@ -668,7 +716,9 @@ class ResultState extends MusicBeatSubState
   {
     bgFlash.visible = true;
     bgFlash.alpha = 1;
-    FlxTween.tween(bgFlash, {alpha: 0}, 14 / 24);
+    FlxTween.tween(bgFlash, {
+      alpha: 0
+    }, 14 / 24);
 
     var rankTextVert:FlxBackdrop = new FlxBackdrop(Paths.image(rank.getVerTextAsset()), Y, 0, 30);
     rankTextVert.x = FlxG.width - 44;
@@ -742,18 +792,33 @@ class ResultState extends MusicBeatSubState
     var diffYTween:Float = 122;
 
     difficulty.y = -difficulty.height;
-    FlxTween.tween(difficulty, {y: diffYTween + (blackTopBar.height - 148)}, 0.5, {ease: FlxEase.expoOut, startDelay: 0.8});
+    FlxTween.tween(difficulty, {
+      y: diffYTween + (blackTopBar.height - 148)
+    }, 0.5, {
+      ease: FlxEase.expoOut,
+      startDelay: 0.8
+    });
 
     if (clearPercentSmall != null)
     {
       clearPercentSmall.x = (difficulty.x + difficulty.width) + 60;
       clearPercentSmall.y = -clearPercentSmall.height;
-      FlxTween.tween(clearPercentSmall, {y: (122 - 5) + (blackTopBar.height - 148)}, 0.5, {ease: FlxEase.expoOut, startDelay: 0.85});
+      FlxTween.tween(clearPercentSmall, {
+        y: (122 - 5) + (blackTopBar.height - 148)
+      }, 0.5, {
+        ease: FlxEase.expoOut,
+        startDelay: 0.85
+      });
     }
 
     songName.y = -songName.height;
     var fuckedupnumber:Float = -(songName.width * 0.5) * Math.sin(songName.angle * FlxAngle.TO_RAD) - 10;
-    FlxTween.tween(songName, {y: (diffYTween - 25 - fuckedupnumber) + ((blackTopBar.height - 148) / 1)}, 0.5, {ease: FlxEase.expoOut, startDelay: 0.9});
+    FlxTween.tween(songName, {
+      y: (diffYTween - 25 - fuckedupnumber) + ((blackTopBar.height - 148) / 1)
+    }, 0.5, {
+      ease: FlxEase.expoOut,
+      startDelay: 0.9
+    });
     songName.x = clearPercentSmall.x + 94;
 
     new FlxTimer().start(timerLength, _ ->
@@ -761,7 +826,12 @@ class ResultState extends MusicBeatSubState
       var tempSpeed = FlxPoint.get(speedOfTween.x, speedOfTween.y);
 
       speedOfTween.set(0, 0);
-      FlxTween.tween(speedOfTween, {x: tempSpeed.x, y: tempSpeed.y}, 0.7, {ease: FlxEase.quadIn});
+      FlxTween.tween(speedOfTween, {
+        x: tempSpeed.x,
+        y: tempSpeed.y
+      }, 0.7, {
+        ease: FlxEase.quadIn
+      });
 
       movingSongStuff = (autoScroll);
     });
@@ -846,7 +916,9 @@ class ResultState extends MusicBeatSubState
         @:nullSafety(Off)
         introMusicAudio.onComplete = null;
 
-        FlxTween.tween(introMusicAudio, {volume: 0}, 0.8, {
+        FlxTween.tween(introMusicAudio, {
+          volume: 0
+        }, 0.8, {
           onComplete: _ ->
           {
             if (introMusicAudio != null)
@@ -857,26 +929,36 @@ class ResultState extends MusicBeatSubState
             }
           }
         });
-        FlxTween.tween(introMusicAudio, {pitch: 3}, 0.1, {
+        FlxTween.tween(introMusicAudio, {
+          pitch: 3
+        }, 0.1, {
           onComplete: _ ->
           {
-            FlxTween.tween(introMusicAudio, {pitch: 0.5}, 0.4);
+            FlxTween.tween(introMusicAudio, {
+              pitch: 0.5
+            }, 0.4);
           }
         });
       }
       else if (FlxG.sound.music != null)
       {
-        FlxTween.tween(FlxG.sound.music, {volume: 0}, 0.8, {
+        FlxTween.tween(FlxG.sound.music, {
+          volume: 0
+        }, 0.8, {
           onComplete: _ ->
           {
             FlxG.sound.music.stop();
             FlxG.sound.music.destroy();
           }
         });
-        FlxTween.tween(FlxG.sound.music, {pitch: 3}, 0.1, {
+        FlxTween.tween(FlxG.sound.music, {
+          pitch: 3
+        }, 0.1, {
           onComplete: _ ->
           {
-            FlxTween.tween(FlxG.sound.music, {pitch: 0.5}, 0.4);
+            FlxTween.tween(FlxG.sound.music, {
+              pitch: 0.5
+            }, 0.4);
           }
         });
       }
@@ -1020,7 +1102,9 @@ class ResultState extends MusicBeatSubState
   {
     if (shouldTween)
     {
-      FlxTween.tween(rankBg, {alpha: 1}, 0.5, {
+      FlxTween.tween(rankBg, {
+        alpha: 1
+      }, 0.5, {
         ease: FlxEase.expoOut,
         onComplete: function(_)
         {

--- a/source/funkin/ui/freeplay/FreeplayState.hx
+++ b/source/funkin/ui/freeplay/FreeplayState.hx
@@ -306,8 +306,8 @@ class FreeplayState extends MusicBeatSubState
       var allScriptedCards:Array<String> = ScriptedBackingCard.listScriptClasses();
       for (cardClass in allScriptedCards)
       {
-        var card:BackingCard = ScriptedBackingCard.scriptInit(cardClass, 'unknown');
-        if (card.currentCharacter == currentCharacterId)
+        var card:Null<BackingCard> = ScriptedBackingCard.scriptInit(cardClass, 'unknown');
+        if (card?.currentCharacter == currentCharacterId)
         {
           backingCardPrep = card;
           break;


### PR DESCRIPTION
## Linked Issues
The compiler yelling at me

## Description
A recent change in polymod's `final-access` testing branch was made to make `scriptInit` return a nullable. However funkin's source was never changed to accomodate this so I'm lead to believe it was either done internally or the elite one just kinda didnt care lol

Epic formatter fail

## Screenshots/Videos
N/A