### PR TITLE
[BUGFIX] Fix hold notes being off-position for 1 frame after being hit early/late

### DIFF
--- a/source/funkin/play/notes/Strumline.hx
+++ b/source/funkin/play/notes/Strumline.hx
@@ -749,7 +749,7 @@ class Strumline extends FlxSpriteGroup
           holdNote.cover.kill();
         }
       }
-      else if (conductorInUse.songPosition > holdNote.strumTime && holdNote.hitNote)
+      else if (holdNote.hitNote)
       {
         // Hold note is currently being hit, clip it off.
         holdConfirm(holdNote.noteDirection);
@@ -761,18 +761,7 @@ class Strumline extends FlxSpriteGroup
         {
           holdNote.visible = false;
         }
-
-        if (!customPositionData)
-        {
-          if (isDownscroll)
-          {
-            holdNote.y = this.y - INITIAL_OFFSET - holdNote.height + STRUMLINE_SIZE / 2;
-          }
-          else
-          {
-            holdNote.y = this.y - INITIAL_OFFSET + STRUMLINE_SIZE / 2;
-          }
-        }
+        updateClippedHoldNote(holdNote);
       }
       else
       {
@@ -987,6 +976,18 @@ class Strumline extends FlxSpriteGroup
     playConfirm(note.direction);
     note.hasBeenHit = true;
 
+    // We update the hold note before killing the note to prevent it being clipped from the hold cover.
+    if (note.holdNoteSprite != null)
+    {
+      note.holdNoteSprite.sustainLength = Math.min(
+        note.holdNoteSprite.fullSustainLength,
+        (note.holdNoteSprite.strumTime + note.holdNoteSprite.fullSustainLength) - conductorInUse.songPosition
+      );
+
+      // Re-position it so it's correct.
+      updateClippedHoldNote(note.holdNoteSprite);
+    }
+
     if (removeNote)
     {
       killNote(note);
@@ -1001,11 +1002,6 @@ class Strumline extends FlxSpriteGroup
     {
       note.holdNoteSprite.hitNote = true;
       note.holdNoteSprite.missedNote = false;
-
-      note.holdNoteSprite.sustainLength = Math.min(
-        note.holdNoteSprite.fullSustainLength,
-        (note.holdNoteSprite.strumTime + note.holdNoteSprite.fullSustainLength) - conductorInUse.songPosition
-      );
     }
 
     #if FEATURE_GHOST_TAPPING
@@ -1027,6 +1023,21 @@ class Strumline extends FlxSpriteGroup
     {
       note.holdNoteSprite.missedNote = true;
       note.holdNoteSprite.visible = false;
+    }
+  }
+
+  function updateClippedHoldNote(holdNote:SustainTrail):Void
+  {
+    if (!customPositionData)
+    {
+      if (isDownscroll)
+      {
+        holdNote.y = this.y - INITIAL_OFFSET - holdNote.height + STRUMLINE_SIZE / 2;
+      }
+      else
+      {
+        holdNote.y = this.y - INITIAL_OFFSET + STRUMLINE_SIZE / 2;
+      }
     }
   }
 


### PR DESCRIPTION
This PR fixes an issue where if you hit a hold note early/late, there's a chance for the hold note to appear clipped from the center of the strumline for 1 frame before it re-positions itself. It's a lot more common when hitting a note early rather than late but still can happen from both states. 

## Old
https://github.com/user-attachments/assets/a3f19ad1-a329-4f25-b892-07d59e97085a

# New
https://github.com/user-attachments/assets/c4905460-1bd6-4aa0-a613-0d3dcf0337b5

