### PR TITLE
[CRASHFIX] Fix Chart Editor crashing when switching between notekinds

### DIFF
--- a/source/funkin/ui/debug/charting/toolboxes/ChartEditorNoteDataToolbox.hx
+++ b/source/funkin/ui/debug/charting/toolboxes/ChartEditorNoteDataToolbox.hx
@@ -120,7 +120,7 @@ class ChartEditorNoteDataToolbox extends ChartEditorBaseToolbox
       var customKind:Null<String> = event?.target?.text;
       chartEditorState.noteKindToPlace = customKind;
 
-      if (toolboxNotesNoteKind.value.id != '~CUSTOM~') return;
+      if (toolboxNotesNoteKind.value == null || toolboxNotesNoteKind.value.id != '~CUSTOM~') return;
 
       if (!_initializing && chartEditorState.currentNoteSelection.length > 0)
       {
@@ -149,8 +149,9 @@ class ChartEditorNoteDataToolbox extends ChartEditorBaseToolbox
     toolboxNotesCustomKind.pauseEvent(UIEvent.CHANGE, true);
 
     toolboxNotesCustomKind.value = chartEditorState.noteKindToPlace;
-    toolboxNotesNoteKind.value = ChartEditorDropdowns.lookupNoteKind(chartEditorState.noteKindToPlace);
-    if (toolboxNotesNoteKind.value.id == '~CUSTOM~' && chartEditorState.noteKindToPlace != null)
+    var noteKindEntry = ChartEditorDropdowns.lookupNoteKind(chartEditorState.noteKindToPlace);
+    toolboxNotesNoteKind.value = noteKindEntry;
+    if (noteKindEntry.id == '~CUSTOM~' && chartEditorState.noteKindToPlace != null)
     {
       showCustom();
     }


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
None
<!-- Briefly describe the issue(s) fixed. -->
## Description
Added some null checks so the chart editor dont crash when you switch the notes
<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos
### Before

https://github.com/user-attachments/assets/0768f255-77b2-41be-aaeb-0fb82d0cc558

### After


https://github.com/user-attachments/assets/7a1d93e9-a79b-4c63-b7af-357eab19607a

