### PR TITLE
[CHORE] Remove `Conductor.songPositionDelta`

### DIFF
--- a/source/funkin/Conductor.hx
+++ b/source/funkin/Conductor.hx
@@ -106,12 +106,6 @@ class Conductor
    */
   public var songPosition(default, null):Float = 0;
 
-  /**
-   * The offset between frame time and music time.
-   * Used in `getTimeWithDelta()` to get a more accurate music time when on higher framerates.
-   */
-  var songPositionDelta(default, null):Float = 0;
-
   var prevTimestamp:Float = 0;
   var prevTime:Float = 0;
 
@@ -440,7 +434,6 @@ class Conductor
     if (FlxG.sound.music != null && FlxG.sound.music.playing)
     {
       this.songPosition = Math.min(this.combinedOffset, 0).clamp(songPos, currentLength);
-      this.songPositionDelta += FlxG.elapsed * 1000 * FlxG.sound.music.pitch;
     }
     else
     {
@@ -504,8 +497,6 @@ class Conductor
     // which it doesn't do every frame!
     if (prevTime != this.songPosition)
     {
-      this.songPositionDelta = 0;
-
       // Update the timestamp for use in-between frames
       prevTime = this.songPosition;
       prevTimestamp = Std.int(Timer.stamp() * 1000);
@@ -518,9 +509,10 @@ class Conductor
    * Returns a more accurate music time for higher framerates.
    * @return Float
    */
+  @:deprecated('Use songPosition directly instead.')
   public function getTimeWithDelta():Float
   {
-    return this.songPosition + this.songPositionDelta;
+    return this.songPosition;
   }
 
   /**

--- a/source/funkin/util/GRhythmUtil.hx
+++ b/source/funkin/util/GRhythmUtil.hx
@@ -137,6 +137,6 @@ class GRhythmUtil
   public static function getNoteY(strumTime:Float, scrollSpeed:Float, downscroll:Bool = false, ?conductorInUse:Conductor):Float
   {
     if (conductorInUse == null) conductorInUse = Conductor.instance;
-    return Constants.PIXELS_PER_MS * (conductorInUse.getTimeWithDelta() - strumTime) * scrollSpeed * (downscroll ? 1 : -1);
+    return Constants.PIXELS_PER_MS * (conductorInUse.songPosition - strumTime) * scrollSpeed * (downscroll ? 1 : -1);
   }
 }


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Briefly describe the issue(s) fixed. -->
## Description
Due to `FunkinCrew/lime` commit [5a3c6d0](https://github.com/FunkinCrew/lime/commit/5a3c6d0b798a9e53aa8eb06f2b41318122e7a00b), `Conductor.songPositionDelta` is no longer needed for "accurate" time calculations.

This PR removes all logic tied to it, since it provides zero benefit. `Conductor.getTimeWithDelta()` is still kept, as a deprecated function, for backwards compatibility.
