### PR TITLE
[CONSISTENCY/FIX] Rename Enemy to Opponent & Reorder Chart Editor Volume Sliders

### DIFF
--- a/source/funkin/ui/debug/charting/ChartEditorState.hx
+++ b/source/funkin/ui/debug/charting/ChartEditorState.hx
@@ -819,7 +819,7 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
 
   /**
    * The audio volume before it was toggled to zero.
-   * Metronome, hitsounds (player and enemy), instrumental, vocals (player and enemy)
+   * Metronome, hitsounds (player and opponent), instrumental, vocals (player and opponent)
    */
   var previousAudioVolumes:Array<Float> = [
     1.0,
@@ -2236,7 +2236,7 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
   var menubarLabelVolumeHitsoundPlayer:Label;
 
   /**
-   * The `Audio -> Enemy Hitsound Volume` label.
+   * The `Audio -> Opponent Hitsound Volume` label.
    */
   var menubarLabelVolumeHitsoundOpponent:Label;
 
@@ -2246,7 +2246,7 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
   var menubarItemVolumeHitsoundPlayer:Slider;
 
   /**
-   * The `Audio -> Enemy Hitsound Volume` slider.
+   * The `Audio -> Opponent Hitsound Volume` slider.
    */
   var menubarItemVolumeHitsoundOpponent:Slider;
 
@@ -2266,7 +2266,7 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
   var menubarLabelVolumeVocalsPlayer:Label;
 
   /**
-   * The `Audio -> Enemy Volume` label.
+   * The `Audio -> Opponent Volume` label.
    */
   var menubarLabelVolumeVocalsOpponent:Label;
 
@@ -2276,7 +2276,7 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
   var menubarItemVolumeVocalsPlayer:Slider;
 
   /**
-   * The `Audio -> Enemy Volume` slider.
+   * The `Audio -> Opponent Volume` slider.
    */
   var menubarItemVolumeVocalsOpponent:Slider;
 
@@ -3768,7 +3768,7 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
     {
       var volume:Float = event.value.toFloat() / 100.0;
       hitsoundVolumeOpponent = volume;
-      menubarLabelVolumeHitsoundOpponent.text = 'Enemy - ${Std.int(event.value)}%';
+      menubarLabelVolumeHitsoundOpponent.text = 'Opponent - ${Std.int(event.value)}%';
     };
     menubarItemVolumeHitsoundOpponent.value = Std.int(hitsoundVolumeOpponent * 100);
     previousAudioVolumes[2] = Std.int(hitsoundVolumeOpponent * 100);
@@ -3793,7 +3793,7 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
     {
       var volume:Float = event.value.toFloat() / 100.0;
       audioVocalTrackGroup.opponentVolume = volume;
-      menubarLabelVolumeVocalsOpponent.text = 'Enemy - ${Std.int(event.value)}%';
+      menubarLabelVolumeVocalsOpponent.text = 'Opponent - ${Std.int(event.value)}%';
     };
     previousAudioVolumes[5] = menubarItemVolumeVocalsOpponent.value;
 
@@ -7950,7 +7950,7 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
           {
             case 'boyfriend' | 'bf' | 'player':
               _eventTarget = currentPlayerCharacterPlayer;
-            case 'dad' | 'opponent' | 'enemy':
+            case 'dad' | 'opponent':
               _eventTarget = currentOpponentCharacterPlayer;
             default:
           }

--- a/source/funkin/util/Constants.hx
+++ b/source/funkin/util/Constants.hx
@@ -174,7 +174,7 @@ class Constants
   // ==============================
 
   /**
-   * The color used by the enemy health bar.
+   * The color used by the opponent health bar.
    */
   public static final COLOR_HEALTH_BAR_RED:FlxColor = 0xFFFF0000;
 


### PR DESCRIPTION
## Associated funkin.assets PR
https://github.com/FunkinCrew/funkin.assets/pull/462

## Description
Really the term "Enemy" isn't used like anywhere, so I changed it to Opponent (like seen in other menus),
and moved the opponent volume sliders to the left to match with the rest of the game

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos
_After_

<img width="374" height="491" alt="image" src="https://github.com/user-attachments/assets/30439c7a-eefe-4fe4-864f-5b1b7f2800cd" />

---
_Before_

<img width="325" height="486" alt="image" src="https://github.com/user-attachments/assets/25963c46-8987-4b25-9d0d-d1bd43656584" />