### PR TITLE
[ENHANCEMENT] Rework how hot reloading behaves

### DIFF
--- a/source/funkin/play/PlayState.hx
+++ b/source/funkin/play/PlayState.hx
@@ -1830,7 +1830,6 @@ class PlayState extends MusicBeatSubState
   override function onPreHotReload():Void
   {
     criticalFailure = true;
-    performCleanup();
   }
 
   override function getHotReloadParams():HotReloadStateParams

--- a/source/funkin/play/PlayState.hx
+++ b/source/funkin/play/PlayState.hx
@@ -60,6 +60,7 @@ import funkin.ui.MusicBeatSubState;
 import funkin.ui.debug.stage.StageOffsetSubState;
 import funkin.ui.mainmenu.MainMenuState;
 import funkin.ui.transition.LoadingState;
+import funkin.ui.transition.preload.hotreload.HotReloadState.HotReloadStateParams;
 import funkin.util.GRhythmUtil;
 import funkin.util.HapticUtil;
 import funkin.util.SerializerUtil;
@@ -1826,28 +1827,26 @@ class PlayState extends MusicBeatSubState
     super.onFocusLost();
   }
 
-  /**
-   * Call this by pressing F5 on a debug build.
-   */
-  override function reloadAssets():Void
+  override function onPreHotReload():Void
   {
-    criticalFailure = true;
-
     performCleanup();
+  }
 
-    // `performCleanup()` clears the static reference to this state
-    // scripts might still need it, so we set it back to `this`
-    instance = this;
-
-    funkin.modding.PolymodHandler.forceReloadAssets();
-    if (lastParams == null)
-    {
-      throw 'No lastParams to refer to';
+  override function getHotReloadParams():HotReloadStateParams
+  {
+    return {
+      onComplete: () ->
+      {
+        @:nullSafety(Off)
+        {
+          lastParams.targetSong = SongRegistry.instance.fetchEntry(currentSong.id, {
+            variation: currentVariation
+          });
+          LoadingState.loadPlayState(lastParams);
+        }
+      },
+      targetState: null
     }
-    lastParams.targetSong = SongRegistry.instance.fetchEntry(currentSong.id, {
-      variation: currentVariation
-    }) ?? throw "Could not load current song from ID. This shouldn't happen!";
-    LoadingState.loadPlayState(lastParams);
   }
 
   override function stepHit():Bool

--- a/source/funkin/play/PlayState.hx
+++ b/source/funkin/play/PlayState.hx
@@ -1829,6 +1829,7 @@ class PlayState extends MusicBeatSubState
 
   override function onPreHotReload():Void
   {
+    criticalFailure = true;
     performCleanup();
   }
 

--- a/source/funkin/ui/MusicBeatState.hx
+++ b/source/funkin/ui/MusicBeatState.hx
@@ -15,6 +15,7 @@ import funkin.util.SortUtil;
 import funkin.util.WindowUtil;
 import funkin.input.Controls;
 import funkin.ui.FullScreenScaleMode;
+import funkin.ui.transition.preload.hotreload.HotReloadState.HotReloadStateParams;
 #if FEATURE_TOUCH_CONTROLS
 import funkin.graphics.FunkinCamera;
 import funkin.mobile.ui.FunkinHitbox;
@@ -257,9 +258,30 @@ class MusicBeatState extends FlxTransitionableState implements IEventHandler
     if (finish) event.finish();
   }
 
-  function reloadAssets():Void
+  /**
+   * The parameters to use when hot reloading.
+   * Can be overwritten by states to ensure that they're hot reloaded properly.
+   * @return HotReloadStateParams
+   */
+  public function getHotReloadParams():HotReloadStateParams
   {
-    PolymodHandler.forceReloadAssets();
+    return {
+      targetState: _constructor
+    };
+  }
+
+  /**
+   * Called right before hot reloading begins.
+   */
+  public function onPreHotReload():Void
+  {
+  }
+
+  /**
+   * Called right after hot reloading and the state is initalized.
+   */
+  public function onPostHotReload():Void
+  {
   }
 
   public function stepHit():Bool

--- a/source/funkin/ui/MusicBeatState.hx
+++ b/source/funkin/ui/MusicBeatState.hx
@@ -8,6 +8,7 @@ import flixel.text.FlxText;
 import flixel.util.FlxColor;
 import funkin.audio.FunkinSound;
 import flixel.util.FlxSort;
+import flixel.util.typeLimit.NextState;
 import funkin.modding.PolymodHandler;
 import funkin.modding.events.ScriptEvent;
 import funkin.modding.module.ModuleHandler;
