### PR TITLE
[ENHANCEMENT] Gray out incompatible Mod Menu items

### DIFF
--- a/source/funkin/modding/PolymodHandler.hx
+++ b/source/funkin/modding/PolymodHandler.hx
@@ -658,12 +658,36 @@ class PolymodHandler
   }
 
   /**
-   * Retrieve a list of metadata for ALL installed mods, including disabled mods.
+   * Get all installed mods. Incompatible mods are excluded.
    *
    * @param force Force the game to reload the list of mods from the file system.
    * @return An array of mod metadata
    */
   public static function getAllMods(force:Bool = false):Array<ModMetadata>
+  {
+    return scanMods(false, force);
+  }
+
+  /**
+   * Get all installed mods including incompatible ones.
+   * Used by the Mod Menu.
+   *
+   * @param force Force the game to reload the list of mods from the file system.
+   * @return An array of mod metadata
+   */
+  public static function getAllModsIncludingIncompatible(force:Bool = false):Array<ModMetadata>
+  {
+    return scanMods(true, force);
+  }
+
+  /**
+   * Scan the mods folder. Optionally include incompatible mods.
+   *
+   * @param includeIncompatible Whether to return mods that don't satisfy `API_VERSION_RULE`.
+   * @param force Force the game to reload the list of mods from the file system.
+   * @return An array of mod metadata
+   */
+  static function scanMods(includeIncompatible:Bool, force:Bool):Array<ModMetadata>
   {
     trace('Scanning the mods folder...');
 
@@ -671,12 +695,14 @@ class PolymodHandler
     try
     {
       if (modFileSystem == null || force) modFileSystem = buildFileSystem();
-      modMetadata = Polymod.scan({
+
+      var scanParams:Dynamic = {
         modRoot: MOD_FOLDER,
-        apiVersionRule: API_VERSION_RULE,
         fileSystem: modFileSystem,
         errorCallback: PolymodErrorHandler.onPolymodError
-      });
+      };
+      if (!includeIncompatible) scanParams.apiVersionRule = API_VERSION_RULE;
+      modMetadata = Polymod.scan(scanParams);
     }
     catch (e:Dynamic)
     {
@@ -685,6 +711,18 @@ class PolymodHandler
     }
     trace('Found ${modMetadata.length} mods when scanning.');
     return modMetadata;
+  }
+
+  /**
+   * Check if a mod is compatible with the current API version.
+   *
+   * @param mod The mod metadata to check.
+   * @return Whether the mod satisfies `API_VERSION_RULE`.
+   */
+  public static function isModCompatible(mod:ModMetadata):Bool
+  {
+    if (mod == null) return true;
+    return mod.isCompatible(API_VERSION_RULE);
   }
 
   /**
@@ -781,6 +819,32 @@ class PolymodHandler
     // Sort the mods by alphabetical mod title.
     disabledMods.sort((a, b) ->
     {
+      return SortUtil.alphabetically(a.title, b.title);
+    });
+
+    return disabledMods;
+  }
+
+  /**
+   * Get all disabled mods including incompatible ones.
+   * Incompatible mods sort to the bottom.
+   * @return An array of mod metadata, in alphabetical order by mod title.
+   */
+  public static function getDisabledModsIncludingIncompatible(force:Bool = false):Array<ModMetadata>
+  {
+    var modMetadata:Array<ModMetadata> = getAllModsIncludingIncompatible(force);
+    var enabledModIds:Array<String> = Save.instance.enabledModIds.value;
+    var disabledMods:Array<ModMetadata> = modMetadata.filter((item) ->
+    {
+      return !enabledModIds.contains(item.id);
+    });
+
+    // Sort the mods by alphabetical mod title, pushing incompatible mods to the bottom.
+    disabledMods.sort((a, b) ->
+    {
+      var aCompatible:Bool = isModCompatible(a);
+      var bCompatible:Bool = isModCompatible(b);
+      if (aCompatible != bCompatible) return aCompatible ? 1 : -1;
       return SortUtil.alphabetically(a.title, b.title);
     });
 

--- a/source/funkin/ui/ScrollingTextBox.hx
+++ b/source/funkin/ui/ScrollingTextBox.hx
@@ -67,7 +67,15 @@ class ScrollingTextBox extends FunkinSpriteGroup
 
   var fontPath:String;
   var fontSize:Int;
-  var textColor:FlxColor;
+  public var textColor(default, set):FlxColor = FlxColor.WHITE;
+
+  function set_textColor(value:FlxColor):FlxColor
+  {
+    if (textColor == value) return textColor;
+    textColor = value;
+    rebuild();
+    return textColor;
+  }
 
   var line:Null<FlxText> = null;
   var lineClip:Null<FlxRect> = null;

--- a/source/funkin/ui/modmenu/ModMenuItem.hx
+++ b/source/funkin/ui/modmenu/ModMenuItem.hx
@@ -12,6 +12,7 @@ import funkin.Paths;
 import flixel.math.FlxMath;
 import flixel.tweens.FlxEase;
 import funkin.ui.ScrollingTextBox;
+import lime.app.Application;
 
 /**
  * Represents an installed mod visually in the mod menu.
@@ -422,6 +423,19 @@ class ModMenuItem extends FunkinSpriteGroup
   public function getModVersion():Dynamic
   {
     return mod != null ? mod.modVersion : null;
+  }
+
+  /**
+   * Mark this item as incompatible.
+   * Greys out the title and shows a warning in the description.
+   */
+  public function setIncompatible():Void
+  {
+    titleText.textColor = FlxColor.GRAY;
+    descriptionText.setFormat(funkin.assets.Paths.font('ui/fonts/FunkinLingLong', 'otf'), 16, 0xFFFF0000);
+    descriptionText.localAlpha = 1.0;
+    descriptionText.text = 'INCOMPATIBLE WITH v${Application.current.meta.get('version')}\nCURRENT MOD VERSION v${mod?.apiVersion.toString() ?? 'UNKNOWN'}';
+    if (modIcon != null) modIcon.localAlpha = 0.5;
   }
 
   override public function toString():String

--- a/source/funkin/ui/modmenu/ModMenuState.hx
+++ b/source/funkin/ui/modmenu/ModMenuState.hx
@@ -2101,7 +2101,7 @@ class ModMenuState extends MusicBeatState
 
   function refreshModList(doFade:Bool = true):Array<ModMenuItem>
   {
-    PolymodHandler.getAllMods(true);
+    PolymodHandler.getDisabledModsIncludingIncompatible(true);
     itemsInFolder = FileUtil.readDir(PolymodHandler.MOD_FOLDER);
 
     tempDisabledMods = disabledModItems.modItems.map((item) -> item.mod);
@@ -2173,7 +2173,7 @@ class ModMenuState extends MusicBeatState
 
   function buildDisabledModList():Array<ModMenuItem>
   {
-    var disabledMods:Array<ModMetadata> = PolymodHandler.getDisabledMods();
+    var disabledMods:Array<ModMetadata> = PolymodHandler.getDisabledModsIncludingIncompatible();
     var newModId:Array<String> = [];
 
     var liveIds:Array<String> = disabledMods.map((m) -> m.id).concat(PolymodHandler.getEnabledMods().map((m) -> m.id));
@@ -2225,6 +2225,7 @@ class ModMenuState extends MusicBeatState
       if (disabledModItems.modItems.exists((it) -> it.getModId() == mod.id)) continue;
 
       var item = new ModMenuItem(mod);
+      if (!PolymodHandler.isModCompatible(mod)) item.setIncompatible();
       item.localAlpha = 0;
       disabledModItems.addModRawWithoutLayout(item, disabledModItems.modItems.length);
       newItems.push(item);
@@ -2235,9 +2236,9 @@ class ModMenuState extends MusicBeatState
 
   function buildEnabledModList():Void
   {
-    var enabledMods:Array<ModMetadata> = PolymodHandler.getEnabledMods();
+    var enabledMods:Array<ModMetadata> = PolymodHandler.getEnabledMods().filter((m) -> PolymodHandler.isModCompatible(m));
 
-    var liveIds:Array<String> = enabledMods.map((m) -> m.id).concat(PolymodHandler.getDisabledMods().map((m) -> m.id));
+    var liveIds:Array<String> = enabledMods.map((m) -> m.id).concat(PolymodHandler.getDisabledModsIncludingIncompatible().map((m) -> m.id));
 
     if (tempDisabledMods.length > 0 || tempEnabledMods.length > 0)
     {
@@ -2328,6 +2329,11 @@ class ModMenuState extends MusicBeatState
     if (item == null) return false;
     if (!disabledModItems.modItems.contains(item)) return false;
     if (item.getModId() == BASE_GAME_MOD_ID) return false;
+    if (!PolymodHandler.isModCompatible(item.mod))
+    {
+      blockedIncompatible(item);
+      return false;
+    }
 
     item.selected = false;
 
@@ -2530,6 +2536,15 @@ class ModMenuState extends MusicBeatState
     {
       item.startFlight(ModMenuItemList.ITEM_X_OFFSET, restY, 0.12, FlxEase.quadOut);
     });
+  }
+
+  /**
+   * Show feedback when trying to enable an incompatible mod.
+   */
+  function blockedIncompatible(item:ModMenuItem):Void
+  {
+    FunkinSound.playOnce(Paths.sound('ui/quick-panel/sounds/menu-deny'), 0.7);
+    item.flashBackground();
   }
 
   function orderMod(modItem:Null<ModMenuItem>, moveUp:Bool):Void


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
closes #7939
<!-- Briefly describe the issue(s) fixed. -->
## Description
Currently, mods whose `api_version` doesn't satisfy the game's API version rule (`>=0.8.0 <0.10.0`) are silently hidden from the Mod Menu. If a mod is incompatible, players have no way to see it, why its missing, or even know that it exists at all.

This PR makes incompatible mods **visible but greyed out** in the Mod Menu:

- **PolymodHandler**  added `getAllModsIncludingIncompatible()`, `scanMods(includeIncompatible, force)` (omits the API version rule so broken mods still surface), `isModCompatible()`, and `getDisabledModsIncludingIncompatible()` (incompatible mods sorted to the bottom of the Disabled list).
- **ModMenuItem**  new `compatible` flag and `setIncompatible()` which greys out the title/description and dims the icon.
- **ModMenuState**  disabled list now scans permissively and marks incompatible items; enabled list filters to compatible-only; attempting to enable an incompatible mod is blocked with the existing deny SFX + background flash feedback.

An incompatible mod still cannot be enabled , it just isn't invisible anymore.
<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos

https://github.com/user-attachments/assets/bf37eb2a-266f-4747-a9c1-5572b9851d1c

