### PR TITLE
[BUGFIX] Fix BF and GF blinking in Mod Menu

### DIFF
--- a/source/funkin/ui/modmenu/ModMenuState.hx
+++ b/source/funkin/ui/modmenu/ModMenuState.hx
@@ -1239,11 +1239,6 @@ class ModMenuState extends MusicBeatState
     {
       blinkTimer += elapsed;
 
-      if (blinkTimer >= 100)
-      {
-        blinkTimer = 0;
-      }
-
       if (blinkTimer >= bfBlink && bf.animation.finished)
       {
         bfBlink = blinkTimer + Math.random() + (Math.random() * 6);

--- a/source/funkin/ui/modmenu/ModMenuState.hx
+++ b/source/funkin/ui/modmenu/ModMenuState.hx
@@ -1239,6 +1239,13 @@ class ModMenuState extends MusicBeatState
     {
       blinkTimer += elapsed;
 
+      if (blinkTimer >= 100)
+      {
+        blinkTimer = 0;
+        bfBlink = 0;
+        gfBlink = 0;
+      }
+
       if (blinkTimer >= bfBlink && bf.animation.finished)
       {
         bfBlink = blinkTimer + Math.random() + (Math.random() * 6);


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues

Closes #7821

<!-- Briefly describe the issue(s) fixed. -->
## Description

After the Mod Menu had been open for around 100 seconds, BF and GF would stop blinking. This happened because `blinkTimer` was reset to `0`, while `bfBlink` and `gfBlink` kept their absolute value deadlines. Once those deadlines were past 100 seconds, the timer could no longer reach them.

This removes the timer reset so the timer and both blink deadlines stay on the same timeline. nothing else is affected.
I confirmed the old timer behavior and the new time behavior with the video below.

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos

https://github.com/user-attachments/assets/8b2e1ad1-fba0-49d2-ab9b-8dadfd6eaf39
> note: yes.. i did a whole edit for this pr..