### PR TITLE
[ENHANCEMENT] Slider improvements to Chart Editor

### DIFF
--- a/source/funkin/ui/debug/charting/ChartEditorState.hx
+++ b/source/funkin/ui/debug/charting/ChartEditorState.hx
@@ -3687,6 +3687,11 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
       metronomeVolume = volume;
       menubarLabelVolumeMetronome.text = 'Metronome - ${Std.int(event.value)}%';
     };
+    menubarLabelVolumeMetronome.onRightClick = _ ->
+    {
+      metronomeVolume = 1.0;
+      menubarLabelVolumeMetronome.text = 'Metronome - 100%';
+    }
     menubarItemVolumeMetronome.value = Std.int(metronomeVolume * 100);
     previousAudioVolumes[0] = Std.int(metronomeVolume * 100);
 
@@ -3707,6 +3712,11 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
       hitsoundVolumePlayer = volume;
       menubarLabelVolumeHitsoundPlayer.text = 'Player - ${Std.int(event.value)}%';
     };
+    menubarItemVolumeHitsoundPlayer.onRightClick = _ ->
+    {
+      hitsoundVolumeOpponent = 1.0;
+      menubarLabelVolumeHitsoundPlayer.text = 'Player - 100%';
+    }
     menubarItemVolumeHitsoundPlayer.value = Std.int(hitsoundVolumePlayer * 100);
     previousAudioVolumes[1] = Std.int(hitsoundVolumePlayer * 100);
 
@@ -3716,6 +3726,11 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
       hitsoundVolumeOpponent = volume;
       menubarLabelVolumeHitsoundOpponent.text = 'Enemy - ${Std.int(event.value)}%';
     };
+    menubarItemVolumeHitsoundOpponent.onRightClick = _ ->
+    {
+      hitsoundVolumeOpponent = 1.0;
+      menubarLabelVolumeHitsoundOpponent.text = 'Enemy - 100%';
+    }
     menubarItemVolumeHitsoundOpponent.value = Std.int(hitsoundVolumeOpponent * 100);
     previousAudioVolumes[2] = Std.int(hitsoundVolumeOpponent * 100);
 
@@ -3725,6 +3740,11 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
       if (audioInstTrack != null) audioInstTrack.volume = volume;
       menubarLabelVolumeInstrumental.text = 'Instrumental - ${Std.int(event.value)}%';
     };
+    menubarLabelVolumeInstrumental.onRightClick = _ ->
+    {
+      if (audioInstTrack != null) audioInstTrack.volume = 1.0;
+      menubarLabelVolumeInstrumental.text = 'Instrumental - 100%';
+    }
     previousAudioVolumes[3] = menubarItemVolumeInstrumental.value;
 
     menubarItemVolumeVocalsPlayer.onChange = event ->
@@ -3733,6 +3753,11 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
       audioVocalTrackGroup.playerVolume = volume;
       menubarLabelVolumeVocalsPlayer.text = 'Player - ${Std.int(event.value)}%';
     };
+    menubarLabelVolumeVocalsPlayer.onRightClick = _ ->
+    {
+      audioVocalTrackGroup.playerVolume = 1.0;
+      menubarLabelVolumeVocalsPlayer.text = 'Player - 100%';
+    }
     previousAudioVolumes[4] = menubarItemVolumeVocalsPlayer.value;
 
     menubarItemVolumeVocalsOpponent.onChange = event ->
@@ -3741,12 +3766,16 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
       audioVocalTrackGroup.opponentVolume = volume;
       menubarLabelVolumeVocalsOpponent.text = 'Enemy - ${Std.int(event.value)}%';
     };
+    menubarLabelVolumeVocalsOpponent.onRightClick = _ ->
+    {
+      audioVocalTrackGroup.opponentVolume = 1.0;
+      menubarLabelVolumeVocalsOpponent.text = 'Enemy - 100%';
+    }
     previousAudioVolumes[5] = menubarItemVolumeVocalsOpponent.value;
 
     menubarItemPlaybackSpeed.onChange = event ->
     {
       var pitch:Float = (event.value.toFloat() * 2.0) / 100.0;
-      pitch = Math.round(pitch / 0.05) * 0.05; // Round to nearest 5%
       pitch = pitch.clamp(0.05, 2.0); // Clamp to 5% to 200%
       #if FLX_PITCH
       if (audioInstTrack != null) audioInstTrack.pitch = pitch;
@@ -3754,6 +3783,34 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
       #end
       var pitchDisplay:Float = Std.int(pitch * 100) / 100; // Round to 2 decimal places.
       menubarLabelPlaybackSpeed.text = 'Playback Speed - ${pitchDisplay}x';
+    }
+    menubarLabelPlaybackSpeed.onRightClick = _ ->
+    {
+      #if FLX_PITCH
+      if (audioInstTrack != null) audioInstTrack.pitch = 1;
+      audioVocalTrackGroup.pitch = 1;
+      #end
+      menubarLabelPlaybackSpeed.text = 'Playback Speed - 1x';
+    }
+
+    menubarItemPlaybackSpeed.onChange = event ->
+    {
+      var pitch:Float = (event.value.toFloat() * 2.0) / 100.0;
+      pitch = pitch.clamp(0.05, 2.0); // Clamp to 5% to 200%
+      #if FLX_PITCH
+      if (audioInstTrack != null) audioInstTrack.pitch = pitch;
+      audioVocalTrackGroup.pitch = pitch;
+      #end
+      var pitchDisplay:Float = Std.int(pitch * 100) / 100; // Round to 2 decimal places.
+      menubarLabelPlaybackSpeed.text = 'Playback Speed - ${pitchDisplay}x';
+    }
+    menubarLabelPlaybackSpeed.onRightClick = _ ->
+    {
+      #if FLX_PITCH
+      if (audioInstTrack != null) audioInstTrack.pitch = 1;
+      audioVocalTrackGroup.pitch = 1;
+      #end
+      menubarLabelPlaybackSpeed.text = 'Playback Speed - 1x';
     }
 
     menubarItemToggleToolboxDifficulty.onChange = event -> this.setToolboxState(CHART_EDITOR_TOOLBOX_DIFFICULTY_LAYOUT, event.value);