@@ -266,8 +267,22 @@ class MusicBeatState extends FlxTransitionableState implements IEventHandler
   public function getHotReloadParams():HotReloadStateParams
   {
     return {
-      targetState: _constructor
+      targetState: getConstructor()
     };
+  }
+
+  function getConstructor():NextState
+  {
+    var scriptedNextState:NextState = () ->
+    {
+      var path:String = _asc?.fullyQualifiedName ?? '';
+      var newState:Null<funkin.ui.MusicBeatState> = MusicBeatState.scriptInit(path);
+      if (newState == null) return new funkin.ui.mainmenu.MainMenuState();
+      return newState;
+    }
+    var nextState:NextState = _asc != null ? scriptedNextState : _constructor;
+
+    return nextState;
   }
 
   /**

--- a/source/funkin/ui/MusicBeatState.hx
+++ b/source/funkin/ui/MusicBeatState.hx
@@ -276,7 +276,7 @@ class MusicBeatState extends FlxTransitionableState implements IEventHandler
     var scriptedNextState:NextState = () ->
     {
       var path:String = _asc?.fullyQualifiedName ?? '';
-      var newState:Null<funkin.ui.MusicBeatState> = MusicBeatState.scriptInit(path);
+      var newState:Null<MusicBeatState> = MusicBeatState.scriptInit(path);
       if (newState == null) return new funkin.ui.mainmenu.MainMenuState();
       return newState;
     }

--- a/source/funkin/ui/MusicBeatSubState.hx
+++ b/source/funkin/ui/MusicBeatSubState.hx
@@ -13,6 +13,7 @@ import funkin.util.SortUtil;
 import funkin.util.WindowUtil;
 import flixel.util.FlxSort;
 import funkin.input.Controls;
+import funkin.ui.transition.preload.hotreload.HotReloadState.HotReloadStateParams;
 #if FEATURE_TOUCH_CONTROLS
 import funkin.graphics.FunkinCamera;
 import funkin.mobile.ui.FunkinBackButton;
@@ -184,12 +185,30 @@ class MusicBeatSubState extends FlxSubState implements IEventHandler
   {
   }
 
-  function reloadAssets()
+  /**
+   * The parameters to use when hot reloading.
+   * Can be overwritten by states to ensure that they're hot reloaded properly.
+   * @return HotReloadStateParams
+   */
+  public function getHotReloadParams():HotReloadStateParams
   {
-    PolymodHandler.forceReloadAssets();
+    return {
+      targetState: _constructor
+    };
+  }
 
-    // Restart the current state, so old data is cleared.
-    FlxG.resetState();
+  /**
+   * Called right before hot reloading begins.
+   */
+  public function onPreHotReload():Void
+  {
+  }
+
+  /**
+   * Called right after hot reloading and the state is initalized.
+   */
+  public function onPostHotReload():Void
+  {
   }
 
   /**

--- a/source/funkin/ui/MusicBeatSubState.hx
+++ b/source/funkin/ui/MusicBeatSubState.hx
@@ -12,6 +12,7 @@ import funkin.modding.PolymodHandler;
 import funkin.util.SortUtil;
 import funkin.util.WindowUtil;
 import flixel.util.FlxSort;
+import flixel.util.typeLimit.NextState;
 import funkin.input.Controls;
 import funkin.ui.transition.preload.hotreload.HotReloadState.HotReloadStateParams;
 #if FEATURE_TOUCH_CONTROLS
@@ -193,8 +194,22 @@ class MusicBeatSubState extends FlxSubState implements IEventHandler
   public function getHotReloadParams():HotReloadStateParams
   {
     return {
-      targetState: _constructor
+      targetState: getConstructor()
     };
+  }
+
+  function getConstructor():NextState
+  {
+    var scriptedNextState:NextState = () ->
+    {
+      var path:String = _asc?.fullyQualifiedName ?? '';
+      var newState:Null<MusicBeatSubState> = MusicBeatSubState.scriptInit(path);
+      if (newState == null) return new funkin.ui.mainmenu.MainMenuState();
+      return newState;
+    }
+    var nextState:NextState = _asc != null ? scriptedNextState : _constructor;
+
+    return nextState;
   }
 
   /**

--- a/source/funkin/ui/debug/cameraeditor/CameraEditorState.hx
+++ b/source/funkin/ui/debug/cameraeditor/CameraEditorState.hx
@@ -76,12 +76,14 @@ import funkin.ui.haxeui.components.editors.timeline.TimelineEvent;
 import funkin.ui.haxeui.components.editors.timeline.TimelineLayerData;
 import funkin.ui.haxeui.components.editors.timeline.TimelineUtil;
 import funkin.ui.mainmenu.MainMenuState;
+import funkin.ui.transition.preload.hotreload.HotReloadState.HotReloadStateParams;
 import funkin.util.FileUtil;
 import funkin.util.InputUtil;
 import funkin.util.MouseUtil;
 import funkin.util.SortUtil;
 import funkin.util.WindowUtil;
 import funkin.util.assets.SoundUtil;
+import funkin.util.file.FNFCUtil.FNFCData;
 import funkin.util.logging.CrashHandler;
 import funkin.util.macro.ConsoleMacro;
 import haxe.io.Bytes;
@@ -731,6 +733,28 @@ class CameraEditorState extends UIState implements ConsoleClass
         return;
       }
     }
+    else if (params != null && params.loadFromFNFCData != null)
+    {
+      try
+      {
+        CameraEditorImportExportHandler.loadSongFromFNFCData(this, params.loadFromFNFCData);
+        if (params.targetSongVariation != null) switchVariation(params.targetSongVariation);
+        if (params.targetSongDifficulty != null) currentDifficulty = params.targetSongDifficulty;
+        if (params.targetSongPosition != null) setTimePosition(params.targetSongPosition);
+      }
+      catch (e)
+      {
+        CameraEditorNotificationHandler.failure(this, 'Failed to Load Song', '$e');
+        // Song failed to load, open the Welcome dialog so we aren't in a broken state.
+        var welcomeDialog = this.openWelcomeDialog();
+        if (shouldShowBackupAvailableDialog)
+        {
+          openBackupAvailableDialog(welcomeDialog);
+        }
+        return;
+      }
+
+    }
     else
     {
       var welcomeDialog = this.openWelcomeDialog();
@@ -753,6 +777,24 @@ class CameraEditorState extends UIState implements ConsoleClass
         root.removeClass(":down", false, true);
       }
     });
+  }
+
+  override function onPreHotReload():Void
+  {
+    performCleanup();
+  }
+
+  override function getHotReloadParams():HotReloadStateParams
+  {
+    return {
+      targetState: () -> new CameraEditorState({
+        loadFromPath: currentWorkingFilePath,
+        loadFromFNFCData: (currentWorkingFilePath == null && chart.songMetadatas.size() > 0) ? CameraEditorImportExportHandler.buildFNFCDataFromCurrentChart(this) : null, // We want to reload the FNFCData so the user doesn't lose progress.
+        targetSongDifficulty: this.currentDifficulty,
+        targetSongVariation: this.currentVariation,
+        targetSongPosition: Conductor.instance.songPosition
+      })
+    }
   }
 
   var goToPoint:FlxPoint = new FlxPoint();
@@ -2335,7 +2377,7 @@ class CameraEditorState extends UIState implements ConsoleClass
     Screen.instance.unregisterEvent(KeyboardEvent.KEY_DOWN, onScreenKeyDown);
 
     Cursor.hide();
-    FlxG.sound.music.stop();
+    FlxG?.sound?.music?.stop();
 
     chart.savedChanged.remove(onChartSavedChanged);
     chart.workingFileChanged.remove(onChartWorkingFileChanged);
@@ -2768,6 +2810,11 @@ typedef CameraEditorParams =
    * If non-null, load an existing song directly from the game's assets.
    */
   var ?loadFromTemplate:String;
