### PR TITLE
[ENHANCEMENT] Load `SongRegistry` asynchronously when hot reloading, clear scripted song variations.

### DIFF
--- a/source/funkin/data/BaseRegistry.hx
+++ b/source/funkin/data/BaseRegistry.hx
@@ -164,9 +164,8 @@ abstract class BaseRegistry<T:(IRegistryEntry<J> & Constructible<EntryConstructo
 
       if (entry != null)
       {
+        onScriptedEntryLoaded(entryCls, entry);
         log('Instantiated scripted entry (${entryCls} = ${entry.id})');
-        entries.set(entry.id, entry);
-        scriptedEntryIds.set(entry.id, entryCls);
       }
       else
       {
@@ -190,8 +189,8 @@ abstract class BaseRegistry<T:(IRegistryEntry<J> & Constructible<EntryConstructo
         var entry:Null<T> = createEntry(entryId);
         if (entry != null)
         {
+          onUnscriptedEntryLoaded(entry);
           log('Instantiated unscripted entry (${entry.id})');
-          entries.set(entry.id, entry);
         }
       }
       catch (e)
@@ -203,6 +202,25 @@ abstract class BaseRegistry<T:(IRegistryEntry<J> & Constructible<EntryConstructo
     }
 
     perf.print();
+  }
+
+  /**
+   * Called when a scripted entry has been successfully loaded.
+   * @param entry The entry that was loaded.
+   */
+  function onScriptedEntryLoaded(clsName:String, entry:T):Void
+  {
+    entries.set(entry.id, entry);
+    scriptedEntryIds.set(entry.id, clsName);
+  }
+
+  /**
+   * Called when an unscripted entry has been successfully loaded.
+   * @param entry The entry that was loaded.
+   */
+  function onUnscriptedEntryLoaded(entry:T):Void
+  {
+    entries.set(entry.id, entry);
   }
 
   #if FEATURE_MULTITHREADING
@@ -244,21 +262,21 @@ abstract class BaseRegistry<T:(IRegistryEntry<J> & Constructible<EntryConstructo
     // When the last task completes, we can complete the promise.
     var checkComplete:Void->Void = () ->
     {
-      var completedCount = entries.size() + entryErrors.length;
+      var completedCount = countEntries() + entryErrors.length;
       if (completedCount == entryCount)
       {
         if (!doneScriptedEntries)
         {
           doneScriptedEntries = true;
           startUnscriptedEntries();
-          log('Finished loading entries (1/2) (${entries.size()}+${entryErrors.length} / ${entryCount})');
+          log('Finished loading entries (1/2) ($completedCount / ${entryCount})');
           return;
         }
         else
         {
-          log('Finished loading entries (2/2) (${entries.size()}+${entryErrors.length} / ${entryCount})');
+          log('Finished loading entries (2/2) ($completedCount / ${entryCount})');
           promise.complete({
-            entriesLoaded: entries.size(),
+            entriesLoaded: countEntries(),
             entriesFailed: entryErrors.length
           });
           perf.print();
@@ -277,7 +295,7 @@ abstract class BaseRegistry<T:(IRegistryEntry<J> & Constructible<EntryConstructo
             log('  Unfinished: ${unfinishedEntries.join(', ')}')
             log('  Scripted (${scriptedEntryIds.length}): ${scriptedEntryClassNames.join(', ')}')
             log('  Unscripted (${unscriptedEntryIds.length}): ${unscriptedEntryIds.join(', ')}')
-            log('  Entries (${entries.size()}): ${entries.keys().array().join(', ')}')
+            log('  Entries (${countEntries()}): ${entries.keys().array().join(', ')}')
            */
         }
       }
@@ -296,21 +314,20 @@ abstract class BaseRegistry<T:(IRegistryEntry<J> & Constructible<EntryConstructo
     };
 
     // Callback when one task completes with success
-    var onScriptedEntryLoaded:({entryId:String, entry:T, entryCls:String}) -> Void = (state) ->
+    var onScriptedEntryLoadedAsync:({entryId:String, entry:T, entryCls:String}) -> Void = (state) ->
     {
-      entries.set(state.entryId, state.entry);
-      scriptedEntryIds.set(state.entryId, state.entryCls);
+      onScriptedEntryLoaded(state.entryCls, state.entry);
 
-      log('  Loaded scripted entry: ${state.entryId} (${state.entryCls}) (${entries.size()}+${entryErrors.length}/${entryCount})');
+      log('  Loaded scripted entry: ${state.entry.id} (${state.entryCls}) (${countEntries()}+${entryErrors.length}/${entryCount})');
       checkComplete();
     };
 
     // Callback when one task completes with success
-    var onUnscriptedEntryLoaded:(
+    var onUnscriptedEntryLoadedAsync:(
       {entryId:String, entry:T}) -> Void = (state) ->
       {
-        entries.set(state.entryId, state.entry);
-        log('  Loaded unscripted entry: ${state.entryId} (${entries.size()}+${entryErrors.length}/${entryCount})');
+        onUnscriptedEntryLoaded(state.entry);
+        log('  Loaded unscripted entry: ${state.entryId} (${countEntries()}+${entryErrors.length}/${entryCount})');
         checkComplete();
       };
 
@@ -420,7 +437,7 @@ abstract class BaseRegistry<T:(IRegistryEntry<J> & Constructible<EntryConstructo
               {entryId:String, entry:T}>());
 
             unscriptedEntryFuture.onError(onError);
-            unscriptedEntryFuture.onComplete(onUnscriptedEntryLoaded);
+            unscriptedEntryFuture.onComplete(onUnscriptedEntryLoadedAsync);
           }
         }
       });
@@ -467,7 +484,7 @@ abstract class BaseRegistry<T:(IRegistryEntry<J> & Constructible<EntryConstructo
             {entryId:String, entry:T, entryCls:String}>());
 
           scriptedEntryFuture.onError(onError);
-          scriptedEntryFuture.onComplete(onScriptedEntryLoaded);
+          scriptedEntryFuture.onComplete(onScriptedEntryLoadedAsync);
         }
       }
     });

