### PR TITLE
[BUGFIX] Change all ERegs to be multi-thread safe

### DIFF
--- a/source/funkin/api/newgrounds/Events.hx
+++ b/source/funkin/api/newgrounds/Events.hx
@@ -13,8 +13,6 @@ import io.newgrounds.objects.events.Result;
 @:nullSafety
 class Events
 {
-  // Only allow letters, numbers, spaces, dashes, and underscores.
-  static final EVENT_NAME_REGEX:EReg = ~/[^a-zA-Z0-9 -_]/g;
   static final ERROR_CODE_INVALID_EVENT_NAME:Int = 103;
 
   /**
@@ -24,6 +22,9 @@ class Events
    */
   public static function logEvent(eventName:String):Void
   {
+    // Only allow letters, numbers, spaces, dashes, and underscores.
+    final EVENT_NAME_REGEX:EReg = ~/[^a-zA-Z0-9 -_]/g;
+
     #if (FEATURE_NEWGROUNDS && FEATURE_NEWGROUNDS_EVENTS)
     if (NewgroundsClient.instance.isLoggedIn())
     {

--- a/source/funkin/play/song/Song.hx
+++ b/source/funkin/play/song/Song.hx
@@ -761,8 +761,6 @@ class Song implements IPlayStateScriptedClass implements IRegistryEntry<SongMeta
     return meta;
   }
 
-  static final VARIATION_REGEX = ~/^[a-z][a-z0-9]+$/;
-
   /**
    * Validate that the variation ID is valid.
    * Auto-accept if it's one of the base game default variations.
@@ -772,7 +770,7 @@ class Song implements IPlayStateScriptedClass implements IRegistryEntry<SongMeta
   {
     if (Constants.DEFAULT_VARIATION_LIST.contains(variation)) return true;
 
-    return VARIATION_REGEX.match(variation);
+    return (~/^[a-z][a-z0-9]+$/).match(variation);
   }
 
   static function log(message:String):Void

--- a/source/funkin/ui/AtlasText.hx
+++ b/source/funkin/ui/AtlasText.hx
@@ -295,9 +295,6 @@ class AtlasChar extends FlxSprite
 @:nullSafety
 private class AtlasFontData
 {
-  static final UPPER_CHAR:EReg = ~/^[A-Z]\d+$/;
-  static final LOWER_CHAR:EReg = ~/^[a-z]\d+$/;
-
   /**
    * The split up graphic for the art.
    */
@@ -339,6 +336,9 @@ private class AtlasFontData
 
     var containsUpper:Bool = false;
     var containsLower:Bool = false;
+
+    final UPPER_CHAR:EReg = ~/^[A-Z]\d+$/;
+    final LOWER_CHAR:EReg = ~/^[a-z]\d+$/;
 
     for (frame in atlas.frames)
     {

--- a/source/funkin/util/FileUtil.hx
+++ b/source/funkin/util/FileUtil.hx
@@ -106,11 +106,6 @@ class FileUtil
     return PROTECTED;
   }
 
-  /**
-   * Regex for invalid filesystem characters.
-   */
-  public static final INVALID_CHARS:EReg = ~/[:*?"<>|\n\r\t]/g;
-
   #if sys
   private static var _gameDirectory:Null<String> = null;
 
@@ -1182,7 +1177,7 @@ class FileUtil
    *
    * @param zipData The Bytes object containing the ZIP data to unzip.
    * @param targetFolder The path to the folder to unzip to. Will be created if it doesn't exist.
-   **/
+  **/
   public static function unzipToFolder(zipData:Bytes, targetFolder:String):Void
   {
     var entries = readZIPFromBytes(zipData);
@@ -1384,7 +1379,8 @@ class FileUtilSandboxed
       path = path.replace('//', '/');
     }
 
-    var parts:Array<String> = FileUtil.INVALID_CHARS.replace(path, '').split('/');
+    final INVALID_CHARS:EReg = ~/[:*?"<>|\n\r\t]/g;
+    var parts:Array<String> = INVALID_CHARS.replace(path, '').split('/');
     var sanitized:Array<String> = [];
     for (part in parts)
     {

--- a/source/funkin/util/InputUtil.hx
+++ b/source/funkin/util/InputUtil.hx
@@ -185,8 +185,6 @@ class InputUtil
     }
   }
 
-  static var dirReg:EReg = ~/^(l|r).?-(left|right|down|up)$/;
-
   /**
    * Get the shortened name of a button for a gamepad.
    *
@@ -207,6 +205,7 @@ class InputUtil
 
   static function shortenButtonName(name:Null<String>):String
   {
+    var dirReg:EReg = ~/^(l|r).?-(left|right|down|up)$/;
     return switch (name == null ? '' : name.toLowerCase())
     {
       case '':

--- a/source/funkin/util/WindowUtil.hx
+++ b/source/funkin/util/WindowUtil.hx
@@ -11,11 +11,6 @@ using StringTools;
 class WindowUtil
 {
   /**
-   * A regex to match valid URLs.
-   */
-  public static final URL_REGEX:EReg = ~/^https?:\/?\/?(?:www\.)?[-a-zA-Z0-9@:%_\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*)$/;
-
-  /**
    * Sanitizes a URL via a regex.
    *
    * @param targetUrl The URL to sanitize.
@@ -35,6 +30,7 @@ class WindowUtil
       targetUrl = 'http://' + targetUrl;
     }
 
+    final URL_REGEX:EReg = ~/^https?:\/?\/?(?:www\.)?[-a-zA-Z0-9@:%_\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*)$/;
     if (URL_REGEX.match(targetUrl))
     {
       return URL_REGEX.matched(0);

--- a/source/funkin/util/logging/AnsiTrace.hx
+++ b/source/funkin/util/logging/AnsiTrace.hx
@@ -18,7 +18,6 @@ using StringTools;
 @:nullSafety
 class AnsiTrace
 {
-  private static final HEADER_REGEX = ~/^\s*\[(.*?)\]\s*(.*)$/;
   #if (sys && FEATURE_DEBUG_FILE_LOGGING)
   private static final logFilePath:String = 'logs/log-${DateUtil.generateTimestamp()}.txt';
   private static var logFile:Null<FileOutput> = null;
@@ -89,14 +88,6 @@ class AnsiTrace
    */
   static function formatOutput(v:Dynamic, ?infos:haxe.PosInfos):String
   {
-    // EReg isn't thread-safe, so we default to the normal function if we're loading asynchronously.
-    if (funkin.util.plugins.ReloadAssetsDebugPlugin.hotReloadInProgress)
-    {
-      if (infos == null) return Std.string(v);
-
-      return haxe.Log.formatOutput(v, infos);
-    }
-
     var str:String = Std.string(v);
     if (infos == null) return str;
 
@@ -115,6 +106,7 @@ class AnsiTrace
     var header:String = "";
     var body:String = str;
 
+    final HEADER_REGEX = ~/^\s*\[(.*?)\]\s*(.*)$/;
     if (HEADER_REGEX.match(str))
     {
       header = ' ${HEADER_REGEX.matched(1)} ';

--- a/source/funkin/util/tools/StringTools.hx
+++ b/source/funkin/util/tools/StringTools.hx
@@ -94,17 +94,13 @@ class StringTools
   }
 
   /**
-   * The regular expression to sanitize strings.
-   */
-  static final SANTIZE_REGEX:EReg = ~/[^-a-zA-Z0-9]/g;
-
-  /**
    * Remove all instances of symbols other than alpha-numeric characters (and dashes)from a string.
    * @param value The string to sanitize.
    * @return The sanitized string.
    */
   public static function sanitize(value:String):String
   {
+    final SANTIZE_REGEX:EReg = ~/[^-a-zA-Z0-9]/g;
     return SANTIZE_REGEX.replace(value, '');
   }
 


### PR DESCRIPTION
Turns out there's a bunch of static ERegs used in the game. This, if not careful enough will cause multi-threads to hang due to ERegs not being safe, so this PR makes (most) ERegs localized to help with thread safety.

PR goes with this also [#1](https://github.com/FunkinCrew/thx.semver/pull/1)