### PR TITLE
[ENHANCEMENT] Update player strumline with Lime instead of Flixel

### DIFF
--- a/source/funkin/play/PlayState.hx
+++ b/source/funkin/play/PlayState.hx
@@ -1034,6 +1034,12 @@ class PlayState extends MusicBeatSubState
 
     super.update(elapsed);
 
+    // Handle keybinds.
+    processInputQueue();
+
+    // Moving notes into position is now done by Strumline.update().
+    if (!isInCutscene) processNotes(elapsed);
+
     updateHealthBar();
     updateScoreText();
 
@@ -1323,13 +1329,8 @@ class PlayState extends MusicBeatSubState
 
     processSongEvents();
 
-    // Handle keybinds.
-    processInputQueue();
     if (!isInCutscene && !disableKeys) debugKeyShit();
     if (isInCutscene && !disableKeys) handleCutsceneKeys(elapsed);
-
-    // Moving notes into position is now done by Strumline.update().
-    if (!isInCutscene) processNotes(elapsed);
 
     #if mobile
     if ((VideoCutscene.isPlaying() || isInCutscene) && !pauseButton.visible) pauseButton.visible = true;

--- a/source/funkin/play/notes/Strumline.hx
+++ b/source/funkin/play/notes/Strumline.hx
@@ -1,5 +1,6 @@
 package funkin.play.notes;
 
+import lime.app.Application;
 import flixel.util.FlxSignal.FlxTypedSignal;
 import flixel.FlxG;
 import funkin.play.notes.NoteVibrationsHandler.NoteStatus;
@@ -281,6 +282,8 @@ class Strumline extends FlxSpriteGroup
 
     // This MUST be true for children to update!
     this.active = true;
+
+    if (isPlayer) Application.current.window.onRender.add(fakeUpdate);
   }
 
   override function set_y(value:Float):Float
@@ -319,12 +322,37 @@ class Strumline extends FlxSpriteGroup
 
   override public function update(elapsed:Float):Void
   {
-    super.update(elapsed);
+    if (isPlayer)
+    {
+      if (shouldUpdate) super.update(elapsed);
+    }
+    else
+    {
+      super.update(elapsed);
+
+      updateNotes();
+
+      #if FEATURE_GHOST_TAPPING
+      updateGhostTapTimer(elapsed);
+      #end
+    }
+  }
+
+  var shouldUpdate:Bool = false;
+
+  public function fakeUpdate(ctx:Dynamic):Void
+  {
+    if (!isPlayer) return;
+    if (@:privateAccess PlayState?.instance?.isGamePaused) return;
+
+    shouldUpdate = true;
+    update(FlxG.elapsed);
+    shouldUpdate = false;
 
     updateNotes();
 
     #if FEATURE_GHOST_TAPPING
-    updateGhostTapTimer(elapsed);
+    updateGhostTapTimer(FlxG.elapsed);
     #end
   }
 
@@ -868,6 +896,13 @@ class Strumline extends FlxSpriteGroup
   public function isKeyHeld(dir:NoteDirection):Bool
   {
     return heldKeys[dir].length > 0;
+  }
+
+  override public function destroy():Void
+  {
+    super.destroy();
+
+    if (isPlayer) Application.current.window.onRender.remove(fakeUpdate);
   }
 
   /**


### PR DESCRIPTION
This makes the player's strumline update before anything in the game, kind of like the reason why inputs are faster than Flixel's built-in inputs in this engine.

This PR also makes the player's notes ignore the locked FPS, but inputs do that anyway, and the player's notes are more like a second layer of input logic than anything else.
In this PR, the player's notes won't draw with the window (as `FlxBasic` just handles the drawing for us), but they'll update with it, meaning timing stuff updates with the window so you can hit tighter timings for example.

Also this PR only applies to the PLAYER's notes, the opponent's notes just update with `FlxBasic`'s loop

Also I believe this will be very rejected, but I thought I should try anyway lol