### PR TITLE
[BUGFIX] Fix exiting Controls Menu with a gamepad going straight to Main Menu

### DIFF
--- a/source/funkin/ui/options/OptionsState.hx
+++ b/source/funkin/ui/options/OptionsState.hx
@@ -130,17 +130,25 @@ class OptionsState extends MusicBeatState
     optionsCodex.switchPage(Options);
   }
 
+  var justExitedControls:Bool = false;
   function exitControls():Void
   {
     // Apply any changes to the controls.
     PlayerSettings.reset();
     PlayerSettings.init();
 
+    justExitedControls = true;
+
     optionsCodex.switchPage(Options);
   }
 
   function exitToMainMenu():Void
   {
+    if (justExitedControls)
+    {
+      justExitedControls = false;
+      return;
+    }
     optionsCodex.currentPage.enabled = false;
     // TODO: Animate this transition?
     if (backState != null)


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues

#7215 

<!-- Briefly describe the issue(s) fixed. -->
## Description

This simple PR fixes a bug reported a while ago where pressing back with a gamepad in the Controls Menu directly sends you to the Main Menu. This is fixed adding a tiny check as the PauseSubState script does to avoid going back again on the first frame

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos

(forget my obs being messy and moving the damn window to the right 😅)

https://github.com/user-attachments/assets/772e09b9-2bcd-499c-8eeb-7301f24f7648


