### PR TITLE
[BUGFIX] Use song position of exact input frame when calculating note timings

### DIFF
--- a/source/funkin/input/PreciseInputManager.hx
+++ b/source/funkin/input/PreciseInputManager.hx
@@ -298,8 +298,7 @@ class PreciseInputManager extends FlxKeyManager<FlxKey, PreciseInputList>
       onInputPressed.dispatch({
         noteDirection: getDirectionForKey(key),
         timestamp: timestamp,
-        keyCode: keyCode,
-        position: Conductor?.instance?.songPosition ?? 0.0,
+        keyCode: keyCode
       });
       _dirPressTimestamps.set(getDirectionForKey(key), timestamp);
     }
@@ -317,8 +316,7 @@ class PreciseInputManager extends FlxKeyManager<FlxKey, PreciseInputList>
       onInputReleased.dispatch({
         noteDirection: getDirectionForKey(key),
         timestamp: timestamp,
-        keyCode: keyCode,
-        position: Conductor?.instance?.songPosition ?? 0.0,
+        keyCode: keyCode
       });
       _dirReleaseTimestamps.set(getDirectionForKey(key), timestamp);
     }
@@ -339,7 +337,6 @@ class PreciseInputManager extends FlxKeyManager<FlxKey, PreciseInputList>
         noteDirection: getDirectionForButton(gamepad, buttonId),
         timestamp: timestamp,
         keyCode: button, // implicit cast to int
-        position: Conductor?.instance?.songPosition ?? 0.0,
       });
       _dirPressTimestamps.set(getDirectionForButton(gamepad, buttonId), timestamp);
     }
@@ -359,8 +356,7 @@ class PreciseInputManager extends FlxKeyManager<FlxKey, PreciseInputList>
       onInputReleased.dispatch({
         noteDirection: getDirectionForButton(gamepad, buttonId),
         timestamp: timestamp,
-        keyCode: button, // implicit cast to int
-        position: Conductor?.instance?.songPosition ?? 0.0,
+        keyCode: button // implicit cast to int
       });
       _dirReleaseTimestamps.set(getDirectionForButton(gamepad, buttonId), timestamp);
     }
@@ -485,5 +481,5 @@ typedef PreciseInputEvent =
    * The current position of the Conductor for this event.
    * Used to help calculate the note timing for the exact time.
    */
-  position:Float,
+  ?position:Float,
 };

--- a/source/funkin/input/PreciseInputManager.hx
+++ b/source/funkin/input/PreciseInputManager.hx
@@ -298,7 +298,8 @@ class PreciseInputManager extends FlxKeyManager<FlxKey, PreciseInputList>
       onInputPressed.dispatch({
         noteDirection: getDirectionForKey(key),
         timestamp: timestamp,
-        keyCode: keyCode
+        keyCode: keyCode,
+        position: Conductor?.instance?.songPosition ?? 0.0,
       });
       _dirPressTimestamps.set(getDirectionForKey(key), timestamp);
     }
@@ -316,7 +317,8 @@ class PreciseInputManager extends FlxKeyManager<FlxKey, PreciseInputList>
       onInputReleased.dispatch({
         noteDirection: getDirectionForKey(key),
         timestamp: timestamp,
-        keyCode: keyCode
+        keyCode: keyCode,
+        position: Conductor?.instance?.songPosition ?? 0.0,
       });
       _dirReleaseTimestamps.set(getDirectionForKey(key), timestamp);
     }
@@ -336,7 +338,8 @@ class PreciseInputManager extends FlxKeyManager<FlxKey, PreciseInputList>
       onInputPressed.dispatch({
         noteDirection: getDirectionForButton(gamepad, buttonId),
         timestamp: timestamp,
-        keyCode: button // implicit cast to int
+        keyCode: button, // implicit cast to int
+        position: Conductor?.instance?.songPosition ?? 0.0,
       });
       _dirPressTimestamps.set(getDirectionForButton(gamepad, buttonId), timestamp);
     }
@@ -356,7 +359,8 @@ class PreciseInputManager extends FlxKeyManager<FlxKey, PreciseInputList>
       onInputReleased.dispatch({
         noteDirection: getDirectionForButton(gamepad, buttonId),
         timestamp: timestamp,
-        keyCode: button // implicit cast to int
+        keyCode: button, // implicit cast to int
+        position: Conductor?.instance?.songPosition ?? 0.0,
       });
       _dirReleaseTimestamps.set(getDirectionForButton(gamepad, buttonId), timestamp);
     }
@@ -475,5 +479,11 @@ typedef PreciseInputEvent =
    * The key that was used for the input.
    * Used to distinguish between multiple inputs for the same direction.
    */
-  keyCode:Int
+  keyCode:Int,
+
+  /**
+   * The current position of the Conductor for this event.
+   * Used to help calculate the note timing for the exact time.
+   */
+  position:Float,
 };

