### PR TITLE
[BUGFIX] Comment shortcut stealing inputs in Chart Editor

### DIFF
--- a/source/funkin/ui/debug/charting/ChartEditorState.hx
+++ b/source/funkin/ui/debug/charting/ChartEditorState.hx
@@ -6864,7 +6864,7 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
     }
 
     // B = New Comment
-    if (!pressingControl() && !FlxG.keys.pressed.SHIFT && !FlxG.keys.pressed.ALT && FlxG.keys.justPressed.B && !isHaxeUIDialogOpen)
+    if (!pressingControl() && !FlxG.keys.pressed.SHIFT && !FlxG.keys.pressed.ALT && FlxG.keys.justPressed.B && !isHaxeUIDialogOpen && !isHaxeUIFocused)
     {
       // Add a new comment at the grid playhead's position.
       var playheadPosMs:Float = scrollPositionInMs + playheadPositionInMs;


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues

Closes #7827

<!-- Briefly describe the issue(s) fixed. -->
## Description

When a HaxeUI text box had focus, pressing B still triggered the chart editor's new comment shortcut. The shortcut now checks for HaxeUI focus first, so B gets typed into the text box instead. Pressing B on the chart still creates a new comment.

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos

https://github.com/user-attachments/assets/4ae0fd6d-efe0-4a43-a0bf-052d70fd5766
> **Note:** In the video, when I said “I can still write them outside the box,” I meant I can still create comments when a text box isn’t focused.