### PR TITLE
[BUGFIX] Invert input offset values

### DIFF
--- a/source/funkin/Conductor.hx
+++ b/source/funkin/Conductor.hx
@@ -289,7 +289,7 @@ class Conductor
 
   function get_combinedOffset():Float
   {
-    return instrumentalOffset + formatOffset + globalOffset;
+    return instrumentalOffset + formatOffset - globalOffset;
   }
 
   /**

--- a/source/funkin/ui/options/OffsetMenu.hx
+++ b/source/funkin/ui/options/OffsetMenu.hx
@@ -490,7 +490,7 @@ class OffsetMenu extends Page<OptionsState.OptionsMenuPageName>
     if (differences.length % 4 == 0 && calibrating)
     {
       var avg:Float = getAverage();
-      tempOffset = Std.int(avg);
+      tempOffset = -Std.int(avg);
       _lastOffset = appliedOffsetLerp;
       _offsetLerpTime = 0;
       trace('New offset calculated: ' + tempOffset + 'ms');

--- a/source/funkin/ui/options/OffsetMenu.hx
+++ b/source/funkin/ui/options/OffsetMenu.hx
@@ -490,7 +490,7 @@ class OffsetMenu extends Page<OptionsState.OptionsMenuPageName>
     if (differences.length % 4 == 0 && calibrating)
     {
       var avg:Float = getAverage();
-      tempOffset = -Std.int(avg);
+      tempOffset = Std.int(avg);
       _lastOffset = appliedOffsetLerp;
       _offsetLerpTime = 0;
       trace('New offset calculated: ' + tempOffset + 'ms');
@@ -627,7 +627,7 @@ class OffsetMenu extends Page<OptionsState.OptionsMenuPageName>
         var arrow:ArrowData = getClosestArrowAtBeat(b);
 
         var closestBeat:Float = Math.round(b);
-        var diff:Float = closestBeat - b;
+        var diff:Float = b - closestBeat;
         var ms:Float = (diff * msPerBeat);
 
         if (arrow != null) // eric sees this and goes "OMG NULL REF!!!!"
@@ -826,7 +826,8 @@ class OffsetMenu extends Page<OptionsState.OptionsMenuPageName>
     var inputLatencyNs:Int64 = PreciseInputManager.getCurrentTimestamp() - input.timestamp;
     var inputLatencyMs:Float = inputLatencyNs.toFloat() / Constants.NS_PER_MS;
 
-    var noteDiff:Int = Std.int(note.noteData.time - inputPosition - inputLatencyMs);
+    var noteDiff:Int = Std.int(inputPosition - note.noteData.time + inputLatencyMs);
+
     addDifference(noteDiff);
 
     if (noteDiff == 0)
@@ -840,7 +841,7 @@ class OffsetMenu extends Page<OptionsState.OptionsMenuPageName>
     }
     else
     {
-      jumpInText.text = noteDiff > 0 ? 'Early!\n' + noteDiff + 'ms' : 'Late!\n' + noteDiff + 'ms';
+      jumpInText.text = noteDiff < 0 ? 'Early!\n' + noteDiff + 'ms' : 'Late!\n' + noteDiff + 'ms';
     }
 
     jumpInText.text += '\nAvg: ' + Std.int(getAverage()) + 'ms';


### PR DESCRIPTION
> [!NOTE]
> Does not handle save migration i.e. flipping the offset for existing players. Players will need to re-calibrate if this is pulled without further changes.
> (I wanted to try doing this initially, but there doesn't seem to be any existing functions for migrating save data...?)

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
https://github.com/FunkinCrew/Funkin/issues/7711
(Reopen of https://github.com/FunkinCrew/Funkin/pull/7990 due to git issues)

<!-- Briefly describe the issue(s) fixed. -->
## Description
Offsets used to be inverted. Now they aren't. Cool?

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos
N/A (Self-explanatory, lazy)