### PR TITLE
[BUGFIX] Hide duplicate sprite when dragging event

### DIFF
--- a/source/funkin/ui/debug/charting/ChartEditorState.hx
+++ b/source/funkin/ui/debug/charting/ChartEditorState.hx
@@ -3990,6 +3990,14 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
 
     // These ones only happen if the modal dialog is not open.
     handleScrollKeybinds();
+
+    if (dragTargetNote != null || dragTargetEvent != null)
+    {
+      if (gridGhostEvent != null) gridGhostEvent.visible = false;
+      if (gridGhostNote != null) gridGhostNote.visible = false;
+      if (gridGhostHoldNote != null) gridGhostHoldNote.visible = false;
+    }
+
     handleCursor();
 
     if (!(isHaxeUIFocused || isCursorOverHaxeUI))


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
Might closes https://github.com/funkinCrew/Funkin/issues/6227
<!-- Briefly describe the issue(s) fixed. -->
## Description
When dragging a note or event in the ChartEditor (e.g., after double-clicking it then drags it) the grid ghost sprites (`gridGhostEvent`, `gridGhostNote`, `gridGhostHoldNote`) remain visible at their last position, creating a "clone" of the dragged item.

This fix hides all three ghost sprites while any drag target is active (`dragTargetNote` or `dragTargetEvent` is not null) removes the clones. The ghosts are naturally re-shown by `handleCursor()` once the drag ends.

### Note:

This bug is very inconsistent to replicate , sometimes you have to doubleclick the event then drags it while sometimes it requires you to doubleclick then click outside of the charting grid then drag which confuses me even more 😭 

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos
Before :

https://github.com/user-attachments/assets/b2dd5686-20de-48d4-b28a-caa8927addc2

After : 


https://github.com/user-attachments/assets/1a6df507-d585-4df8-a54f-546d51ec35aa

