### PR TITLE
Implement `S3TC` (`.dds`) compressed textures for `desktop`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ temp/
 docs/temp/
 export/
 astc-textures/
+dds-textures/
 RECOVER_*.fla
 shitAudio/
 .build_time

--- a/hmm.json
+++ b/hmm.json
@@ -199,7 +199,7 @@
     {
       "name": "openfl",
       "type": "git",
-      "ref": "a2cc2c58f0f7f20e518ff78673fc29ee8c3c585f",
+      "ref": "af3dd918ef4b27f4165b9be1b146f2b8dc004514",
       "url": "https://github.com/FunkinCrew/openfl"
     },
     {

--- a/project.hxp
+++ b/project.hxp
@@ -623,7 +623,7 @@ class Project extends HXProject
     configureCustomMacros();
     configurePolymod();
     configureHaxelibs();
-    configureASTCTextures();
+    configureCompressedTextures();
     configureAssets();
 
     if (!isLinux())
@@ -1708,14 +1708,21 @@ class Project extends HXProject
   }
 
   /**
-   * Configure the astc textures.
+   * Configure the compressed textures.
    */
-  function configureASTCTextures()
+  function configureCompressedTextures()
   {
     if (!(isDisplay() && isCleanCommand()) && FEATURE_COMPRESSED_TEXTURES.isEnabled(this))
     {
-      readASTCExclusion();
-      runASTCCompressor();
+      if (isDesktop())
+      {
+        // Nothing for now
+      }
+      else
+      {
+        readASTCExclusion();
+        runASTCCompressor();
+      }
     }
   }
 
@@ -1947,12 +1954,27 @@ class Project extends HXProject
     // path, rename, type, embed, setDefaults
     if (Path.extension(path) == 'png' && FEATURE_COMPRESSED_TEXTURES.isEnabled(this))
     {
-      final astcPath:String = "astc-textures/" + path.substr(0, path.length - 3) + "astc";
-      if (!isASTCExcluded(path) && FileSystem.exists(astcPath))
+      if (isDesktop())
       {
-        path = astcPath;
+        final ddsPath:String = "dds-textures/" + path.substr(0, path.length - 3) + "dds";
 
-        if (rename != null) rename = rename.substr(0, rename.length - 3) + "astc";
+        if (FileSystem.exists(ddsPath))
+        {
+          path = ddsPath;
+
+          if (rename != null) rename = rename.substr(0, rename.length - 3) + "dds";
+        }
+      }
+      else
+      {
+        final astcPath:String = "astc-textures/" + path.substr(0, path.length - 3) + "astc";
+
+        if (!isASTCExcluded(path) && FileSystem.exists(astcPath))
+        {
+          path = astcPath;
+
+          if (rename != null) rename = rename.substr(0, rename.length - 3) + "astc";
+        }
       }
     }
 

