### PR TITLE
[CRASHFIX] Fix crash when reopening ease graph previews in editors

### DIFF
--- a/source/funkin/play/event/SongEventHelper.hx
+++ b/source/funkin/play/event/SongEventHelper.hx
@@ -3,6 +3,7 @@ package funkin.play.event;
 import flixel.tweens.FlxEase;
 import openfl.display.BitmapData;
 import flixel.FlxSprite;
+import funkin.assets.FunkinBitmapFrontend;
 
 class SongEventHelper
 {
@@ -204,7 +205,20 @@ class SongEventHelper
 
   public static function getOrCreateEaseDotSprites(key:String, frameCount:Int = 30, dotRadius:Int = 3, dotWidth:Int = 16):Array<FlxSprite>
   {
-    if (easeDotCache.exists(key)) return easeDotCache.get(key);
+    if (easeDotCache.exists(key))
+    {
+      var valid:Bool = true;
+      for (spr in easeDotCache.get(key))
+      {
+        if (spr == null || !FunkinBitmapFrontend.instance.isValid(spr.graphic))
+        {
+          valid = false;
+          break;
+        }
+      }
+      if (valid) return easeDotCache.get(key);
+      easeDotCache.remove(key);
+    }
     var baseBd:BitmapData = getEaseBitmap(key);
     if (baseBd == null) return null;
     var easeFunc:Dynamic = resolveEaseFuncForKey(key);


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
closes #7882 
<!-- Briefly describe the issue(s) fixed. -->
## Description
### Cause:
The ease previews cache their dot images (`easeDotCache` in `SongEventHelper`) so they only get generated once. The problem: when you exit an editor the game purges its cached graphics , but the ease preview cache was never cleared or told about it.
So on the next open the editor pulled sprites out of the cache that were already destroyed tried to draw them and crashed with a Null Object Reference.
### Fix:
`getOrCreateEaseDotSprites()` now checks that each cached sprite's graphic is still alive before reusing it. If the game purged them during the previous editor exit, the cache entry is dropped and the sprites get rebuilt fresh instead of crashing.
A one-function change in SongEventHelper.hx.
<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos
### before (chart editor)

https://github.com/user-attachments/assets/56c67af0-f187-4d6d-8548-d09d5a3999af

### before (camera editor)

https://github.com/user-attachments/assets/367d627d-b451-4821-9c85-39739fe1325e

### after (chart editor)

https://github.com/user-attachments/assets/695316ae-c2b4-453a-b780-03bf7f7f5baa

### after (camera editor)

https://github.com/user-attachments/assets/0cb33fa2-b137-46e3-bffc-8c42b47fa825

