### PR TITLE
[BUGFIX] Fix hold note score being inconsistent on different FPS

### DIFF
--- a/source/funkin/play/PlayState.hx
+++ b/source/funkin/play/PlayState.hx
@@ -2994,8 +2994,10 @@ class PlayState extends MusicBeatSubState
         // Grant the player health.
         if (!isBotPlayMode && holdNote.scoreable)
         {
-          health += Constants.HEALTH_HOLD_BONUS_PER_SECOND * elapsed;
-          songScore += Constants.SCORE_HOLD_BONUS_PER_SECOND * elapsed;
+          var holdElapsed = Math.min(elapsed, holdNote.sustainLength / Constants.MS_PER_SEC);
+
+          health += Constants.HEALTH_HOLD_BONUS_PER_SECOND * holdElapsed;
+          songScore += Constants.SCORE_HOLD_BONUS_PER_SECOND * holdElapsed;
         }
 
         // Make sure the player keeps singing while the note is held by the bot.


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues

* https://github.com/FunkinCrew/Funkin/issues/4512

<!-- Briefly describe the issue(s) fixed. -->
## Description

Fix hold note score being inconsistent on different FPS by limiting `elapsed` to `holdNote.sustainLength`

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos
