### PR TITLE
[BUGFIX] Fix crash when mirroring an empty note selection in chart editor

### DIFF
--- a/source/funkin/data/song/SongDataUtils.hx
+++ b/source/funkin/data/song/SongDataUtils.hx
@@ -175,6 +175,8 @@ class SongDataUtils
    */
   public static function mirrorNotes(notes:Array<SongNoteData>, strumlineSize:Int = 4, flip:Bool = false, mirrorX:Bool = true, mirrorY:Bool = true):Array<SongNoteData>
   {
+    if (notes.length == 0) return notes;
+
     var minTime = notes[0].time;
     var maxTime = notes[0].time;
     var minStrumline = notes[0].data;


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Briefly describe the issue(s) fixed. -->
## Description

Basically when you press the shortcut for mirroring notes, there's no check for the amount of notes selected, causing a crash to occur.

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos

<img width="1273" height="717" alt="image" src="https://github.com/user-attachments/assets/5448dcc3-762b-41a3-9ce1-3bb8d0c8e925" />