### PR TITLE
[TYPO/CHORE] Change `nulNoteStyle` to `nullNoteStyle` in PlayState

### DIFF
--- a/source/funkin/play/PlayState.hx
+++ b/source/funkin/play/PlayState.hx
@@ -803,9 +803,9 @@ class PlayState extends MusicBeatSubState
 
     var currentChart = currentSong.getDifficulty(currentDifficulty, currentVariation);
     var noteStyleId:String = currentChart?.noteStyle ?? '';
-    var nulNoteStyle:Null<NoteStyle> = NoteStyleRegistry.instance.fetchEntry(noteStyleId);
-    if (nulNoteStyle == null) nulNoteStyle = NoteStyleRegistry.instance.fetchDefault();
-    noteStyle = nulNoteStyle;
+    var nullNoteStyle:Null<NoteStyle> = NoteStyleRegistry.instance.fetchEntry(noteStyleId);
+    if (nullNoteStyle == null) nullNoteStyle = NoteStyleRegistry.instance.fetchDefault();
+    noteStyle = nullNoteStyle;
 
     // Strumlines
     playerStrumline = new Strumline(noteStyle, !isBotPlayMode, currentChart?.scrollSpeed);


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
No linked issues.

<!-- Briefly describe the issue(s) fixed. -->
## Description
This PR fixes a typo in PlayState, related to a variable called "nulNoteStyle". This has now been changed to "nullNoteStyle".

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos
<img width="926" height="284" alt="image" src="https://github.com/user-attachments/assets/435091ed-aa67-4927-992e-9a1af3edef1f" />
<img width="458" height="66" alt="image" src="https://github.com/user-attachments/assets/b1ea45cb-f408-48e8-864f-19815602004e" />


