### PR TITLE
[ENHANCEMENT] Add a motion blur option for note scrolling

### DIFF
--- a/source/funkin/Preferences.hx
+++ b/source/funkin/Preferences.hx
@@ -115,6 +115,27 @@ class Preferences
   }
 
   /**
+   * If enabled, any notes going toward the strumline have a blur effect placed on them, which makes their movements appear smoother.
+   *
+   * WARNING: This can cause eye strain and/or motion sickness!
+   * @default `true`
+   */
+  public static var motionBlur(get, set):Bool;
+
+  static function get_motionBlur():Bool
+  {
+    return Save?.instance?.options?.motionBlur ?? true;
+  }
+
+  static function set_motionBlur(value:Bool):Bool
+  {
+    var save:Save = Save.instance;
+    save.options.motionBlur = value;
+    Save.system.flush();
+    return value;
+  }
+
+  /**
    * If disabled, flashing lights in the main menu and other areas will be less intense.
    * @default `true`
    */

--- a/source/funkin/input/PreciseInputManager.hx
+++ b/source/funkin/input/PreciseInputManager.hx
@@ -298,8 +298,7 @@ class PreciseInputManager extends FlxKeyManager<FlxKey, PreciseInputList>
       onInputPressed.dispatch({
         noteDirection: getDirectionForKey(key),
         timestamp: timestamp,
-        keyCode: keyCode,
-        position: Conductor?.instance?.songPosition ?? 0.0,
+        keyCode: keyCode
       });
       _dirPressTimestamps.set(getDirectionForKey(key), timestamp);
     }
@@ -317,8 +316,7 @@ class PreciseInputManager extends FlxKeyManager<FlxKey, PreciseInputList>
       onInputReleased.dispatch({
         noteDirection: getDirectionForKey(key),
         timestamp: timestamp,
-        keyCode: keyCode,
-        position: Conductor?.instance?.songPosition ?? 0.0,
+        keyCode: keyCode
       });
       _dirReleaseTimestamps.set(getDirectionForKey(key), timestamp);
     }
@@ -339,7 +337,6 @@ class PreciseInputManager extends FlxKeyManager<FlxKey, PreciseInputList>
         noteDirection: getDirectionForButton(gamepad, buttonId),
         timestamp: timestamp,
         keyCode: button, // implicit cast to int
-        position: Conductor?.instance?.songPosition ?? 0.0,
       });
       _dirPressTimestamps.set(getDirectionForButton(gamepad, buttonId), timestamp);
     }
@@ -359,8 +356,7 @@ class PreciseInputManager extends FlxKeyManager<FlxKey, PreciseInputList>
       onInputReleased.dispatch({
         noteDirection: getDirectionForButton(gamepad, buttonId),
         timestamp: timestamp,
-        keyCode: button, // implicit cast to int
-        position: Conductor?.instance?.songPosition ?? 0.0,
+        keyCode: button // implicit cast to int
       });
       _dirReleaseTimestamps.set(getDirectionForButton(gamepad, buttonId), timestamp);
     }
@@ -485,5 +481,5 @@ typedef PreciseInputEvent =
    * The current position of the Conductor for this event.
    * Used to help calculate the note timing for the exact time.
    */
-  position:Float,
+  ?position:Float,
 };

--- a/source/funkin/input/PreciseInputManager.hx
+++ b/source/funkin/input/PreciseInputManager.hx
@@ -298,7 +298,8 @@ class PreciseInputManager extends FlxKeyManager<FlxKey, PreciseInputList>
       onInputPressed.dispatch({
         noteDirection: getDirectionForKey(key),
         timestamp: timestamp,
-        keyCode: keyCode
+        keyCode: keyCode,
+        position: Conductor?.instance?.songPosition ?? 0.0,
       });
       _dirPressTimestamps.set(getDirectionForKey(key), timestamp);
     }
@@ -316,7 +317,8 @@ class PreciseInputManager extends FlxKeyManager<FlxKey, PreciseInputList>
       onInputReleased.dispatch({
         noteDirection: getDirectionForKey(key),
         timestamp: timestamp,
-        keyCode: keyCode
+        keyCode: keyCode,
+        position: Conductor?.instance?.songPosition ?? 0.0,
       });
       _dirReleaseTimestamps.set(getDirectionForKey(key), timestamp);
     }
