### PR TITLE
[ENHANCEMENT] Better trackpad support for debug editors

### DIFF
--- a/source/funkin/ui/debug/anim/DebugBoundingState.hx
+++ b/source/funkin/ui/debug/anim/DebugBoundingState.hx
@@ -335,7 +335,7 @@ class DebugBoundingState extends FlxState
     if (FlxG.mouse.justReleased || FlxG.mouse.justReleasedMiddle) FunkinSound.playOnce(Paths.sound('ui/editors/chart-editor/charting-sounds/click-up'));
 
     MouseUtil.mouseCamDrag();
-    if (!haxeUIFocused) MouseUtil.mouseWheelZoom();
+    if (!haxeUIFocused) handleTrackpadScroll();
 
     // bg.scale.x = FlxG.camera.zoom;
     // bg.scale.y = FlxG.camera.zoom;
@@ -343,6 +343,30 @@ class DebugBoundingState extends FlxState
     bg.setGraphicSize(Std.int(bg.width / FlxG.camera.zoom));
 
     super.update(elapsed);
+  }
+
+  static final TRACKPAD_PAN_SCALE:Float = 25.0;
+
+  function handleTrackpadScroll():Void
+  {
+    var dx:Float = FlxG.mouse.deltaWheel.x;
+    var dy:Float = FlxG.mouse.deltaWheel.y;
+    if (dx == 0 && dy == 0) return;
+
+    if (FlxG.keys.pressed.CONTROL)
+    {
+      if (dy == 0) return;
+      var scaledDelta:Float = dy * 10.0;
+      var rawScale:Float = Math.exp(scaledDelta / 100.0);
+      rawScale = Math.min(1.25, Math.max(0.75, rawScale));
+      FlxG.camera.zoom *= rawScale;
+      if (FlxG.camera.zoom < 0.1) FlxG.camera.zoom = 0.1;
+      if (FlxG.camera.zoom > 10.0) FlxG.camera.zoom = 10.0;
+      return;
+    }
+
+    FlxG.camera.scroll.x -= (-dx * TRACKPAD_PAN_SCALE) / FlxG.camera.zoom;
+    FlxG.camera.scroll.y -= (dy * TRACKPAD_PAN_SCALE) / FlxG.camera.zoom;
   }
 
   function resetWindowTitle():Void

--- a/source/funkin/ui/debug/cameraeditor/CameraEditorState.hx
+++ b/source/funkin/ui/debug/cameraeditor/CameraEditorState.hx
@@ -1062,7 +1062,12 @@ class CameraEditorState extends UIState implements ConsoleClass
       }
     }
 
-    if (timeline != null && timeline.viewport != null) timeline.viewport.tickEdgeAutoScroll(elapsed);
+    if (timeline != null && timeline.viewport != null)
+    {
+      timeline.viewport.tickEdgeAutoScroll(elapsed);
+      timeline.viewport.handleTrackpadScroll();
+    }
+    if (mainView != null) mainView.handleTrackpadScroll();
 
     super.update(elapsed);
 
@@ -2633,15 +2638,26 @@ class CameraEditorState extends UIState implements ConsoleClass
     performAutoSortLayersByType();
   }
 
-  // TODO: make this wheel zoom sensitivity configurable
-
   function onViewportZoom(e:CameraViewportEvent):Void
   {
+    var scaledDelta:Float = e.zoomDelta * 10.0;
+    var rawScale:Float = Math.exp(scaledDelta / 100.0);
+    rawScale = Math.min(1.25, Math.max(0.75, rawScale));
+
     pivotZoomOnViewport(() ->
     {
-      if (isCameraRelative) relativeZoom += MouseUtil.mouseWheelZoomData(0.08, e.zoomDelta);
+      if (isCameraRelative)
+      {
+        relativeZoom *= rawScale;
+        if (relativeZoom < 0.1) relativeZoom = 0.1;
+        if (relativeZoom > 10.0) relativeZoom = 10.0;
+      }
       else
-        MouseUtil.mouseWheelZoom(0.08, e.zoomDelta);
+      {
+        FlxG.camera.zoom *= rawScale;
+        if (FlxG.camera.zoom < 0.1) FlxG.camera.zoom = 0.1;
+        if (FlxG.camera.zoom > 10.0) FlxG.camera.zoom = 10.0;
+      }
     });
   }
 

