### PR TITLE
[ENHANCEMENT/BUGFIX] Rewrite wiggle shader.

### DIFF
--- a/source/funkin/graphics/shaders/WiggleEffectRuntime.hx
+++ b/source/funkin/graphics/shaders/WiggleEffectRuntime.hx
@@ -66,7 +66,15 @@ class WiggleEffectRuntime extends FlxRuntimeShader
     return time = v;
   }
 
-  public function new(speed:Float, freq:Float, amplitude:Float, ?effect:WiggleEffectType = DREAMY):Void
+  var antialiasing(default, set):Bool = false;
+
+  function set_antialiasing(v:Bool):Bool
+  {
+    this.setBool('antialiasing', v);
+    return antialiasing = v;
+  }
+
+  public function new(speed:Float, freq:Float, amplitude:Float, ?effect:WiggleEffectType = DREAMY, antialiasing:Bool = false):Void
   {
     super(Assets.getText(Paths.frag('wiggle')));
 
@@ -75,6 +83,7 @@ class WiggleEffectRuntime extends FlxRuntimeShader
     this.waveFrequency = freq;
     this.waveAmplitude = amplitude;
     this.effectType = effect;
+    this.antialiasing = antialiasing;
   }
 
   public function update(elapsed:Float)


### PR DESCRIPTION
Rewrites the wiggle shader to be less confusing and fixes issue #7976 where the wiggle shader doesn't render correctly on certain GPUs due to precision issues. Also adds the ability to enable or disable pixel snapping across the whole shader instead of it being automatically disabled only on the dreamy effect.

Requires FunkinCrew/funkin.assets#468 to also be merged.

Here are 2 videos [MistrDJ](https://github.com/MistrDJ) recorded for me since my GPU doesn't have the issue. The first is how the shader currently looks and the second is how it looks with this fix.

https://github.com/user-attachments/assets/5b492625-a92a-4e1f-a27f-77e1f94b9387

https://github.com/user-attachments/assets/1dedaf7f-d3bb-49d3-be01-9df66d3b2a6a

This shouldn't change how the shader looks at all in the context of how it is used in Week 6 as long as you didn't have the shader issue.