### PR TITLE
[BUGFIX] Fix listDataFilesInPath incorrectly listing nested paths

### DIFF
--- a/source/funkin/assets/Assets.hx
+++ b/source/funkin/assets/Assets.hx
@@ -119,6 +119,8 @@ class Assets implements ConsoleClass
       var pathNoPrefix:String = textPath.substring(queryPath.length, textPath.length - suffix.length);
       var id:String = nested ? pathNoPrefix.split('/')[0] : pathNoPrefix;
 
+      if (nested && !StringTools.endsWith(textPath, '$id$suffix')) continue;
+
       if (blacklist != null && blacklist.contains(id)) continue;
 
       results.pushUnique(id);


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
Me

<!-- Briefly describe the issue(s) fixed. -->
## Description
This pr adds a new check in `funkin.assets.Assets`'s `listDataFilesInPath` function that checks if the nested json actually exists.

Currently it will list a file even if the actual data part doesn't exist which can cause issues

## Example:

Currently if you have character folder `gameplay/characters/bf-test` and that folder doesn't actually have a `bf-test.json` file, the game will still list it if that folder has a .json file anywhere inside of it. This ends up causing the game to get softlocked when hot-reloading as it continually tries to find that file even though it doesn't exist.