### PR TITLE
[ENHANCEMENT] Make Game Over sound files check Player Owner ID

### DIFF
--- a/source/funkin/play/GameOverSubState.hx
+++ b/source/funkin/play/GameOverSubState.hx
@@ -643,8 +643,7 @@ class GameOverSubState extends MusicBeatSubState
 
   function getDeathAudioPath(location:String):String
   {
-    final charID:String = boyfriend?.characterId ?? 'bf';
-    final playerID:String = charID.split('-')[0];
+    final playerID:String = PlayerRegistry.instance.getCharacterOwnerId(boyfriend?.characterId) ?? 'bf';
 
     final audioPath:String = 'gameplay/playable-characters/$playerID/game-over/$location';
     return audioPath;


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
Me (Again)

<!-- Briefly describe the issue(s) fixed. -->
## Description
This PR switches how the game paths to the game over sounds so it now checks what player owns the current character instead of getting the first part of a character's id. There's also an assets pr that gets rid of the duplicated sserafim game over files, which are no longer needed since the game will now get the sounds from bf's folder

Associated assets pr: https://github.com/FunkinCrew/funkin.assets/pull/448