### PR TITLE
[BUGFIX] Fix waveforms rendering outside of Chart Editor toolboxes when first opened

### DIFF
--- a/source/funkin/ui/debug/charting/toolboxes/ChartEditorFreeplayToolbox.hx
+++ b/source/funkin/ui/debug/charting/toolboxes/ChartEditorFreeplayToolbox.hx
@@ -122,6 +122,13 @@ class ChartEditorFreeplayToolbox extends ChartEditorBaseToolbox
     this.onDialogClosed = onClose;
   }
 
+  override function onReady():Void
+  {
+    refreshAudioPreview();
+    refresh();
+    refreshTicks();
+  }
+
   function onClose(event:UIEvent)
   {
     chartEditorState.menubarItemToggleToolboxFreeplay.selected = false;
@@ -222,15 +229,21 @@ class ChartEditorFreeplayToolbox extends ChartEditorBaseToolbox
     refresh();
     refreshTicks();
 
-    waveformMusic.registerEvent(MouseEvent.MOUSE_DOWN, (_) ->
-    {
-      onStartDragWaveform();
-    });
+    waveformMusic.registerEvent(MouseEvent.MOUSE_DOWN, (_) -> onStartDragWaveform());
+    freeplayTicksContainer.registerEvent(MouseEvent.MOUSE_DOWN, (_) -> onStartDragPlayhead());
 
-    freeplayTicksContainer.registerEvent(MouseEvent.MOUSE_DOWN, (_) ->
-    {
-      onStartDragPlayhead();
-    });
+    // Immediately hide the waveforms when they're ready
+    // We need to wait for the whole menu to be built before showing to prevent them clipping.
+    waveformMusic.registerEvent(UIEvent.INITIALIZE, hideWaveform);
+  }
+
+  function hideWaveform(e:UIEvent):Void
+  {
+    var player = cast(e.target, WaveformPlayer);
+    player.waveform.duration = 0;
+
+    // Unregister the event to make sure this function isn't called again.
+    player.unregisterEvent(UIEvent.INITIALIZE, hideWaveform);
   }
 
   function initializeTicks():Void

--- a/source/funkin/ui/debug/charting/toolboxes/ChartEditorOffsetsToolbox.hx
+++ b/source/funkin/ui/debug/charting/toolboxes/ChartEditorOffsetsToolbox.hx
@@ -222,27 +222,33 @@ class ChartEditorOffsetsToolbox extends ChartEditorBaseToolbox
 
     initializeTicks();
 
+    // Immediately hide the waveforms when they're ready
+    // We need to wait for the whole menu to be built before showing to prevent them clipping.
+    waveformPlayer.registerEvent(UIEvent.INITIALIZE, hideWaveform);
+    waveformOpponent.registerEvent(UIEvent.INITIALIZE, hideWaveform);
+    waveformInstrumental.registerEvent(UIEvent.INITIALIZE, hideWaveform);
+
+    waveformPlayer.registerEvent(MouseEvent.MOUSE_DOWN, (_) -> onStartDragWaveform(PLAYER));
+    waveformOpponent.registerEvent(MouseEvent.MOUSE_DOWN, (_) -> onStartDragWaveform(OPPONENT));
+    waveformInstrumental.registerEvent(MouseEvent.MOUSE_DOWN, (_) -> onStartDragWaveform(INSTRUMENTAL));
+
+    offsetTicksContainer.registerEvent(MouseEvent.MOUSE_DOWN, (_) -> onStartDragPlayhead());
+  }
+
+  override function onReady():Void
+  {
     refreshAudioPreview();
     refresh();
     refreshTicks();
+  }
 
-    waveformPlayer.registerEvent(MouseEvent.MOUSE_DOWN, (_) ->
-    {
-      onStartDragWaveform(PLAYER);
-    });
-    waveformOpponent.registerEvent(MouseEvent.MOUSE_DOWN, (_) ->
-    {
-      onStartDragWaveform(OPPONENT);
-    });
-    waveformInstrumental.registerEvent(MouseEvent.MOUSE_DOWN, (_) ->
-    {
-      onStartDragWaveform(INSTRUMENTAL);
-    });
+  function hideWaveform(e:UIEvent):Void
+  {
+    var player = cast(e.target, WaveformPlayer);
+    player.waveform.duration = 0;
 
-    offsetTicksContainer.registerEvent(MouseEvent.MOUSE_DOWN, (_) ->
-    {
-      onStartDragPlayhead();
-    });
+    // Unregister the event to make sure this function isn't called again.
+    player.unregisterEvent(UIEvent.INITIALIZE, hideWaveform);
   }
 
   function initializeTicks():Void

--- a/source/funkin/ui/debug/charting/toolboxes/ChartEditorOffsetsToolbox.hx
+++ b/source/funkin/ui/debug/charting/toolboxes/ChartEditorOffsetsToolbox.hx
@@ -95,6 +95,13 @@ class ChartEditorOffsetsToolbox extends ChartEditorBaseToolbox
     this.onDialogClosed = onClose;
   }
 
+  override function onReady():Void
+  {
+    refreshAudioPreview();
+    refresh();
+    refreshTicks();
+  }
+
   function onClose(event:UIEvent)
   {
     stopAudioPreview(); // Pause it instead, maybe?
@@ -233,13 +240,6 @@ class ChartEditorOffsetsToolbox extends ChartEditorBaseToolbox
     waveformInstrumental.registerEvent(MouseEvent.MOUSE_DOWN, (_) -> onStartDragWaveform(INSTRUMENTAL));
 
     offsetTicksContainer.registerEvent(MouseEvent.MOUSE_DOWN, (_) -> onStartDragPlayhead());
-  }
-
-  override function onReady():Void
-  {
-    refreshAudioPreview();
-    refresh();
-    refreshTicks();
   }
 
   function hideWaveform(e:UIEvent):Void


### PR DESCRIPTION
**Fixed issues:**
This probably has been reported before but I wouldn't know the IDs so.
*Note from Hundrec:* Doesn't fix #4982  

Title explains, this bug has existed since the Chart Editor was first made publicly available and still exists somehow lol.

## Old
https://github.com/user-attachments/assets/109d5bd1-e669-4c96-b3bb-2e9efa9a9e26

## New
https://github.com/user-attachments/assets/afe6c685-9907-44d6-97a7-26a987057439