@@ -7101,7 +7158,6 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
     if (playtestAudioSettings)
     {
       playbackRate = ((menubarItemPlaybackSpeed.value / 100.0) ?? 0.5) * 2.0;
-      playbackRate = Math.round(playbackRate / 0.05) * 0.05; // Round to nearest 5%
       playbackRate = playbackRate.clamp(0.05, 2.0); // Clamp to 5% to 200%
     }
 
@@ -7651,7 +7707,6 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
     var vocalOpponentTargetVolume:Float = (menubarItemVolumeVocalsOpponent.value / 100.0) ?? 1.0;
 
     var playbackRate = ((menubarItemPlaybackSpeed.value / 100.0) ?? 0.5) * 2.0;
-    playbackRate = Math.round(playbackRate / 0.05) * 0.05; // Round to nearest 5%
     playbackRate = playbackRate.clamp(0.05, 2.0); // Clamp to 5% to 200%
 
     if (audioInstTrack != null)
@@ -7953,7 +8008,6 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
     // Reapply the volume and playback rate.
     var instTargetVolume:Float = ((menubarItemVolumeInstrumental.value / 100) ?? 1.0);
     var playbackRate:Float = ((menubarItemPlaybackSpeed.value / 100.0) ?? 0.5) * 2.0;
-    playbackRate = Math.round(playbackRate / 0.05) * 0.05; // Round to nearest 5%
     playbackRate = playbackRate.clamp(0.05, 2.0); // Clamp to 5% to 200%
     if (audioInstTrack != null)
     {
@@ -8006,7 +8060,6 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
     var vocalPlayerTargetVolume:Float = (menubarItemVolumeVocalsPlayer.value / 100.0) ?? 1.0;
     var vocalOpponentTargetVolume:Float = (menubarItemVolumeVocalsOpponent.value / 100.0) ?? 1.0;
     var playbackRate:Float = ((menubarItemPlaybackSpeed.value / 100.0) ?? 0.5) * 2.0;
-    playbackRate = Math.round(playbackRate / 0.05) * 0.05; // Round to nearest 5%
     playbackRate = playbackRate.clamp(0.05, 2.0); // Clamp to 5% to 200%
 
     if (audioVocalTrackGroup != null)

--- a/source/funkin/ui/debug/charting/handlers/ChartEditorDialogHandler.hx
+++ b/source/funkin/ui/debug/charting/handlers/ChartEditorDialogHandler.hx
@@ -1530,6 +1530,11 @@ class ChartEditorDialogHandler
     {
       labelScrollSpeed.text = 'Scroll Speed: ${inputScrollSpeed.value}x';
     };
+    inputScrollSpeed.onRightClick = _ ->
+    {
+      inputScrollSpeed.value = 1;
+      labelScrollSpeed.text = 'Scroll Speed: 1x';
+    }
     inputScrollSpeed.value = state.currentSongChartScrollSpeed;
     labelScrollSpeed.text = 'Scroll Speed: ${inputScrollSpeed.value}x';
 
@@ -1595,6 +1600,11 @@ class ChartEditorDialogHandler
     {
       labelScrollSpeed.text = 'Scroll Speed: ${inputScrollSpeed.value}x';
     };
+    inputScrollSpeed.onRightClick = _ ->
+    {
+      inputScrollSpeed.value = 1;
+      labelScrollSpeed.text = 'Scroll Speed: 1x';
+    }
     inputScrollSpeed.value = state.currentSongChartScrollSpeed;
     labelScrollSpeed.text = 'Scroll Speed: ${inputScrollSpeed.value}x';
 

--- a/source/funkin/ui/debug/charting/toolboxes/ChartEditorMetadataToolbox.hx
+++ b/source/funkin/ui/debug/charting/toolboxes/ChartEditorMetadataToolbox.hx
@@ -333,6 +333,13 @@ class ChartEditorMetadataToolbox extends ChartEditorBaseToolbox
       labelScrollSpeed.text = 'Scroll Speed: ${chartEditorState.currentSongChartScrollSpeed}x';
     };
 
+    inputScrollSpeed.onRightClick = _ ->
+    {
+      chartEditorState.currentSongChartScrollSpeed = 1.0;
+      inputScrollSpeed.value = 1;
+      labelScrollSpeed.text = 'Scroll Speed: 1x';
+    }
+
     inputDifficultyRating.onChange = function(event:UIEvent)
     {
       chartEditorState.currentSongChartDifficultyRating = event.target.value;


### PR DESCRIPTION
<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
https://github.com/FunkinCrew/Funkin/issues/7693

<!-- Briefly describe the issue(s) fixed. -->
## Description
this makes it so right-clicking the sliders' labels in the Chart Editor resets the value to default. playback rate now uses 0.01 steps instead of 0.25, idk thought it'd be neat :)

i still haven't polished it yet (hence the draft status), like right-clicking the slider doesn't reset the actual slider to its default value, gonna need a way to fix that...

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos
https://github.com/user-attachments/assets/0c17a743-d891-4a6a-a795-eae60f63da8d

https://github.com/user-attachments/assets/5bf549e5-005d-453c-afd0-276530902aca