--- a/source/funkin/ui/debug/stageeditor/StageEditorState.hx
+++ b/source/funkin/ui/debug/stageeditor/StageEditorState.hx
@@ -645,11 +645,7 @@ class StageEditorState extends UIState
     camGame.follow(camFollow);
     // camera movement
 
-    if ((FlxG.mouse.deltaWheel.y > 0 || (FlxG.mouse.deltaWheel.y < 0 && camGame.zoom > 0.11)) && !isCursorOverHaxeUI) // include the floating poing error thing
-    {
-      camGame.zoom += FlxG.mouse.deltaWheel.y / 10;
-      updateBGSize();
-    }
+    if (!isCursorOverHaxeUI) handleTrackpadScroll();
 
     // key shortcuts and inputs
     if (pressingControl() && FlxG.keys.justPressed.Q) onMenuItemClick('exit');
@@ -1057,6 +1053,31 @@ class StageEditorState extends UIState
     bg.scale.set(1 / FlxG.camera.zoom, 1 / FlxG.camera.zoom);
     bg.updateHitbox();
     bg.screenCenter();
+  }
+
+  static final TRACKPAD_PAN_SCALE:Float = 25.0;
+
+  function handleTrackpadScroll():Void
+  {
+    var dx:Float = FlxG.mouse.deltaWheel.x;
+    var dy:Float = FlxG.mouse.deltaWheel.y;
+    if (dx == 0 && dy == 0) return;
+
+    if (FlxG.keys.pressed.CONTROL)
+    {
+      if (dy == 0) return;
+      var scaledDelta:Float = dy * 10.0;
+      var rawScale:Float = Math.exp(scaledDelta / 100.0);
+      rawScale = Math.min(1.25, Math.max(0.75, rawScale));
+      camGame.zoom *= rawScale;
+      if (camGame.zoom < 0.11) camGame.zoom = 0.11;
+      if (camGame.zoom > 10.0) camGame.zoom = 10.0;
+      updateBGSize();
+      return;
+    }
+
+    camFollow.x += (dx * TRACKPAD_PAN_SCALE) / camGame.zoom;
+    camFollow.y -= (dy * TRACKPAD_PAN_SCALE) / camGame.zoom;
   }
 
   var sprDependant:Array<MenuItem> = [];

--- a/source/funkin/ui/haxeui/components/editors/camera/CameraViewport.hx
+++ b/source/funkin/ui/haxeui/components/editors/camera/CameraViewport.hx
@@ -1,5 +1,6 @@
 package funkin.ui.haxeui.components.editors.camera;
 
+import flixel.FlxG;
 import flixel.input.keyboard.FlxKey;
 import haxe.ui.containers.Box;
 import haxe.ui.core.Screen;
@@ -15,6 +16,31 @@ import funkin.util.HaxeUIUtil;
 @:composite(CameraViewportEvents)
 class CameraViewport extends Box
 {
+  public static inline var TRACKPAD_PAN_SCALE:Float = 25.0;
+
+  public function handleTrackpadScroll():Void
+  {
+    var dx:Float = FlxG.mouse.deltaWheel.x;
+    var dy:Float = FlxG.mouse.deltaWheel.y;
+    if (dx == 0 && dy == 0) return;
+    if (FlxG.keys.pressed.SHIFT) return;
+    if (FlxG.mouse.gameX < screenLeft || FlxG.mouse.gameX > screenLeft + width
+      || FlxG.mouse.gameY < screenTop || FlxG.mouse.gameY > screenTop + height) return;
+
+    if (FlxG.keys.pressed.CONTROL)
+    {
+      if (dy == 0) return;
+      var zoomEvent:CameraViewportEvent = new CameraViewportEvent(CameraViewportEvent.ZOOM);
+      zoomEvent.zoomDelta = dy;
+      dispatch(zoomEvent);
+      return;
+    }
+
+    var panEvent:CameraViewportEvent = new CameraViewportEvent(CameraViewportEvent.GESTURE_PAN);
+    panEvent.panDeltaX = -dx * TRACKPAD_PAN_SCALE;
+    panEvent.panDeltaY = dy * TRACKPAD_PAN_SCALE;
+    dispatch(panEvent);
+  }
 }
 
 private enum PanSource
