### PR TITLE
[ENHANCEMENT] Automatically add instrumental field in metadata if song is a variation

### DIFF
--- a/source/funkin/data/song/SongData.hx
+++ b/source/funkin/data/song/SongData.hx
@@ -75,12 +75,12 @@ class SongMetadata implements ICloneable<SongMetadata> implements ISerializable
     this.playData = new SongPlayData();
     this.playData.songVariations = [];
     this.playData.difficulties = [];
-    this.playData.characters = new SongCharacterData('bf', 'gf', 'dad');
+    // Variation ID.
+    this.variation = (variation == null) ? Constants.DEFAULT_VARIATION : variation;
+    this.playData.characters = new SongCharacterData('bf', 'gf', 'dad', this.variation == Constants.DEFAULT_VARIATION ? '' : this.variation);
     this.playData.stage = 'mainStage';
     this.playData.noteStyle = Constants.DEFAULT_NOTE_STYLE;
     this.generatedBy = SongRegistry.DEFAULT_GENERATEDBY;
-    // Variation ID.
-    this.variation = (variation == null) ? Constants.DEFAULT_VARIATION : variation;
   }
 
   /**


### PR DESCRIPTION
## Description
This PR makes that, when saving a song, if it's a variation, it will automatically add the "instrumental" field into the json with the variation name, and if's not a variation of a already existing song, it will not write it to the JSON metadata.

## Screenshots/Videos

Here is a video of the feature in action !

https://github.com/user-attachments/assets/88fd390a-1559-4098-aada-ed8673bd40dd