### PR TITLE
[ENHANCEMENT] Gamepad compatibility for Mod Menu

### DIFF
--- a/source/funkin/ui/modmenu/ModMenuState.hx
+++ b/source/funkin/ui/modmenu/ModMenuState.hx
@@ -1297,116 +1297,6 @@ class ModMenuState extends MusicBeatState
 
     oldSelection = selection;
 
-    if (controls.UI_UP || controls.UI_DOWN || controls.UI_LEFT || controls.UI_RIGHT)
-    {
-      if (holdDirection == 0)
-      {
-        holdDirection = controls.UI_UP ? -1 : controls.UI_DOWN ? 1 : controls.UI_LEFT ? -2 : 2;
-        holdTimer = 0.5; // initial delay before starting to scroll
-      }
-      else if
-        ((controls.UI_UP && holdDirection == -1)
-          || (controls.UI_DOWN && holdDirection == 1)
-          || (controls.UI_LEFT && holdDirection == -2)
-          || (controls.UI_RIGHT && holdDirection == 2)
-        )
-      {
-        holdTimer -= FlxG.elapsed;
-        if (holdTimer <= 0)
-        {
-          doHoldAction = true;
-        }
-      }
-    }
-    else
-    {
-      holdDirection = 0;
-      doHoldAction = false;
-    }
-
-    if (doHoldAction && delay <= 0)
-    {
-      delay = 0.1;
-      switch (selection)
-      {
-        case DisabledModList:
-          switch (holdDirection)
-          {
-            case -1:
-              disabledModItems.moveUp();
-            case 1:
-              disabledModItems.moveDown();
-            case -2:
-              selection = Done;
-              lastSelectDir = -2;
-            case 2:
-              selection = EnabledModList;
-              lastSelectDir = 2;
-          }
-        case EnabledModList:
-          switch (holdDirection)
-          {
-            case -1:
-              enabledModItems.moveUp();
-            case 1:
-              enabledModItems.moveDown();
-            case -2:
-              if (disabledModItems.modItems.length > 0) selection = DisabledModList;
-              else
-                selection = Done;
-              lastSelectDir = -2;
-            case 2:
-              selection = OpenModsFolder;
-              lastSelectDir = 2;
-          }
-        case OpenModsFolder:
-          switch (holdDirection)
-          {
-            case -1:
-              selection = DisabledModList;
-              lastSelectDir = -1;
-            case 1:
-              selection = DisabledModList;
-              lastSelectDir = 1;
-            case -2:
-              selection = EnabledModList;
-              lastSelectDir = -2;
-            case 2:
-              selection = Done;
-              lastSelectDir = 2;
-          }
-        case Done:
-          switch (holdDirection)
-          {
-            case -1:
-              selection = EnabledModList;
-              lastSelectDir = -1;
-            case 1:
-              selection = EnabledModList;
-              lastSelectDir = 1;
-            case -2:
-              selection = OpenModsFolder;
-              lastSelectDir = -2;
-            case 2:
-              selection = DisabledModList;
-              lastSelectDir = 2;
-          }
-        case BackToMenu:
-          switch (holdDirection)
-          {
-            case -1:
-              if (lastSelectDir == -1) selection = Done; else selection = OpenModsFolder;
-            case 1:
-              if (lastSelectDir == -1) selection = EnabledModList; else selection = DisabledModList;
-            case -2:
-              // Nothing
-            case 2:
-              // Nothing
-          }
-      }
-    }
-    if (delay > 0) delay -= FlxG.elapsed;
-
     if (controls.UI_LEFT_P)
     {
       switch (selection)
@@ -1526,7 +1416,117 @@ class ModMenuState extends MusicBeatState
       }
     }
 
