### PR TITLE
[BUGFIX] Make Open Mod Folder open folder from game directory 

### DIFF
--- a/source/funkin/ui/modmenu/ModMenuState.hx
+++ b/source/funkin/ui/modmenu/ModMenuState.hx
@@ -2439,7 +2439,11 @@ class ModMenuState extends MusicBeatState
     #elseif ios
     System.openURL('shareddocuments://');
     #else
+    #if sys
+    FileUtil.openFolder(Path.join([FileUtil.gameDirectory, PolymodHandler.MOD_FOLDER]));
+    #else
     FileUtil.openFolder(PolymodHandler.MOD_FOLDER);
+    #end
     #end
     openFolderAnimator.playAnimation('select');
   }


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues

Fixes #7824

<!-- Briefly describe the issue(s) fixed. -->
## Description

On Windows, the Open Mod Folder button passed the relative `mods` path straight to Explorer. If the game was launched with another working directory, Explorer opened that directory's `mods` folder instead of the folder beside the game executable.

The button now resolves the mod path from `FileUtil.gameDirectory` before opening it. The Android and iOS paths are unchanged.

I reproduced this with a `mods` folder on the Windows v0.9 Feature Preview #3 build before making this change.

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos

N/A. (I tested from source with a debug build, which opened the correct folder, i wish i coulve tried this with a non debug build, i guess i still have a bit more to learn about contributing in Funkin)
