### PR TITLE
[BUGFIX] Fix hotreloading during playtest starting later than the start timestamp

### DIFF
--- a/source/funkin/ui/debug/charting/ChartEditorState.hx
+++ b/source/funkin/ui/debug/charting/ChartEditorState.hx
@@ -2587,7 +2587,7 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
       loadFromFNFCData: (currentWorkingFilePath == null && hasInstrumentalData) ? this.buildFNFCDataFromCurrentChart() : null, // We want to reload the FNFCData so the user doesn't lose progress.
       targetSongDifficulty: this.selectedDifficulty,
       targetSongVariation: this.selectedVariation,
-      targetSongPosition: Conductor.instance.songPosition
+      targetSongPosition: scrollPositionInMs + playheadPositionInMs
     });
 
     return {


### PR DESCRIPTION
## Linked Issues
Me while goofing around again

## Description
Right now it's set that the target song position of the ChartEditorState while hotreloading is the song position of the conductor. However, during playtest, the same Conductor is updated, making hotreloading during playtest start in a later position of the song.

## Screenshots/Videos
### Old

https://github.com/user-attachments/assets/015cffb2-2d83-45b1-ade6-e8aa7326d80d

### New

https://github.com/user-attachments/assets/1c1611f7-abda-45a9-801c-7976c609cd11
