### PR TITLE
[POLISH] Unify the `FunkinDebugDisplay` rounded corner radius

### DIFF
--- a/source/funkin/ui/debug/FunkinDebugDisplay.hx
+++ b/source/funkin/ui/debug/FunkinDebugDisplay.hx
@@ -105,7 +105,7 @@ class FunkinDebugDisplay extends Sprite
       INNER_RECT_DIFF,
       OUTER_RECT_DIMENSIONS[0] * bgWidthMultiplier,
       OUTER_RECT_DIMENSIONS[1] * bgHeightMultiplier,
-      BG_CORNER_WIDTH
+      BG_CORNER_WIDTH - (INNER_RECT_DIFF * 2)
     );
     background.graphics.endFill();
     background.alpha = backgroundOpacity;


### PR DESCRIPTION
## Description
The corner radius of the debug display was not calculated correctly as the same radius should not used for both the inside and "outside" aka the border

## Screenshots/Videos
<img width="252" height="213" alt="image" src="https://github.com/user-attachments/assets/1e5ef6a5-6abc-423b-8d6d-c5b04297ce6a" />
