### PR TITLE
[BUGFIX] Preserve scripted state constructor arguments when hot reloading

### DIFF
--- a/source/funkin/ui/MusicBeatState.hx
+++ b/source/funkin/ui/MusicBeatState.hx
@@ -276,7 +276,9 @@ class MusicBeatState extends FlxTransitionableState implements IEventHandler
     var scriptedNextState:NextState = () ->
     {
       var path:String = _asc?.fullyQualifiedName ?? '';
-      var newState:Null<MusicBeatState> = MusicBeatState.scriptInit(path);
+      var constructorArgs:Array<Dynamic> = _asc?.getConstructorArgs() ?? [];
+
+      var newState:Null<MusicBeatState> = MusicBeatState.scriptInit(path, ...constructorArgs);
       if (newState == null) return new funkin.ui.mainmenu.MainMenuState();
       return newState;
     }

--- a/source/funkin/ui/MusicBeatSubState.hx
+++ b/source/funkin/ui/MusicBeatSubState.hx
@@ -203,7 +203,9 @@ class MusicBeatSubState extends FlxSubState implements IEventHandler
     var scriptedNextState:NextState = () ->
     {
       var path:String = _asc?.fullyQualifiedName ?? '';
-      var newState:Null<MusicBeatSubState> = MusicBeatSubState.scriptInit(path);
+      var constructorArgs:Array<Dynamic> = _asc?.getConstructorArgs() ?? [];
+
+      var newState:Null<MusicBeatSubState> = MusicBeatSubState.scriptInit(path, ...constructorArgs);
       if (newState == null) return new funkin.ui.mainmenu.MainMenuState();
       return newState;
     }

--- a/source/funkin/util/plugins/ReloadAssetsDebugPlugin.hx
+++ b/source/funkin/util/plugins/ReloadAssetsDebugPlugin.hx
@@ -56,6 +56,8 @@ class ReloadAssetsDebugPlugin extends FlxBasic
     {
       @:privateAccess
       var path:String = state._asc?.fullyQualifiedName ?? '';
+      var constructorArgs:Array<Dynamic> = state._asc?.getConstructorArgs() ?? [];
+
       trace('Hot-reloading scripted state: ' + path);
 
       if (Std.isOfType(state, MusicBeatState) || Std.isOfType(state, MusicBeatSubState))
@@ -73,11 +75,11 @@ class ReloadAssetsDebugPlugin extends FlxBasic
         {
           if (Std.isOfType(state, FlxState))
           {
-            newState = FlxState.scriptInit(path);
+            newState = FlxState.scriptInit(path, ...constructorArgs);
           }
           else if (Std.isOfType(state, FlxSubState))
           {
-            newState = FlxSubState.scriptInit(path);
+            newState = FlxSubState.scriptInit(path, ...constructorArgs);
           }
           if (newState == null) return new funkin.ui.mainmenu.MainMenuState();
           return newState;


### PR DESCRIPTION
This PR allows for scripted state to retain their previous constructor arguments when hot reloading, instead of them instantiating before with no arguments.

**Requires this PR to be merged:**
[polymod#477](https://github.com/FunkinCrew/polymod/pull/477)