### PR TITLE
[ENHANCEMENT] Improve navigation behavior between mod lists 

### DIFF
--- a/source/funkin/ui/modmenu/ModMenuState.hx
+++ b/source/funkin/ui/modmenu/ModMenuState.hx
@@ -1754,9 +1754,20 @@ class ModMenuState extends MusicBeatState
   }
   #end
 
+  var lastModIndex:Int = 0;
   function handleSelection():Void
   {
     FunkinSound.playOnce(Paths.sound('ui/main-menu/scroll-menu'), 0.4);
+
+    switch (selection)
+    {
+      case DisabledModList:
+        lastModIndex = enabledModItems.selectedItemIndex;
+      case EnabledModList:
+        lastModIndex = disabledModItems.selectedItemIndex;
+      default:
+        // nothing.
+    }
 
     if (selection != BackToMenu) playBackButtonAnimation('idle');
     disabledModItems.deselect();
@@ -1770,13 +1781,31 @@ class ModMenuState extends MusicBeatState
     switch (selection)
     {
       case DisabledModList:
-        if (oldSelection == OpenModsFolder && lastInput == 'up') disabledModItems.selectLastItem(lastSelectDir);
-        else
-          disabledModItems.selectFirstItem(lastSelectDir);
+        switch(oldSelection)
+        {
+          case OpenModsFolder:
+            if(lastInput == 'up') disabledModItems.selectLastItem(lastSelectDir);
+          case EnabledModList:
+            var offset = (disabledModItems.length - 1) - (enabledModItems.length - 1);
+
+            if (disabledModItems.modItems.indexOf(disabledModItems.modItems[lastModIndex + offset]) == -1) disabledModItems.selectLastItem(lastSelectDir);
+            else disabledModItems.selectItem(lastModIndex + offset, lastSelectDir);
+          default:
+            disabledModItems.selectFirstItem(lastSelectDir);
+        }
       case EnabledModList:
-        if (oldSelection == OpenModsFolder && lastInput == 'up') enabledModItems.selectLastItem(lastSelectDir);
-        else
-          enabledModItems.selectFirstItem(lastSelectDir);
+        switch(oldSelection)
+        {
+          case OpenModsFolder:
+            if(lastInput == 'up') enabledModItems.selectLastItem(lastSelectDir);
+          case DisabledModList:
+            var offset = (enabledModItems.length - 1) - (disabledModItems.length - 1);
+
+            if(enabledModItems.modItems.indexOf(enabledModItems.modItems[lastModIndex + offset]) == -1) enabledModItems.selectLastItem(lastSelectDir);
+            else enabledModItems.selectItem(lastModIndex + offset, lastSelectDir);
+          default:
+            enabledModItems.selectFirstItem(lastSelectDir);
+        }
       case OpenModsFolder:
         openFolderAnimator.playAnimation('select');
       case Done:


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues

Nope.

<!-- Briefly describe the issue(s) fixed. -->
## Description

This PR changes a bit how user navigates through the Mod Menu to give a more comfortable way of use it by modifying how changing lists work. Before, changing from disabled to enabled would make you be always at the first mod, even if you were selecting the mod 20th from the list. Now, you go to the mod which is exactly next to the mod you are selecting (and if there are less mods, you will select the last mod)

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos

Before:

https://github.com/user-attachments/assets/afec2203-0099-4b04-9612-697a38f5f636

After:

https://github.com/user-attachments/assets/b73637ff-45eb-4525-a65f-1e76bfad45bf

