### PR TITLE
[CRASHFIX] Fix crash scrolling waveforms in the Offsets Toolbox when exiting with F4

### DIFF
--- a/source/funkin/ui/debug/charting/toolboxes/ChartEditorOffsetsToolbox.hx
+++ b/source/funkin/ui/debug/charting/toolboxes/ChartEditorOffsetsToolbox.hx
@@ -215,6 +215,7 @@ class ChartEditorOffsetsToolbox extends ChartEditorBaseToolbox
     }
     waveformScrollview.onScroll = (_) ->
     {
+      if (audioPreviewTracks == null || audioPreviewTracks.members == null) return;
       if (!audioPreviewTracks.playing)
       {
         // Move the playhead if it would go out of view.
@@ -740,6 +741,7 @@ class ChartEditorOffsetsToolbox extends ChartEditorBaseToolbox
 
   override public function update(elapsed:Float)
   {
+    if (audioPreviewTracks == null || audioPreviewTracks.members == null) return;
     super.update(elapsed);
 
     if (audioPreviewTracks.playing)


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
closes #6732
<!-- Briefly describe the issue(s) fixed. -->
## Description
Prevent crash when pressing F4 while scrolling in OffsetToolbox in ChartEditor
<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos
### Before :


https://github.com/user-attachments/assets/16020350-5761-4eb4-9b8a-ebb56ddd85da



### After :


https://github.com/user-attachments/assets/414ad639-6015-4949-9e4a-db952ddb27f9