@@ -336,7 +338,8 @@ class PreciseInputManager extends FlxKeyManager<FlxKey, PreciseInputList>
       onInputPressed.dispatch({
         noteDirection: getDirectionForButton(gamepad, buttonId),
         timestamp: timestamp,
-        keyCode: button // implicit cast to int
+        keyCode: button, // implicit cast to int
+        position: Conductor?.instance?.songPosition ?? 0.0,
       });
       _dirPressTimestamps.set(getDirectionForButton(gamepad, buttonId), timestamp);
     }
@@ -356,7 +359,8 @@ class PreciseInputManager extends FlxKeyManager<FlxKey, PreciseInputList>
       onInputReleased.dispatch({
         noteDirection: getDirectionForButton(gamepad, buttonId),
         timestamp: timestamp,
-        keyCode: button // implicit cast to int
+        keyCode: button, // implicit cast to int
+        position: Conductor?.instance?.songPosition ?? 0.0,
       });
       _dirReleaseTimestamps.set(getDirectionForButton(gamepad, buttonId), timestamp);
     }
@@ -475,5 +479,11 @@ typedef PreciseInputEvent =
    * The key that was used for the input.
    * Used to distinguish between multiple inputs for the same direction.
    */
-  keyCode:Int
+  keyCode:Int,
+
+  /**
+   * The current position of the Conductor for this event.
+   * Used to help calculate the note timing for the exact time.
+   */
+  position:Float,
 };

--- a/source/funkin/play/PlayState.hx
+++ b/source/funkin/play/PlayState.hx
@@ -2821,6 +2821,9 @@ class PlayState extends MusicBeatSubState
   {
     if (isGamePaused) return;
 
+    // Set the current position for further calculation.
+    event.position = Conductor.instance.songPosition;
+
     // Do the minimal possible work here.
     inputPressQueue.push(event);
   }
@@ -2830,6 +2833,9 @@ class PlayState extends MusicBeatSubState
    */
   function onKeyRelease(event:PreciseInputEvent):Void
   {
+    // Set the current position for further calculation.
+    event.position = Conductor.instance.songPosition;
+
     // Do the minimal possible work here.
     inputReleaseQueue.push(event);
   }
