### PR TITLE
[BUGFIX] Scale soundtray with window size

### DIFF
--- a/source/funkin/ui/options/FunkinSoundTray.hx
+++ b/source/funkin/ui/options/FunkinSoundTray.hx
@@ -156,6 +156,13 @@ class FunkinSoundTray extends FlxSoundTray
     for (i in 0..._bars.length) _bars[i].visible = i < globalVolume;
   }
 
+  override public function screenCenter():Void
+  {
+    scaleX = _defaultScale * (FlxG.scaleMode.scale.x > 0 ? FlxG.scaleMode.scale.x : 1);
+    scaleY = _defaultScale * (FlxG.scaleMode.scale.y > 0 ? FlxG.scaleMode.scale.y : 1);
+    x = (0.5 * (FlxG.stage.stageWidth - _bg.width * scaleX) - FlxG.game.x);
+  }
+
   function saveVolumePreferences():Void
   {
     // Actually save when the volume is changed / modified


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
closes #7923 
<!-- Briefly describe the issue(s) fixed. -->
## Description
Overrode `screenCenter()` in FunkinSoundTray so the tray:
- Scales proportionally to the window using` FlxG.scaleMode.scale` (the same scale factor applied to the game content) preserving its intended size relative to the UI at any window size.
- Re-centers itself based on the current stageWidth and game offset so it stays perfectly centered after a resize.
<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos
### before :

https://github.com/user-attachments/assets/48f87912-d878-4782-af54-424c478a7ec4

### after :

https://github.com/user-attachments/assets/c155e3a1-b64a-4d75-8776-af91282d10f2

