### PR TITLE
[BUGFIX] Fix volume increasing on focus if it was 0

### DIFF
--- a/source/funkin/InitState.hx
+++ b/source/funkin/InitState.hx
@@ -340,7 +340,7 @@ class InitState extends FlxState
     #end
 
     #if FEATURE_LOST_FOCUS_VOLUME
-    if (FlxG.sound.muted || FlxG.autoPause) return;
+    if (FlxG.sound.muted || FlxG.sound.volume == 0 || FlxG.autoPause) return;
     if (_lastFocusVolume != null) FlxG.sound.volume = _lastFocusVolume;
     #end
   }


### PR DESCRIPTION
## Description
This pull request fixes an issue where the game volume would incorrectly increase or reset upon regaining window focus if the player had manually set the volume to 0

This bug specifically triggers when `autoPause` is disabled. By adding proper volume checks during focus changes, the engine now correctly respects the muted/zero-volume state instead of forcing the volume back up.
## Screenshots/Videos
Before

https://github.com/user-attachments/assets/8fd47761-7d02-43c7-adcc-06abdf6f727f

After

https://github.com/user-attachments/assets/3bb98e57-9342-4f07-a517-f72be575c27b

thanks for @requazar for the test