### PR TITLE
[BUGFIX] Fix Character Select transition breaking when spamming Android back button

### DIFF
--- a/source/funkin/ui/charSelect/CharSelectSubState.hx
+++ b/source/funkin/ui/charSelect/CharSelectSubState.hx
@@ -166,7 +166,9 @@ class CharSelectSubState extends MusicBeatSubState
   override public function create():Void
   {
     super.create();
-
+    #if android
+    FlxG.android.enabled = false;
+    #end
     loadAvailableCharacters();
 
     bopInfo = FramesJSFLParser.parse(Paths.file('ui/character-select/interface/icon-bop/info.txt'));
@@ -451,6 +453,9 @@ class CharSelectSubState extends MusicBeatSubState
 
   override public function destroy():Void
   {
+    #if android
+    FlxG.android.enabled = true;
+    #end
     CharSelectAtlasHandler.clearAtlasCache();
     super.destroy();
   }


### PR DESCRIPTION

<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
https://github.com/FunkinCrew/Funkin/issues/8022
<!-- Briefly describe the issue(s) fixed. -->
## Description
I added a `#if android` to `super.create` and `super.destroy` where the create i use the `#if android` as false which disables the  native Flixel Android features while we're selecting a playable character like Pico for example and when it is picked, the `#in android` with true value will obviously re-enable native Flixel Android features back to it original self which prevents the Character Select transition from breaking
<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos
gotta use medal cuz the video busted : https://medal.tv/games/imported-clips/clips/npAwOKYi24UTs2XmM?invite=cr-MSxjZmwsNDM2NzU1ODA4