+
+/**
+   * If non-null, load from existing FNFCData.
+   */
+  var ?loadFromFNFCData:FNFCData;
 
   // STARTING POSITION
 

--- a/source/funkin/ui/debug/cameraeditor/CameraEditorState.hx
+++ b/source/funkin/ui/debug/cameraeditor/CameraEditorState.hx
@@ -2297,10 +2297,9 @@ class CameraEditorState extends UIState implements ConsoleClass
     CameraEditorCommandHandler.redoLastCommand(this);
   }
 
-  override function reloadAssets():Void
+  override function onPreHotReload():Void
   {
     performCleanup();
-    super.reloadAssets();
   }
 
   @:nullSafety(Off)

--- a/source/funkin/ui/debug/cameraeditor/CameraEditorState.hx
+++ b/source/funkin/ui/debug/cameraeditor/CameraEditorState.hx
@@ -2297,11 +2297,6 @@ class CameraEditorState extends UIState implements ConsoleClass
     CameraEditorCommandHandler.redoLastCommand(this);
   }
 
-  override function onPreHotReload():Void
-  {
-    performCleanup();
-  }
-
   @:nullSafety(Off)
   function destroyHaxeUIComponents():Void
   {

--- a/source/funkin/ui/debug/cameraeditor/handlers/CameraEditorImportExportHandler.hx
+++ b/source/funkin/ui/debug/cameraeditor/handlers/CameraEditorImportExportHandler.hx
@@ -152,7 +152,7 @@ class CameraEditorImportExportHandler
     return funkin.ui.debug.charting.handlers.ChartEditorImportExportHandler.getLatestBackupInfo('camera-editor-');
   }
 
