### PR TITLE
[BUGFIX] Prevent `selectSound` from playing when holding opposite directional keys at once

### DIFF
--- a/source/funkin/ui/charSelect/CharSelectSubState.hx
+++ b/source/funkin/ui/charSelect/CharSelectSubState.hx
@@ -787,32 +787,32 @@ class CharSelectSubState extends MusicBeatSubState
       if (controls.UI_UP_P)
       {
         cursorY -= 1;
-        cursors.resetDeny();
-
         holdTmrUp = 0;
-
-        selectSound.play(true);
       }
       if (controls.UI_DOWN_P)
       {
         cursorY += 1;
-        cursors.resetDeny();
         holdTmrDown = 0;
-        selectSound.play(true);
       }
       if (controls.UI_LEFT_P)
       {
         cursorX -= 1;
-        cursors.resetDeny();
-
         holdTmrLeft = 0;
-        selectSound.play(true);
       }
       if (controls.UI_RIGHT_P)
       {
         cursorX += 1;
-        cursors.resetDeny();
         holdTmrRight = 0;
+      }
+
+      if ((controls.UI_UP_P || controls.UI_DOWN_P) && !(controls.UI_UP_P && controls.UI_DOWN_P))
+      {
+        cursors.resetDeny();
+        selectSound.play(true);
+      }
+      if ((controls.UI_LEFT_P || controls.UI_RIGHT_P) && !(controls.UI_LEFT_P && controls.UI_RIGHT_P))
+      {
+        cursors.resetDeny();
         selectSound.play(true);
       }
 
@@ -1036,33 +1036,39 @@ class CharSelectSubState extends MusicBeatSubState
 
   function spamOnStep():Void
   {
-    if (spamDirections.hasAny(ANY))
+    var moveX:Int = 0;
+    var moveY:Int = 0;
+
+    if (spamDirections.has(UP))
     {
+      moveY -= 1;
+      holdTmrUp = 0;
+    }
+    if (spamDirections.has(DOWN))
+    {
+      moveY += 1;
+      holdTmrDown = 0;
+    }
+    if (spamDirections.has(LEFT))
+    {
+      moveX -= 1;
+      holdTmrLeft = 0;
+    }
+    if (spamDirections.has(RIGHT))
+    {
+      moveX += 1;
+      holdTmrRight = 0;
+    }
+
+    if (moveX != 0 || moveY != 0)
+    {
+      cursorX += moveX;
+      cursorY += moveY;
+
       if (selectSound.pitch > 5) selectSound.pitch = 5;
       selectSound.play(true);
 
       cursors.resetDeny();
-
-      if (spamDirections.has(UP))
-      {
-        cursorY -= 1;
-        holdTmrUp = 0;
-      }
-      if (spamDirections.has(DOWN))
-      {
-        cursorY += 1;
-        holdTmrDown = 0;
-      }
-      if (spamDirections.has(LEFT))
-      {
-        cursorX -= 1;
-        holdTmrLeft = 0;
-      }
-      if (spamDirections.has(RIGHT))
-      {
-        cursorX += 1;
-        holdTmrRight = 0;
-      }
     }
   }
 


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
- #7937

<!-- Briefly describe the issue(s) fixed. -->
## Description
This PR fixes a minor audio issue in the character select menu.

### Changes:
- `update()`: Moved `selectSound.play()`/`resetDeny()` out of the four `UI_*_P` blocks, and only play the sound after if just one of Up/Down or Left/Right was pressed, not both
- `spamOnStep()`: Now calculates `moveX`/`moveY` first, then only moves the cursor and plays the sound if either is non-zero
