### PR TITLE
[BUGFIX] Correct scale multiplier in scaleElement function

### DIFF
--- a/source/funkin/graphics/FunkinSprite.hx
+++ b/source/funkin/graphics/FunkinSprite.hx
@@ -850,8 +850,8 @@ class FunkinSprite extends FlxAnimate
     var symbolInstance:SymbolInstance = element.parentFrame.convertToSymbol(0, 1);
     var transformPoint:FlxPoint = symbolInstance.transformationPoint;
 
-    elementMatrix.a += scale;
-    elementMatrix.d += scale;
+    elementMatrix.a *= scale;
+    elementMatrix.d *= scale;
 
     elementMatrix.tx -= transformPoint.x * scale;
     elementMatrix.ty -= transformPoint.y * scale;


### PR DESCRIPTION
The documentation describes scale as a multiplier, even though the implementation adds it to the current scale (addition). If this behavior is intentional, then the documentation should be updated, otherwise I propose this change.
