### PR TITLE
[CRASHFIX] Fix crash scanning partially written zips in the mod menu

### DIFF
--- a/source/funkin/modding/PolymodHandler.hx
+++ b/source/funkin/modding/PolymodHandler.hx
@@ -142,7 +142,14 @@ class PolymodHandler
   {
     buildImports();
 
-    if (modFileSystem == null) modFileSystem = buildFileSystem();
+    try
+    {
+      if (modFileSystem == null) modFileSystem = buildFileSystem();
+    }
+    catch (e:Dynamic)
+    {
+      trace('Failed to build mod file system: ${Std.string(e)}');
+    }
 
     // Check if the mods to load are actually present before trying to load them.
     var allModIds:Array<String> = getAllModIds();
@@ -599,10 +606,10 @@ class PolymodHandler
   {
     trace('Scanning the mods folder...');
 
-    if (modFileSystem == null || force) modFileSystem = buildFileSystem();
     var modMetadata:Array<ModMetadata> = [];
     try
     {
+      if (modFileSystem == null || force) modFileSystem = buildFileSystem();
       modMetadata = Polymod.scan({
         modRoot: MOD_FOLDER,
         apiVersionRule: API_VERSION_RULE,

--- a/source/funkin/ui/modmenu/ModMenuState.hx
+++ b/source/funkin/ui/modmenu/ModMenuState.hx
@@ -794,7 +794,16 @@ class ModMenuState extends MusicBeatState
 
   function rescanFolder():Void
   {
-    var newItems = FileUtil.readDir(PolymodHandler.MOD_FOLDER);
+    var newItems:Array<String> = [];
+    try
+    {
+      newItems = FileUtil.readDir(PolymodHandler.MOD_FOLDER);
+    }
+    catch (e:Dynamic)
+    {
+      trace('Failed to read mods folder: ${Std.string(e)}');
+      return;
+    }
 
     if (newItems.length != itemsInFolder.length)
     {


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
closes #7917 
<!-- Briefly describe the issue(s) fixed. -->
## Description
while a zip is mid write that rescan tick is skipped; the mod appears once the zip finishes. No crash and the game still boots with a bad zip present.
<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos
### before :

https://github.com/user-attachments/assets/6e6a86b6-6c31-4593-a9c1-24baa696ffbf

### after :

https://github.com/user-attachments/assets/1afd6281-2415-4d6e-8bcc-832921ce5ebb

