### PR TITLE
[Enhancement] Add discordRPCImage to CharacterData

### DIFF
--- a/source/funkin/data/character/CharacterData.hx
+++ b/source/funkin/data/character/CharacterData.hx
@@ -1208,6 +1208,13 @@ typedef CharacterData =
    */
   @:optional
   var atlasSettings:funkin.data.stage.StageData.TextureAtlasData;
+
+  /**
+   * An external image link for the health icon.
+   * This is used for Discord Rich Presence.
+   */
+  @:optional
+  var discordRPCImage:Null<String>;
 };
 
 /**

--- a/source/funkin/play/PlayState.hx
+++ b/source/funkin/play/PlayState.hx
@@ -2175,7 +2175,7 @@ class PlayState extends MusicBeatSubState
       {
         var albumEntry:Null<funkin.ui.freeplay.Album> = funkin.data.freeplay.album.AlbumRegistry.instance.fetchEntry(currentChart?.album ?? '');
         var album:Null<String> = albumEntry?.getDiscordRPCImage() ?? 'album-${(currentChart?.album ?? '')}';
-        var icon:Null<String> = currentChart?.discordRPCImage ?? 'icon-${dad.getHealthIconId()}';
+        var icon:Null<String> = currentChart?.discordRPCImage ?? dad.getDiscordRPCImage();
 
         discordRPCAlbum = album;
         discordRPCIcon = icon;

--- a/source/funkin/play/character/BaseCharacter.hx
+++ b/source/funkin/play/character/BaseCharacter.hx
@@ -374,6 +374,11 @@ class BaseCharacter extends Bopper
     return _data?.healthIcon?.id ?? Constants.DEFAULT_HEALTH_ICON;
   }
 
+  public function getDiscordRPCImage():String
+  {
+    return _data?.discordRPCImage ?? 'icon-${getHealthIconId()}';
+  }
+
   public function initHealthIcon(isOpponent:Bool):Void
   {
     // Modders may want to use characters outside of PlayState and this still gets called, so we ignore it.


### PR DESCRIPTION
## Description
This PR adds the `discordRPCImage` field directly to `CharacterData`.

If a character appeared in multiple songs, you previously had to duplicate the same character icon link inside every single song's data for the Discord Rich Presence icon.

So I added this field to character configuration so the character's Discord RPC icon can be defined once and reused across all songs automatically.

## Screenshots/Videos
<img width="358" height="152" alt="{8DF52E4D-93DC-47B9-B4FF-0E50400F7ECC}" src="https://github.com/user-attachments/assets/232d4f4c-4962-4e9a-849a-b91adcc363ba" />
<img width="904" height="185" alt="{FFAB0D82-E9A2-41EB-9536-E346C35255F6}" src="https://github.com/user-attachments/assets/191956e8-ae86-4327-a2ff-50d8c5e4e30f" />
