### PR TITLE
Fix `FunkinTween` not properly calling its `onUpdate` callback

### DIFF
--- a/source/funkin/tweens/FunkinTween.hx
+++ b/source/funkin/tweens/FunkinTween.hx
@@ -114,8 +114,15 @@ class FunkinTween extends FlxTween
       return;
     }
 
+    var delta:Float = rawProgress * duration - _secondsSinceStart;
     _secondsSinceStart = rawProgress * duration;
     super.update(0);
+
+    var delay:Float = (executions > 0) ? loopDelay : startDelay;
+    if (onUpdate != null && delta != 0 && _secondsSinceStart < duration + delay)
+    {
+      onUpdate(this);
+    }
   }
 
   public function resetConductorSync():Void
@@ -158,8 +165,16 @@ class FunkinVarTween extends VarTween
       super.update(elapsed);
       return;
     }
+
+    var delta:Float = rawProgress * duration - _secondsSinceStart;
     _secondsSinceStart = rawProgress * duration;
     super.update(0);
+
+    var delay:Float = (executions > 0) ? loopDelay : startDelay;
+    if (onUpdate != null && delta != 0 && _secondsSinceStart < duration + delay)
+    {
+      onUpdate(this);
+    }
   }
 
   public function resetConductorSync():Void


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
N/A (Only reported internally)
<!-- Briefly describe the issue(s) fixed. -->
## Description
`FunkinTween` was not triggering the `onUpdate` callback for every tick, causing stuff like the Spaghetti lights to act up on the Camera Editor branch.
Not sure if this is a good way to fix it, but it seems like a good compromise for now.
<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos

https://github.com/user-attachments/assets/0b92780b-4fda-4485-ace6-df3b68cf2c9d