--- a/scripts/dds/compress-textures.ps1
+++ b/scripts/dds/compress-textures.ps1
@@ -1,0 +1,127 @@
+param (
+	[Parameter(Mandatory = $true)]
+	[string]$Bc7enc
+)
+
+Remove-Item -Recurse -Force "dds-textures" -ErrorAction SilentlyContinue
+
+New-Item -ItemType Directory -Force -Path "dds-textures" | Out-Null
+
+$Excludes = @(
+	"assets/ui/options/",
+	"assets/ui/cursor/",
+	"assets/ui/fonts/",
+	"assets/ui/freeplay/",
+	"assets/ui/soundtray/",
+	"assets/ui/story-mode/levels/",
+	"assets/ui/editors/",
+	"assets/gameplay/dialogue/",
+	"assets/gameplay/notestyles/pixel/",
+	"assets/gameplay/characters/bf-pixel/",
+	"assets/gameplay/characters/gf/",
+	"assets/gameplay/characters/gf-car/",
+	"assets/gameplay/characters/gf-christmas/",
+	"assets/gameplay/characters/gf-dark/",
+	"assets/gameplay/characters/gf-pixel/",
+	"assets/gameplay/characters/nene-pixel/",
+	"assets/gameplay/characters/pico-pixel/",
+	"assets/gameplay/characters/senpai/",
+	"assets/gameplay/characters/spirit/",
+	"assets/gameplay/stages/mainStage/",
+	"assets/gameplay/stages/school/",
+	"assets/gameplay/stages/schoolErect/",
+	"assets/gameplay/stages/schoolEvil/",
+	"assets/gameplay/stages/schoolEvilErect/",
+	"assets/ui/results/clear-percent/",
+	"assets/ui/results/difficulty/",
+	"assets/ui/results/rank-text/"
+)
+
+$ExcludeFiles = @(
+	"assets/gameplay/characters/bf/icon-bf.png",
+	"assets/gameplay/characters/bf-old/icon-bf-old.png",
+	"assets/gameplay/characters/bf-pixel/icon-bf-pixel.png",
+	"assets/gameplay/characters/dad/icon-dad.png",
+	"assets/gameplay/characters/darnell/icon-darnell.png",
+	"assets/gameplay/characters/face/icon-face.png",
+	"assets/gameplay/characters/gf/icon-gf.png",
+	"assets/gameplay/characters/mom/icon-mom.png",
+	"assets/gameplay/characters/monster/icon-monster.png",
+	"assets/gameplay/characters/parents-christmas/icon-parents.png",
+	"assets/gameplay/characters/parents-christmas/icon-parents-christmas.png",
+	"assets/gameplay/characters/pico/icon-pico.png",
+	"assets/gameplay/characters/senpai/icon-senpai.png",
+	"assets/gameplay/characters/spirit/icon-spirit.png",
+	"assets/gameplay/characters/spooky/icon-spooky.png",
+	"assets/gameplay/characters/tankman/icon-tankman.png",
+	"assets/gameplay/characters/tankman/icon-tankman-bloody.png",
+	"assets/gameplay/characters/sserafim-chaewon/icon-sserafim-chaewon.png",
+	"assets/gameplay/characters/sserafim-eunchae/icon-sserafim-eunchae.png",
+	"assets/gameplay/characters/sserafim-kazuha/icon-sserafim-kazuha.png",
+	"assets/gameplay/characters/sserafim-sakura/icon-sserafim-sakura.png",
+	"assets/gameplay/characters/sserafim-yunjin/icon-sserafim-yunjin.png",
+	"assets/ui/title/title-screen-text/spritemap1.png",
+	"assets/ui/title/title-screen-text-mobile/spritemap1.png",
+	"assets/gameplay/characters/nene/nene/spritemap1.png",
+	"assets/gameplay/characters/pico-holding-nene/pico-holding-nene/spritemap1.png",
+	"assets/gameplay/characters/sserafim-eunchae/sserafim-eunchae/spritemap1.png",
+	"assets/gameplay/characters/sserafim-kazuha/sserafim-kazuha/spritemap1.png",
+	"assets/gameplay/characters/sserafim-akura/sserafim-sakura/spritemap1.png",
+	"assets/gameplay/characters/sserafim-gf/sserafim-gf/spritemap1.png",
+	"assets/gameplay/characters/sserafim-yunjin/sserafim-yunjin/spritemap1.png",
+	"assets/gameplay/general/health-bar.png",
+	"assets/gameplay/playable-characters/bf/results/graphics/results-excellent/spritemap1.png",
+	"assets/gameplay/playable-characters/bf/results/graphics/results-good/gf.png",
+	"assets/gameplay/playable-characters/bf/results/graphics/results-great/gf/spritemap1.png",
+	"assets/gameplay/playable-characters/bf/results/graphics/results-shit/spritemap1.png",
+	"assets/gameplay/stages/mainStageErect/bright-light.png",
+	"assets/gameplay/stages/mainStageErect/light-above.png",
+	"assets/gameplay/stages/mainStageErect/light-green.png",
+	"assets/gameplay/stages/mainStageErect/light-red.png",
+	"assets/gameplay/stages/mainStageErect/light-orange.png",
+	"assets/gameplay/stages/spookyMansionErect/stairs-dark.png",
+	"assets/gameplay/stages/spookyMansionErect/stairs-light.png",
+	"assets/gameplay/stages/tankmanBattlefield/bricks-ground.png",
+	"assets/gameplay/stages/tankmanBattlefieldErect/bricks-ground.png",
+	"assets/gameplay/stages/sserafim/cutscene/cutscene-main/spritemap1.png"
+)
+
+Get-ChildItem -Path "assets" -Filter "*.png" -Recurse -File | ForEach-Object
+{
+	$relative = $_.FullName.Substring((Get-Location).Path.Length + 1).Replace("", "/")
+
+	if ($ExcludeFiles -contains $relative)
+	{
+		return
+	}
+
+	foreach ($exclude in $Excludes)
+	{
+		if ($relative.StartsWith($exclude))
+		{
+			return
+		}
+	}
+
+	$directory = Split-Path $relative -Parent
+
+	$out = Join-Path "dds-textures" $directory
+
+	New-Item -ItemType Directory -Force -Path $out | Out-Null
+
+	$dds = Join-Path $out ([System.IO.Path]::GetFileNameWithoutExtension($_.Name) + ".dds")
+
+	Write-Host "Compressing: $relative"
+
+	& $Bc7enc `
+		-3 `
+		-g `
+		-q `
+		$_.FullName `
+		$dds
+
+	if ($LASTEXITCODE -ne 0)
+	{
+		throw "bc7enc failed for $($_.FullName)"
+	}
+}

--- a/scripts/dds/compress-textures.sh
+++ b/scripts/dds/compress-textures.sh
@@ -1,0 +1,130 @@
+#!/bin/bash
+
+set -e
+
+if [ -z "$1" ]; then
+	echo "Usage: $0 <bc7enc>"
+	exit 1
+fi
+
+BC7ENC="$1"
+
+chmod +x "$BC7ENC"
+
+rm -rf "dds-textures"
+
+mkdir -p "dds-textures"
+
+EXCLUDES=(
+	"assets/ui/options/"
+	"assets/ui/cursor/"
+	"assets/ui/fonts/"
+	"assets/ui/freeplay/"
+	"assets/ui/soundtray/"
+	"assets/ui/story-mode/levels/"
+	"assets/ui/editors/"
+	"assets/gameplay/dialogue/"
+	"assets/gameplay/notestyles/pixel/"
+	"assets/gameplay/characters/bf-pixel/"
+	"assets/gameplay/characters/gf/"
+	"assets/gameplay/characters/gf-car/"
+	"assets/gameplay/characters/gf-christmas/"
+	"assets/gameplay/characters/gf-dark/"
+	"assets/gameplay/characters/gf-pixel/"
+	"assets/gameplay/characters/nene-pixel/"
+	"assets/gameplay/characters/pico-pixel/"
+	"assets/gameplay/characters/senpai/"
+	"assets/gameplay/characters/spirit/"
+	"assets/gameplay/stages/mainStage/"
+	"assets/gameplay/stages/school/"
+	"assets/gameplay/stages/schoolErect/"
+	"assets/gameplay/stages/schoolEvil/"
+	"assets/gameplay/stages/schoolEvilErect/"
+	"assets/ui/results/clear-percent/"
+	"assets/ui/results/difficulty/"
+	"assets/ui/results/rank-text/"
+)
+
+EXCLUDE_FILES=(
+	"assets/gameplay/characters/bf/icon-bf.png"
+	"assets/gameplay/characters/bf-old/icon-bf-old.png"
+	"assets/gameplay/characters/bf-pixel/icon-bf-pixel.png"
+	"assets/gameplay/characters/dad/icon-dad.png"
+	"assets/gameplay/characters/darnell/icon-darnell.png"
+	"assets/gameplay/characters/face/icon-face.png"
+	"assets/gameplay/characters/gf/icon-gf.png"
+	"assets/gameplay/characters/mom/icon-mom.png"
+	"assets/gameplay/characters/monster/icon-monster.png"
+	"assets/gameplay/characters/parents-christmas/icon-parents.png"
+	"assets/gameplay/characters/parents-christmas/icon-parents-christmas.png"
+	"assets/gameplay/characters/pico/icon-pico.png"
+	"assets/gameplay/characters/senpai/icon-senpai.png"
+	"assets/gameplay/characters/spirit/icon-spirit.png"
+	"assets/gameplay/characters/spooky/icon-spooky.png"
+	"assets/gameplay/characters/tankman/icon-tankman.png"
+	"assets/gameplay/characters/tankman/icon-tankman-bloody.png"
+	"assets/gameplay/characters/sserafim-chaewon/icon-sserafim-chaewon.png"
+	"assets/gameplay/characters/sserafim-eunchae/icon-sserafim-eunchae.png"
+	"assets/gameplay/characters/sserafim-kazuha/icon-sserafim-kazuha.png"
+	"assets/gameplay/characters/sserafim-sakura/icon-sserafim-sakura.png"
+	"assets/gameplay/characters/sserafim-yunjin/icon-sserafim-yunjin.png"
+	"assets/ui/title/title-screen-text/spritemap1.png"
+	"assets/ui/title/title-screen-text-mobile/spritemap1.png"
+	"assets/gameplay/characters/nene/nene/spritemap1.png"
+	"assets/gameplay/characters/pico-holding-nene/pico-holding-nene/spritemap1.png"
+	"assets/gameplay/characters/sserafim-eunchae/sserafim-eunchae/spritemap1.png"
+	"assets/gameplay/characters/sserafim-kazuha/sserafim-kazuha/spritemap1.png"
+	"assets/gameplay/characters/sserafim-akura/sserafim-sakura/spritemap1.png"
+	"assets/gameplay/characters/sserafim-gf/sserafim-gf/spritemap1.png"
+	"assets/gameplay/characters/sserafim-yunjin/sserafim-yunjin/spritemap1.png"
+	"assets/gameplay/general/health-bar.png"
+	"assets/gameplay/playable-characters/bf/results/graphics/results-excellent/spritemap1.png"
+	"assets/gameplay/playable-characters/bf/results/graphics/results-good/gf.png"
+	"assets/gameplay/playable-characters/bf/results/graphics/results-great/gf/spritemap1.png"
+	"assets/gameplay/playable-characters/bf/results/graphics/results-shit/spritemap1.png"
+	"assets/gameplay/stages/mainStageErect/bright-light.png"
+	"assets/gameplay/stages/mainStageErect/light-above.png"
+	"assets/gameplay/stages/mainStageErect/light-green.png"
+	"assets/gameplay/stages/mainStageErect/light-red.png"
+	"assets/gameplay/stages/mainStageErect/light-orange.png"
+	"assets/gameplay/stages/spookyMansionErect/stairs-dark.png"
+	"assets/gameplay/stages/spookyMansionErect/stairs-light.png"
+	"assets/gameplay/stages/tankmanBattlefield/bricks-ground.png"
+	"assets/gameplay/stages/tankmanBattlefieldErect/bricks-ground.png"
+	"assets/gameplay/stages/sserafim/cutscene/cutscene-main/spritemap1.png"
+)
+
+is_excluded()
+{
+	local file="$1"
+
+	for exclude in "${EXCLUDE_FILES[@]}"; do
+		[ "$file" = "$exclude" ] && return 0
+	done
+
+	for exclude in "${EXCLUDES[@]}"; do
+		[[ "$file" == "$exclude"* ]] && return 0
+	done
+
+	return 1
+}
+
+find "assets" -type f -name "*.png" | while read -r f; do
+	if is_excluded "$f"; then
+		continue
+	fi
+
+	out="dds-textures/$(dirname "$f")"
+	mkdir -p "$out"
+
+	dds="$out/$(basename "${f%.png}.dds")"
+
+	echo "Compressing: $f"
+
+	"$BC7ENC" \
+		-3 \
+		-g \
+		-q \
+		"$f" \
+		"$dds"
+done

--- a/source/funkin/util/assets/AssetsUtil.hx
+++ b/source/funkin/util/assets/AssetsUtil.hx
@@ -14,6 +14,7 @@ class AssetsUtil
 {
   static final EXTENSIONS:Map<String, FunkinAssetType> = [
     'astc' => FunkinAssetType.IMAGE, // Texture image utilizing Adaptive scalable texture compression
+    'dds' => FunkinAssetType.IMAGE, // Texture image utilizing Adaptive scalable texture compression
     'bmp' => FunkinAssetType.IMAGE, // Bitmap image
     'css' => FunkinAssetType.TEXT, // Cascading stylesheet
     'csv' => FunkinAssetType.TEXT, // Comma-separated values file


### PR DESCRIPTION
This PR implements `S3TC` (`.dds`) compressed textures for `desktop`, the format that's currently used is `BC3/DXT5`, the reason why this format is used over smth newer like `BC7` is because `MacOS` doesnt really support anything past `BC3` so for now we are stuck with it, this should make loading times for textures way faster. In order to compress the assets as `BC3` textures you need to download `bc7enc` from [here](https://github.com/MAJigsaw77/bc7enc_rdo/actions) for your current os, then run `./scripts/dds/compress-textures` script and to add the path to `bc7enc` program to it, like `./scripts/dds/compress-textures.sh abs/path/to/bc7enc`, make sure to run this inside the root of the game and not somewhere else.