### PR TITLE
[BUGFIX] Fix flipping quick menu causing the state's volume to increasingly lower

### DIFF
--- a/source/funkin/ui/quickpanel/QuickPanelGroup.hx
+++ b/source/funkin/ui/quickpanel/QuickPanelGroup.hx
@@ -293,6 +293,11 @@ class QuickPanelGroup extends FunkinSpriteGroup
 
     repositionButtons();
 
+    if (FlxG.sound.music != null)
+    {
+      FlxG.sound.music.volume = rememberedVolume;
+    }
+
     switch (curState)
     {
       case OPEN:


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
None

<!-- Briefly describe the issue(s) fixed. -->
## Description
This PR fixes flipping the quick menu causing the rememberedVolume to change to the currently lowered volume, causing the music in the custom state to keep lowering

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos
BEFORE:

https://github.com/user-attachments/assets/512e79a8-b97d-4e15-9b5a-bf1fda227039


AFTER:

https://github.com/user-attachments/assets/608ce2fe-e907-4c97-b7fa-affde0af1935

