### PR TITLE
[TEMP FIX] Display keyboard bind on skip text in cutscenes when gamepad shows N/A

### DIFF
--- a/source/funkin/util/InputUtil.hx
+++ b/source/funkin/util/InputUtil.hx
@@ -27,7 +27,9 @@ class InputUtil
       case Keys:
         getKeyName(id);
       case Gamepad(gamepadID):
-        FlxG.gamepads.getByID(gamepadID) != null ? getButtonName(id, FlxG.gamepads.getByID(gamepadID)) : 'N/A';
+        if(FlxG.gamepads.getByID(gamepadID) != null) getButtonName(id, FlxG.gamepads.getByID(gamepadID));
+        else if (FlxG.gamepads.getByID(gamepadID) == null) getKeyName(id); // temp fix to cutscenes N/A gamepad
+        else 'N/A';
     }
   }
 


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues

Temp fix of #7733 

<!-- Briefly describe the issue(s) fixed. -->
## Description

As the title describes, this is a **TEMPORAL FIX** for the skip text bug related with gamepads. 
>[!NOTE]
> Since this is a temporal fix and may get fixed by devs (leading to this PR being closed), if it's a bit of a help, this bug is caused because `FlxG.gamepads.getByID()` returns `null` (somehow) only during cutscenes.
> 
> <img width="1005" height="217" alt="screens1" src="https://github.com/user-attachments/assets/f7ddc642-7308-4cfd-a417-01ad80fcc8ce" />
> <img width="901" height="445" alt="screens2" src="https://github.com/user-attachments/assets/64699b31-d766-45b0-becf-67599256d5e9" />


<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos

(If someone panics because it says ENTER instead of Z, ENTER also works to skip the cutscene lmao :))

https://github.com/user-attachments/assets/960ecd55-b1ed-471d-ab75-7a17717a64c1

