### PR TITLE
[BUGFIX] Fix Test Stage button in Stage Editor

### DIFF
--- a/source/funkin/ui/debug/stageeditor/StageEditorState.hx
+++ b/source/funkin/ui/debug/stageeditor/StageEditorState.hx
@@ -672,7 +672,11 @@ class StageEditorState extends UIState
 
       if (FlxG.keys.justPressed.TAB) onMenuItemClick('switch mode');
       if (FlxG.keys.justPressed.DELETE) onMenuItemClick('delete object');
-      if (FlxG.keys.justPressed.ENTER) onMenuItemClick('test stage');
+      if (FlxG.keys.justPressed.ENTER)
+{
+  haxe.ui.focus.FocusManager.instance.focus = null;
+  onMenuItemClick('test stage');
+}
       if (FlxG.keys.justPressed.F1) onMenuItemClick('user guide');
 
       if (FlxG.keys.justPressed.T)
@@ -1480,9 +1484,10 @@ class StageEditorState extends UIState
         #end
 
       case 'test stage':
-        if (!allowInput) return;
+  // Force clearing focus from any text input so the button works even if a text box was selected
+  haxe.ui.focus.FocusManager.instance.focus = null;
 
-        camFollow.velocity.set();
+  camFollow.velocity.set();
 
         for (a in spriteArray)
         {


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
https://github.com/FunkinCrew/Funkin/issues/7856
<!-- Briefly describe the issue(s) fixed. -->
## Description
Fixed an issue in `StageEditorState.hx` where clicking the "Test Stage" button or pressing `ENTER` had no effect if a HaxeUI component currently held input focus.

- Forces `FocusManager.instance.focus = null` when triggering the test stage action so `allowInput` does not silently block the transition.
<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos

https://github.com/user-attachments/assets/2142045b-520d-45e7-97f7-f41b7fce9d79