--- a/source/funkin/data/song/SongRegistry.hx
+++ b/source/funkin/data/song/SongRegistry.hx
@@ -23,6 +23,7 @@ class SongRegistry extends BaseRegistry<Song, SongMetadata, SongEntryParams> imp
    * and adding migration to the `migrateStageData()` function.
    */
   public static final SONG_METADATA_VERSION:thx.semver.Version = '2.2.8';
+
   public static final SONG_METADATA_VERSION_RULE:thx.semver.VersionRule = '2.2.x';
   public static final SONG_CHART_DATA_VERSION:thx.semver.Version = '2.0.0';
   public static final SONG_CHART_DATA_VERSION_RULE:thx.semver.VersionRule = '2.0.x';
@@ -47,68 +48,45 @@ class SongRegistry extends BaseRegistry<Song, SongMetadata, SongEntryParams> imp
     });
   }
 
-  override public function loadEntries():Void
+  override function onScriptedEntryLoaded(clsName:String, entry:Song):Void
   {
-    clearEntries();
-
-    //
-    // SCRIPTED ENTRIES
-    //
-    var scriptedEntryClassNames:Array<String> = getScriptedClassNames();
-    log(' INFO '.info() + 'Parsing ${scriptedEntryClassNames.length} scripted entries...');
-
-    for (entryCls in scriptedEntryClassNames)
+    if (entry.variation != null)
     {
-      var entry:Null<Song> = createScriptedEntry(entryCls);
+      scriptedSongVariations.set('${entry.id}:${entry.variation}', entry);
+      log('Successfully created scripted entry (${clsName} = ${entry.id}, ${entry.variation})');
+    }
+    else
+    {
+      entries.set(entry.id, entry);
+      scriptedEntryIds.set(entry.id, clsName);
+      log('Successfully created scripted entry (${clsName} = ${entry.id})');
+    }
+  }
 
-      if (entry != null)
-      {
-        if (entry.variation != null)
-        {
-          scriptedSongVariations.set('${entry.id}:${entry.variation}', entry);
-          log('Successfully created scripted entry (${entryCls} = ${entry.id}, ${entry.variation})');
-        }
-        else
-        {
-          entries.set(entry.id, entry);
-          scriptedEntryIds.set(entry.id, entryCls);
-          log('Successfully created scripted entry (${entryCls} = ${entry.id})');
-        }
-      }
-      else
-      {
-        log('Failed to create scripted entry (${entryCls})');
-      }
+  override function countEntries():Int
+  {
+    // Account for song variations.
+    return entries.size() + scriptedSongVariations.size();
+  }
+
+  override function clearEntries():Void
+  {
+    log('Destroying ${countEntries()} entries in registry...');
+
+    for (entry in entries)
+    {
+      entry.destroy();
     }
 
-    //
-    // UNSCRIPTED ENTRIES
-    //
-    var entryIdList:Array<String> = funkin.modding.compat.RegistryData.listEntryIds('gameplay/songs/', '-metadata', true);
-    var unscriptedEntryIds:Array<String> = entryIdList.filter((entryId:String) ->
+    // Override to clear song variations.
+    for (entry in scriptedSongVariations)
     {
-      return !entries.exists(entryId);
-    });
-    log('Parsing ${unscriptedEntryIds.length} unscripted entries...');
-    for (entryId in unscriptedEntryIds)
-    {
-      try
-      {
-        var entry:Null<Song> = createEntry(entryId);
-        if (entry != null)
-        {
-          log('Loaded entry data: ${entry}');
-          entries.set(entry.id, entry);
-        }
-      }
-      catch (e:Dynamic)
-      {
-        // Print the error.
-        log(' ERROR '.error() + 'Failed to load entry data: ${entryId}');
-        log(' ERROR '.error() + e);
-        continue;
-      }
+      entry.destroy();
     }
+
+    entries.clear();
+    scriptedEntryIds.clear();
+    scriptedSongVariations.clear();
   }
 
   /**

--- a/source/funkin/ui/transition/preload/hotreload/HotReloadState.hx
+++ b/source/funkin/ui/transition/preload/hotreload/HotReloadState.hx
@@ -266,8 +266,7 @@ class HotReloadState extends MusicBeatState
 
     var futures:Array<Future<LoadEntriesResult>> = [];
 
-    // All of these create task which can be performed in parallel. Beautiful.
-
+    futures.push(SongRegistry.instance.loadEntriesAsync());
     futures.push(LevelRegistry.instance.loadEntriesAsync());
     futures.push(NoteStyleRegistry.instance.loadEntriesAsync());
     futures.push(PlayerRegistry.instance.loadEntriesAsync());
@@ -305,7 +304,6 @@ class HotReloadState extends MusicBeatState
     TaskHandler.performSimpleTask(() ->
     {
       // These use the registry system (sorta) but need more work to support async loading.
-      SongRegistry.instance.loadEntries();
       CharacterDataParser.loadCharacterCache();
 
       // These don't use the registry system at all, they're synchronous but fairly quick.


### PR DESCRIPTION
This PR fixes `SongRegistry` not being asynchronously loaded when hot reloading the game, by treating scripted song variations as entries as well. This also allows them to be properly cleared out when the registry is being reloaded.