### PR TITLE
[COMPILEFIX] Remove the useless 'dir' field from `grig.audio`

### DIFF
--- a/hmm.json
+++ b/hmm.json
@@ -95,7 +95,6 @@
     {
       "name": "grig.audio",
       "type": "git",
-      "dir": "src",
       "ref": "6409f3c6d1b4c52176813d3ede86c0d34e8af2c1",
       "url": "https://github.com/FunkinCrew/grig.audio"
     },


### PR DESCRIPTION
<!-- Briefly describe the issue(s) fixed. -->
## Description
<img width="705" height="246" alt="image" src="https://github.com/user-attachments/assets/1c2c1c10-4fac-4790-91a2-2f0befc6cf14" />