### PR TITLE
[CRASHFIX] Fix Stage Editor crashing on exit when unsaved changes exist

### DIFF
--- a/source/funkin/ui/debug/stageeditor/StageEditorState.hx
+++ b/source/funkin/ui/debug/stageeditor/StageEditorState.hx
@@ -502,7 +502,7 @@ class StageEditorState extends UIState
         var filestats:Array<sys.FileStat> = [];
         if (files.length > 0)
         {
-          while (!files[files.length - 1].endsWith(FileUtil.FILE_FILTER_FNFS.extension) || !files[files.length - 1].startsWith('stage-editor-'))
+          while (!files[files.length - 1].endsWith('.fnfs') || !files[files.length - 1].startsWith('stage-editor-'))
           {
             if (files.length == 0) break;
             files.pop();
@@ -1637,7 +1637,7 @@ class StageEditorState extends UIState
     var data = this.packShitToZip();
     var path = haxe.io.Path.join([
       BACKUPS_PATH,
-      'stage-editor-${stageName}-${funkin.util.DateUtil.generateTimestamp()}.${FileUtil.FILE_FILTER_FNFS.extension}'
+      'stage-editor-${stageName}-${funkin.util.DateUtil.generateTimestamp()}.fnfs'
     ]);
 
     FileUtil.writeBytesToPath(path, data);


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
Closes #8077
<!-- Briefly describe the issue(s) fixed. -->
## Description
`FileFilter.extension` returns `"*.fnfs"` (with a wildcard `*` meant for file dialog filtering). Two places in `StageEditorState` were using it as a literal filename extension, producing invalid paths like `stage-editor-Limo Ride-...-.*.fnfs` which crash on file write.

Fixed by replacing `FileUtil.FILE_FILTER_FNFS.extension` with the literal string `'.fnfs'` in backup filename construction and backup file matching.
<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos
### Before :


https://github.com/user-attachments/assets/a3802ba5-466d-428c-83c0-0cabfb17891a



### After :



https://github.com/user-attachments/assets/b2ce59b1-ae6d-4676-b91c-d4d9dcf8c0f0

