### PR TITLE
[ENHANCEMENT] Queue asynchronous Polymod errors

### DIFF
--- a/source/funkin/modding/PolymodErrorHandler.hx
+++ b/source/funkin/modding/PolymodErrorHandler.hx
@@ -5,8 +5,35 @@ import polymod.Polymod.PolymodError;
 @:nullSafety
 class PolymodErrorHandler
 {
+  #if FEATURE_MULTITHREADING
+  private static var queuedErrors:Array<PolymodError> = [];
+
+  /**
+   * There's a possibility for scripted registry entries to throw errors when they're initialized.
+   * If the registries are loaded asynchronously, error windows would overlay one another.
+   * For this reason, the errors should get added to an array and then emptied in the main thread,
+   * making the window popups appear one after another.
+   */
+  public static function printQueuedErrors():Void
+  {
+    while (queuedErrors.length > 0)
+    {
+      @:nullSafety(Off)
+      onPolymodError(queuedErrors.shift());
+    }
+  }
+  #end
+
   public static function onPolymodError(error:PolymodError):Void
   {
+    #if FEATURE_MULTITHREADING
+    if (!funkin.util.tasks.TaskHandler.isMainThread())
+    {
+      PolymodErrorHandler.queuedErrors.push(error);
+      return;
+    }
+    #end
+
     // Perform an action based on the error code.
     switch (error.code)
     {

--- a/source/funkin/ui/transition/preload/hotreload/HotReloadState.hx
+++ b/source/funkin/ui/transition/preload/hotreload/HotReloadState.hx
@@ -226,6 +226,10 @@ class HotReloadState extends MusicBeatState
 
       initModules();
 
+      #if FEATURE_MULTITHREADING
+      funkin.modding.PolymodErrorHandler.printQueuedErrors();
+      #end
+
       // Move to the title state next frame.
       isComplete = true;
     });


### PR DESCRIPTION
## Linked Issues
Comedy Lost posted this in the Contributors server
<img width="1222" height="265" alt="image" src="https://github.com/user-attachments/assets/0d29bb06-f2bf-4762-9c2f-fe18862d4d75" />

## Description
This PR stores every error from Polymod during the entry list reinitialization process to prevent two or more errors from overlapping one another.
This was tested by commenting out the super constructors from a mod.

## Screenshots/Videos
### Before:

https://github.com/user-attachments/assets/ae5bfae2-7e7e-4f71-bdfc-a88f30423128

### After:

https://github.com/user-attachments/assets/7aad4f61-5466-40be-8105-40ffe62a822a
