### PR TITLE
[OPTIMIZATION] Set `active` to `false` on `SustainTrail`s

### DIFF
--- a/source/funkin/play/notes/Strumline.hx
+++ b/source/funkin/play/notes/Strumline.hx
@@ -89,7 +89,19 @@ class Strumline extends FlxSpriteGroup
   public var conductorInUse(get, set):Conductor;
 
   // Used in-game to control the scroll speed within a song
-  public var scrollSpeed:Float = 1.0;
+  public var scrollSpeed(default, set):Float = 1.0;
+
+  function set_scrollSpeed(val:Float):Float
+  {
+    scrollSpeed = val;
+
+    holdNotes.forEachAlive(holdNote ->
+    {
+      @:privateAccess holdNote?.triggerRedraw();
+    });
+
+    return scrollSpeed;
+  }
 
   /**
    * Reset the scroll speed to the current chart's scroll speed.

--- a/source/funkin/play/notes/SustainTrail.hx
+++ b/source/funkin/play/notes/SustainTrail.hx
@@ -157,7 +157,7 @@ class SustainTrail extends FlxSprite
 
     setIndices(TRIANGLE_VERTEX_INDICES);
 
-    this.active = true; // This NEEDS to be true for the note to be drawn!
+    this.active = false;
   }
 
   /**


### PR DESCRIPTION
This is the same optimisation used by `NoteSprite` when the graphic isn't animated to prevent FPS drops.
`SustainTrail`s are obviously not animated, so this fix seems like a no-brainer to me.