### PR TITLE
[BUGFIX] Hide difficulty flames when exiting Freeplay

### DIFF
--- a/source/funkin/ui/freeplay/FreeplayFlames.hx
+++ b/source/funkin/ui/freeplay/FreeplayFlames.hx
@@ -65,7 +65,6 @@ class FreeplayFlames extends FlxSpriteGroup
       timers.remove(timer);
     }
 
-    this.properPositions = false;
     this.flameCount = value;
     var visibleCount:Int = 0;
     for (i in 0...5)


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues

Closes #7852

<!-- Briefly describe the issue(s) fixed. -->
## Description

When leaving Freeplay on a song with more than 10 stars, the difficulty flames stayed on screen.

When `flameCount` changed, `FreeplayFlames` reset the flame positions on the next update. This put them back at their normal Freeplay position while `DifficultyStars` was moving off screen.

The flames no longer resets the positions. It still changes the other stuff around them. The position still update when needed.

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos

> N/A yet, recording videos
> if someone could check this on their 
> own on the meanwhile i would be very happy