### PR TITLE
[Enhancement] Pause sounds when window alerts pop up

### DIFF
--- a/source/funkin/util/WindowUtil.hx
+++ b/source/funkin/util/WindowUtil.hx
@@ -161,7 +161,7 @@ class WindowUtil
    */
   public static function showError(name:String, desc:String):Void
   {
-    lime.app.Application.current.window.alert(lime.ui.MessageBoxType.ERROR, desc, name);
+    alert(lime.ui.MessageBoxType.ERROR, desc, name);
   }
 
   /**
@@ -171,7 +171,7 @@ class WindowUtil
    */
   public static function showWarning(name:String, desc:String):Void
   {
-    lime.app.Application.current.window.alert(lime.ui.MessageBoxType.WARNING, desc, name);
+    alert(lime.ui.MessageBoxType.WARNING, desc, name);
   }
 
   /**
@@ -181,7 +181,22 @@ class WindowUtil
    */
   public static function showInformation(name:String, desc:String):Void
   {
-    lime.app.Application.current.window.alert(lime.ui.MessageBoxType.INFORMATION, desc, name);
+    alert(lime.ui.MessageBoxType.INFORMATION, desc, name);
+  }
+
+  /**
+   * Displays a native system alert dialog.
+   * @param type The type/severity icon of the message box (e.g. ERROR, WARNING, INFORMATION). Defaults to INFORMATION.
+   * @param message The main body content/description of the alert dialog.
+   * @param title The title text displayed in the window header.
+   * @param buttons Optional list of custom button labels for the dialog.
+   */
+  public static function alert(type:lime.ui.MessageBoxType = INFORMATION, ?message:String, ?title:String, ?buttons:Array<String>) {
+    @:privateAccess
+    FlxG.sound?.onFocusLost();
+    lime.app.Application.current.window.alert(type, message, title, buttons);
+    @:privateAccess
+    FlxG.sound?.onFocus();
   }
 
   /**


### PR DESCRIPTION
## Linked Issues
https://github.com/FunkinCrew/Funkin/issues/7875

## Description
This PR pauses all game audio whenever native window alerts pop up to prevent music and sound effects from continuing while the main thread is frozen.

### Changes:
- Added a `WindowUtil.alert()` helper method that wraps `lime.app.Application.current.window.alert()`.
- Added `FlxG.sound.onFocusLost()` and `onFocus()` calls inside the wrapper to safely pause and resume audio during native popups.
- Refactored `showError()`, `showWarning()`, and `showInformation()` in `WindowUtil` to route through the new `alert()` method.

## Screenshots/Videos
Before

https://github.com/user-attachments/assets/2c817b68-5a36-4827-9a78-9c7fda069a05

After

https://github.com/user-attachments/assets/8474d125-34af-4850-ae66-58da56fc7ea4



