### PR TITLE
[BUGFIX] make the offset in pause menu correct again

### DIFF
--- a/source/funkin/play/PauseSubState.hx
+++ b/source/funkin/play/PauseSubState.hx
@@ -743,7 +743,7 @@ class PauseSubState extends MusicBeatSubState
 
         if (controls.UI_UP_P || controls.UI_DOWN_P)
         {
-          offset += (controls.UI_UP_P || controls.UI_UP) ? 1 : -1;
+          offset += (controls.UI_UP_P || controls.UI_UP) ? -1 : 1;
 
           offsetText.text = 'Global Offset: ${Std.int(offset)}ms';
         }


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
Probably closes #7711 
<!-- Briefly describe the issue(s) fixed. -->
## Description
Change from
`offset += (controls.UI_UP_P || controls.UI_UP) ? 1 : -1;`
To
`offset += (controls.UI_UP_P || controls.UI_UP) ? -1 : 1;`
Now the offset is correct
<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos
None