### PR TITLE
[BUGFIX] Fix non-scoreable notes making default notes unavailable to score

### DIFF
--- a/source/funkin/play/notes/Strumline.hx
+++ b/source/funkin/play/notes/Strumline.hx
@@ -1210,7 +1210,7 @@ class Strumline extends FlxSpriteGroup
 
       noteSprite.graphic.destroyOnNoUse = false;
 
-      if (noteKind != null) noteSprite.scoreable = noteKind.scoreable;
+      noteSprite.scoreable = noteKind?.scoreable ?? true;
     }
 
     return noteSprite;
@@ -1253,7 +1253,7 @@ class Strumline extends FlxSpriteGroup
 
       holdNoteSprite.graphic.destroyOnNoUse = false;
 
-      if (noteKind != null) holdNoteSprite.scoreable = noteKind.scoreable;
+      holdNoteSprite.scoreable = noteKind?.scoreable ?? true;
     }
 
     return holdNoteSprite;


### PR DESCRIPTION
## Linked Issues
Me while messing around

## Description
By overloading the note pool with notes that aren't scoreable, reusing these notes wont properly reset their non-scoreable trait for notes that should use the default notekind.

https://github.com/user-attachments/assets/a2aeff70-b19f-43f8-8278-1dcecc139277

## Screenshots/Videos

https://github.com/user-attachments/assets/e22d054d-42c2-4ffc-ab9b-3ef9556b2b5d