-    if (controls.ACCEPT_P && acceptDelay <= 0)
+    if (controls.UI_UP || controls.UI_DOWN || controls.UI_LEFT || controls.UI_RIGHT)
+    {
+      if (holdDirection == 0)
+      {
+        holdDirection = controls.UI_UP ? -1 : controls.UI_DOWN ? 1 : controls.UI_LEFT ? -2 : 2;
+        holdTimer = 0.5; // initial delay before starting to scroll
+      }
+      else if
+        ((controls.UI_UP && holdDirection == -1)
+          || (controls.UI_DOWN && holdDirection == 1)
+          || (controls.UI_LEFT && holdDirection == -2)
+          || (controls.UI_RIGHT && holdDirection == 2)
+        )
+      {
+        holdTimer -= FlxG.elapsed;
+        if (holdTimer <= 0)
+        {
+          doHoldAction = true;
+        }
+      }
+    }
+    else
+    {
+      holdDirection = 0;
+      doHoldAction = false;
+    }
+
+    if (doHoldAction && delay <= 0)
+    {
+      delay = 0.1;
+      switch (selection)
+      {
+        case DisabledModList:
+          switch (holdDirection)
+          {
+            case -1:
+              disabledModItems.moveUp();
+            case 1:
+              disabledModItems.moveDown();
+            case -2:
+              selection = Done;
+              lastSelectDir = -2;
+            case 2:
+              selection = EnabledModList;
+              lastSelectDir = 2;
+          }
+        case EnabledModList:
+          switch (holdDirection)
+          {
+            case -1:
+              enabledModItems.moveUp();
+            case 1:
+              enabledModItems.moveDown();
+            case -2:
+              if (disabledModItems.modItems.length > 0) selection = DisabledModList;
+              else
+                selection = Done;
+              lastSelectDir = -2;
+            case 2:
+              selection = OpenModsFolder;
+              lastSelectDir = 2;
+          }
+        case OpenModsFolder:
+          switch (holdDirection)
+          {
+            case -1:
+              selection = DisabledModList;
+              lastSelectDir = -1;
+            case 1:
+              selection = DisabledModList;
+              lastSelectDir = 1;
+            case -2:
+              selection = EnabledModList;
+              lastSelectDir = -2;
+            case 2:
+              selection = Done;
+              lastSelectDir = 2;
+          }
+        case Done:
+          switch (holdDirection)
+          {
+            case -1:
+              selection = EnabledModList;
+              lastSelectDir = -1;
+            case 1:
+              selection = EnabledModList;
+              lastSelectDir = 1;
+            case -2:
+              selection = OpenModsFolder;
+              lastSelectDir = -2;
+            case 2:
+              selection = DisabledModList;
+              lastSelectDir = 2;
+          }
+        case BackToMenu:
+          switch (holdDirection)
+          {
+            case -1:
+              if (lastSelectDir == -1) selection = Done; else selection = OpenModsFolder;
+            case 1:
+              if (lastSelectDir == -1) selection = EnabledModList; else selection = DisabledModList;
+            case -2:
+              // Nothing
+            case 2:
+              // Nothing
+          }
+      }
+    }
+    if (delay > 0) delay -= FlxG.elapsed;
+
+    if (controls.ACCEPT_P && !hasTransitions() && acceptDelay <= 0)
     {
       FunkinSound.playOnce(Paths.sound('ui/main-menu/scroll-menu'), 0.4);
       enabledModItems.repositionItems();


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues

Nope

<!-- Briefly describe the issue(s) fixed. -->
## Description

This PR makes gamepads work in the Mod Menu. This happened because just pressed actions were checked after pressed ones, which works on keyboard, but not with gamepad for some reason (`checkFiltered` i'm looking at you.) Simply by moving these checks to execute before the pressed ones fixes the issue. This is also why some actions like `ACCEPT_P` worked but no directions. (fun fact this also happened with the Char Select menu lmao and the fix was exactly the same)

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos

https://github.com/user-attachments/assets/e61a48e9-ca7e-4920-9a50-2c92f521484e