@@ -47,7 +73,6 @@ private class CameraViewportEvents extends haxe.ui.events.Events
 
   override public function register():Void
   {
-    if (!hasEvent(MouseEvent.MOUSE_WHEEL, _onMouseWheel)) registerEvent(MouseEvent.MOUSE_WHEEL, _onMouseWheel);
     if (!hasEvent(MouseEvent.MIDDLE_MOUSE_DOWN, _onMiddleMouseDown)) registerEvent(MouseEvent.MIDDLE_MOUSE_DOWN, _onMiddleMouseDown);
     if (!hasEvent(MouseEvent.MOUSE_OVER, _onMouseOver)) registerEvent(MouseEvent.MOUSE_OVER, _onMouseOver);
     if (!hasEvent(MouseEvent.MOUSE_OUT, _onMouseOut)) registerEvent(MouseEvent.MOUSE_OUT, _onMouseOut);
@@ -71,7 +96,6 @@ private class CameraViewportEvents extends haxe.ui.events.Events
 
   override public function unregister():Void
   {
-    unregisterEvent(MouseEvent.MOUSE_WHEEL, _onMouseWheel);
     unregisterEvent(MouseEvent.MIDDLE_MOUSE_DOWN, _onMiddleMouseDown);
     unregisterEvent(MouseEvent.MOUSE_OVER, _onMouseOver);
     unregisterEvent(MouseEvent.MOUSE_OUT, _onMouseOut);
@@ -87,13 +111,6 @@ private class CameraViewportEvents extends haxe.ui.events.Events
       gesture = null;
     }
     #end
-  }
-
-  function _onMouseWheel(e:MouseEvent):Void
-  {
-    var event:CameraViewportEvent = new CameraViewportEvent(CameraViewportEvent.ZOOM);
-    event.zoomDelta = e.delta;
-    _viewport.dispatch(event);
   }
 
   function _onMouseOver(_:MouseEvent):Void
