### PR TITLE
[BUGFIX] Fix freeplay blur overflow past capsule edge

### DIFF
--- a/source/funkin/ui/freeplay/CapsuleText.hx
+++ b/source/funkin/ui/freeplay/CapsuleText.hx
@@ -22,6 +22,8 @@ class CapsuleText extends FlxSpriteGroup
   public var clipWidth(default, set):Int = 255;
   public var tooLong:Bool = false;
 
+  static inline var BLUR_OVERSHOOT:Int = 10;
+
   var glowColor:FlxColor = 0xFF00ccff;
 
   // 255, 27 normal
@@ -88,19 +90,14 @@ class CapsuleText extends FlxSpriteGroup
     if (whiteText.width > wid)
     {
       tooLong = true;
-
-      blurredText.clipRect = new FlxRect(0, 0, wid, blurredText.height);
-      whiteText.clipRect = new FlxRect(0, 0, wid, whiteText.height);
     }
     else
     {
       tooLong = false;
-
-      @:nullSafety(Off)
-      blurredText.clipRect = null;
-      @:nullSafety(Off)
-      whiteText.clipRect = null;
     }
+
+    blurredText.clipRect = new FlxRect(0, 0, wid - BLUR_OVERSHOOT, blurredText.height);
+    whiteText.clipRect = new FlxRect(0, 0, wid, whiteText.height);
   }
 
   function set_text(value:String):String
@@ -149,7 +146,7 @@ class CapsuleText extends FlxSpriteGroup
       {
         whiteText.clipRect = new FlxRect(whiteText.offset.x, 0, clipWidth, whiteText.height);
         blurredText.offset = whiteText.offset;
-        blurredText.clipRect = new FlxRect(whiteText.offset.x, 0, clipWidth, blurredText.height);
+        blurredText.clipRect = new FlxRect(whiteText.offset.x, 0, clipWidth - BLUR_OVERSHOOT, blurredText.height);
       },
       onComplete: function(_)
       {
@@ -171,7 +168,7 @@ class CapsuleText extends FlxSpriteGroup
       {
         whiteText.clipRect = new FlxRect(whiteText.offset.x, 0, clipWidth, whiteText.height);
         blurredText.offset = whiteText.offset;
-        blurredText.clipRect = new FlxRect(whiteText.offset.x, 0, clipWidth, blurredText.height);
+        blurredText.clipRect = new FlxRect(whiteText.offset.x, 0, clipWidth - BLUR_OVERSHOOT, blurredText.height);
       },
       onComplete: function(_)
       {
@@ -192,7 +189,7 @@ class CapsuleText extends FlxSpriteGroup
     if (moveTimer != null) moveTimer.cancel();
     whiteText.offset.x = 0;
     whiteText.clipRect = new FlxRect(whiteText.offset.x, 0, clipWidth, whiteText.height);
-    blurredText.clipRect = new FlxRect(whiteText.offset.x, 0, clipWidth, whiteText.height);
+    blurredText.clipRect = new FlxRect(whiteText.offset.x, 0, clipWidth - BLUR_OVERSHOOT, whiteText.height);
   }
 
   var flickerState:Bool = false;

--- a/source/funkin/ui/freeplay/SongMenuItem.hx
+++ b/source/funkin/ui/freeplay/SongMenuItem.hx
@@ -767,7 +767,7 @@ class SongMenuItem extends FlxSpriteGroup
 
     grayscaleShader.setAmount(isSelected ? 0 : 0.8);
     songText.alpha = isSelected ? 1 : 0.6;
-    songText.blurredText.visible = isSelected ? true : false;
+    songText.blurredText.visible = isSelected && songText.clipWidth >= 290;
     capsule.offset.x = isSelected ? 0 : -5;
     if (!Preferences.flashingLights)
     {


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
closes #7994 
<!-- Briefly describe the issue(s) fixed. -->
## Description
Always apply `clipRect` to song title text layers to prevent blur/glow from rendering past capsule bounds
<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos
### before:

https://github.com/user-attachments/assets/3ee5290d-b3b2-4d42-ad43-e22069310ad8


### after:

https://github.com/user-attachments/assets/707beecb-1a31-4ea0-b2f4-adc78a709872

