### PR TITLE
[BUGFIX] Don't start countdown during game over

### DIFF
--- a/source/funkin/play/PlayState.hx
+++ b/source/funkin/play/PlayState.hx
@@ -1283,6 +1283,9 @@ class PlayState extends MusicBeatSubState
 
       if (health <= Constants.HEALTH_MIN && !isPracticeMode && !isPlayerDying)
       {
+        // Stops the countdown at the current step so that the countdown voices don't leak into the death state.
+        Countdown.stopCountdown();
+
         vocals?.pause();
 
         if (FlxG.sound.music != null) FlxG.sound.music.pause();

--- a/source/funkin/ui/charSelect/CharSelectSubState.hx
+++ b/source/funkin/ui/charSelect/CharSelectSubState.hx
@@ -868,7 +868,6 @@ class CharSelectSubState extends MusicBeatSubState
 
         var event:CharacterSelectScriptEvent = CharacterSelectScriptEvent.get(CHARACTER_DESELECTED, curChar);
         dispatchEvent(event);
-        event.put();
 
         #if FEATURE_TOUCH_CONTROLS
         if (backButton != null)
@@ -907,7 +906,6 @@ class CharSelectSubState extends MusicBeatSubState
 
         var event:CharacterSelectScriptEvent = CharacterSelectScriptEvent.get(CHARACTER_CONFIRMED, curChar);
         dispatchEvent(event);
-        event.put();
 
         #if FEATURE_TOUCH_CONTROLS
         if (backButton != null)
@@ -1024,14 +1022,15 @@ class CharSelectSubState extends MusicBeatSubState
     }
   }
 
-  override public function dispatchEvent(event:ScriptEvent):Void
+  override public function dispatchEvent(event:ScriptEvent, finish:Bool = true):Void
   {
     // super.dispatchEvent(event) dispatches event to module scripts.
-    super.dispatchEvent(event);
+    super.dispatchEvent(event, false);
 
     // Dispatch events (like onBeatHit) to props
     ScriptEventDispatcher.callEvent(playerChill, event);
     ScriptEventDispatcher.callEvent(gfChill, event);
+    if (finish) event.finish();
   }
 
   function spamOnStep():Void


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
- #7966 

<!-- Briefly describe the issue(s) fixed. -->
## Description
Fixes countdown starting after the player has already died.
