### PR TITLE
[BUGFIX] Fix hotreloading in a custom state not carrying over the changes

### DIFF
--- a/source/funkin/util/plugins/ReloadAssetsDebugPlugin.hx
+++ b/source/funkin/util/plugins/ReloadAssetsDebugPlugin.hx
@@ -45,8 +45,11 @@ class ReloadAssetsDebugPlugin extends FlxBasic
       @:privateAccess
       var path = s._asc.fullyQualifiedName;
       trace('Hot-reloading scripted state: ' + path);
-      var state:Dynamic = ScriptedMusicBeatState.scriptInit(path);
-      FlxG.switchState(() -> new HotReloadState(state));
+      FlxG.switchState(() -> new HotReloadState(() -> {
+        var newState:Null<funkin.ui.MusicBeatState> = ScriptedMusicBeatState.scriptInit(path);
+        if (newState == null) return new funkin.ui.mainmenu.MainMenuState();
+        return newState;
+      }));
     }
     else
     {


### PR DESCRIPTION
## Linked Issues
My tweaking ass

## Description
When hot-reloading in a custom menu, the changes wouldn't be carried over and would only be visible in the subsequent hotreload. This is because the scripted menu was being initialized before the actual hotreloading would happen.

Co-authored by @MightyTheArmiddilo cuz he originally came up with the idea for the fix. I just had to modify it because null-safety and type checking were being a pain in the ass.

## Screenshots/Videos
### Before

https://github.com/user-attachments/assets/7e571592-4b4b-4f24-835e-75c822c6c8c5

### After

https://github.com/user-attachments/assets/ad209736-5f80-4132-96e1-ed9f50622a1a
