### PR TITLE
[BUGFIX] Fix event dropdown crashing when switching to another event

### DIFF
--- a/source/funkin/ui/debug/charting/toolboxes/ChartEditorEventDataToolbox.hx
+++ b/source/funkin/ui/debug/charting/toolboxes/ChartEditorEventDataToolbox.hx
@@ -152,7 +152,8 @@ class ChartEditorEventDataToolbox extends ChartEditorBaseToolbox
 
     if (newDropdownElement == null)
     {
-      throw 'CHART EDITOR - In Event Toolbox, event kind "${chartEditorState.eventKindToPlace}" not in dropdown!';
+      trace(' WARNING '.bold().bg_yellow() + ' CHART EDITOR - Event kind "${chartEditorState.eventKindToPlace}" not found in dropdown lookup. Attempting to proceed...');
+      newDropdownElement = toolboxEventsEventKind.dataSource.get(0);
     }
     else if (toolboxEventsEventKind.value != newDropdownElement || lastEventKind != toolboxEventsEventKind.value.id)
     {
@@ -180,33 +181,34 @@ class ChartEditorEventDataToolbox extends ChartEditorBaseToolbox
       var value:Null<Dynamic> = pair.value;
 
       var field:Component = toolboxEventsDataBox.findComponent(fieldId);
-      field.pauseEvent(UIEvent.CHANGE, true);
 
-      if (field == null)
+      if (field != null)
       {
-        throw 'ChartEditorEventDataToolbox - Field "${fieldId}" does not exist in the event data form for kind ${lastEventKind}.';
-      }
-      else
-      {
-        switch (field)
+        field.pauseEvent(UIEvent.CHANGE, true);
+
+        switch (Type.getClass(field))
         {
-          case Std.isOfType(_, NumberStepper) => true:
+          case NumberStepper:
             var numberStepper:NumberStepper = cast field;
             numberStepper.value = value;
-          case Std.isOfType(_, CheckBox) => true:
+          case CheckBox:
             var checkBox:CheckBox = cast field;
             checkBox.selected = value;
-          case Std.isOfType(_, DropDown) => true:
+          case DropDown:
             var dropDown:DropDown = cast field;
             dropDown.value = value;
-          case Std.isOfType(_, TextField) => true:
+          case TextField:
             var textField:TextField = cast field;
             textField.text = value;
           default:
-            throw 'ChartEditorEventDataToolbox - Field "${fieldId}" is of unknown type "${Type.getClassName(Type.getClass(field))}".';
+            trace(' WARNING '.bg_yellow().bold() + ' CHART EDITOR '.bold().bg_bright_yellow() + 'Field "${fieldId}" is of unknown or unsupported type.');
         }
+        field.resumeEvent(UIEvent.CHANGE, true, true);
       }
-      field.resumeEvent(UIEvent.CHANGE, true, true);
+      else
+      {
+        trace(' WARNING '.bg_yellow().bold() + ' CHART EDITOR '.bold().bg_bright_yellow() + 'Field "${fieldId}" was not found in the form.');
+      }
     }
 
     shouldTriggerOnEventKindChanged = true;


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
https://github.com/FunkinCrew/Funkin/issues/7766
<!-- Briefly describe the issue(s) fixed. -->
## Description
Fixed a crash in ChartEditorEventDataToolbox.hx where the game would error out if findComponent returned null. I replaced the buggy switch block with a simple if-else check using Std.isOfType. It’s much safer now and stops the editor from crashing when it tries to rebuild the form.
<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos
Gotta use Medal.tv cuz it exceeds 10MB  
link: https://medal.tv/games/friday-night-funkin/clips/n7uQni31cp_IvgoIO?invite=cr-MSxFQ3AsNDM2NzU1ODA4
