### PR TITLE
[BUGFIX] Fix Game Over music not finding alternatives if file doesn't exist

### DIFF
--- a/source/funkin/play/GameOverSubState.hx
+++ b/source/funkin/play/GameOverSubState.hx
@@ -496,10 +496,8 @@ class GameOverSubState extends MusicBeatSubState
     if (!Assets.exists(musicPath))
     {
       // wtf is this crap
-      if (starting || ending)
+      if (suffix.length > 0)
       {
-        if (suffix.length == 0) return null;
-
         var newSuffix:String = suffix.split('-').slice(0, -1).join('-');
         return resolveMusicPath(newSuffix, starting, ending);
       }


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
https://github.com/FunkinCrew/Funkin/issues/7971

<!-- Briefly describe the issue(s) fixed. -->
## Description
This PR fixes the game over music not being able to strip down the suffix correctly, preventing the game from finding an alternative game over song to use in the event that the file doesn't exist

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos

https://github.com/user-attachments/assets/68e5df2e-74a4-447f-ae3b-bb83b22f6857


