### PR TITLE
[BUGFIX] Disable certain plugins while in HotReloadState

### DIFF
--- a/source/funkin/ui/transition/preload/hotreload/HotReloadState.hx
+++ b/source/funkin/ui/transition/preload/hotreload/HotReloadState.hx
@@ -62,7 +62,8 @@ class HotReloadState extends MusicBeatState
   {
     super.create();
 
-    FlxG.keys.enabled = false;
+    FlxG.plugins.get(funkin.util.plugins.EvacuateDebugPlugin).active = false;
+    FlxG.plugins.get(funkin.util.plugins.ReloadAssetsDebugPlugin).active = false;
 
     // Fix a specific bug where the game tries to render the 0-character long text,
     // fails and shits its pants.
@@ -313,7 +314,8 @@ class HotReloadState extends MusicBeatState
     trace('Transitioning to title state...');
     transitioning = true;
 
-    FlxG.keys.enabled = true;
+    FlxG.plugins.get(funkin.util.plugins.EvacuateDebugPlugin).active = true;
+    FlxG.plugins.get(funkin.util.plugins.ReloadAssetsDebugPlugin).active = true;
 
     if (targetState != null)
     {


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
Contributor's server

<!-- Briefly describe the issue(s) fixed. -->
## Description
So I found out with Kolo's help that one of my prs (https://github.com/FunkinCrew/Funkin/pull/7906) caused a bug where after the first hot reload it required you to press F5 twice for it to work. whoopsies

This pr reverts that and just disables the plugins that would allow you to leave the state early before it has finished loading the mods

Co-authored by Kolo and Ahmed7p since they both showed ways on how to fix it