### PR TITLE
[BUGFIX] Fix music metadata backwards compat not finding the right file

### DIFF
--- a/source/funkin/modding/compat/Paths.hx
+++ b/source/funkin/modding/compat/Paths.hx
@@ -1,5 +1,6 @@
 package funkin.modding.compat;
 
+import haxe.io.Path;
 import openfl.utils.AssetType as OpenFLAssetType;
 
 /**
@@ -3693,16 +3694,17 @@ class Paths
           + 'Chill/$fileName';
 
         // Redirect for music metadata
-        var musicDataFilePath:String = (library == 'default') ? 'assets/music/$id' : 'assets/$library/music/$id';
-        var musicMetadataFilePath:String = (library == 'default') ? 'assets/music/${id.replace('.json', '-metadata.json')}' : 'assets/$library/music/${id.replace('.json', '-metadata.json')}';
+        var musPath:Path = new Path(id);
+        var file:String = musPath.file.replace('-metadata', '');
+
+        musPath.dir = (library == 'default' ? 'assets/music/' : 'assets/$library/music/') + (musPath.dir ?? '') + file;
 
         usePathIfExists(dataFilePath);
         usePathIfExists(imageFilePath);
         usePathIfExists(songDataFilePath);
         usePathIfExists(songFilePath);
         usePathIfExists(charSelectFilePath);
-        usePathIfExists(musicDataFilePath);
-        usePathIfExists(musicMetadataFilePath);
+        usePathIfExists(musPath.toString());
 
       case 'ogg': // Music or sound
         // Redirect for music files


### PR DESCRIPTION
## Linked Issues
N/A

## Description
Previously, the backwards compatibility for the music metadata would point to `assets/music/song-metadata.json`, however in older versions, music metadata was stored in `assets/music/song/song-metadata.json`, whoopsie! This PR fixes that and also removes the data filepath from the `assets/music` lookup since I don't think that was ever supported.

## Screenshots/Videos
Dunno man im lowk kinda lazy