### PR TITLE
[ENHANCEMENT] Align the Menu Bar depending on your Debug Display mode

### DIFF
--- a/source/funkin/ui/debug/cameraeditor/CameraEditorState.hx
+++ b/source/funkin/ui/debug/cameraeditor/CameraEditorState.hx
@@ -628,7 +628,6 @@ class CameraEditorState extends UIState implements ConsoleClass
     root.height = FlxG.height;
 
     menubar.height = 35;
-    if (Preferences.debugDisplay == DebugDisplayMode.Off) menubar.paddingLeft = null;
 
     WindowManager.instance.container = root;
     Screen.instance.addComponent(root);
@@ -978,6 +977,8 @@ class CameraEditorState extends UIState implements ConsoleClass
     }
 
     if (criticalFailure) return;
+
+    Preferences.debugDisplay == DebugDisplayMode.Off ? menubar.paddingLeft = null : menubar.paddingLeft = 256;
 
     if (autoSeek)
     {

--- a/source/funkin/ui/debug/charting/ChartEditorState.hx
+++ b/source/funkin/ui/debug/charting/ChartEditorState.hx
@@ -3238,8 +3238,6 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
     txtCopyNotif.zIndex = 120;
     add(txtCopyNotif);
 
-    if (Preferences.debugDisplay == DebugDisplayMode.Off) menubar.paddingLeft = null;
-
     this.setupNotifications();
 
     // Setup character dropdowns.
@@ -3977,6 +3975,8 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
     super.update(elapsed);
 
     if (criticalFailure) return;
+
+    Preferences.debugDisplay == DebugDisplayMode.Off ? menubar.paddingLeft = null : menubar.paddingLeft = 256;
 
     // These ones happen even if the modal dialog is open.
     handleMusicPlayback(elapsed);

--- a/source/funkin/ui/debug/stageeditor/StageEditorState.hx
+++ b/source/funkin/ui/debug/stageeditor/StageEditorState.hx
@@ -26,6 +26,7 @@ import haxe.ui.containers.menus.MenuOptionBox;
 import haxe.ui.containers.menus.MenuCheckBox;
 import funkin.util.FileUtil;
 import funkin.ui.mainmenu.MainMenuState;
+import funkin.ui.debug.FunkinDebugDisplay.DebugDisplayMode;
 import funkin.ui.debug.stageeditor.handlers.AssetDataHandler;
 import funkin.ui.debug.stageeditor.handlers.AssetDataHandler.StageEditorObjectData;
 import funkin.ui.debug.stageeditor.handlers.StageDataHandler;
@@ -588,6 +589,8 @@ class StageEditorState extends UIState
     conductorInUse.update();
 
     super.update(elapsed);
+
+    Preferences.debugDisplay == DebugDisplayMode.Off ? menubar.paddingLeft = null : menubar.paddingLeft = 256;
 
     if (FlxG.mouse.justPressed || FlxG.mouse.justPressedRight) FunkinSound.playOnce(Paths.sound("ui/editors/chart-editor/charting-sounds/click-down"));
     if (FlxG.mouse.justReleased || FlxG.mouse.justReleasedRight) FunkinSound.playOnce(Paths.sound("ui/editors/chart-editor/charting-sounds/click-up"));


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
No Linked Issues.

<!-- Briefly describe the issue(s) fixed. -->
## Description
This PR shifts the menubar depending on what Debug Display mode you are using. If you have it disabled, the menubar will be shifted to the right, and vice versa.

Sometimes, this would cause overlapping/gap issues, depending on how you entered any of these editors. For example, if you entered with Debug Display off, and then turned it on, certain UI elements would overlap with the Debug Display. Another issue would be entering with the Debug Display on, and then turning it off. This would cause a gap on the top-left side of the screen.

The Stage Editor never had this detection added in the first place, so I added it as a tiny bonus!

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos
https://youtu.be/QQBKcI0Q76k?si=qm-iTWm2nxnJjWuf