### PR TITLE
[BUGFIX] Reset audio settings before chart playtests

### DIFF
--- a/source/funkin/ui/debug/charting/ChartEditorState.hx
+++ b/source/funkin/ui/debug/charting/ChartEditorState.hx
@@ -6555,6 +6555,9 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
       playbackRate = playbackRate.clamp(0.05, 2.0); // Clamp to 5% to 200%
     }
 
+    funkin.play.GameOverSubState.reset();
+    funkin.play.PauseSubState.reset();
+
     var targetSong:Song;
     try
     {


### PR DESCRIPTION
## Linked Issues

Closes #8085

## Description

Fixes incorrect death sounds after switching from Pico to BF variations in the chart editor. Resets game over and pause settings before a playtest.

## Screenshots/Videos

https://github.com/user-attachments/assets/ede9a8bb-2b2f-4f72-a8b9-3388bab358ed