### PR TITLE
[BUGFIX] Fix Metronome volume toggling when mirroring notes

### DIFF
--- a/source/funkin/ui/debug/charting/ChartEditorState.hx
+++ b/source/funkin/ui/debug/charting/ChartEditorState.hx
@@ -6965,7 +6965,7 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
   function handleAudioKeybinds():Void
   {
     // Metronome volume toggle
-    if (!isHaxeUIFocused && FlxG.keys.pressed.SHIFT && FlxG.keys.justPressed.M)
+    if (!isHaxeUIFocused && FlxG.keys.pressed.SHIFT && FlxG.keys.justPressed.M && !pressingControl())
     {
       // Changing values of the audio slider directly because it'll update the audio anyway and makes this code much cleaner, though more verbose.
       var oldValue = previousAudioVolumes[0];


### PR DESCRIPTION
## Description
This PR prevents  Metronome volume from toggeling if u try to mirror notes X Axis or XY Axis using short cuts

## Screenshots
Before
<img width="408" height="82" alt="{5CDBDE6B-DD4E-4EB2-8ED2-97A28C515729}" src="https://github.com/user-attachments/assets/0d2d68e8-4d42-439a-900e-3f3098ee7388" />
not checking making it toggel even if u don't want to toggel it
<img width="781" height="78" alt="{1708F04E-9142-42CA-BDC7-8EC105793A12}" src="https://github.com/user-attachments/assets/73afbf7c-b2f8-46eb-8c1a-3ae86c7c040f" />
