### PR TITLE
[BUGFIX] Stop all active timers when Quick Panel is open

### DIFF
--- a/source/funkin/ui/quickpanel/QuickPanelGroup.hx
+++ b/source/funkin/ui/quickpanel/QuickPanelGroup.hx
@@ -887,6 +887,11 @@ class QuickPanelGroup extends FunkinSpriteGroup
       FlxG.sound.music.volume = rememberedVolume * 0.2;
     }
 
+    FlxTimer.globalManager.forEach(function(timers:FlxTimer)
+    {
+      timers.active = false;
+    });
+
     if (moveTween != null) moveTween.cancel();
 
     if (instant)
@@ -919,6 +924,11 @@ class QuickPanelGroup extends FunkinSpriteGroup
     {
       FlxG.sound.music.volume = rememberedVolume;
     }
+
+    FlxTimer.globalManager.forEach(function(timers:FlxTimer)
+    {
+      timers.active = true;
+    });
 
     if (moveTween != null) moveTween.cancel();
 


### PR DESCRIPTION
<!-- Does this PR close any issues? If so, link them below. -->
https://github.com/FunkinCrew/Funkin/issues/8063

<!-- Briefly describe the issue(s) fixed. -->
The Quick Panel wasn't pausing the AttractState timer, so I made sure that when the menu opens, all the timers in the active state are paused