### PR TITLE
[BUGFIX] Prevent Story Mode props from resetting during fade

### DIFF
--- a/source/funkin/ui/story/StoryMenuState.hx
+++ b/source/funkin/ui/story/StoryMenuState.hx
@@ -583,7 +583,7 @@ class StoryMenuState extends MusicBeatState
     // super.dispatchEvent(event) dispatches event to module scripts.
     super.dispatchEvent(event);
 
-    if (!selectedLevel && levelProps?.members != null && levelProps.members.length > 0)
+    if (levelProps?.members != null && levelProps.members.length > 0)
     {
       // Dispatch event to props.
       for (prop in levelProps.members)

--- a/source/funkin/ui/story/StoryMenuState.hx
+++ b/source/funkin/ui/story/StoryMenuState.hx
@@ -583,11 +583,12 @@ class StoryMenuState extends MusicBeatState
     // super.dispatchEvent(event) dispatches event to module scripts.
     super.dispatchEvent(event);
 
-    if (levelProps?.members != null && levelProps.members.length > 0)
+    if (!selectedLevel && levelProps?.members != null && levelProps.members.length > 0)
     {
       // Dispatch event to props.
       for (prop in levelProps.members)
       {
+        if (selectedLevel && prop != null && prop.hasAnimation('confirm')) continue;
         ScriptEventDispatcher.callEvent(prop, event);
       }
     }


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues

Closes #7865

<!-- Briefly describe the issue(s) fixed. -->
## Description

When selecting a Story Mode level during player/BF prop's idle, the prop could resume its idle animation after the confirm animation finished while the screen was fading out.

The Story Menu now stops dispatching events to level props with a `'confirm'` animation after a level has been selected. This prevents beat and update events from restarting prop animations during the transition, while allowing the confirmation to play normally.

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos

<img width="1280" height="720" alt="Gif with the issue fixed Lmao" src="https://github.com/user-attachments/assets/2d97b0b2-7572-4890-85d0-5b474b9ed402" />

