### PR TITLE
[ENHANCEMENT] Scale the Chart Editor background for widescreen

### DIFF
--- a/source/funkin/ui/debug/charting/ChartEditorState.hx
+++ b/source/funkin/ui/debug/charting/ChartEditorState.hx
@@ -2775,7 +2775,7 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
     menuBG = new FlxSprite().loadGraphic(Paths.image('menuDesat'));
     add(menuBG);
 
-    menuBG.setGraphicSize(Std.int(menuBG.width * 1.1));
+    menuBG.setGraphicSize(Std.int(FlxG.width * 1.1));
     menuBG.updateHitbox();
     menuBG.screenCenter();
     menuBG.scrollFactor.set(0, 0);


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues

No Linked Issues.

<!-- Briefly describe the issue(s) fixed. -->
## Description

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos

This pull request changes how the background in the Chart Editor is scaled. Rather than scaling it by its width * 1.1, it scales it by your game's width * 1.1, which fixes the black bars on the side of the Chart Editor.

### Before:
<img width="2348" height="1055" alt="image" src="https://github.com/user-attachments/assets/825f9bde-367c-49af-a106-d8329e6ccf73" />
(image from my buddy @ExtraCode75, using dark mode theme)

### After:
<img width="1599" height="717" alt="image" src="https://github.com/user-attachments/assets/3d0af4b8-08b0-4879-a868-6526374f8809" />

