### PR TITLE
[ENHANCEMENT] Remove the offset hack in DropShadowShader

### DIFF
--- a/source/funkin/graphics/shaders/DropShadowShader.hx
+++ b/source/funkin/graphics/shaders/DropShadowShader.hx
@@ -449,12 +449,7 @@ class DropShadowShader extends FlxShader
 
         float delta = lwidth_manual(color3_light, uv, px);
 
-        // FIXME: Threshold now uses Luma instead of Gray.
-        // The -0.05 offset is a temporary hack and does NOT accurately match
-        // the old behavior, since the difference varies per color.
-        // Proper fix: adjust thresholds in scripts/mods to account for Luma.
-        float threshold = getThreshold(uv) - 0.05;
-
+        float threshold = getThreshold(uv);
         float intensity = smoothstep(threshold - delta, threshold + delta, color3_light);
 
         float shadowAlpha = 0.0;


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues

<!-- Briefly describe the issue(s) fixed. -->
## Description

I'm removing this offset hack because it doesn't replicate the old shader behavior very well making it look off on some mods

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos
