### PR TITLE
[BUGFIX] Disable keys in HotReloadState

### DIFF
--- a/source/funkin/ui/transition/preload/hotreload/HotReloadState.hx
+++ b/source/funkin/ui/transition/preload/hotreload/HotReloadState.hx
@@ -62,6 +62,8 @@ class HotReloadState extends MusicBeatState
   {
     super.create();
 
+    FlxG.keys.enabled = false;
+
     // Fix a specific bug where the game tries to render the 0-character long text,
     // fails and shits its pants.
     if (leftWatermarkText != null)
@@ -335,6 +337,8 @@ class HotReloadState extends MusicBeatState
 
     trace('Transitioning to title state...');
     transitioning = true;
+
+    FlxG.keys.enabled = true;
 
     if (targetState != null)
     {


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
Fixes https://github.com/FunkinCrew/Funkin/issues/7810

<!-- Briefly describe the issue(s) fixed. -->
## Description
This PR disables key presses in HotReloadState, preventing the debug keys F4 & F5 from activating and stopping the mod loading process

This stops a crash from happening where if you leave the state while mods are still loading it will throw an NOR