### PR TITLE
[BUGFIX] fix framerate dependent freeplay scroll speed

### DIFF
--- a/source/funkin/ui/freeplay/FreeplayState.hx
+++ b/source/funkin/ui/freeplay/FreeplayState.hx
@@ -2056,7 +2056,7 @@ class FreeplayState extends MusicBeatSubState
         var dpiScale = FlxG.stage.window.display.dpi / 160;
 
         dpiScale = dpiScale.clamp(0.5, #if android 1 #else 2 #end);
-        var velocityMove = flickVelocity * elapsed / dpiScale;
+        var velocityMove = flickVelocity * elapsed * framerateMultiplier / dpiScale;
         _moveLength += Math.abs(velocityMove);
         curSelectedFloat -= velocityMove;
         updateSongsScroll();


### PR DESCRIPTION
<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
Closes https://github.com/FunkinCrew/Funkin/issues/7698
<!-- Briefly describe the issue(s) fixed. -->
## Description
It fixes the problem that makes the freeplay scroll speed fps dependant
Where if you're on 120 fps it goes faster and if 60 fps it goes slower
By adding `framerateMultiplier` in the line 2059 it causes freeplay scroll speed to be the same across all fps
<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos)
None because I currently don't have my laptop to recompile to android 