### PR TITLE
[ENHANCEMENT] Implement loading modules asynchronously

### DIFF
--- a/source/funkin/modding/module/ModuleHandler.hx
+++ b/source/funkin/modding/module/ModuleHandler.hx
@@ -1,15 +1,14 @@
 package funkin.modding.module;
 
-import hx.concurrent.collection.SynchronizedArray;
-import funkin.util.tasks.TaskHandler;
 import flixel.FlxG;
 import funkin.data.BaseRegistry.LoadEntriesResult;
-import funkin.modding.events.ScriptEvent.UpdateScriptEvent;
 import funkin.modding.events.ScriptEvent;
 import funkin.modding.events.ScriptEventDispatcher;
 import funkin.modding.module.Module;
 import funkin.modding.module.ScriptedModule;
 import funkin.util.SortUtil;
+import funkin.util.tasks.TaskHandler;
+import hx.concurrent.collection.SynchronizedArray;
 import lime.app.Future;
 
 /**
@@ -77,19 +76,22 @@ class ModuleHandler
 
     var checkAsyncProgress:Void->Void = () ->
     {
-      var completedCount = moduleCache.size() + entryErrors.length;
+      var completedCount = getModuleCount() + entryErrors.length;
       if (completedCount == moduleCount)
       {
         // Finish the promise.
         promise.complete({
-          entriesLoaded: moduleCache.size(),
+          entriesLoaded: getModuleCount(),
           entriesFailed: entryErrors.length
         });
         trace('Finished loading modules ($completedCount / $moduleCount)');
         perf.print();
+
+        reorderModuleCache();
       }
     };
 
+    // Called when an error occurs while a module was being loaded.
     var onError:(String,
       {error:Any, moduleCls:Null<String>}) -> Void = (moduleId, state) ->
       {
@@ -97,10 +99,11 @@ class ModuleHandler
           moduleId: moduleId,
           error: state.error
         });
-        trace('  Failed to load entry data (${moduleId}): ${state.error}');
+        trace('  Failed to load module (${moduleId}): ${state.error}');
         checkAsyncProgress();
       };
 
+    // Called once a module's task has been completed.
     var onModuleLoadedAsync:(String,
       {module:Module, moduleCls:String}) -> Void = (_, state) ->
       {
@@ -108,6 +111,7 @@ class ModuleHandler
         checkAsyncProgress();
       };
 
+    // Task for loading a single module.
     var loadModuleAsync:Task = (currentState:State, workOutput:WorkOutput) ->
     {
       var moduleCls:String = currentState.moduleCls;
@@ -116,7 +120,6 @@ class ModuleHandler
         var module:Null<Module> = ScriptedModule.scriptInit(moduleCls, moduleCls);
         if (module != null)
         {
-          // log('Successfully created scripted entry (${entryCls} = ${entry.id})');
           workOutput.sendComplete({
             moduleCls: moduleCls,
             module: module
@@ -177,15 +180,20 @@ class ModuleHandler
     return promise.future;
   }
 
+  public static function buildModuleCallbacks():Void
+  {
+    FlxG.signals.postStateSwitch.add(onStateSwitchComplete);
+  }
+
   static function onModuleLoaded(module:Module, moduleCls:String):Void
   {
     addToModuleCache(module);
     trace('   Loaded module: ${moduleCls}');
   }
 
-  public static function buildModuleCallbacks():Void
+  static function getModuleCount():Int
   {
-    FlxG.signals.postStateSwitch.add(onStateSwitchComplete);
+    return moduleCache.size();
   }
 
   static function onStateSwitchComplete():Void

--- a/source/funkin/modding/module/ModuleHandler.hx
+++ b/source/funkin/modding/module/ModuleHandler.hx
@@ -51,6 +51,7 @@ class ModuleHandler
     trace('[MODULEHANDLER] Module cache loaded.');
   }
 
+  #if FEATURE_MULTITHREADING
   public static function loadModuleCacheAsync():lime.app.Future<LoadEntriesResult>
   {
     // Clear module cache first.
@@ -179,6 +180,7 @@ class ModuleHandler
 
     return promise.future;
   }
+  #end
 
   public static function buildModuleCallbacks():Void
   {

--- a/source/funkin/modding/module/ModuleHandler.hx
+++ b/source/funkin/modding/module/ModuleHandler.hx
@@ -1,12 +1,16 @@
 package funkin.modding.module;
 
-import funkin.util.SortUtil;
+import hx.concurrent.collection.SynchronizedArray;
+import funkin.util.tasks.TaskHandler;
+import flixel.FlxG;
+import funkin.data.BaseRegistry.LoadEntriesResult;
 import funkin.modding.events.ScriptEvent.UpdateScriptEvent;
 import funkin.modding.events.ScriptEvent;
 import funkin.modding.events.ScriptEventDispatcher;
 import funkin.modding.module.Module;
 import funkin.modding.module.ScriptedModule;
-import flixel.FlxG;
+import funkin.util.SortUtil;
+import lime.app.Future;
 
 /**
  * Utility functions for loading and manipulating active modules.
@@ -35,10 +39,8 @@ class ModuleHandler
       var module:Null<Module> = ScriptedModule.scriptInit(moduleCls, moduleCls);
       if (module != null)
       {
-        trace('   Loaded module: ${moduleCls}');
-
         // Then store it.
-        addToModuleCache(module);
+        onModuleLoaded(module, moduleCls);
       }
       else
       {
@@ -48,6 +50,137 @@ class ModuleHandler
     reorderModuleCache();
 
     trace('[MODULEHANDLER] Module cache loaded.');
+  }
+
+  public static function loadModuleCacheAsync():lime.app.Future<LoadEntriesResult>
+  {
+    // Clear module cache first.
+    clearModuleCache();
+
+    var scriptedModuleClassNames:Array<String> = ScriptedModule.listScriptClasses();
+    var promise:lime.app.Promise<LoadEntriesResult> = new lime.app.Promise<LoadEntriesResult>();
+
+    // We don't have any modules to load so we can just immediately complete the promise.
+    if (scriptedModuleClassNames.length == 0)
+    {
+      promise.complete({
+        entriesLoaded: 0,
+        entriesFailed: 0,
+      });
+      return promise.future;
+    }
+
+    var entryErrors:SynchronizedArray<
+      {moduleId:String, error:Any, ?moduleCls:String}> = new SynchronizedArray();
+    var moduleCount:Int = scriptedModuleClassNames.length;
+    var perf:funkin.util.logging.Perf = new funkin.util.logging.Perf('loadModuleCacheAsync()');
+
+    var checkAsyncProgress:Void->Void = () ->
+    {
+      var completedCount = moduleCache.size() + entryErrors.length;
+      if (completedCount == moduleCount)
+      {
+        // Finish the promise.
+        promise.complete({
+          entriesLoaded: moduleCache.size(),
+          entriesFailed: entryErrors.length
+        });
+        trace('Finished loading modules ($completedCount / $moduleCount)');
+        perf.print();
+      }
+    };
+
+    var onError:(String,
+      {error:Any, moduleCls:Null<String>}) -> Void = (moduleId, state) ->
+      {
+        entryErrors.push({
+          moduleId: moduleId,
+          error: state.error
+        });
+        trace('  Failed to load entry data (${moduleId}): ${state.error}');
+        checkAsyncProgress();
+      };
+
+    var onModuleLoadedAsync:(String,
+      {module:Module, moduleCls:String}) -> Void = (_, state) ->
+      {
+        onModuleLoaded(state.module, state.moduleCls);
+        checkAsyncProgress();
+      };
+
+    var loadModuleAsync:Task = (currentState:State, workOutput:WorkOutput) ->
+    {
+      var moduleCls:String = currentState.moduleCls;
+      try
+      {
+        var module:Null<Module> = ScriptedModule.scriptInit(moduleCls, moduleCls);
+        if (module != null)
+        {
+          // log('Successfully created scripted entry (${entryCls} = ${entry.id})');
+          workOutput.sendComplete({
+            moduleCls: moduleCls,
+            module: module
+          }, []);
+        }
+        else
+        {
+          workOutput.sendError({
+            moduleCls: moduleCls,
+            error: 'Failed to create module (${moduleCls})'
+          });
+        }
+      }
+      catch (e)
+      {
+        workOutput.sendError({
+          moduleCls: moduleCls,
+          error: e,
+        });
+      }
+    }
+
+    // Perform a task to load each module.
+    TaskHandler.performTask({
+      task: (currentState:State, workOutput:WorkOutput) ->
+      {
+        trace(' Instantiating ${scriptedModuleClassNames.length} modules...');
+
+        workOutput.sendComplete({}, []);
+      },
+      initialState: {
+      },
+      taskCallbacks: {
+        onStart: null,
+        onError: null,
+        onComplete: (_) ->
+        {
+          // Load each module asynchronously.
+          for (moduleCls in scriptedModuleClassNames)
+          {
+            TaskHandler.performTask({
+              task: loadModuleAsync,
+              initialState: {
+                moduleCls: moduleCls
+              },
+              taskCallbacks: {
+                onStart: (_) -> {
+                },
+                onError: onError.bind(moduleCls),
+                onComplete: onModuleLoadedAsync.bind(moduleCls)
+              }
+            });
+          }
+        }
+      }
+    });
+
+    return promise.future;
+  }
+
+  static function onModuleLoaded(module:Module, moduleCls:String):Void
+  {
+    addToModuleCache(module);
+    trace('   Loaded module: ${moduleCls}');
   }
 
   public static function buildModuleCallbacks():Void

--- a/source/funkin/ui/transition/preload/hotreload/HotReloadState.hx
+++ b/source/funkin/ui/transition/preload/hotreload/HotReloadState.hx
@@ -291,6 +291,22 @@ class HotReloadState extends MusicBeatState
     {
       updateProgress(10, 10);
 
+      queueLoadModules();
+    });
+  }
+
+  /**
+   * Initialize any ScriptedModules provided by mods.
+   */
+  function queueLoadModules():Void
+  {
+    var future:Future<LoadEntriesResult> = ModuleHandler.loadModuleCacheAsync();
+
+    future.onComplete((result:LoadEntriesResult) ->
+    {
+      // Call create() on each module when the future is complte.
+      ModuleHandler.callOnCreate();
+
       queueLoadAdditionalData();
     });
   }
@@ -311,11 +327,6 @@ class HotReloadState extends MusicBeatState
       // These don't use the registry system at all, they're synchronous but fairly quick.
       SongEventRegistry.loadEventCache();
       NoteKindManager.initialize();
-
-      // Load and initialize modules.
-      // We do this only once everything else is done.
-      ModuleHandler.loadModuleCache();
-      ModuleHandler.callOnCreate();
 
       return true;
     }).onComplete((_) ->


### PR DESCRIPTION
This PR implements modules being able to load asynchronously, because modules are the last thing the game loads, when hot-reloading the future for them must be completed before moving back to the title screen.