@@ -3170,6 +3176,7 @@ class PlayState extends MusicBeatSubState
 
   function goodNoteHit(note:NoteSprite, input:PreciseInputEvent):Void
   {
+    var inputPosition:Float = input.position ?? 0.0;
     // Calculate the input latency (do this as late as possible).
     // trace('Compare: ${PreciseInputManager.getCurrentTimestamp()} - ${input.timestamp}');
     var inputLatencyNs:Int64 = PreciseInputManager.getCurrentTimestamp() - input.timestamp;
@@ -3178,7 +3185,7 @@ class PlayState extends MusicBeatSubState
 
     // Use the input's song position when calculating the ms difference.
     // Also compensate for input latency.
-    var noteDiff:Int = Std.int(input.position - note.noteData.time - inputLatencyMs);
+    var noteDiff:Int = Std.int(inputPosition - note.noteData.time - inputLatencyMs);
 
     var score = Scoring.scoreNote(noteDiff);
     var daRating = Scoring.judgeNote(noteDiff);

--- a/source/funkin/play/PlayState.hx
+++ b/source/funkin/play/PlayState.hx
@@ -3176,9 +3176,9 @@ class PlayState extends MusicBeatSubState
     var inputLatencyMs:Float = inputLatencyNs.toFloat() / Constants.NS_PER_MS;
     // trace('Input: ${daNote.noteData.getDirectionName()} pressed ${inputLatencyMs}ms ago!');
 
-    // Get the offset and compensate for input latency.
-    // Round inward (trim remainder) for consistency.
-    var noteDiff:Int = Std.int(Conductor.instance.songPosition - note.noteData.time - inputLatencyMs);
+    // Use the input's song position when calculating the ms difference.
+    // Also compensate for input latency.
+    var noteDiff:Int = Std.int(input.position - note.noteData.time - inputLatencyMs);
 
     var score = Scoring.scoreNote(noteDiff);
     var daRating = Scoring.judgeNote(noteDiff);

--- a/source/funkin/play/notes/NoteSprite.hx
+++ b/source/funkin/play/notes/NoteSprite.hx
@@ -5,6 +5,8 @@ import funkin.data.song.SongData.NoteParamData;
 import funkin.play.notes.notestyle.NoteStyle;
 import funkin.graphics.FunkinSprite;
 import funkin.graphics.shaders.HSVShader;
+import openfl.filters.BlurFilter;
+import openfl.filters.BitmapFilterQuality;
 
 class NoteSprite extends FunkinSprite
 {
@@ -16,6 +18,7 @@ class NoteSprite extends FunkinSprite
   public var holdNoteSprite:SustainTrail;
 
   var hsvShader:HSVShader;
+  var blurFilter:BlurFilter;
 
   /**
    * The strum time at which the note should be hit, in milliseconds.
@@ -174,6 +177,11 @@ class NoteSprite extends FunkinSprite
 
     this.alpha = 1;
     if (noteStyle != null) setupNoteGraphic(noteStyle);
+
+    if (antialiasing && Preferences.motionBlur) {
+      blurFilter = new BlurFilter(1, 2.5, BitmapFilterQuality.LOW);
+      this.filters = [blurFilter];
+    }
   }
 
   /**
@@ -264,11 +272,17 @@ class NoteSprite extends FunkinSprite
     this.hsvShader.hue = 1.0;
     this.hsvShader.saturation = 1.0;
     this.hsvShader.value = 1.0;
+
+    if (antialiasing && Preferences.motionBlur)
+      this.filters = [blurFilter];
   }
 
   override public function kill():Void
   {
     super.kill();
+
+    if (antialiasing && Preferences.motionBlur)
+      this.filters = [];
   }
 
   override public function destroy():Void

--- a/source/funkin/play/notes/NoteSprite.hx
+++ b/source/funkin/play/notes/NoteSprite.hx
@@ -179,8 +179,10 @@ class NoteSprite extends FunkinSprite
     if (noteStyle != null) setupNoteGraphic(noteStyle);
 
     if (antialiasing && Preferences.motionBlur) {
-      blurFilter = new BlurFilter(1, 2.5, BitmapFilterQuality.LOW);
-      this.filters = [blurFilter];
+      blurFilter = new BlurFilter(1, 2.25, BitmapFilterQuality.LOW);
+
+      filters ??= [];
+      filters = filters.concat([blurFilter]);
     }
   }
 
@@ -274,7 +276,10 @@ class NoteSprite extends FunkinSprite
     this.hsvShader.value = 1.0;
 
     if (antialiasing && Preferences.motionBlur)
-      this.filters = [blurFilter];
+    {
+      filters ??= [];
+      filters = filters.concat([blurFilter]);
+    }
   }
 
   override public function kill():Void

--- a/source/funkin/play/notes/SustainTrail.hx
+++ b/source/funkin/play/notes/SustainTrail.hx
@@ -3,10 +3,12 @@ package funkin.play.notes;
 import funkin.play.notes.notestyle.NoteStyle;
 import funkin.data.song.SongData.SongNoteData;
 import funkin.mobile.ui.FunkinHitbox.FunkinHitboxControlSchemes;
-import flixel.FlxSprite;
+import funkin.graphics.FunkinSprite;
 import flixel.graphics.FlxGraphic;
 import flixel.graphics.tile.FlxDrawTrianglesItem.DrawData;
 import flixel.math.FlxMath;
+import openfl.filters.BlurFilter;
+import openfl.filters.BitmapFilterQuality;
 
 /**
  * This is based heavily on the `FlxStrip` class. It uses `drawTriangles()` to clip a sustain note
@@ -16,7 +18,7 @@ import flixel.math.FlxMath;
  *
  * @author MtH
  */
-class SustainTrail extends FlxSprite
+class SustainTrail extends FunkinSprite
 {
   /**
    * The triangles corresponding to the hold, followed by the endcap.
@@ -134,6 +136,8 @@ class SustainTrail extends FlxSprite
   public var isPixel:Bool;
   public var noteStyleOffsets:Array<Float>;
 
+  var blurFilter:BlurFilter;
+
   var graphicWidth:Float = 0;
   var graphicHeight:Float = 0;
 
@@ -158,6 +162,11 @@ class SustainTrail extends FlxSprite
     setIndices(TRIANGLE_VERTEX_INDICES);
 
     this.active = true; // This NEEDS to be true for the note to be drawn!
+
+    if (antialiasing && Preferences.motionBlur) {
+      blurFilter = new BlurFilter(1, 2.5, BitmapFilterQuality.LOW);
+      this.filters = [blurFilter];
+    }
   }
 
   /**
@@ -556,6 +565,9 @@ class SustainTrail extends FlxSprite
 
     hitNote = false;
     missedNote = false;
+
+    if (antialiasing && Preferences.motionBlur)
+      filters = [];
   }
 
   override public function revive():Void
@@ -572,6 +584,9 @@ class SustainTrail extends FlxSprite
     hitNote = false;
     missedNote = false;
     handledMiss = false;
+
+    if (antialiasing && Preferences.motionBlur)
+      this.filters = [blurFilter];
   }
 
   override public function destroy():Void

--- a/source/funkin/play/notes/SustainTrail.hx
+++ b/source/funkin/play/notes/SustainTrail.hx
@@ -164,8 +164,10 @@ class SustainTrail extends FunkinSprite
     this.active = true; // This NEEDS to be true for the note to be drawn!
 
     if (antialiasing && Preferences.motionBlur) {
-      blurFilter = new BlurFilter(1, 2.5, BitmapFilterQuality.LOW);
-      this.filters = [blurFilter];
+      blurFilter = new BlurFilter(1, 2.25, BitmapFilterQuality.LOW);
+
+      filters ??= [];
+      filters = filters.concat([blurFilter]);
     }
   }
 
@@ -586,7 +588,10 @@ class SustainTrail extends FunkinSprite
     handledMiss = false;
 
     if (antialiasing && Preferences.motionBlur)
-      this.filters = [blurFilter];
+    {
+      filters ??= [];
+      filters = filters.concat([blurFilter]);
+    }
   }
 
   override public function destroy():Void

--- a/source/funkin/save/Save.hx
+++ b/source/funkin/save/Save.hx
@@ -129,6 +129,7 @@ class Save implements ConsoleClass implements ISerializable
         // Reasonable defaults.
         framerate: #if mobile refreshRate #else 60 #end,
         naughtyness: true,
+        motionBlur: false,
         downscroll: false,
         flashingLights: true,
         zoomCamera: true,
@@ -1353,6 +1354,14 @@ typedef SaveDataOptions =
    * @default `true`
    */
   var naughtyness:Bool;
+
+  /**
+   * If enabled, any notes going toward the strumline have a blur effect placed on them, which makes their movements appear smoother.
+   *
+   * WARNING: This can cause eye strain and/or motion sickness!
+   * @default `false`
+   */
+  var motionBlur:Bool;
 
   /**
    * If enabled, the strumline is at the bottom of the screen rather than the top.

--- a/source/funkin/ui/debug/anim/DebugBoundingState.hx
+++ b/source/funkin/ui/debug/anim/DebugBoundingState.hx
@@ -335,7 +335,7 @@ class DebugBoundingState extends FlxState
     if (FlxG.mouse.justReleased || FlxG.mouse.justReleasedMiddle) FunkinSound.playOnce(Paths.sound('ui/editors/chart-editor/charting-sounds/click-up'));
 
     MouseUtil.mouseCamDrag();
-    if (!haxeUIFocused) MouseUtil.mouseWheelZoom();
+    if (!haxeUIFocused) handleTrackpadScroll();
 
     // bg.scale.x = FlxG.camera.zoom;
     // bg.scale.y = FlxG.camera.zoom;
@@ -343,6 +343,30 @@ class DebugBoundingState extends FlxState
     bg.setGraphicSize(Std.int(bg.width / FlxG.camera.zoom));
 
     super.update(elapsed);
+  }
+
+  static final TRACKPAD_PAN_SCALE:Float = 25.0;
+
+  function handleTrackpadScroll():Void
+  {
+    var dx:Float = FlxG.mouse.deltaWheel.x;
+    var dy:Float = FlxG.mouse.deltaWheel.y;
+    if (dx == 0 && dy == 0) return;
+
+    if (FlxG.keys.pressed.CONTROL)
+    {
+      if (dy == 0) return;
+      var scaledDelta:Float = dy * 10.0;
+      var rawScale:Float = Math.exp(scaledDelta / 100.0);
+      rawScale = Math.min(1.25, Math.max(0.75, rawScale));
+      FlxG.camera.zoom *= rawScale;
+      if (FlxG.camera.zoom < 0.1) FlxG.camera.zoom = 0.1;
+      if (FlxG.camera.zoom > 10.0) FlxG.camera.zoom = 10.0;
+      return;
+    }
+
+    FlxG.camera.scroll.x -= (-dx * TRACKPAD_PAN_SCALE) / FlxG.camera.zoom;
+    FlxG.camera.scroll.y -= (dy * TRACKPAD_PAN_SCALE) / FlxG.camera.zoom;
   }
 
   function resetWindowTitle():Void

--- a/source/funkin/ui/debug/cameraeditor/CameraEditorState.hx
+++ b/source/funkin/ui/debug/cameraeditor/CameraEditorState.hx
@@ -1062,7 +1062,12 @@ class CameraEditorState extends UIState implements ConsoleClass
       }
     }
 
-    if (timeline != null && timeline.viewport != null) timeline.viewport.tickEdgeAutoScroll(elapsed);
+    if (timeline != null && timeline.viewport != null)
+    {
+      timeline.viewport.tickEdgeAutoScroll(elapsed);
+      timeline.viewport.handleTrackpadScroll();
+    }
+    if (mainView != null) mainView.handleTrackpadScroll();
 
     super.update(elapsed);
 
@@ -2633,15 +2638,26 @@ class CameraEditorState extends UIState implements ConsoleClass
     performAutoSortLayersByType();
   }
 
-  // TODO: make this wheel zoom sensitivity configurable
-
   function onViewportZoom(e:CameraViewportEvent):Void
   {
+    var scaledDelta:Float = e.zoomDelta * 10.0;
+    var rawScale:Float = Math.exp(scaledDelta / 100.0);
+    rawScale = Math.min(1.25, Math.max(0.75, rawScale));
+
     pivotZoomOnViewport(() ->
     {
-      if (isCameraRelative) relativeZoom += MouseUtil.mouseWheelZoomData(0.08, e.zoomDelta);
+      if (isCameraRelative)
+      {
+        relativeZoom *= rawScale;
+        if (relativeZoom < 0.1) relativeZoom = 0.1;
+        if (relativeZoom > 10.0) relativeZoom = 10.0;
+      }
       else
-        MouseUtil.mouseWheelZoom(0.08, e.zoomDelta);
+      {
+        FlxG.camera.zoom *= rawScale;
+        if (FlxG.camera.zoom < 0.1) FlxG.camera.zoom = 0.1;
+        if (FlxG.camera.zoom > 10.0) FlxG.camera.zoom = 10.0;
+      }
     });
   }
 

--- a/source/funkin/ui/debug/stageeditor/StageEditorState.hx
+++ b/source/funkin/ui/debug/stageeditor/StageEditorState.hx
@@ -645,11 +645,7 @@ class StageEditorState extends UIState
     camGame.follow(camFollow);
     // camera movement
 
-    if ((FlxG.mouse.deltaWheel.y > 0 || (FlxG.mouse.deltaWheel.y < 0 && camGame.zoom > 0.11)) && !isCursorOverHaxeUI) // include the floating poing error thing
-    {
-      camGame.zoom += FlxG.mouse.deltaWheel.y / 10;
-      updateBGSize();
-    }
+    if (!isCursorOverHaxeUI) handleTrackpadScroll();
 
     // key shortcuts and inputs
     if (pressingControl() && FlxG.keys.justPressed.Q) onMenuItemClick('exit');
@@ -1057,6 +1053,31 @@ class StageEditorState extends UIState
     bg.scale.set(1 / FlxG.camera.zoom, 1 / FlxG.camera.zoom);
     bg.updateHitbox();
     bg.screenCenter();
+  }
+
+  static final TRACKPAD_PAN_SCALE:Float = 25.0;
+
+  function handleTrackpadScroll():Void
+  {
+    var dx:Float = FlxG.mouse.deltaWheel.x;
+    var dy:Float = FlxG.mouse.deltaWheel.y;
+    if (dx == 0 && dy == 0) return;
+
+    if (FlxG.keys.pressed.CONTROL)
+    {
+      if (dy == 0) return;
+      var scaledDelta:Float = dy * 10.0;
+      var rawScale:Float = Math.exp(scaledDelta / 100.0);
+      rawScale = Math.min(1.25, Math.max(0.75, rawScale));
+      camGame.zoom *= rawScale;
+      if (camGame.zoom < 0.11) camGame.zoom = 0.11;
+      if (camGame.zoom > 10.0) camGame.zoom = 10.0;
+      updateBGSize();
+      return;
+    }
+
+    camFollow.x += (dx * TRACKPAD_PAN_SCALE) / camGame.zoom;
+    camFollow.y -= (dy * TRACKPAD_PAN_SCALE) / camGame.zoom;
   }
 
   var sprDependant:Array<MenuItem> = [];

--- a/source/funkin/ui/haxeui/components/editors/camera/CameraViewport.hx
+++ b/source/funkin/ui/haxeui/components/editors/camera/CameraViewport.hx
@@ -1,5 +1,6 @@
 package funkin.ui.haxeui.components.editors.camera;
 
+import flixel.FlxG;
 import flixel.input.keyboard.FlxKey;
 import haxe.ui.containers.Box;
 import haxe.ui.core.Screen;
@@ -15,6 +16,31 @@ import funkin.util.HaxeUIUtil;
 @:composite(CameraViewportEvents)
 class CameraViewport extends Box
 {
+  public static inline var TRACKPAD_PAN_SCALE:Float = 25.0;
+
+  public function handleTrackpadScroll():Void
+  {
+    var dx:Float = FlxG.mouse.deltaWheel.x;
+    var dy:Float = FlxG.mouse.deltaWheel.y;
+    if (dx == 0 && dy == 0) return;
+    if (FlxG.keys.pressed.SHIFT) return;
+    if (FlxG.mouse.gameX < screenLeft || FlxG.mouse.gameX > screenLeft + width
+      || FlxG.mouse.gameY < screenTop || FlxG.mouse.gameY > screenTop + height) return;
+
+    if (FlxG.keys.pressed.CONTROL)
+    {
+      if (dy == 0) return;
+      var zoomEvent:CameraViewportEvent = new CameraViewportEvent(CameraViewportEvent.ZOOM);
+      zoomEvent.zoomDelta = dy;
+      dispatch(zoomEvent);
+      return;
+    }
+
+    var panEvent:CameraViewportEvent = new CameraViewportEvent(CameraViewportEvent.GESTURE_PAN);
+    panEvent.panDeltaX = -dx * TRACKPAD_PAN_SCALE;
+    panEvent.panDeltaY = dy * TRACKPAD_PAN_SCALE;
+    dispatch(panEvent);
+  }
 }
 
 private enum PanSource
@@ -47,7 +73,6 @@ private class CameraViewportEvents extends haxe.ui.events.Events
 
   override public function register():Void
   {
-    if (!hasEvent(MouseEvent.MOUSE_WHEEL, _onMouseWheel)) registerEvent(MouseEvent.MOUSE_WHEEL, _onMouseWheel);
     if (!hasEvent(MouseEvent.MIDDLE_MOUSE_DOWN, _onMiddleMouseDown)) registerEvent(MouseEvent.MIDDLE_MOUSE_DOWN, _onMiddleMouseDown);
     if (!hasEvent(MouseEvent.MOUSE_OVER, _onMouseOver)) registerEvent(MouseEvent.MOUSE_OVER, _onMouseOver);
     if (!hasEvent(MouseEvent.MOUSE_OUT, _onMouseOut)) registerEvent(MouseEvent.MOUSE_OUT, _onMouseOut);
@@ -71,7 +96,6 @@ private class CameraViewportEvents extends haxe.ui.events.Events
 
   override public function unregister():Void
   {
-    unregisterEvent(MouseEvent.MOUSE_WHEEL, _onMouseWheel);
     unregisterEvent(MouseEvent.MIDDLE_MOUSE_DOWN, _onMiddleMouseDown);
     unregisterEvent(MouseEvent.MOUSE_OVER, _onMouseOver);
     unregisterEvent(MouseEvent.MOUSE_OUT, _onMouseOut);
@@ -87,13 +111,6 @@ private class CameraViewportEvents extends haxe.ui.events.Events
       gesture = null;
     }
     #end
-  }
-
-  function _onMouseWheel(e:MouseEvent):Void
-  {
-    var event:CameraViewportEvent = new CameraViewportEvent(CameraViewportEvent.ZOOM);
-    event.zoomDelta = e.delta;
-    _viewport.dispatch(event);
   }
 
   function _onMouseOver(_:MouseEvent):Void
@@ -176,8 +193,6 @@ private class CameraViewportEvents extends haxe.ui.events.Events
 
   function onGestureStart(g:Gesture):Void
   {
-    if (hasEvent(MouseEvent.MOUSE_WHEEL, _onMouseWheel)) unregisterEvent(MouseEvent.MOUSE_WHEEL, _onMouseWheel);
-
     if (g.type == SCROLL)
     {
       _viewport.dispatch(new CameraViewportEvent(CameraViewportEvent.PAN_START));
@@ -186,8 +201,6 @@ private class CameraViewportEvents extends haxe.ui.events.Events
 
   function onGestureEnd(g:Gesture):Void
   {
-    if (!hasEvent(MouseEvent.MOUSE_WHEEL, _onMouseWheel)) registerEvent(MouseEvent.MOUSE_WHEEL, _onMouseWheel);
-
     if (g.type == SCROLL)
     {
       _viewport.dispatch(new CameraViewportEvent(CameraViewportEvent.PAN_END));

--- a/source/funkin/ui/haxeui/components/editors/timeline/TimelineViewport.hx
+++ b/source/funkin/ui/haxeui/components/editors/timeline/TimelineViewport.hx
@@ -35,6 +35,9 @@ class TimelineViewport extends Box
   public static inline var EDGE_AUTOSCROLL_ZONE_PX:Float = 40.0;
   public static inline var EDGE_AUTOSCROLL_MAX_PX_PER_SEC:Float = 1500.0;
   public static inline var EDGE_AUTOSCROLL_MAX_OVERDRAG_FACTOR:Float = 3.0;
+  public static inline var TRACKPAD_WHEEL_THRESHOLD:Float = 1.0;
+  public static inline var TRACKPAD_TIME_SCROLL_MULT:Float = 100.0;
+  public static inline var TRACKPAD_LAYER_SCROLL_MULT:Float = 48.0;
 
   @:clonable @:behaviour(DataBehaviour, 0.0)
   public var scrollOffsetMs:Float;
@@ -157,6 +160,44 @@ class TimelineViewport extends Box
   public function tickEdgeAutoScroll(elapsed:Float):Void
   {
     _eventsInstance.tickEdgeAutoScroll(elapsed);
+  }
+
+  public function handleTrackpadScroll():Void
+  {
+    var dx:Float = FlxG.mouse.deltaWheel.x;
+    var dy:Float = FlxG.mouse.deltaWheel.y;
+    if (dx == 0 && dy == 0) return;
+    if (FlxG.keys.pressed.SHIFT) return;
+    if (FlxG.mouse.gameX < screenLeft || FlxG.mouse.gameX > screenLeft + width
+      || FlxG.mouse.gameY < screenTop || FlxG.mouse.gameY > screenTop + height) return;
+
+    var isTrackpad:Bool = dx != 0 || Math.abs(dy) < TRACKPAD_WHEEL_THRESHOLD;
+    if (!isTrackpad) return;
+
+    if (FlxG.keys.pressed.CONTROL)
+    {
+      scrollVertical((dy * TRACKPAD_LAYER_SCROLL_MULT) / LAYER_HEIGHT);
+    }
+    else
+    {
+      if (dx != 0)
+      {
+        var pxPerMs:Float = pixelsPerMs * zoomLevel;
+        var scrollMs:Float = pxPerMs > 0 ? (dx * TRACKPAD_TIME_SCROLL_MULT) / pxPerMs : 0;
+        scrollOffsetMs = scrollOffsetMs + scrollMs;
+        if (scrollOffsetMs < 0) scrollOffsetMs = 0;
+      }
+
+      if (dy != 0)
+      {
+        scrollVertical((dy * TRACKPAD_LAYER_SCROLL_MULT) / LAYER_HEIGHT);
+      }
+    }
+
+    refreshLayout();
+
+    var zoomEvent = new TimelineEvent(TimelineEvent.ZOOM_CHANGED);
+    dispatch(zoomEvent);
   }
 
   // Caller is responsible for `refreshLayout()` afterwards.
@@ -1102,6 +1143,9 @@ private class TimelineViewportEvents extends haxe.ui.events.Events
 
   function _onMouseWheel(e:MouseEvent):Void
   {
+    // Skip trackpad input, handled by handleTrackpadScroll().
+    if (FlxG.mouse.deltaWheel.x != 0 || Math.abs(FlxG.mouse.deltaWheel.y) < TimelineViewport.TRACKPAD_WHEEL_THRESHOLD) return;
+
     if (e.shiftKey)
     {
       var localX = e.screenX - _viewport.screenLeft;

--- a/source/funkin/ui/options/OffsetMenu.hx
+++ b/source/funkin/ui/options/OffsetMenu.hx
@@ -387,6 +387,9 @@ class OffsetMenu extends Page<OptionsState.OptionsMenuPageName>
      */
   function onKeyPress(event:PreciseInputEvent):Void
   {
+    // Set the current position for further calculation.
+    event.position = localConductor.songPosition;
+
     // Do the minimal possible work here.
     inputPressQueue.push(event);
   }
@@ -396,6 +399,9 @@ class OffsetMenu extends Page<OptionsState.OptionsMenuPageName>
      */
   function onKeyRelease(event:PreciseInputEvent):Void
   {
+    // Set the current position for further calculation.
+    event.position = localConductor.songPosition;
+
     // Do the minimal possible work here.
     inputReleaseQueue.push(event);
   }
@@ -816,11 +822,11 @@ class OffsetMenu extends Page<OptionsState.OptionsMenuPageName>
 
   function hitNote(note:NoteSprite, input:PreciseInputEvent):Void
   {
+    var inputPosition:Float = input.position ?? 0.0;
     var inputLatencyNs:Int64 = PreciseInputManager.getCurrentTimestamp() - input.timestamp;
     var inputLatencyMs:Float = inputLatencyNs.toFloat() / Constants.NS_PER_MS;
 
-    var noteDiff:Int = Std.int(note.noteData.time - localConductor.songPosition - inputLatencyMs);
-
+    var noteDiff:Int = Std.int(note.noteData.time - inputPosition - inputLatencyMs);
     addDifference(noteDiff);
 
     if (noteDiff == 0)

--- a/source/funkin/ui/options/PreferencesMenu.hx
+++ b/source/funkin/ui/options/PreferencesMenu.hx
@@ -121,6 +121,12 @@ class PreferencesMenu extends Page<OptionsState.OptionsMenuPageName>
       #if FEATURE_TOUCH_CONTROLS ControlsHandler.hasExternalInputDevice
       || Preferences.controlsScheme != FunkinHitboxControlSchemes.Arrows
       #end);
+    createPrefItemCheckbox('Motion Blur',
+    'If enabled, notes have motion blur.\nWARNING: This can cause eye strain and/or motion sickness!',
+    function(value:Bool):Void
+    {
+      Preferences.motionBlur = value;
+    }, Preferences.motionBlur);
     createPrefItemPercentage('Strumline Background', 'Show a semi-transparent background behind the strumline.', function(value:Int):Void
     {
       Preferences.strumlineBackgroundOpacity = value;


### PR DESCRIPTION
## Description
This PR adds a motion blur option for notes going toward the strumline, making the notes' movements look smoother.

## Screenshots/Videos
Without Motion Blur:

https://github.com/user-attachments/assets/1cc80f42-d6ca-4813-8b75-09c232b1050c

With Motion Blur:

https://github.com/user-attachments/assets/ca94e80e-7e7e-408f-a8cb-df8748e6604c