### PR TITLE
[BUGFIX] Fix cursor sprites becoming invisible after hot reload

### DIFF
--- a/source/funkin/input/Cursor.hx
+++ b/source/funkin/input/Cursor.hx
@@ -309,7 +309,8 @@ class Cursor
       return;
     }
 
-    if (data.cache != null)
+    @:privateAccess
+    if (data.cache != null && !(data.cache.image == null && data.cache.__texture == null))
     {
       applyGraphic(data.cache, data.params);
       return;


### PR DESCRIPTION
## Linked Issues
https://github.com/FunkinCrew/Funkin/issues/8028

## Description
This PR fixes an issue where cursor sprites become invisible after hot reloading (or cache purges). 

During hot reload, the underlying `BitmapData` gets cleared while the static `data.cache` reference remains populated. Because `applyCursorParams` previously only checked `data.cache != null`, it tried to render a cleared graphic. 

This PR adds an explicit check for valid bitmap data (`!(image == null && __texture == null)`) so the system detects disposed caches and reloads the cursor graphic properly instead of rendering nothing.
## Screenshots/Videos
Before

https://github.com/user-attachments/assets/91fefd10-4b3a-4a1c-b47f-9e206c438699

After

https://github.com/user-attachments/assets/1c41d6d7-682c-42ac-9cc6-9b59734ba838

