### PR TITLE
[BUGFIX] Fix the Stage Editor file extension adding unnecessary symbols

### DIFF
--- a/source/funkin/ui/debug/stageeditor/StageEditorState.hx
+++ b/source/funkin/ui/debug/stageeditor/StageEditorState.hx
@@ -1300,7 +1300,7 @@ class StageEditorState extends UIState
         {
           saved = true;
           currentFile = path;
-        }, null, stageName + '.' + FileUtil.FILE_FILTER_FNFS.extension);
+        }, null, stageName + '.' + Constants.EXT_STAGE);
 
       case 'save stage':
         if (currentFile == '')


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
No Linked Issues.

<!-- Briefly describe the issue(s) fixed. -->
## Description
When saving a stage editor file, the extension would contain a few unnecessary symbols. This would prevent the file from saving, and would require the user to manually edit the extension so that you could save the file.

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos
### Before:
<img width="602" height="107" alt="image" src="https://github.com/user-attachments/assets/e52c346f-ce99-4b25-b0a6-85c8cfc12c2d" />

### After:
<img width="602" height="102" alt="image" src="https://github.com/user-attachments/assets/14572221-c4b6-4d0b-9dd6-9b04c0b9e65e" />

