### PR TITLE
[BUGFIX] Fix being able to press buttons when exiting Mod Menu on Mobile

### DIFF
--- a/source/funkin/ui/modmenu/ModMenuState.hx
+++ b/source/funkin/ui/modmenu/ModMenuState.hx
@@ -1845,6 +1845,7 @@ class ModMenuState extends MusicBeatState
 
   function handleTouch(elapsed:Float):Void
   {
+    if (hasTransitions() || exitingMenu || backPressStage > 0) return;
     if (touchScrolling)
     {
       var targetList:ModMenuItemList = null;


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Briefly describe the issue(s) fixed. -->
## Description

This PR fixes how tapping the back button in the mod menu on mobile still allows for the other buttons to be pressed, despite currently backing out of the menu. This means that if you were to tap the back button, you can also tap the done button to start the electrocution sequence.

<img width="1280" height="720" alt="back button on mobile" src="https://github.com/user-attachments/assets/96715b77-c3be-40b3-b554-681e9af2c3b0" />