### PR TITLE
[BUGFIX] Fix FPS drop from the "Y" title screen easter egg

### DIFF
--- a/source/funkin/ui/title/TitleState.hx
+++ b/source/funkin/ui/title/TitleState.hx
@@ -3,6 +3,7 @@ package funkin.ui.title;
 import flixel.group.FlxGroup;
 import flixel.input.gamepad.FlxGamepad;
 import funkin.ui.FullScreenScaleMode;
+import flixel.math.FlxPoint;
 import flixel.tweens.FlxEase;
 import flixel.tweens.FlxTween;
 import flixel.util.FlxColor;
@@ -248,6 +249,11 @@ class TitleState extends MusicBeatState
 
   var transitioning:Bool = false;
 
+  static final WINDOW_MOVE_INTERVAL:Float = 1.0 / 60.0;
+
+  var windowWobblePosition:FlxPoint;
+  var windowMoveTimer:Float = 0;
+
   override function update(elapsed:Float):Void
   {
     FlxG.bitmapLog.add(FlxG.camera.buffer);
@@ -268,20 +274,31 @@ class TitleState extends MusicBeatState
 
     if (FlxG.keys.justPressed.Y)
     {
-      FlxTween.cancelTweensOf(FlxG.stage.window, ['x', 'y']);
-      FlxTween.tween(FlxG.stage.window, {
-        x: FlxG.stage.window.x + 300
-      }, 1.4, {
+      if (windowWobblePosition == null) windowWobblePosition = FlxPoint.get();
+      windowWobblePosition.set(FlxG.stage.window.x, FlxG.stage.window.y);
+      FlxTween.cancelTweensOf(windowWobblePosition);
+      windowMoveTimer = 0;
+
+      FlxTween.tween(windowWobblePosition, {x: windowWobblePosition.x + 300}, 1.4, {
         ease: FlxEase.quadInOut,
         type: PINGPONG,
         startDelay: 0.35
       });
-      FlxTween.tween(FlxG.stage.window, {
-        y: FlxG.stage.window.y + 100
-      }, 0.7, {
+      FlxTween.tween(windowWobblePosition, {y: windowWobblePosition.y + 100}, 0.7, {
         ease: FlxEase.quadInOut,
         type: PINGPONG
       });
+    }
+
+    if (windowWobblePosition != null)
+    {
+      windowMoveTimer += elapsed;
+      while (windowMoveTimer >= WINDOW_MOVE_INTERVAL)
+      {
+        windowMoveTimer -= WINDOW_MOVE_INTERVAL;
+        FlxG.stage.window.x = Std.int(windowWobblePosition.x);
+        FlxG.stage.window.y = Std.int(windowWobblePosition.y);
+      }
     }
 
     if (FlxG.sound.music != null) Conductor.instance.update(FlxG.sound.music.time);


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
closes #7830 
<!-- Briefly describe the issue(s) fixed. -->
## Description
Pressing `Y` on the title screen used to run two infinite `PINGPONG` tweens directly against `FlxG.stage.window.x/y`. At an uncapped framerate the tween steps every frame so the native OS window was being repositioned thousands of times per second causing a massive FPS drop (2000+ > 500-) and visible stutter.

The wobble itself is now driven by the same easing/`PINGPONG` setup but on a dummy `FlxPoint` instead of the real window. The actual OS window is only moved at a capped rate (max 60 times/sec) via a time accumulator which keeps the easter egg's infinite wobble while removing the per-frame native window churn.
<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos
### before :

https://github.com/user-attachments/assets/03a64d39-184f-4aee-b91d-e815ae675720

### after :

https://github.com/user-attachments/assets/b0f1a57d-5f9b-4410-a57a-8b0b293beef0

