### PR TITLE
[BUGFIX] Fix compiling with `-DNO_FEATURE_NEWGROUNDS`

### DIFF
--- a/source/funkin/assets/Assets.hx
+++ b/source/funkin/assets/Assets.hx
@@ -889,8 +889,11 @@ class Assets implements ConsoleClass
 
     // Keep the cursor assets cached persistently, since they could be used at any time.
     results = results.concat(funkin.input.Cursor.queryAssets(type));
+
+    #if FEATURE_NEWGROUNDS
     // Keep the medal popup assets cached persistently, since it could show up at any time.
     results = results.concat(funkin.api.newgrounds.Medals.queryAssets(type));
+    #end
 
     // Keep transition assets cached persistently, since we don't want to require a loading screen FOR a loading screen.
     // results = results.concat(funkin.ui.transition.Transition.queryAssets(type));


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
no...
<!-- Briefly describe the issue(s) fixed. -->
## Description
The new Assets caching tries to cache the Newgrounds medal assets, which breaks if you choose to compile without it. (I like to compile without just because I don't have the environment variables anyways...)

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos
<img width="818" height="188" alt="image" src="https://github.com/user-attachments/assets/595542fc-03de-4d1c-93fa-d669d60216fc" />