-  static function buildFNFCDataFromCurrentChart(state:CameraEditorState):FNFCData
+  public static function buildFNFCDataFromCurrentChart(state:CameraEditorState):FNFCData
   {
     return {
       songMetadatas: state.songMetadatas,

--- a/source/funkin/ui/debug/charting/ChartEditorState.hx
+++ b/source/funkin/ui/debug/charting/ChartEditorState.hx
@@ -100,11 +100,13 @@ import funkin.ui.debug.charting.toolboxes.ChartEditorOffsetsToolbox;
 import funkin.ui.haxeui.components.CharacterPlayer;
 import funkin.ui.mainmenu.MainMenuState;
 import funkin.ui.transition.LoadingState;
+import funkin.ui.transition.preload.hotreload.HotReloadState.HotReloadStateParams;
 import funkin.util.Constants;
 import funkin.util.FileUtil;
 import funkin.util.MathUtil;
 import funkin.util.SortUtil;
 import funkin.util.WindowUtil;
+import funkin.util.file.FNFCUtil.FNFCData;
 import funkin.util.logging.CrashHandler;
 import haxe.DynamicAccess;
 import haxe.io.Bytes;
@@ -903,6 +905,11 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
    * For example, `0.5` would be displayed as `1/32`, and `0` would show as `Exact`.
    */
   public static var stackedNoteThreshold:Float = 0;
+
+  /**
+   * Whether the user was playtesting a chart before hot reloading began.
+   */
+  static var wasPlaytesting:Bool = false;
 
   // Note Movement
 
@@ -2567,23 +2574,47 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
     if (finish) event.finish();
   }
 
-  override public function reloadAssets()
+  override function onPreHotReload():Void
   {
     performCleanup();
-    // If PlayState isn't open, do a regular reload.
-    if (!isPlaytesting)
-    {
-      super.reloadAssets();
-      return;
-    }
+    wasPlaytesting = isPlaytesting;
+  }
 
-    funkin.modding.PolymodHandler.forceReloadAssets();
-
-    // Create a new instance of the current substate, so old data is cleared.
-    this.resetSubState();
-
+  override function getHotReloadParams():HotReloadStateParams
+  {
     @:privateAccess
-    testSongInPlayState(PlayState.lastParams.minimalMode);
+    if (wasPlaytesting)
+    {
+      return {
+        onComplete: () -> {
+          if (wasPlaytesting)
+          {
+            // Fixes a bug where hot-reloading after playtesting would close PlayState.
+            FlxTransitionableState.skipNextTransIn = true;
+          }
+        },
+        targetState: () -> new ChartEditorState({
+          loadFromPath: currentWorkingFilePath,
+          loadFromFNFCData: currentWorkingFilePath == null ? this.buildFNFCDataFromCurrentChart() : null, // We want to reload the FNFCData so the user doesn't lose progress.
+          targetSongDifficulty: PlayState.lastParams.targetDifficulty,
+          targetSongVariation: PlayState.lastParams.targetVariation,
+          targetSongPosition: Conductor.instance.songPosition
+        })
+      }
+    }
+    else
+    {
+      return super.getHotReloadParams();
+    }
+  }
+
+  override function onPostHotReload():Void
+  {
+    if (wasPlaytesting)
+    {
+      @:privateAccess
+      testSongInPlayState(PlayState.lastParams.minimalMode);
+    }
   }
 
   override function create():Void
@@ -2676,6 +2707,30 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
       catch (e)
       {
         this.error('Failure', 'Failed to load chart (${targetSongId})\n$e');
+
+        // Song failed to load, open the Welcome dialog so we aren't in a broken state.
+        var welcomeDialog = this.openWelcomeDialog(false);
+        if (shouldShowBackupAvailableDialog)
+        {
+          this.openBackupAvailableDialog(welcomeDialog);
+        }
+      }
+    }
+    else if (params != null && params.loadFromFNFCData != null)
+    {
+      try
+      {
+        this.loadSongFromFNFCData(params.loadFromFNFCData);
+        if (params.targetSongPosition != null)
+        {
+          this.scrollPositionInMs = params.targetSongPosition;
+          moveSongToScrollPosition();
+          this.currentScrollEase = this.scrollPositionInPixels;
+        }
+      }
+      catch (e)
+      {
+        this.error('Failure', 'Failed to load FNFCData (${params.loadFromFNFCData})\n$e');
 
         // Song failed to load, open the Welcome dialog so we aren't in a broken state.
         var welcomeDialog = this.openWelcomeDialog(false);
@@ -3963,13 +4018,6 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
     if (FlxG.keys.justPressed.F4 && !criticalFailure)
     {
       quitChartEditor();
-      return;
-    }
-
-    // Hot reloading
-    if (FlxG.keys.justPressed.F5 && !criticalFailure)
-    {
-      performCleanup();
       return;
     }
 
@@ -6562,6 +6610,8 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
     @:privateAccess
     ChartEditorEventSprite.eventFrames = null;
 
+    activeToolboxes.clear();
+
     // TODO: In loading screens, you should be  caching BETWEEN these.
     FunkinAssetCache.instance.purgeCache(true);
 
@@ -7097,8 +7147,10 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
   {
     autoSave(true);
 
-    // Force pauses audio preview from OffsetsToolbox, if it exists.
-    cast(this.getToolbox(CHART_EDITOR_TOOLBOX_OFFSETS_LAYOUT), ChartEditorOffsetsToolbox)?.pauseAudioPreview();
+    if (!wasPlaytesting)
+    {
+      cast(this.getToolbox(CHART_EDITOR_TOOLBOX_OFFSETS_LAYOUT), ChartEditorOffsetsToolbox)?.pauseAudioPreview();
+    }
 
     // Stop audio playback after note preview is stopped.
     // `false` to force the welcome theme to stop too.
@@ -8271,6 +8323,11 @@ typedef ChartEditorParams =
    * If non-null, load an existing song directly from the game's assets.
    */
   var ?loadFromTemplate:String;
+
+  /**
+   * If non-null, load from existing FNFCData.
+   */
+  var ?loadFromFNFCData:FNFCData;
 
   // STARTING POSITION
 

--- a/source/funkin/ui/debug/charting/ChartEditorState.hx
+++ b/source/funkin/ui/debug/charting/ChartEditorState.hx
@@ -2584,7 +2584,7 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
     @:privateAccess
     var nextState = () -> new ChartEditorState({
       loadFromPath: currentWorkingFilePath,
-      loadFromFNFCData: (currentWorkingFilePath == null && saveDataDirty) ? this.buildFNFCDataFromCurrentChart() : null, // We want to reload the FNFCData so the user doesn't lose progress.
+      loadFromFNFCData: (currentWorkingFilePath == null && hasInstrumentalData) ? this.buildFNFCDataFromCurrentChart() : null, // We want to reload the FNFCData so the user doesn't lose progress.
       targetSongDifficulty: this.selectedDifficulty,
       targetSongVariation: this.selectedVariation,
       targetSongPosition: Conductor.instance.songPosition

--- a/source/funkin/ui/debug/charting/ChartEditorState.hx
+++ b/source/funkin/ui/debug/charting/ChartEditorState.hx
@@ -2585,7 +2585,7 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
     @:privateAccess
     var nextState = () -> new ChartEditorState({
       loadFromPath: currentWorkingFilePath,
-      loadFromFNFCData: currentWorkingFilePath == null ? this.buildFNFCDataFromCurrentChart() : null, // We want to reload the FNFCData so the user doesn't lose progress.
+      loadFromFNFCData: (currentWorkingFilePath == null && saveDataDirty) ? this.buildFNFCDataFromCurrentChart() : null, // We want to reload the FNFCData so the user doesn't lose progress.
       targetSongDifficulty: this.selectedDifficulty,
       targetSongVariation: this.selectedVariation,
       targetSongPosition: Conductor.instance.songPosition

--- a/source/funkin/ui/debug/charting/ChartEditorState.hx
+++ b/source/funkin/ui/debug/charting/ChartEditorState.hx
@@ -2576,7 +2576,6 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
 
   override function onPreHotReload():Void
   {
-    performCleanup();
     wasPlaytesting = isPlaytesting;
   }
 

--- a/source/funkin/ui/debug/charting/ChartEditorState.hx
+++ b/source/funkin/ui/debug/charting/ChartEditorState.hx
@@ -2583,28 +2583,24 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
   override function getHotReloadParams():HotReloadStateParams
   {
     @:privateAccess
-    if (wasPlaytesting)
-    {
-      return {
-        onComplete: () -> {
-          if (wasPlaytesting)
-          {
-            // Fixes a bug where hot-reloading after playtesting would close PlayState.
-            FlxTransitionableState.skipNextTransIn = true;
-          }
-        },
-        targetState: () -> new ChartEditorState({
-          loadFromPath: currentWorkingFilePath,
-          loadFromFNFCData: currentWorkingFilePath == null ? this.buildFNFCDataFromCurrentChart() : null, // We want to reload the FNFCData so the user doesn't lose progress.
-          targetSongDifficulty: PlayState.lastParams.targetDifficulty,
-          targetSongVariation: PlayState.lastParams.targetVariation,
-          targetSongPosition: Conductor.instance.songPosition
-        })
-      }
-    }
-    else
-    {
-      return super.getHotReloadParams();
+    var nextState = () -> new ChartEditorState({
+      loadFromPath: currentWorkingFilePath,
+      loadFromFNFCData: currentWorkingFilePath == null ? this.buildFNFCDataFromCurrentChart() : null, // We want to reload the FNFCData so the user doesn't lose progress.
+      targetSongDifficulty: this.selectedDifficulty,
+      targetSongVariation: this.selectedVariation,
+      targetSongPosition: Conductor.instance.songPosition
+    });
+
+    return {
+      onComplete: () ->
+      {
+        if (wasPlaytesting)
+        {
+          // Fixes a bug where hot-reloading after playtesting would close PlayState.
+          FlxTransitionableState.skipNextTransIn = true;
+        }
+      },
+      targetState: nextState
     }
   }
 
@@ -2697,6 +2693,8 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
       try
       {
         this.loadSongFromTemplate(targetSongId, targetSongDifficulty, targetSongVariation);
+        if (targetSongVariation != null) this.selectedVariation = targetSongVariation;
+        if (targetSongDifficulty != null) this.selectedDifficulty = targetSongDifficulty;
         if (params.targetSongPosition != null)
         {
           this.scrollPositionInMs = params.targetSongPosition;
@@ -2721,6 +2719,8 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
       try
       {
         this.loadSongFromFNFCData(params.loadFromFNFCData);
+        if (params.targetSongVariation != null) this.selectedVariation = params.targetSongVariation;
+        if (params.targetSongDifficulty != null) this.selectedDifficulty = params.targetSongDifficulty;
         if (params.targetSongPosition != null)
         {
           this.scrollPositionInMs = params.targetSongPosition;

--- a/source/funkin/ui/transition/preload/hotreload/HotReloadState.hx
+++ b/source/funkin/ui/transition/preload/hotreload/HotReloadState.hx
@@ -332,6 +332,7 @@ class HotReloadState extends MusicBeatState
 
     FlxG.plugins.get(funkin.util.plugins.EvacuateDebugPlugin).active = true;
     FlxG.plugins.get(funkin.util.plugins.ReloadAssetsDebugPlugin).active = true;
+    funkin.util.plugins.ReloadAssetsDebugPlugin.hotReloadInProgress = false;
     var postHotReloadCallback = () ->
     {
       var state:Dynamic = cast FlxG.state;

--- a/source/funkin/ui/transition/preload/hotreload/HotReloadState.hx
+++ b/source/funkin/ui/transition/preload/hotreload/HotReloadState.hx
@@ -67,8 +67,8 @@ class HotReloadState extends MusicBeatState
     super();
     @:nullSafety(Off)
     {
-      this.onComplete = params.onComplete ?? null;
-      this.targetState = params.targetState ?? null;
+      this.onComplete = params?.onComplete ?? null;
+      this.targetState = params?.targetState ?? null;
     }
     this.progressBar = new FunkinSprite(BAR_PAD, FlxG.height - BAR_HEIGHT - BAR_PAD);
     throbber = new FunkinSprite(0, 0);

--- a/source/funkin/ui/transition/preload/hotreload/HotReloadState.hx
+++ b/source/funkin/ui/transition/preload/hotreload/HotReloadState.hx
@@ -1,6 +1,5 @@
 package funkin.ui.transition.preload.hotreload;
 
-import flixel.util.typeLimit.NextState;
 import funkin.assets.FunkinAssetCache;
 import funkin.data.BaseRegistry.LoadEntriesResult;
 import funkin.data.character.CharacterData.CharacterDataParser;
@@ -22,6 +21,7 @@ import funkin.modding.module.ModuleHandler;
 import funkin.play.notes.notekind.NoteKindManager;
 import funkin.ui.title.TitleState;
 import funkin.util.tasks.TaskHandler;
+import flixel.util.typeLimit.NextState;
 import lime.app.Future;
 import polymod.Polymod;
 
@@ -31,13 +31,27 @@ import polymod.Polymod;
  *
  * Includes a progress bar and a throbber to indicate progress and working status.
  */
+typedef HotReloadStateParams =
+{
+  /**
+   * Callback for when hotreloading finishes.
+   */
+  var ?onComplete:Void->Void;
+
+  /**
+   * The state to switch to after hot reloading is complete.
+   * If `null`, `HotReloadState` will go to the Title instead unless explicitly specified in `onComplete`
+   */
+  var ?targetState:NextState;
+}
+
 @:nullSafety
 class HotReloadState extends MusicBeatState
 {
   static final BAR_PAD:Int = 16;
   static final BAR_HEIGHT:Int = 24;
 
-  // The state to move to.
+  var onComplete:Null<Void->Void> = null;
   var targetState:Null<NextState> = null;
   // Status.
   var hasStartedLoading:Bool = false;
@@ -48,13 +62,15 @@ class HotReloadState extends MusicBeatState
   var progressBar:FunkinSprite;
   var throbber:FunkinSprite;
 
-  public function new(?targetState:NextState)
+  public function new(?params:HotReloadStateParams)
   {
     super();
-
-    this.targetState = targetState;
+    @:nullSafety(Off)
+    {
+      this.onComplete = params.onComplete ?? null;
+      this.targetState = params.targetState ?? null;
+    }
     this.progressBar = new FunkinSprite(BAR_PAD, FlxG.height - BAR_HEIGHT - BAR_PAD);
-
     throbber = new FunkinSprite(0, 0);
   }
 
@@ -316,18 +332,42 @@ class HotReloadState extends MusicBeatState
 
     FlxG.plugins.get(funkin.util.plugins.EvacuateDebugPlugin).active = true;
     FlxG.plugins.get(funkin.util.plugins.ReloadAssetsDebugPlugin).active = true;
+    var postHotReloadCallback = () ->
+    {
+      if (FlxG.state is MusicBeatState)
+      {
+        var state:MusicBeatState = cast FlxG.state;
+        state.onPostHotReload();
+      }
+    }
+
+    // This'll dispatch after create() is called when the state is created.
+    FlxG.signals.postStateSwitch.addOnce(postHotReloadCallback);
 
     if (targetState != null)
     {
+      if (onComplete != null) onComplete();
+
       FlxG.switchState(targetState);
-    }
-    else if (InitState.customTitleState == null)
-    {
-      FlxG.switchState(() -> new TitleState());
     }
     else
     {
-      FlxG.switchState(() -> InitState.customTitleState);
+      if (onComplete != null)
+      {
+        // Assume `onComplete` handles switching to the next state.
+        this.onComplete();
+        return;
+      }
+
+      // Fallback to TitleState.
+      if (InitState.customTitleState == null)
+      {
+        FlxG.switchState(() -> new TitleState());
+      }
+      else
+      {
+        FlxG.switchState(() -> InitState.customTitleState);
+      }
     }
   }
 }

--- a/source/funkin/ui/transition/preload/hotreload/HotReloadState.hx
+++ b/source/funkin/ui/transition/preload/hotreload/HotReloadState.hx
@@ -334,9 +334,9 @@ class HotReloadState extends MusicBeatState
     FlxG.plugins.get(funkin.util.plugins.ReloadAssetsDebugPlugin).active = true;
     var postHotReloadCallback = () ->
     {
-      if (FlxG.state is MusicBeatState)
+      var state:Dynamic = cast FlxG.state;
+      if (state is MusicBeatState || state is MusicBeatSubState)
       {
-        var state:MusicBeatState = cast FlxG.state;
         state.onPostHotReload();
       }
     }

--- a/source/funkin/util/plugins/ReloadAssetsDebugPlugin.hx
+++ b/source/funkin/util/plugins/ReloadAssetsDebugPlugin.hx
@@ -18,6 +18,8 @@ import funkin.ui.MusicBeatSubState;
 @:nullSafety
 class ReloadAssetsDebugPlugin extends FlxBasic
 {
+  public static var hotReloadInProgress:Bool = false;
+
   public static function initialize():Void
   {
     FlxG.plugins.addPlugin(new ReloadAssetsDebugPlugin());
@@ -27,19 +29,23 @@ class ReloadAssetsDebugPlugin extends FlxBasic
   {
     super.update(elapsed);
 
-    #if html5
-    if (FlxG.keys.justPressed.FIVE && FlxG.keys.pressed.SHIFT)
-    #else
-    if (FlxG.keys.justPressed.F5)
-    #end
+    if (!hotReloadInProgress)
     {
-      reload();
+      #if html5
+      if (FlxG.keys.justPressed.FIVE && FlxG.keys.pressed.SHIFT)
+      #else
+      if (FlxG.keys.justPressed.F5)
+      #end
+      {
+        reload();
+      }
     }
   }
 
   @:noCompletion
   function reload():Void
   {
+    hotReloadInProgress = true;
     FlxTransitionableState.skipNextTransIn = true;
 
     var state:Dynamic = cast FlxG.state;

--- a/source/funkin/util/plugins/ReloadAssetsDebugPlugin.hx
+++ b/source/funkin/util/plugins/ReloadAssetsDebugPlugin.hx
@@ -1,9 +1,12 @@
 package funkin.util.plugins;
 
+import flixel.util.typeLimit.NextState;
 import flixel.FlxBasic;
 import flixel.FlxG;
+import flixel.FlxState;
 import flixel.addons.transition.FlxTransitionableState;
 import funkin.ui.transition.preload.hotreload.HotReloadState;
+import funkin.ui.transition.preload.hotreload.HotReloadState.HotReloadStateParams;
 import funkin.ui.MusicBeatState;
 
 /**
@@ -37,34 +40,55 @@ class ReloadAssetsDebugPlugin extends FlxBasic
   {
     FlxTransitionableState.skipNextTransIn = true;
 
-    var state:Dynamic = FlxG.state;
-    var isScripted:Bool = state._asc != null;
+    var isScripted:Bool = FlxG.state._asc != null;
+
+    var hotReloadParams:HotReloadStateParams = {};
     if (isScripted)
     {
-      var s:MusicBeatState = cast FlxG.state;
       @:privateAccess
-      var path:String = s._asc?.fullyQualifiedName ?? '';
+      var path:String = FlxG.state._asc?.fullyQualifiedName ?? '';
+
       trace('Hot-reloading scripted state: ' + path);
 
-      s.onPreHotReload();
+      // FlxState is a scripted state, give it a different constructor
+      if (FlxG.state is MusicBeatState)
+      {
+        var s:MusicBeatState = cast FlxG.state;
+        s.onPreHotReload();
 
-      var hotReloadParams = s.getHotReloadParams();
+        hotReloadParams = s.getHotReloadParams();
+      }
+      else
+      {
+        // Just load the scripted FlxState instead.
+        var scriptedNextState:NextState = () ->
+        {
+          var newState:Null<FlxState> = FlxState.scriptInit(path);
+          if (newState == null) return new funkin.ui.mainmenu.MainMenuState();
+          return newState;
+        }
 
+        hotReloadParams = {
+          targetState: scriptedNextState
+        }
+      }
       FlxG.switchState(() -> new HotReloadState(hotReloadParams));
     }
     else
     {
-      // Default params incase the current state is a ScriptedFlxState or anything we can't get custom params from.
-      var hotReloadParams = {
-        targetState: state._constructor
+      // Fallback to using default params.
+      @:privateAccess
+      hotReloadParams = {
+        targetState: FlxG.state._constructor
       };
 
-      if (Std.isOfType(state, MusicBeatState))
+      if (Std.isOfType(FlxG.state, MusicBeatState))
       {
-        state.onPreHotReload();
+        var s:MusicBeatState = cast FlxG.state;
+        s.onPreHotReload();
 
         // Fetch the custom hot reload params for this state.
-        hotReloadParams = state.getHotReloadParams();
+        hotReloadParams = s.getHotReloadParams();
       }
       FlxG.switchState(() -> new HotReloadState(hotReloadParams));
     }

--- a/source/funkin/util/plugins/ReloadAssetsDebugPlugin.hx
+++ b/source/funkin/util/plugins/ReloadAssetsDebugPlugin.hx
@@ -4,10 +4,12 @@ import flixel.util.typeLimit.NextState;
 import flixel.FlxBasic;
 import flixel.FlxG;
 import flixel.FlxState;
+import flixel.FlxSubState;
 import flixel.addons.transition.FlxTransitionableState;
 import funkin.ui.transition.preload.hotreload.HotReloadState;
 import funkin.ui.transition.preload.hotreload.HotReloadState.HotReloadStateParams;
 import funkin.ui.MusicBeatState;
+import funkin.ui.MusicBeatSubState;
 
 /**
  * A plugin which adds functionality to press `F5` to reload all game assets, then reload the current state.
@@ -40,30 +42,37 @@ class ReloadAssetsDebugPlugin extends FlxBasic
   {
     FlxTransitionableState.skipNextTransIn = true;
 
-    var isScripted:Bool = FlxG.state._asc != null;
+    var state:Dynamic = cast FlxG.state;
+    var isScripted:Bool = state._asc != null;
 
     var hotReloadParams:HotReloadStateParams = {};
     if (isScripted)
     {
       @:privateAccess
-      var path:String = FlxG.state._asc?.fullyQualifiedName ?? '';
-
+      var path:String = state._asc?.fullyQualifiedName ?? '';
       trace('Hot-reloading scripted state: ' + path);
 
-      // FlxState is a scripted state, give it a different constructor
-      if (FlxG.state is MusicBeatState)
+      if (Std.isOfType(state, MusicBeatState) || Std.isOfType(state, MusicBeatSubState))
       {
-        var s:MusicBeatState = cast FlxG.state;
-        s.onPreHotReload();
+        state.onPreHotReload();
 
-        hotReloadParams = s.getHotReloadParams();
+        hotReloadParams = state.getHotReloadParams();
       }
       else
       {
+        var newState:Null<FlxState> = null;
+
         // Just load the scripted FlxState instead.
         var scriptedNextState:NextState = () ->
         {
-          var newState:Null<FlxState> = FlxState.scriptInit(path);
+          if (Std.isOfType(state, FlxState))
+          {
+            newState = FlxState.scriptInit(path);
+          }
+          else if (Std.isOfType(state, FlxSubState))
+          {
+            newState = FlxSubState.scriptInit(path);
+          }
           if (newState == null) return new funkin.ui.mainmenu.MainMenuState();
           return newState;
         }
@@ -77,18 +86,16 @@ class ReloadAssetsDebugPlugin extends FlxBasic
     else
     {
       // Fallback to using default params.
-      @:privateAccess
       hotReloadParams = {
-        targetState: FlxG.state._constructor
+        targetState: state._constructor
       };
 
-      if (Std.isOfType(FlxG.state, MusicBeatState))
+      if (Std.isOfType(state, MusicBeatState) || Std.isOfType(state, MusicBeatSubState))
       {
-        var s:MusicBeatState = cast FlxG.state;
-        s.onPreHotReload();
+        state.onPreHotReload();
 
         // Fetch the custom hot reload params for this state.
-        hotReloadParams = s.getHotReloadParams();
+        hotReloadParams = state.getHotReloadParams();
       }
       FlxG.switchState(() -> new HotReloadState(hotReloadParams));
     }

--- a/source/funkin/util/plugins/ReloadAssetsDebugPlugin.hx
+++ b/source/funkin/util/plugins/ReloadAssetsDebugPlugin.hx
@@ -45,19 +45,28 @@ class ReloadAssetsDebugPlugin extends FlxBasic
       @:privateAccess
       var path:String = s._asc?.fullyQualifiedName ?? '';
       trace('Hot-reloading scripted state: ' + path);
-      FlxG.switchState(() -> new HotReloadState(() ->
-      {
-        var newState:Null<funkin.ui.MusicBeatState> = MusicBeatState.scriptInit(path);
-        if (newState == null) return new funkin.ui.mainmenu.MainMenuState();
-        return newState;
-      }));
+
+      s.onPreHotReload();
+
+      var hotReloadParams = s.getHotReloadParams();
+
+      FlxG.switchState(() -> new HotReloadState(hotReloadParams));
     }
     else
     {
-      var builder = state._constructor;
+      // Default params incase the current state is a ScriptedFlxState or anything we can't get custom params from.
+      var hotReloadParams = {
+        targetState: state._constructor
+      };
 
-      trace('Hot-reloading unscripted state: ' + state);
-      FlxG.switchState(() -> new HotReloadState(builder));
+      if (Std.isOfType(state, MusicBeatState))
+      {
+        state.onPreHotReload();
+
+        // Fetch the custom hot reload params for this state.
+        hotReloadParams = state.getHotReloadParams();
+      }
+      FlxG.switchState(() -> new HotReloadState(hotReloadParams));
     }
   }
 }


### PR DESCRIPTION
**Fixes issues:**
[Funkin#7915](https://github.com/FunkinCrew/Funkin/issues/7915)

Right now hot-reloading behaves really finicky as it simply just loads the state's constructor.
Because of this, there are a couple bugs like:
- Hot-reloading in PlayState doesn't update the song script (This is because after hot-reloading, PlayState updates its params but it isn't accounted for now.)
- You aren't really able to playtest charts anymore in the Chart Editor.

This PR reworks how hot-reloading is handled, attempting to give states more control of its behavior by:
- `HotReloadState` is now initialized given a `HotReloadStateParams` object containing:
  - `onComplete` callback for after hot-reloading is finished.
  - `targetState` for the state to go to after finishing (Defaults to the state's constructor).

_If `targetState` is null, it'll first assume that `onComplete` is the one handling state switching, else it fallbacks to going back to the TitleState._

- States now have functions `onPreHotReload()`, `onPostHotReload()`, & `getHotReloadParams`
  - `onPreHotReload()` is called right before hot-reloading begins, allowing states to save any necessary information needed.
  - `onPostHotReload()` is called right after hot-reloading is finished and `create()` is called when the state is initialized.
  - `getHotReloadParams()` is a function that states can override incase they have a specific way they want to hot-reload (For ex. PlayState doesn't use `targetState` to hot-reload and instead utilizes `onComplete()` to switch back.)

With this rework, the above issues are fixed and you're now able to go into a chart and playtest it with it saving.

Courtesy of @ComedyLost for helping with fixing this issue!