### PR TITLE
[BUGFIX] Prevent screenshots from being taken when Haxe UI is focused

### DIFF
--- a/source/funkin/util/plugins/ScreenshotPlugin.hx
+++ b/source/funkin/util/plugins/ScreenshotPlugin.hx
@@ -259,6 +259,8 @@ class ScreenshotPlugin extends FlxBasic
    */
   public function capture():Void
   {
+    if (haxe.ui.focus.FocusManager.instance.focus != null) return;
+    
     onPreScreenshot.dispatch();
 
     var shot:Bitmap = new Bitmap(BitmapData.fromImage(FlxG.stage.window.readPixels()));


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
#7961

<!-- Briefly describe the issue(s) fixed. -->
## Description
This PR fixes a screenshot bug when Haxe UI is focused. If you set your screenshot keybind to any alphanumeric character, and typed into a box in the Chart Editor, the game would take screenshots while you were typing.

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos

### Before:
https://github.com/user-attachments/assets/6c50fddf-d186-4be5-b773-b38586575106

### After:
https://github.com/user-attachments/assets/8e2ac8d1-643a-4299-bedf-f0dc9a754c05