@@ -176,8 +193,6 @@ private class CameraViewportEvents extends haxe.ui.events.Events
 
   function onGestureStart(g:Gesture):Void
   {
-    if (hasEvent(MouseEvent.MOUSE_WHEEL, _onMouseWheel)) unregisterEvent(MouseEvent.MOUSE_WHEEL, _onMouseWheel);
-
     if (g.type == SCROLL)
     {
       _viewport.dispatch(new CameraViewportEvent(CameraViewportEvent.PAN_START));
@@ -186,8 +201,6 @@ private class CameraViewportEvents extends haxe.ui.events.Events
 
   function onGestureEnd(g:Gesture):Void
   {
-    if (!hasEvent(MouseEvent.MOUSE_WHEEL, _onMouseWheel)) registerEvent(MouseEvent.MOUSE_WHEEL, _onMouseWheel);
-
     if (g.type == SCROLL)
     {
       _viewport.dispatch(new CameraViewportEvent(CameraViewportEvent.PAN_END));

--- a/source/funkin/ui/haxeui/components/editors/timeline/TimelineViewport.hx
+++ b/source/funkin/ui/haxeui/components/editors/timeline/TimelineViewport.hx
@@ -35,6 +35,9 @@ class TimelineViewport extends Box
   public static inline var EDGE_AUTOSCROLL_ZONE_PX:Float = 40.0;
   public static inline var EDGE_AUTOSCROLL_MAX_PX_PER_SEC:Float = 1500.0;
   public static inline var EDGE_AUTOSCROLL_MAX_OVERDRAG_FACTOR:Float = 3.0;
+  public static inline var TRACKPAD_WHEEL_THRESHOLD:Float = 1.0;
+  public static inline var TRACKPAD_TIME_SCROLL_MULT:Float = 100.0;
+  public static inline var TRACKPAD_LAYER_SCROLL_MULT:Float = 48.0;
 
   @:clonable @:behaviour(DataBehaviour, 0.0)
   public var scrollOffsetMs:Float;
@@ -157,6 +160,44 @@ class TimelineViewport extends Box
   public function tickEdgeAutoScroll(elapsed:Float):Void
   {
     _eventsInstance.tickEdgeAutoScroll(elapsed);
+  }
+
+  public function handleTrackpadScroll():Void
+  {
+    var dx:Float = FlxG.mouse.deltaWheel.x;
+    var dy:Float = FlxG.mouse.deltaWheel.y;
+    if (dx == 0 && dy == 0) return;
+    if (FlxG.keys.pressed.SHIFT) return;
+    if (FlxG.mouse.gameX < screenLeft || FlxG.mouse.gameX > screenLeft + width
+      || FlxG.mouse.gameY < screenTop || FlxG.mouse.gameY > screenTop + height) return;
+
+    var isTrackpad:Bool = dx != 0 || Math.abs(dy) < TRACKPAD_WHEEL_THRESHOLD;
+    if (!isTrackpad) return;
+
+    if (FlxG.keys.pressed.CONTROL)
+    {
+      scrollVertical((dy * TRACKPAD_LAYER_SCROLL_MULT) / LAYER_HEIGHT);
+    }
+    else
+    {
+      if (dx != 0)
+      {
+        var pxPerMs:Float = pixelsPerMs * zoomLevel;
+        var scrollMs:Float = pxPerMs > 0 ? (dx * TRACKPAD_TIME_SCROLL_MULT) / pxPerMs : 0;
+        scrollOffsetMs = scrollOffsetMs + scrollMs;
+        if (scrollOffsetMs < 0) scrollOffsetMs = 0;
+      }
+
+      if (dy != 0)
+      {
+        scrollVertical((dy * TRACKPAD_LAYER_SCROLL_MULT) / LAYER_HEIGHT);
+      }
+    }
+
+    refreshLayout();
+
+    var zoomEvent = new TimelineEvent(TimelineEvent.ZOOM_CHANGED);
+    dispatch(zoomEvent);
   }
 
   // Caller is responsible for `refreshLayout()` afterwards.
@@ -1102,6 +1143,9 @@ private class TimelineViewportEvents extends haxe.ui.events.Events
 
   function _onMouseWheel(e:MouseEvent):Void
   {
+    // Skip trackpad input, handled by handleTrackpadScroll().
+    if (FlxG.mouse.deltaWheel.x != 0 || Math.abs(FlxG.mouse.deltaWheel.y) < TimelineViewport.TRACKPAD_WHEEL_THRESHOLD) return;
+
     if (e.shiftKey)
     {
       var localX = e.screenX - _viewport.screenLeft;


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
closes #7957
<!-- Briefly describe the issue(s) fixed. -->
## Description
Adds trackpad (two-finger scroll) support to the debug editors on Windows, where trackpads previously had no way to pan or horizontally scroll.
### Added :
#### Chart editor :
- the ability to scroll horizontally on offset and freeplay properties window
#### Camera editor :
- the ability to scroll vertical or horizontally in the events timeline view
- the ability to pan vertical or horizontally on the canvas as well as zoom in or zoom out
#### Animation editor :
- the ability to pan vertical or horizontally on the canvas as well as zoom in or zoom out
#### Stage editor :
- pan vertical or horizontally on the canvas as well as zoom in or zoom out
<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos
### Chart editor :

https://github.com/user-attachments/assets/38870d34-a97a-48fe-b8a1-b53c9f4cb4c7


### Camera editor :

https://github.com/user-attachments/assets/2b11e665-7718-49dc-a385-8dd182809fed


### Animation editor :

https://github.com/user-attachments/assets/91c2d316-1e02-4457-8018-1687ca53368f


### Stage editor :

https://github.com/user-attachments/assets/75378249-3c03-4753-8928-4b7ece70096e

