### PR TITLE
[BUGFIX] Apply haxedef `openfl_pool_events` to decrease stuttering in GC

### DIFF
--- a/project.hxp
+++ b/project.hxp
@@ -1087,6 +1087,9 @@ class Project extends HXProject
     // Enable OpenFL's error handler. Required for the crash logger.
     setHaxedef("openfl-enable-handle-error");
 
+    // Enable OpenFL's experimental event-pooling flag. Fixes the broken event allocation.
+    setHaxedef("openfl_pool_events");
+
     // Disable a macro in Lime that generates a random number for Assets.cache.version every build.
     // This doesn't seem to be of any use and it causes lime.utils.AssetCache to be re-compiled on every build.
     setHaxedef("lime_disable_assets_version");


### PR DESCRIPTION
PORT OF #7151 (i forgot about this AAAAAAA)

## Description
it's in the title. openfl's event allocation is kinda bugged, which is one of many reasons of the memory leaks. 

this may decrease the chances of memory leakage, since it reduces the memory allocated and garbage collected when using event listeners...

<img width="615" height="121" alt="image" src="https://github.com/user-attachments/assets/03d6d796-0736-4caa-9297-71e17f76587b" />

_thx @Raltyro for this btw_