### PR TITLE
[BUGFIX] Fix cancel sound being replayable when leaving Mod Menu

### DIFF
--- a/source/funkin/ui/modmenu/ModMenuState.hx
+++ b/source/funkin/ui/modmenu/ModMenuState.hx
@@ -1115,7 +1115,7 @@ class ModMenuState extends MusicBeatState
 
   function handleMouse():Void
   {
-    if (hasTransitions()) return;
+    if (hasTransitions() || exitingMenu) return;
 
     if (FlxG.mouse.justPressed)
     {
@@ -1285,7 +1285,7 @@ class ModMenuState extends MusicBeatState
 
   function handleKeyboard():Void
   {
-    if (hasTransitions()) return;
+    if (hasTransitions() || exitingMenu) return;
 
     var pressingCtrl:Bool = FlxG.keys.pressed.CONTROL;
     if (controls.BACK_P)
@@ -1526,7 +1526,7 @@ class ModMenuState extends MusicBeatState
       }
     }
 
-    if (controls.ACCEPT_P && !hasTransitions() && acceptDelay <= 0)
+    if (controls.ACCEPT_P && acceptDelay <= 0)
     {
       FunkinSound.playOnce(Paths.sound('ui/main-menu/scroll-menu'), 0.4);
       enabledModItems.repositionItems();


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
None

<!-- Briefly describe the issue(s) fixed. -->
## Description
This PR fixes the cancel menu sound being able to still be played when leaving the mod menu state

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos

BEFORE:

https://github.com/user-attachments/assets/fe3b3253-585b-4b90-8b7e-e1819f4e3c06

AFTER:

https://github.com/user-attachments/assets/b9ea9828-7014-4341-8a31-388c1da9d44c

