### PR TITLE
Remove unused sprites in Freeplay

### DIFF
--- a/source/funkin/ui/freeplay/FreeplayState.hx
+++ b/source/funkin/ui/freeplay/FreeplayState.hx
@@ -281,8 +281,6 @@ class FreeplayState extends MusicBeatSubState
   var fromCharSelect:Bool = false;
   var forceSkipIntro:Bool = false;
 
-  public var freeplayArrow:Null<FlxText>;
-
   public function new(?params:FreeplayStateParams, ?stickers:StickerSubState)
   {
     var fetchPlayableCharacter = function():PlayableCharacter
@@ -401,7 +399,7 @@ class FreeplayState extends MusicBeatSubState
         // Set rememberedSongId to last played song if accessed from the RANDOM option
         rememberedSongId = fromResultsParams.songId;
       }
-    
+
       @:privateAccess
       this._parentState._constructor = () ->
       {
@@ -586,15 +584,6 @@ class FreeplayState extends MusicBeatSubState
     topLeftCornerText.setFormat(funkin.assets.Paths.font('ui/fonts/VCR OSD Mono'), 48);
     topLeftCornerText.visible = false;
 
-    var freeplayTxtBg:FlxSprite = new FlxSprite()
-      .makeGraphic(Math.round(topLeftCornerText.width + 16), Math.round(topLeftCornerText.height + 16), FlxColor.BLACK);
-    freeplayTxtBg.x = topLeftCornerText.x - 8;
-    freeplayTxtBg.visible = false;
-
-    freeplayArrow = new FlxText(Math.max(FullScreenScaleMode.gameNotchSize.x, 8), 8, 0, '<---');
-    freeplayArrow.setFormat(funkin.assets.Paths.font('ui/fonts/VCR OSD Mono'), 48);
-    freeplayArrow.visible = false;
-
     ostName.setFormat(funkin.assets.Paths.font('ui/fonts/VCR OSD Mono'), 48);
     ostName.alignment = RIGHT;
     ostName.visible = false;
@@ -619,9 +608,7 @@ class FreeplayState extends MusicBeatSubState
       overhangStuff,
       topLeftCornerText,
       ostName,
-      charSelectHint,
-      freeplayTxtBg,
-      freeplayArrow
+      charSelectHint
     ], {
       y: -overhangStuff.height,
       x: 0,
@@ -633,9 +620,7 @@ class FreeplayState extends MusicBeatSubState
       overhangStuff,
       topLeftCornerText,
       ostName,
-      charSelectHint,
-      freeplayTxtBg,
-      freeplayArrow
+      charSelectHint
     ], {
       y: -300,
       speed: 0.8,
@@ -644,7 +629,6 @@ class FreeplayState extends MusicBeatSubState
 
     var sillyStroke:StrokeShader = new StrokeShader(0xFFFFFFFF, 2, 2);
     topLeftCornerText.shader = sillyStroke;
-    freeplayArrow.shader = sillyStroke;
 
     var fnfHighscoreSpr:FlxSprite = new FlxSprite(FlxG.width - (FullScreenScaleMode.gameNotchSize.x + 420), 70);
     fnfHighscoreSpr.frames = Paths.getSparrowAtlas('ui/freeplay/interface/highscore');
@@ -752,8 +736,6 @@ class FreeplayState extends MusicBeatSubState
 
     // putting these here to fix the layering
     add(overhangStuff);
-    add(freeplayArrow);
-    add(freeplayTxtBg);
     add(topLeftCornerText);
     add(ostName);
 
@@ -832,8 +814,6 @@ class FreeplayState extends MusicBeatSubState
       {
         fnfHighscoreSpr.visible = true;
         topLeftCornerText.visible = true;
-        freeplayTxtBg.visible = true;
-        if (freeplayArrow != null) freeplayArrow.visible = true;
         ostName.visible = true;
         updateOSTName(true);
         fpScoreDisplay.visible = true;
@@ -1397,7 +1377,7 @@ class FreeplayState extends MusicBeatSubState
     new FlxTimer().start(0.5, _ ->
     {
       dispatchEvent(new CapsuleScriptEvent(FREEPLAY_CAPSULE_SLAM, currentCapsule, currentDifficulty, currentVariation, fromResultsParams?.newRank));
-      
+
       // Capsule slam vibration.
       HapticUtil.vibrate(Constants.DEFAULT_VIBRATION_PERIOD, Constants.DEFAULT_VIBRATION_DURATION, Constants.MAX_VIBRATION_AMPLITUDE);
 

--- a/source/funkin/ui/freeplay/FreeplayState.hx
+++ b/source/funkin/ui/freeplay/FreeplayState.hx
@@ -258,8 +258,6 @@ class FreeplayState extends MusicBeatSubState
   var fromCharSelect:Bool = false;
   var forceSkipIntro:Bool = false;
 
-  public var freeplayArrow:Null<FlxText>;
-
   public function new(?params:FreeplayStateParams, ?stickers:StickerSubState)
   {
     var fetchPlayableCharacter = function():PlayableCharacter
@@ -533,15 +531,6 @@ class FreeplayState extends MusicBeatSubState
     topLeftCornerText.font = 'VCR OSD Mono';
     topLeftCornerText.visible = false;
 
-    var freeplayTxtBg:FlxSprite = new FlxSprite().makeGraphic(Math.round(topLeftCornerText.width + 16), Math.round(topLeftCornerText.height + 16),
-      FlxColor.BLACK);
-    freeplayTxtBg.x = topLeftCornerText.x - 8;
-    freeplayTxtBg.visible = false;
-
-    freeplayArrow = new FlxText(Math.max(FullScreenScaleMode.gameNotchSize.x, 8), 8, 0, '<---', 48);
-    freeplayArrow.font = 'VCR OSD Mono';
-    freeplayArrow.visible = false;
-
     ostName.font = 'VCR OSD Mono';
     ostName.alignment = RIGHT;
     ostName.visible = false;
@@ -562,9 +551,7 @@ class FreeplayState extends MusicBeatSubState
       overhangStuff,
       topLeftCornerText,
       ostName,
-      charSelectHint,
-      freeplayTxtBg,
-      freeplayArrow
+      charSelectHint
     ], {
       y: -overhangStuff.height,
       x: 0,
@@ -576,9 +563,7 @@ class FreeplayState extends MusicBeatSubState
       overhangStuff,
       topLeftCornerText,
       ostName,
-      charSelectHint,
-      freeplayTxtBg,
-      freeplayArrow
+      charSelectHint
     ], {
       y: -300,
       speed: 0.8,
@@ -587,7 +572,6 @@ class FreeplayState extends MusicBeatSubState
 
     var sillyStroke:StrokeShader = new StrokeShader(0xFFFFFFFF, 2, 2);
     topLeftCornerText.shader = sillyStroke;
-    freeplayArrow.shader = sillyStroke;
 
     var fnfHighscoreSpr:FlxSprite = new FlxSprite(FlxG.width - (FullScreenScaleMode.gameNotchSize.x + 420), 70);
     fnfHighscoreSpr.frames = Paths.getSparrowAtlas('freeplay/highscore');
@@ -684,8 +668,6 @@ class FreeplayState extends MusicBeatSubState
 
     // putting these here to fix the layering
     add(overhangStuff);
-    add(freeplayArrow);
-    add(freeplayTxtBg);
     add(topLeftCornerText);
     add(ostName);
 
@@ -755,8 +737,6 @@ class FreeplayState extends MusicBeatSubState
       {
         fnfHighscoreSpr.visible = true;
         topLeftCornerText.visible = true;
-        freeplayTxtBg.visible = true;
-        if (freeplayArrow != null) freeplayArrow.visible = true;
         ostName.visible = true;
         updateOSTName(true);
         fpScoreDisplay.visible = true;


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
N/A

<!-- Briefly describe the issue(s) fixed. -->
## Description

These sprites were added in https://github.com/FunkinCrew/Funkin/commit/b9230b6eb2c4b68ae7d01e281469f43d126867ac, meant to be used for a swipe gesture to exit Freeplay, but were made useless in https://github.com/FunkinCrew/Funkin/commit/d79f99475e1d9a328c50fdde785cb43a89124364. Despite this, they are still part of the Freeplay state, and the game renders them... before drawing over them with the actual sprites. 

By removing them we can get rid of 2 useless draw calls. Yay!

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos

A showcase of the draw calls made by the game in [RenderDoc](https://renderdoc.org/). You can see the top border and the arrow get drawn before being drawn over by the background again and the "FREEPLAY" text.

https://github.com/user-attachments/assets/96929eb9-7e7b-40fe-ada1-32960098447b
