### PR TITLE
[ENHANCEMENT] Change amount variable in GaussianBlurShader to a setter

### DIFF
--- a/source/funkin/graphics/shaders/GaussianBlurShader.hx
+++ b/source/funkin/graphics/shaders/GaussianBlurShader.hx
@@ -8,17 +8,25 @@ import flixel.addons.display.FlxRuntimeShader;
 @:nullSafety
 class GaussianBlurShader extends FlxRuntimeShader
 {
-  public var amount:Float = 1;
+  public var amount(default, set):Float = 1;
+
+  function set_amount(val:Float):Float
+  {
+    this.amount = val;
+    this.setFloat('_amount', val);
+
+    return val;
+  }
 
   public function new(amount:Float = 1.0)
   {
     super(Assets.getText(Paths.frag('ui/shaders/gaussian-blur')));
-    setAmount(amount);
+    this.amount = amount;
   }
 
+  @:deprecated('Set amount directly instead')
   public function setAmount(value:Float):Void
   {
     this.amount = value;
-    this.setFloat('_amount', amount);
   }
 }


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
Me :pureevil:

<!-- Briefly describe the issue(s) fixed. -->
## Description
This PR makes the `amount` variable in the GaussianBlurShader class a setter, allowing people to easily tween the amount.
Also deprecates the `setAmount` function