--- a/source/funkin/play/PlayState.hx
+++ b/source/funkin/play/PlayState.hx
@@ -3179,9 +3179,9 @@ class PlayState extends MusicBeatSubState
     var inputLatencyMs:Float = inputLatencyNs.toFloat() / Constants.NS_PER_MS;
     // trace('Input: ${daNote.noteData.getDirectionName()} pressed ${inputLatencyMs}ms ago!');
 
-    // Get the offset and compensate for input latency.
-    // Round inward (trim remainder) for consistency.
-    var noteDiff:Int = Std.int(Conductor.instance.songPosition - note.noteData.time - inputLatencyMs);
+    // Use the input's song position when calculating the ms difference.
+    // Also compensate for input latency.
+    var noteDiff:Int = Std.int(input.position - note.noteData.time - inputLatencyMs);
 
     var score = Scoring.scoreNote(noteDiff, PBOT1);
     var daRating = Scoring.judgeNote(noteDiff, PBOT1);

--- a/source/funkin/play/PlayState.hx
+++ b/source/funkin/play/PlayState.hx
@@ -2824,6 +2824,9 @@ class PlayState extends MusicBeatSubState
   {
     if (isGamePaused) return;
 
+    // Set the current position for further calculation.
+    event.position = Conductor.instance.songPosition;
+
     // Do the minimal possible work here.
     inputPressQueue.push(event);
   }
@@ -2833,6 +2836,9 @@ class PlayState extends MusicBeatSubState
    */
   function onKeyRelease(event:PreciseInputEvent):Void
   {
+    // Set the current position for further calculation.
+    event.position = Conductor.instance.songPosition;
+
     // Do the minimal possible work here.
     inputReleaseQueue.push(event);
   }
@@ -3173,6 +3179,7 @@ class PlayState extends MusicBeatSubState
 
   function goodNoteHit(note:NoteSprite, input:PreciseInputEvent):Void
   {
+    var inputPosition:Float = input.position ?? 0.0;
     // Calculate the input latency (do this as late as possible).
     // trace('Compare: ${PreciseInputManager.getCurrentTimestamp()} - ${input.timestamp}');
     var inputLatencyNs:Int64 = PreciseInputManager.getCurrentTimestamp() - input.timestamp;
@@ -3181,7 +3188,7 @@ class PlayState extends MusicBeatSubState
 
     // Use the input's song position when calculating the ms difference.
     // Also compensate for input latency.
-    var noteDiff:Int = Std.int(input.position - note.noteData.time - inputLatencyMs);
+    var noteDiff:Int = Std.int(inputPosition - note.noteData.time - inputLatencyMs);
 
     var score = Scoring.scoreNote(noteDiff, PBOT1);
     var daRating = Scoring.judgeNote(noteDiff, PBOT1);

--- a/source/funkin/ui/options/OffsetMenu.hx
+++ b/source/funkin/ui/options/OffsetMenu.hx
@@ -387,6 +387,9 @@ class OffsetMenu extends Page<OptionsState.OptionsMenuPageName>
      */
   function onKeyPress(event:PreciseInputEvent):Void
   {
+    // Set the current position for further calculation.
+    event.position = localConductor.songPosition;
+
     // Do the minimal possible work here.
     inputPressQueue.push(event);
   }
@@ -396,6 +399,9 @@ class OffsetMenu extends Page<OptionsState.OptionsMenuPageName>
      */
   function onKeyRelease(event:PreciseInputEvent):Void
   {
+    // Set the current position for further calculation.
+    event.position = localConductor.songPosition;
+
     // Do the minimal possible work here.
     inputReleaseQueue.push(event);
   }
@@ -816,11 +822,11 @@ class OffsetMenu extends Page<OptionsState.OptionsMenuPageName>
 
   function hitNote(note:NoteSprite, input:PreciseInputEvent):Void
   {
+    var inputPosition:Float = input.position ?? 0.0;
     var inputLatencyNs:Int64 = PreciseInputManager.getCurrentTimestamp() - input.timestamp;
     var inputLatencyMs:Float = inputLatencyNs.toFloat() / Constants.NS_PER_MS;
 
-    var noteDiff:Int = Std.int(note.noteData.time - localConductor.songPosition - inputLatencyMs);
-
+    var noteDiff:Int = Std.int(note.noteData.time - inputPosition - inputLatencyMs);
     addDifference(noteDiff);
 
     if (noteDiff == 0)


### PR DESCRIPTION
Currently, the game calculates note timings by comparing the milliseconds of the conductor's current position with the note's millisecond time while also compensating for input latency.

However, due to there being latency between the exact frame the input was pressed and the frame at which the input is actually being processed, the song position the game uses to calculate the ms difference is not accurate. 

This PR stores the milliseconds of the current song position for the precise input frame and uses that to calculate the note timing, which should help with bringing more accurate inputs.