### PR TITLE
[BUGFIX] Refresh mod icons after reload in mod menu

### DIFF
--- a/source/funkin/ui/modmenu/ModMenuItem.hx
+++ b/source/funkin/ui/modmenu/ModMenuItem.hx
@@ -234,39 +234,42 @@ class ModMenuItem extends FunkinSpriteGroup
     }
     else if (mod != null)
     {
-      @:privateAccess
-      if (mod.id != null && funkin.assets.FunkinBitmapFrontend.instance.exists(mod.id))
-      {
-        modIcon.loadGraphic(funkin.assets.FunkinBitmapFrontend.instance.get(mod.id));
-        add(modIcon);
-
-        modIcon.scrollFactor.set();
-        modIcon.antialiasing = true;
-
-        // FunkinGroup is funny
-        modIcon.setGraphicSize(ICON_HEIGHT, ICON_HEIGHT);
-        modIcon.localScale.x = modIcon.scale.x;
-        modIcon.localScale.y = modIcon.scale.y;
-
-        modIcon.updateHitbox();
-      }
-      else if (mod.icon != null)
+      if (mod.icon != null)
       {
         loadModIcon(mod.icon);
       }
       else
       {
-        trace('No icon found for mod ${mod.id}, using fallback');
-        // Fallback icon
-        modIcon.loadGraphic(Paths.image('ui/mods/fallback-icon'));
-        add(modIcon);
+        @:privateAccess
+        if (mod.id != null && funkin.assets.FunkinBitmapFrontend.instance.exists(mod.id))
+        {
+          modIcon.loadGraphic(funkin.assets.FunkinBitmapFrontend.instance.get(mod.id));
+          add(modIcon);
 
-        modIcon.scrollFactor.set();
-        modIcon.antialiasing = true;
-        modIcon.setGraphicSize(ICON_HEIGHT, ICON_HEIGHT);
-        modIcon.localScale.x = modIcon.scale.x;
-        modIcon.localScale.y = modIcon.scale.y;
-        modIcon.updateHitbox();
+          modIcon.scrollFactor.set();
+          modIcon.antialiasing = true;
+
+          // FunkinGroup is funny
+          modIcon.setGraphicSize(ICON_HEIGHT, ICON_HEIGHT);
+          modIcon.localScale.x = modIcon.scale.x;
+          modIcon.localScale.y = modIcon.scale.y;
+
+          modIcon.updateHitbox();
+        }
+        else
+        {
+          trace('No icon found for mod ${mod.id}, using fallback');
+          // Fallback icon
+          modIcon.loadGraphic(Paths.image('ui/mods/fallback-icon'));
+          add(modIcon);
+
+          modIcon.scrollFactor.set();
+          modIcon.antialiasing = true;
+          modIcon.setGraphicSize(ICON_HEIGHT, ICON_HEIGHT);
+          modIcon.localScale.x = modIcon.scale.x;
+          modIcon.localScale.y = modIcon.scale.y;
+          modIcon.updateHitbox();
+        }
       }
     }
 


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues

Closes #7820

<!-- Briefly describe the issue(s) fixed. -->
## Description

After changing a mod's icon and pressing Alt+F5, the Mod Menu could still show the old icon,
and in general wouldnt change until you retarted the whole game.

The preloader keeps mod icons in the bitmap cache under the mod ID. `ModMenuItem` was checking that cache before using the freshly scanned icon, so the old cached image won. The menu now uses `mod.icon` when it is available and keeps the old cache path as a fallback when metadata has no icon. which is atleast less regressive than not using the fallback.

I reproduced the issue before making this change.

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos

https://github.com/user-attachments/assets/f081d4de-53ee-4186-8672-81802971e674