### PR TITLE
[BUGFIX] Fix crash when re-opening an exported legacy FNF chart

### DIFF
--- a/source/funkin/data/song/importer/FNFLegacyImporter.hx
+++ b/source/funkin/data/song/importer/FNFLegacyImporter.hx
@@ -37,7 +37,7 @@ class FNFLegacyImporter
   {
     trace('Migrating song metadata from FNF Legacy.');
 
-    var songMetadata:SongMetadata = new SongMetadata('Import', Constants.DEFAULT_ARTIST, Constants.DEFAULT_CHARTER, Constants.DEFAULT_VARIATION);
+    var songMetadata:SongMetadata = new SongMetadata('Import', "", "", Constants.DEFAULT_VARIATION);
 
     // Set generatedBy string for debugging.
     songMetadata.generatedBy = 'Chart Editor Import (FNF Legacy)';


### PR DESCRIPTION
**Related Issues:**
[#7951](https://github.com/FunkinCrew/Funkin/issues/7951)

Currently, when you try importing a chart from the legacy FNF format, it crashes as the json file doesn't generate some fields like "artist", because when imported they are set to "Unknown", and due to that being the default value for the serialize for `SongData`, it crashes.

More in-deep Explanation from Mr. DJ:
<img width="1663" height="1152" alt="image" src="https://github.com/user-attachments/assets/56aa1308-c4c3-4181-bf1f-4c8ddf60c7c1" />
