### PR TITLE
[ENHANCEMENT] Reduce flashing on Freeplay capsules when flashing lights preference is disabled

### DIFF
--- a/source/funkin/ui/freeplay/SongMenuItem.hx
+++ b/source/funkin/ui/freeplay/SongMenuItem.hx
@@ -723,7 +723,7 @@ class SongMenuItem extends FlxSpriteGroup
     if (songText != null)
     {
       textAppear();
-      songText.flickerText();
+      if (Preferences.flashingLights) songText.flickerText();
     }
     if (pixelIcon != null && pixelIcon.visible)
     {
@@ -769,7 +769,16 @@ class SongMenuItem extends FlxSpriteGroup
     songText.alpha = isSelected ? 1 : 0.6;
     songText.blurredText.visible = isSelected ? true : false;
     capsule.offset.x = isSelected ? 0 : -5;
-    capsule.animation.play(isSelected ? 'selected' : 'unselected');
+    if (!Preferences.flashingLights)
+    {
+      // Show a single static frame instead of the flashing animation.
+      capsule.animation.play(isSelected ? 'selected' : 'unselected', true, false, 0);
+      capsule.animation.stop();
+    }
+    else
+    {
+      capsule.animation.play(isSelected ? 'selected' : 'unselected');
+    }
     ranking.alpha = isSelected ? 1 : 0.7;
     favIcon.alpha = isSelected ? 1 : 0.6;
     favIconBlurred.alpha = isSelected ? 1 : 0;


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
- #3816

<!-- Briefly describe the issue(s) fixed. -->
## Description
This PR fixes the freeplay capsules from flashing when the option is disabled.

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos

### `Preferences.flashingLights` Enabled
https://github.com/user-attachments/assets/30939b2c-9c1f-42cd-87b6-954414c9bd2f

### `Preferences.flashingLights` Disabled
https://github.com/user-attachments/assets/b7196821-1bed-40c5-b21b-4a3f04db6b16