### PR TITLE
[BUGFIX]  Save Chart Editor preferences when switching to Camera Editor

### DIFF
--- a/source/funkin/ui/debug/charting/ChartEditorState.hx
+++ b/source/funkin/ui/debug/charting/ChartEditorState.hx
@@ -7203,6 +7203,7 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
         if (f != null) f.focus = false;
       }
 
+      writePreferences(false);
       performCleanup();
 
       FlxG.switchState(() -> new CameraEditorState({


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
closes #7496
<!-- Briefly describe the issue(s) fixed. -->
## Description
When switching from Chart Editor to Camera Editor, Chart Editor preferences were not saved because `moveToCameraEditor()` called `performCleanup()` without first calling `writePreferences()`.

Added a single `writePreferences(false)` call before `performCleanup()` and matching the pattern used in `testSongInPlayState()` which calls `autoSave(true)`.

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos
### Before :

https://github.com/user-attachments/assets/d9022f74-d464-4ee3-8fc2-0b1a5e877cb5




### After :


https://github.com/user-attachments/assets/01d15917-3d1e-4f50-979b-19cce0780206



