### PR TITLE
Correct scale multiplier in scaleElement function

### DIFF
--- a/source/funkin/graphics/FunkinSprite.hx
+++ b/source/funkin/graphics/FunkinSprite.hx
@@ -707,8 +707,8 @@ class FunkinSprite extends FlxAnimate
     var symbolInstance:SymbolInstance = element.parentFrame.convertToSymbol(0, 1);
     var transformPoint:FlxPoint = symbolInstance.transformationPoint;
 
-    elementMatrix.a += scale;
-    elementMatrix.d += scale;
+    elementMatrix.a *= scale;
+    elementMatrix.d *= scale;
 
     elementMatrix.tx -= transformPoint.x * scale;
     elementMatrix.ty -= transformPoint.y * scale;


### PR DESCRIPTION
(Move pull request from Main to Develop, https://github.com/FunkinCrew/Funkin/pull/7778,  so sorry)

<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
The documentation describes scale as a multiplier, even though the implementation adds it to the current scale. If this behavior is intentional, then the documentation should be updated

<!-- Briefly describe the issue(s) fixed. -->
## Description
Scale using multiplication instead of addition.

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos
none
