### PR TITLE
[BUGFIX] Fix duplicate notes on non-zero start position

### DIFF
--- a/source/funkin/play/PlayState.hx
+++ b/source/funkin/play/PlayState.hx
@@ -2745,11 +2745,6 @@ class PlayState extends MusicBeatSubState
     });
     #end
 
-    if (startTimestamp > 0)
-    {
-      handleSkippedNotes();
-    }
-
     var event:ScriptEvent = ScriptEvent.get(SONG_START);
     dispatchEvent(event);
 


### PR DESCRIPTION
This PR fixes a bug where if you playtest a song on the exact timestamp as one of the notes, that note will duplicate as if it's a stacked note.