### PR TITLE
[ENHANCEMENT]: Fix incrementing difficulty keybinds in the Chart Editor

### DIFF
--- a/source/funkin/ui/debug/charting/ChartEditorState.hx
+++ b/source/funkin/ui/debug/charting/ChartEditorState.hx
@@ -6352,10 +6352,22 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
     // SHIFT + End = Select all below playhead
     if (FlxG.keys.pressed.SHIFT && FlxG.keys.justPressed.END)
     {
-      // CTRL +  SHIFT + Home = Inverse - deselect all below playhead
+      // CTRL + SHIFT + Home = Inverse - deselect all below playhead
       if (FlxG.keys.pressed.CONTROL) performCommand(new DeselectAllItemsBetweenTimeCommand(scrollPositionInMs + playheadPositionInMs, false, true, true));
       else
         performCommand(new SelectAllItemsBetweenTimeCommand(scrollPositionInMs + playheadPositionInMs, false, true, true));
+    }
+    
+    // CTRL + Right Arrow = Increase difficulty
+    if (pressingControl() && FlxG.keys.justPressed.RIGHT)
+    {
+      incrementDifficulty(1);
+    }
+
+    // CTRL + Left Arrow = Decrease difficulty
+    if (pressingControl() && FlxG.keys.justPressed.LEFT) 
+    {
+      incrementDifficulty(-1);
     }
   }
 


### PR DESCRIPTION
<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
No.
<!-- Briefly describe the issue(s) fixed. -->
## Description
In the chart editor, the view tab shows keybinds to switch from an easy to harder difficulty, as well as the user guide. However it currently does not work. So this PR fixes that issue. **(Authored by @JVNpixels)**
<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos
https://github.com/user-attachments/assets/0fa235e5-ebe0-498d-8163-51fb0d706080