### PR TITLE
[BUGFIX] Multiple Quick Panel Changes

### DIFF
--- a/source/funkin/ui/quickpanel/QuickPanelGroup.hx
+++ b/source/funkin/ui/quickpanel/QuickPanelGroup.hx
@@ -157,13 +157,22 @@ class QuickPanelGroup extends FunkinSpriteGroup
     });
   }
 
+  public static function stopMusic():Void
+  {
+    if (FlxG.sound.music != null)
+    {
+      FlxG.sound.music.destroy();
+      FlxG.sound.music = null;
+    }
+  }
+
   // maybe this could not be hardcoded one day? but it also lowkey doesnt matter at all
   var defaultButtonData:Array<QuickPanelButtonData> = [
     {
       text: 'Exit Mod',
       callback: () ->
       {
-        playMenuMusic();
+        stopMusic();
         FlxG.switchState(() -> new funkin.ui.title.TitleState());
       },
       icon: 'back',
@@ -174,7 +183,7 @@ class QuickPanelGroup extends FunkinSpriteGroup
       text: 'Mods',
       callback: () ->
       {
-        playMenuMusic();
+        stopMusic();
         FlxG.switchState(() -> new funkin.ui.modmenu.ModMenuState());
       },
       icon: 'mods',
@@ -185,7 +194,8 @@ class QuickPanelGroup extends FunkinSpriteGroup
       text: 'Freeplay',
       callback: () ->
       {
-        FlxG.switchState(() -> new funkin.ui.freeplay.FreeplayState());
+        flixel.addons.transition.FlxTransitionableState.skipNextTransIn = true;
+        FlxG.switchState(() -> funkin.ui.freeplay.FreeplayState.build({fromCharSelect: true}));
       },
       icon: 'freeplay',
       description: "Choose and play any song you've previously unlocked.",


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
Fixes: https://github.com/FunkinCrew/Funkin/issues/8006

<!-- Briefly describe the issue(s) fixed. -->
## Description
This PR makes a couple of changes to the callbacks in `QuickPanelGroup.hx`
- Remove `playMenuMusic()` for states that can play music by itself
- Switch the Freeplay callback to use `FreeplayState.build` instead of `new FreeplayState()`, making the FreeplayState open as a SubState instead of a State

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos

https://github.com/user-attachments/assets/d43a4623-5f27-4da0-a841-0ae420c37487

