### PR TITLE
[ENHANCEMENT] Add time signature support to Chart Editor osu!mania Importer

### DIFF
--- a/source/funkin/data/song/importer/OsuManiaImporter.hx
+++ b/source/funkin/data/song/importer/OsuManiaImporter.hx
@@ -110,7 +110,7 @@ class OsuManiaImporter
       {
         var bpmPoint:TimingPoint = bpmPoints[i];
 
-        result.push(new SongTimeChange(bpmPoint.time, bpmPoint.bpm ?? Constants.DEFAULT_BPM));
+        result.push(new SongTimeChange(bpmPoint.time, bpmPoint.bpm ?? Constants.DEFAULT_BPM, bpmPoint.meter ?? 4));
       }
     }
 


### PR DESCRIPTION
This PR imports the time signatures used in an osu!mania beatmap when they're imported.

Time signatures in osu!mania beatmaps are supported under the values `meters`, unfortunately osu!mania only support the time signature numerator within this value though they exist nonetheless. The importer right now parses them completely fine but does not add them into the `TimeChange` object when added.

<img width="600" height="450" alt="image" src="https://github.com/user-attachments/assets/22a3a489-49e4-47c1-a28a-cf008fa82be8" />
