### PR TITLE
Fix incorrect checks for `display` during macro context

### DIFF
--- a/source/funkin/ui/credits/CreditsDataMacro.hx
+++ b/source/funkin/ui/credits/CreditsDataMacro.hx
@@ -11,7 +11,14 @@ class CreditsDataMacro
 {
   public static macro function loadCreditsData():haxe.macro.Expr.ExprOf<CreditsData>
   {
-    #if !display
+    if (Context.defined('display'))
+    {
+      // `display` is used for code completion. In this case we return
+      // a minimal value to keep code completion fast.
+      Context.info('Using fallback credits', Context.currentPos());
+      return macro $v{CreditsDataHandler.getFallback()};
+    }
+
     Sys.println(' INFO '.info() + ' Hardcoding credits data...');
     var json = CreditsDataMacro.fetchJSON();
 
@@ -31,12 +38,6 @@ class CreditsDataMacro
 
     CreditsDataHandler.debugPrint(creditsData);
     return macro $v{creditsData};
-    // return macro $v{null};
-    #else
-    // `#if display` is used for code completion. In this case we return
-    // a minimal value to keep code completion fast.
-    return macro $v{CreditsDataHandler.getFallback()};
-    #end
   }
 
   #if macro

--- a/source/funkin/util/macro/FlxMacro.hx
+++ b/source/funkin/util/macro/FlxMacro.hx
@@ -1,6 +1,5 @@
 package funkin.util.macro;
 
-#if !display
 #if macro
 @:nullSafety
 class FlxMacro
@@ -90,5 +89,4 @@ class FlxMacro
     return fields;
   }
 }
-#end
 #end

--- a/source/funkin/util/macro/GitCommit.hx
+++ b/source/funkin/util/macro/GitCommit.hx
@@ -2,7 +2,6 @@ package funkin.util.macro;
 
 using funkin.util.AnsiUtil;
 
-#if !display
 @:nullSafety
 class GitCommit
 {
@@ -11,7 +10,13 @@ class GitCommit
    */
   public static macro function getGitCommitHash():haxe.macro.Expr.ExprOf<String>
   {
-    #if !display
+    if (haxe.macro.Context.defined('display'))
+    {
+      // `display` is used for code completion. In this case returning an
+      // empty string is good enough; We don't want to call git on every hint.
+      return macro '';
+    }
+
     // Get the current line number.
     var pos = haxe.macro.Context.currentPos();
 
@@ -30,12 +35,6 @@ class GitCommit
 
     // Generates a string expression
     return macro $v{commitHashSplice};
-    #else
-    // `#if display` is used for code completion. In this case returning an
-    // empty string is good enough; We don't want to call git on every hint.
-    var commitHash:String = "";
-    return macro $v{commitHashSplice};
-    #end
   }
 
   /**
@@ -43,7 +42,13 @@ class GitCommit
    */
   public static macro function getGitBranch():haxe.macro.Expr.ExprOf<String>
   {
-    #if !display
+    if (haxe.macro.Context.defined('display'))
+    {
+      // `display` is used for code completion. In this case returning an
+      // empty string is good enough; We don't want to call git on every hint.
+      return macro '';
+    }
+
     // Get the current line number.
     var pos = haxe.macro.Context.currentPos();
     var branchProcess = new sys.io.Process('git', ['rev-parse', '--abbrev-ref', 'HEAD']);
@@ -59,12 +64,6 @@ class GitCommit
 
     // Generates a string expression
     return macro $v{branchName};
-    #else
-    // `#if display` is used for code completion. In this case returning an
-    // empty string is good enough; We don't want to call git on every hint.
-    var branchName:String = "";
-    return macro $v{branchName};
-    #end
   }
 
   /**
@@ -72,14 +71,16 @@ class GitCommit
    */
   public static macro function getGitHasLocalChanges():haxe.macro.Expr.ExprOf<Bool>
   {
-    #if !display
-    var branchProcess = new sys.io.Process('git', ['diff', '--quiet']);
+    if (!haxe.macro.Context.defined('display'))
+    {
+      var branchProcess = new sys.io.Process('git', ['diff', '--quiet']);
 
-    return macro $v{branchProcess.exitCode(true) == 1};
-    #else
-    // `#if display` is used for code completion. In this case we just assume true.
-    return macro $v{true};
-    #end
+      return macro $v{branchProcess.exitCode(true) == 1};
+    }
+    else
+    {
+      // `display` is used for code completion. In this case we just assume true.
+      return macro true;
+    }
   }
 }
-#end

--- a/source/funkin/util/macro/HaxelibVersions.hx
+++ b/source/funkin/util/macro/HaxelibVersions.hx
@@ -7,14 +7,15 @@ class HaxelibVersions
 {
   public static macro function getLibraryVersions():haxe.macro.Expr.ExprOf<Array<String>>
   {
-    #if !display
-    return macro $v{formatHmmData()};
-    #else
+    if (!haxe.macro.Context.defined('display'))
+    {
+      return macro $v{formatHmmData()};
+    }
+
     // `#if display` is used for code completion. In this case returning an
-    // empty string is good enough; We don't want to call functions on every hint.
+    // empty array is good enough; We don't want to call functions on every hint.
     var commitHash:Array<String> = [];
     return macro $v{commitHash};
-    #end
   }
 
   #if (macro)


### PR DESCRIPTION
## Linked Issues
N/A
<!-- Briefly describe the issue(s) fixed. -->
## Description
This one has been on my backlog for a while. According to https://github.com/HaxeFoundation/haxe/pull/12441, `#if display` is not the correct way to check for Display mode, as preprocessor checks are parse-time only.

This PR replaces the checks with `Context.defined` ones, which is the correct way. Note that you may still see messages in the Haxe Language Server logs from the macros (viewed through Output -> Haxe), as if the `display` checks still didn't work. That's because those are not coming from `display`, but rather during the Completion Cache build, which is just a normal build with the `--no-output` option.

Some places with a `#if display` check were kept intact because those are not in a macro context, so I was not sure what to do with them. I think we should just remove them.
<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos
N/A